### PR TITLE
feat: working/committed split for the JSON parquet cache

### DIFF
--- a/src/haute/_json_flatten.py
+++ b/src/haute/_json_flatten.py
@@ -364,6 +364,7 @@ def _flatten_and_write_streaming(
     progress_key: str | None = None,
     t0: float | None = None,
     cancel_event: threading.Event | None = None,
+    parquet_metadata: Mapping[bytes, bytes] | None = None,
 ) -> int:
     """Stream JSON records through flatten → PyArrow ParquetWriter.
 
@@ -373,6 +374,9 @@ def _flatten_and_write_streaming(
 
     Peak memory per chunk ≈ ``n_cols × chunk_size × value_size``.
     Chunk size adapts to the schema width via :func:`_adaptive_chunk_size`.
+
+    When *parquet_metadata* is supplied, it is embedded in the parquet
+    footer KV-metadata for single-file robustness (DUAL_CACHE.md §3).
 
     Returns the total number of rows written.
     """
@@ -385,6 +389,8 @@ def _flatten_and_write_streaming(
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = cache_path.with_suffix(".parquet.tmp")
     arrow_schema = _arrow_schema_from_flatten(flatten_schema)
+    if parquet_metadata:
+        arrow_schema = arrow_schema.with_metadata(dict(parquet_metadata))
     col_names = [f.name for f in arrow_schema]
     n_cols = len(arrow_schema)
 
@@ -780,12 +786,16 @@ def _flatten_raw_parquet(
     progress_key: str | None = None,
     t0: float | None = None,
     cancel_event: threading.Event | None = None,
+    parquet_metadata: Mapping[bytes, bytes] | None = None,
 ) -> int:
     """Step 2: Stream raw Parquet → flattened Parquet, one row group at a time.
 
     Tries Polars expression-based flatten first (fast, Arrow memory).
     Falls back to Python ``flatten()`` per row group if expressions fail
     (e.g. deeply nested mixed-type schemas).
+
+    When *parquet_metadata* is supplied, the schema-level KV-metadata is
+    embedded in the parquet footer (DUAL_CACHE.md §3 single-file robustness).
 
     Returns total rows written.
     """
@@ -804,7 +814,12 @@ def _flatten_raw_parquet(
     if n_groups == 0 or not exprs:
         cols = schema_columns(flatten_schema)
         empty = pl.DataFrame({c: pl.Series([], dtype=pl.String) for c in cols})
-        empty.write_parquet(str(tmp), compression="zstd")
+        if parquet_metadata:
+            empty_table = empty.to_arrow()
+            empty_table = empty_table.replace_schema_metadata(dict(parquet_metadata))
+            pq.write_table(empty_table, str(tmp), compression="zstd")
+        else:
+            empty.write_parquet(str(tmp), compression="zstd")
         tmp.replace(dest)
         return 0
 
@@ -830,9 +845,12 @@ def _flatten_raw_parquet(
         del df0
 
         at = flat0.to_arrow()
+        if parquet_metadata:
+            at = at.replace_schema_metadata(dict(parquet_metadata))
         total_rows = len(flat0)
         del flat0
-        writer = pq.ParquetWriter(str(tmp), at.schema, compression="zstd")
+        writer_schema = at.schema
+        writer = pq.ParquetWriter(str(tmp), writer_schema, compression="zstd")
         writer.write_table(at)
         del at
         _release_memory()
@@ -857,6 +875,8 @@ def _flatten_raw_parquet(
                 del flat_rows, rows
 
             at = flat.to_arrow()
+            if parquet_metadata:
+                at = at.replace_schema_metadata(dict(parquet_metadata))
             total_rows += len(flat)
             del flat
             writer.write_table(at)
@@ -898,6 +918,7 @@ def _flatten_jsonl_to_cache(
     progress_key: str | None = None,
     t0: float | None = None,
     cancel_event: threading.Event | None = None,
+    parquet_metadata: Mapping[bytes, bytes] | None = None,
 ) -> int:
     """Flatten JSONL to cache, using Polars only when it preserves semantics."""
     raw_path = cache_path.with_suffix(".raw.parquet")
@@ -919,6 +940,7 @@ def _flatten_jsonl_to_cache(
                     progress_key=progress_key,
                     t0=t0,
                     cancel_event=cancel_event,
+                    parquet_metadata=parquet_metadata,
                 )
             return _flatten_raw_parquet(
                 raw_path,
@@ -927,6 +949,7 @@ def _flatten_jsonl_to_cache(
                 progress_key=progress_key,
                 t0=t0,
                 cancel_event=cancel_event,
+                parquet_metadata=parquet_metadata,
             )
         except JsonFlattenDataError:
             raise
@@ -945,6 +968,7 @@ def _flatten_jsonl_to_cache(
                 progress_key=progress_key,
                 t0=t0,
                 cancel_event=cancel_event,
+                parquet_metadata=parquet_metadata,
             )
     finally:
         raw_path.unlink(missing_ok=True)
@@ -1124,36 +1148,178 @@ def flatten_to_frame(
 
 
 # ---------------------------------------------------------------------------
-# Parquet cache for flattened JSON — avoids re-flattening on every run
+# Parquet cache for flattened JSON — dual-layer (working / committed)
 # ---------------------------------------------------------------------------
+#
+# The cache is split into two layers, each under `.haute_cache/<layer>/<hash>/`:
+#
+#  - `working/<hash>/` — written by the "Cache as Parquet" button. Volatile,
+#    in-session. Reflects whatever the editor's in-memory schema was at click
+#    time. Disposable.
+#  - `committed/<hash>/` — written by Save, which mirrors `working/<hash>/`
+#    into committed/ (including absence — if working/ doesn't exist, Save
+#    ensures committed/ also doesn't exist). The durable contract that
+#    survives a server restart.
+#
+# Each layer's `<hash>/` directory contains:
+#   - `data.parquet` — the cached parquet bytes. The flatten_schema is
+#     embedded under key `haute.flatten_schema` in the parquet footer
+#     kv-metadata (single-file robustness — no schema-wrote / data-failed
+#     race, since both land in the same file).
+#   - `meta.json` — sidecar carrying `{schema_mode, schema_fingerprint}`.
+#     The fingerprint backs the no-op trapdoors (cache: skip rebuild when
+#     in-memory schema fingerprint == working/meta.json fingerprint; save:
+#     skip mirror when working/meta.json fingerprint == committed/meta.json
+#     fingerprint).
+#
+# Emitter precedence (DUAL_CACHE.md §4 + §11):
+#   - If the current Python process has cached this data file (i.e. the
+#     data-path hash is in `_session_consulted_hashes`), the emitter
+#     prefers `working/` and falls through to `committed/` only if working/
+#     is invalid for the requested schema. This is the "active editing
+#     session" semantic.
+#   - Otherwise (e.g. immediately post-restart), the emitter reads
+#     `committed/` only. `working/` on disk is preserved untouched (no
+#     server-startup cleanup) so a future recovery UX can offer to
+#     reinstate it, but the running emitter does not consult it.
+
+import hashlib
+import os
+import shutil
+from collections.abc import Mapping
 
 _CACHE_DIR = ".haute_cache"
+_LAYER_WORKING = "working"
+_LAYER_COMMITTED = "committed"
+_DATA_FILENAME = "data.parquet"
+_META_FILENAME = "meta.json"
 
 
-def _json_cache_path(data_path: str | Path) -> Path:
-    """Compute the parquet cache path for a JSON data file.
+# Module-level session tracking. Empty per Python process. The emitter
+# consults `working/` only for data-file hashes in this set; otherwise it
+# falls through to `committed/`. The set is populated when `working/` is
+# written via `build_json_cache(layer="working")`, when `read_json_flat`
+# auto-builds into working/, and when `mirror_cache_to_committed` runs
+# (post-save the local process is still authoritative for working/).
+_session_consulted_hashes: set[str] = set()
 
-    Uses a SHA-256 hash of the canonical absolute path to keep filenames
-    short, avoid exceeding Windows MAX_PATH (260 chars), and ensure
-    semantically identical relative/absolute paths share the same cache.
+
+def _path_hash(data_path: str | Path) -> str:
+    """SHA-256 (32-char) hash of the canonical absolute data file path.
+
+    Identical for any pair of relative/absolute paths that resolve to the
+    same file, so the cache identity is stable across cwd changes.
     """
-    import hashlib
-    import os
-
     canonical_path = os.path.normcase(str(Path(data_path).expanduser().resolve()))
-    path_hash = hashlib.sha256(canonical_path.encode()).hexdigest()[:32]
-    return Path.cwd() / _CACHE_DIR / f"json_{path_hash}.parquet"
+    return hashlib.sha256(canonical_path.encode()).hexdigest()[:32]
 
 
-def _json_cache_meta_path(cache_path: Path) -> Path:
-    return Path(str(cache_path) + ".meta.json")
+def _json_cache_dir(data_path: str | Path, layer: str) -> Path:
+    """Return the `<layer>/<hash>/` directory for a JSON data file's cache."""
+    if layer not in (_LAYER_WORKING, _LAYER_COMMITTED):
+        raise ValueError(f"Unknown cache layer: {layer!r}")
+    return Path.cwd() / _CACHE_DIR / layer / f"json_{_path_hash(data_path)}"
+
+
+def _json_cache_data_path(cache_dir: Path) -> Path:
+    """Return the `data.parquet` path inside a `<layer>/<hash>/` directory."""
+    return cache_dir / _DATA_FILENAME
+
+
+def _json_cache_meta_path(cache_dir: Path) -> Path:
+    """Return the `meta.json` sidecar path inside a `<layer>/<hash>/` directory."""
+    return cache_dir / _META_FILENAME
+
+
+def _working_cache_data_path(data_path: str | Path) -> Path:
+    """Shortcut for the working layer's `data.parquet` — used by tests and
+    by callers that previously dealt in single-file cache paths.
+    """
+    return _json_cache_data_path(_json_cache_dir(data_path, _LAYER_WORKING))
+
+
+def _committed_cache_data_path(data_path: str | Path) -> Path:
+    """Shortcut for the committed layer's `data.parquet` — symmetrical helper
+    used by tests that simulate a "saved cache" pre-existing on disk.
+    """
+    return _json_cache_data_path(_json_cache_dir(data_path, _LAYER_COMMITTED))
+
+
+# Backwards-compatible alias for tests that predate the dual-layer split.
+# Points at the working layer's data.parquet, which is where the
+# Cache-as-Parquet button (and `build_json_cache(layer="working")`) writes.
+# Tests that pre-create cache fixtures without going through
+# `build_json_cache` should additionally invoke `_mark_working_consulted`
+# so the emitter's precedence picks up the working layer.
+_json_cache_path = _working_cache_data_path
+
+
+def _mark_working_consulted(data_path: str | Path) -> None:
+    """Record that working/ is authoritative for this data file in this process."""
+    _session_consulted_hashes.add(_path_hash(data_path))
+
+
+def _is_working_consulted(data_path: str | Path) -> bool:
+    """True if working/ has been written (or read-built) for this data file in this process."""
+    return _path_hash(data_path) in _session_consulted_hashes
+
+
+def _clear_session() -> None:
+    """Test-only hook: simulate a process restart by clearing the consulted-hashes set."""
+    _session_consulted_hashes.clear()
+
+
+def _wipe_legacy_flat_cache(data_path: str | Path) -> bool:
+    """Remove legacy `.haute_cache/json_<hash>.parquet` flat-layout artifacts.
+
+    Pre-dual-cache, the cache was a single parquet at
+    `.haute_cache/json_<hash>.parquet` with a sidecar `.meta.json`. The
+    dual-cache migration policy is wipe-on-first-run: on the first
+    dual-cache operation for a given data file, legacy artifacts get
+    unlinked and the user must rebuild via the Cache button.
+
+    Returns True if anything was deleted (so callers can log).
+    """
+    cache_root = Path.cwd() / _CACHE_DIR
+    legacy_stem = f"json_{_path_hash(data_path)}"
+    artifacts = [
+        cache_root / f"{legacy_stem}.parquet",
+        cache_root / f"{legacy_stem}.parquet.meta.json",
+        cache_root / f"{legacy_stem}.parquet.tmp",
+        cache_root / f"{legacy_stem}.raw.parquet",
+        cache_root / f"{legacy_stem}.raw.parquet.tmp",
+    ]
+    deleted = False
+    for artifact in artifacts:
+        if artifact.exists() and artifact.is_file():
+            artifact.unlink()
+            deleted = True
+    if deleted:
+        logger.info("legacy_flat_cache_wiped", data_path=str(data_path))
+    return deleted
 
 
 def _schema_fingerprint(flatten_schema: dict[str, Any]) -> str:
-    import hashlib
-
     payload = orjson.dumps(flatten_schema, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(payload).hexdigest()
+
+
+def _build_parquet_metadata(
+    flatten_schema: dict[str, Any],
+    schema_mode: str,
+) -> dict[bytes, bytes]:
+    """KV-metadata embedded in the parquet footer for single-file robustness.
+
+    Encodes the flatten_schema (canonical JSON, sorted keys) under
+    `haute.flatten_schema` and the schema mode (explicit/config/inferred)
+    under `haute.schema_mode`. Downstream consumers that get only the
+    parquet file (no sidecar JSON) can still reconstruct schema + mode.
+    """
+    payload = orjson.dumps(flatten_schema, option=orjson.OPT_SORT_KEYS)
+    return {
+        b"haute.flatten_schema": payload,
+        b"haute.schema_mode": schema_mode.encode(),
+    }
 
 
 def _schema_cache_mode(
@@ -1171,8 +1337,9 @@ def _schema_cache_mode(
     return "inferred"
 
 
-def _read_json_cache_meta(cache_path: Path) -> dict[str, object] | None:
-    meta_path = _json_cache_meta_path(cache_path)
+def _read_cache_meta(cache_dir: Path) -> dict[str, object] | None:
+    """Read `meta.json` from a layer's `<hash>/` directory, or return None if absent."""
+    meta_path = _json_cache_meta_path(cache_dir)
     if not meta_path.exists():
         return None
     payload = orjson.loads(meta_path.read_bytes())
@@ -1181,13 +1348,19 @@ def _read_json_cache_meta(cache_path: Path) -> dict[str, object] | None:
     return cast(dict[str, object], payload)
 
 
-def _write_json_cache_meta(
-    cache_path: Path,
+def _write_cache_meta(
+    cache_dir: Path,
     *,
     schema_mode: str,
     flatten_schema: dict[str, Any],
 ) -> None:
-    meta_path = _json_cache_meta_path(cache_path)
+    """Write `meta.json` atomically into a layer's `<hash>/` directory.
+
+    Creates the directory if needed. The atomic-tmp-then-rename pattern
+    means a failed write never leaves a corrupt sidecar behind.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    meta_path = _json_cache_meta_path(cache_dir)
     payload = {
         "schema_mode": schema_mode,
         "schema_fingerprint": _schema_fingerprint(flatten_schema),
@@ -1202,12 +1375,13 @@ def _write_json_cache_meta(
 
 
 def _is_cache_schema_compatible(
-    cache_path: Path,
+    cache_dir: Path,
     *,
     schema_mode: str,
     flatten_schema: dict[str, Any] | None = None,
 ) -> bool:
-    meta = _read_json_cache_meta(cache_path)
+    """Compare `meta.json` against expected mode+fingerprint."""
+    meta = _read_cache_meta(cache_dir)
     if meta is None:
         return schema_mode == "inferred"
     if meta.get("schema_mode") != schema_mode:
@@ -1217,58 +1391,103 @@ def _is_cache_schema_compatible(
     return meta.get("schema_fingerprint") == _schema_fingerprint(flatten_schema)
 
 
+def cache_layer_if_valid(
+    data_path: str | Path,
+    *,
+    schema: dict[str, Any] | None = None,
+    config_path: str | Path | None = None,
+) -> tuple[Path, str] | None:
+    """Return `(data_parquet_path, layer)` for the first valid layer, else None.
+
+    Layer precedence:
+      1. If `_is_working_consulted(data_path)` (i.e. this process has cached
+         the file via the cache button or read-build), try `working/` first.
+      2. Always fall through to `committed/`.
+
+    The session-set gate is what closes the cross-restart vulnerability:
+    after a server restart, the set is empty, so the emitter skips `working/`
+    even if it remains on disk from a previous session.
+
+    Schema-compatibility match (preserves pre-dual-cache semantics):
+    - If ``config_path`` is supplied, the cache's ``meta.json``
+      ``schema_mode`` AND fingerprint must both match.
+    - If only ``schema`` is supplied, fingerprint match alone is sufficient
+      (the mode may differ if the cache was built via a config_path).
+    - If neither is supplied, only inferred-mode caches are accepted.
+    """
+    if schema is not None:
+        _validate_flatten_schema(schema)
+
+    source_paths = [Path(data_path)]
+    if config_path is not None:
+        source_paths.append(Path(config_path))
+    schema_mode = _schema_cache_mode(schema, config_path)
+
+    layers_to_try: list[str] = []
+    if _is_working_consulted(data_path):
+        layers_to_try.append(_LAYER_WORKING)
+    layers_to_try.append(_LAYER_COMMITTED)
+
+    for layer in layers_to_try:
+        cache_dir = _json_cache_dir(data_path, layer)
+        if not _is_cache_valid(cache_dir, *source_paths):
+            continue
+
+        meta = _read_cache_meta(cache_dir)
+
+        if config_path is not None:
+            if schema_mode == "inferred":
+                if _is_cache_schema_compatible(cache_dir, schema_mode=schema_mode):
+                    return _json_cache_data_path(cache_dir), layer
+                continue
+            resolved = _resolve_flatten_schema(Path(data_path), schema, config_path)
+            _validate_flatten_schema(resolved)
+            if _is_cache_schema_compatible(
+                cache_dir,
+                schema_mode=schema_mode,
+                flatten_schema=resolved,
+            ):
+                return _json_cache_data_path(cache_dir), layer
+            continue
+
+        if schema is None:
+            if meta is None or meta.get("schema_mode") == "inferred":
+                return _json_cache_data_path(cache_dir), layer
+            continue
+
+        if meta is None:
+            continue
+        if meta.get("schema_fingerprint") != _schema_fingerprint(schema):
+            continue
+        return _json_cache_data_path(cache_dir), layer
+    return None
+
+
 def json_cache_path_if_valid(
     data_path: str | Path,
     *,
     schema: dict[str, Any] | None = None,
     config_path: str | Path | None = None,
 ) -> Path | None:
-    """Return the parquet cache path only when it is safe to scan directly."""
-    if schema is not None:
-        _validate_flatten_schema(schema)
+    """Return the path to a valid `data.parquet`, or None if no layer is valid.
 
-    cache_path = _json_cache_path(data_path)
-    source_paths = [Path(data_path)]
-    if config_path is not None:
-        source_paths.append(Path(config_path))
-    if not _is_cache_valid(cache_path, *source_paths):
-        return None
-
-    meta = _read_json_cache_meta(cache_path)
-    if config_path is not None:
-        schema_mode = _schema_cache_mode(schema, config_path)
-        if schema_mode == "inferred":
-            if _is_cache_schema_compatible(cache_path, schema_mode=schema_mode):
-                return cache_path
-            return None
-
-        resolved = _resolve_flatten_schema(Path(data_path), schema, config_path)
-        _validate_flatten_schema(resolved)
-        if _is_cache_schema_compatible(
-            cache_path,
-            schema_mode=schema_mode,
-            flatten_schema=resolved,
-        ):
-            return cache_path
-        return None
-
-    if schema is None:
-        if meta is None or meta.get("schema_mode") == "inferred":
-            return cache_path
-        return None
-
-    if meta is None:
-        return None
-    if meta.get("schema_fingerprint") != _schema_fingerprint(schema):
-        return None
-    return cache_path
+    Thin wrapper over `cache_layer_if_valid` for callers that don't need
+    to know which layer produced the hit.
+    """
+    result = cache_layer_if_valid(
+        data_path,
+        schema=schema,
+        config_path=config_path,
+    )
+    return result[0] if result is not None else None
 
 
-def _is_cache_valid(cache_path: Path, *source_paths: Path) -> bool:
-    """Return True if cache exists and is newer than all source files."""
-    if not cache_path.exists():
+def _is_cache_valid(cache_dir: Path, *source_paths: Path) -> bool:
+    """Return True if a layer's `data.parquet` exists and is newer than all sources."""
+    data_path = _json_cache_data_path(cache_dir)
+    if not data_path.exists():
         return False
-    cache_mtime = cache_path.stat().st_mtime
+    cache_mtime = data_path.stat().st_mtime
     for src in source_paths:
         if not src.exists():
             return False
@@ -1281,20 +1500,30 @@ def _flatten_and_write(
     samples: list[dict[str, Any]],
     schema: dict[str, Any],
     cache_path: Path,
+    *,
+    parquet_metadata: Mapping[bytes, bytes] | None = None,
 ) -> None:
     """Flatten samples and write to a parquet cache file.
 
     Writes to a temporary file first and atomically renames on success
-    so a failed flatten never leaves a corrupt cache behind.
+    so a failed flatten never leaves a corrupt cache behind. When
+    *parquet_metadata* is supplied, the bytes are embedded in the parquet
+    footer KV-metadata for single-file robustness.
     """
     import polars as pl
+    import pyarrow.parquet as pq
 
     from haute._polars_utils import atomic_write
 
     with atomic_write(cache_path) as tmp_path:
         rows = [flatten(d, schema) for d in samples]
         df = pl.from_dicts(rows) if rows else pl.DataFrame()
-        df.write_parquet(tmp_path, compression="zstd")
+        if parquet_metadata:
+            table = df.to_arrow()
+            table = table.replace_schema_metadata(dict(parquet_metadata))
+            pq.write_table(table, str(tmp_path), compression="zstd")
+        else:
+            df.write_parquet(tmp_path, compression="zstd")
 
     logger.info(
         "json_cache_written",
@@ -1338,65 +1567,57 @@ def read_json_flat(
 ) -> pl.LazyFrame:
     """Load JSON/JSONL, flatten to tabular, return a Polars ``LazyFrame``.
 
-    On the first call, flattens the data and writes a parquet cache under
-    ``.haute_cache/``.  Subsequent calls return ``pl.scan_parquet()`` directly
-    — truly lazy with predicate pushdown.  The cache auto-invalidates when
-    the source data file or config file is modified.
+    Looks up the cache via the dual-layer precedence (`working/` first if
+    this process has cached the file, else `committed/`). On a miss,
+    auto-builds into `working/` — preserving the existing "auto-cache on
+    read" affordance — and marks the data-file hash as consulted so the
+    emitter prefers `working/` for subsequent reads in this process.
 
-    For ``.jsonl`` files, uses the same two-step streaming pipeline as
-    :func:`build_json_cache`:
+    Auto-cache-on-read mirrors the existing dev workflow. Deployed
+    pipelines should have `committed/` pre-built and bundled; if a deploy
+    auto-builds because the cache is missing, that signals a packaging
+    issue but the runtime still works.
 
-    1. JSONL -> raw Parquet  (Polars/Arrow memory, freed between chunks)
-    2. raw Parquet -> flat Parquet  (row-group streaming)
-
-    For ``.json`` files, streams records through PyArrow ``ParquetWriter``
-    in chunks (JSON format requires eager parsing anyway).
+    For ``.jsonl`` files, uses the two-step streaming pipeline as
+    :func:`build_json_cache`. For ``.json`` files, streams records through
+    PyArrow ``ParquetWriter``.
     """
     import polars as pl
 
     p = Path(data_path)
-    cache_path = _json_cache_path(data_path)
 
-    source_paths = [p]
-    if config_path is not None:
-        source_paths.append(Path(config_path))
+    cache_path = json_cache_path_if_valid(data_path, schema=schema, config_path=config_path)
+    if cache_path is not None:
+        logger.info("json_cache_hit", path=str(data_path), cache=str(cache_path))
+        return pl.scan_parquet(cache_path)
 
     schema_mode = _schema_cache_mode(schema, config_path)
-    resolved: dict[str, Any] | None = None
-
-    if _is_cache_valid(cache_path, *source_paths):
-        if schema_mode == "inferred":
-            cache_compatible = _is_cache_schema_compatible(
-                cache_path,
-                schema_mode=schema_mode,
-            )
-        else:
-            resolved = _resolve_flatten_schema(p, schema, config_path)
-            cache_compatible = _is_cache_schema_compatible(
-                cache_path,
-                schema_mode=schema_mode,
-                flatten_schema=resolved,
-            )
-
-        if cache_compatible:
-            logger.info("json_cache_hit", path=str(data_path), cache=str(cache_path))
-            return pl.scan_parquet(cache_path)
-
-    if resolved is None:
-        resolved = _resolve_flatten_schema(p, schema, config_path)
+    resolved = _resolve_flatten_schema(p, schema, config_path)
     _validate_flatten_schema(resolved)
 
-    if p.suffix == ".jsonl":
-        _flatten_jsonl_to_cache(p, resolved, cache_path)
-    else:
-        _flatten_and_write_streaming(_iter_json_records(p), resolved, cache_path)
+    _wipe_legacy_flat_cache(data_path)
+    cache_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    data_parquet = _json_cache_data_path(cache_dir)
+    parquet_metadata = _build_parquet_metadata(resolved, schema_mode)
 
-    _write_json_cache_meta(
-        cache_path,
+    if p.suffix == ".jsonl":
+        _flatten_jsonl_to_cache(p, resolved, data_parquet, parquet_metadata=parquet_metadata)
+    else:
+        _flatten_and_write_streaming(
+            _iter_json_records(p),
+            resolved,
+            data_parquet,
+            parquet_metadata=parquet_metadata,
+        )
+
+    _write_cache_meta(
+        cache_dir,
         schema_mode=schema_mode,
         flatten_schema=resolved,
     )
-    return pl.scan_parquet(cache_path)
+    _mark_working_consulted(data_path)
+    return pl.scan_parquet(data_parquet)
 
 
 # ---------------------------------------------------------------------------
@@ -1431,7 +1652,11 @@ def json_cache_info(
     *,
     schema: dict[str, Any] | None = None,
 ) -> JsonCacheInfoDict | None:
-    """Return metadata about a cached JSON file, or ``None`` if not cached."""
+    """Return metadata about a cached JSON file, or ``None`` if not cached.
+
+    Uses the precedence rule via :func:`json_cache_path_if_valid` so the
+    info reflects the layer the emitter would read from.
+    """
     from haute._polars_utils import read_parquet_metadata
 
     cache_path = json_cache_path_if_valid(data_path, schema=schema)
@@ -1449,27 +1674,32 @@ def json_cache_info(
     }
 
 
-def clear_json_cache(data_path: str | Path) -> bool:
-    """Delete cached parquet artifacts for a JSON data file.
+def clear_json_cache(
+    data_path: str | Path,
+    *,
+    layer: str = _LAYER_WORKING,
+) -> bool:
+    """Delete cached parquet artifacts for a JSON data file in one layer.
 
-    Returns True if any cache artifact was deleted.
+    Default is the volatile working/ layer — used by the DELETE endpoint
+    (test 4: "delete only affects volatile"). Always wipes any legacy
+    flat-layout artifacts too.
+
+    The consulted-hashes flag is intentionally NOT cleared. The user is
+    still in the same process, so they remain authoritative for this
+    data file. The emitter precedence then resolves to: try working/
+    (gone → invalid), fall through to committed/. And on the next save,
+    ``mirror_cache_to_committed`` sees consulted=True + working/ absent
+    and propagates the absence to committed/ — that's test 5.
+
+    Returns True if anything was deleted.
     """
-    cache_path = _json_cache_path(data_path)
-    raw_path = cache_path.with_suffix(".raw.parquet")
-    artifacts = [
-        cache_path,
-        _json_cache_meta_path(cache_path),
-        Path(str(cache_path) + ".tmp"),
-        raw_path,
-        Path(str(raw_path) + ".tmp"),
-    ]
-
-    deleted = False
-    for artifact in artifacts:
-        if artifact.exists():
-            artifact.unlink()
-            deleted = True
-    return deleted
+    _wipe_legacy_flat_cache(data_path)
+    cache_dir = _json_cache_dir(data_path, layer)
+    if not cache_dir.exists():
+        return False
+    shutil.rmtree(cache_dir)
+    return True
 
 
 class JsonBuildResultDict(JsonCacheInfoDict):
@@ -1480,24 +1710,74 @@ def build_json_cache(
     data_path: str | Path,
     schema: dict[str, Any] | None = None,
     config_path: str | Path | None = None,
+    *,
+    layer: str = _LAYER_WORKING,
 ) -> JsonBuildResultDict:
     """Build the parquet cache for a JSON/JSONL file with progress tracking.
 
     This is the explicit entry point for the "Cache as Parquet" button.
+    By default targets the volatile ``working/`` layer; the ``committed/``
+    layer is populated only via :func:`mirror_cache_to_committed` (invoked
+    by Save).
 
-    For ``.jsonl`` files, uses a two-step streaming approach to avoid
-    Python memory fragmentation:
+    No-op trapdoor (DUAL_CACHE.md §6 cache trapdoor): if the target
+    layer's ``meta.json`` fingerprint already matches the resolved
+    in-memory schema fingerprint, skip the rebuild and return the
+    existing summary. The session-set is still updated when
+    ``layer="working"`` so the precedence flag persists across the no-op.
 
-    1. JSONL → raw Parquet  (Polars/Arrow memory, freed between chunks)
-    2. raw Parquet → flat Parquet  (row-group streaming)
-
-    For ``.json`` files, falls back to the Python streaming path (JSON
-    format requires eager parsing anyway, and files are typically small).
+    For ``.jsonl`` files uses the two-step streaming approach:
+    JSONL → raw Parquet → flat Parquet. For ``.json`` files streams
+    records through PyArrow ``ParquetWriter``.
     """
+    if layer not in (_LAYER_WORKING, _LAYER_COMMITTED):
+        raise ValueError(f"Unknown cache layer: {layer!r}")
+
     p = Path(data_path)
     data_path_str = str(data_path)
-    cache_path = _json_cache_path(data_path)
     schema_mode = _schema_cache_mode(schema, config_path)
+
+    # Wipe any legacy flat-layout artifacts before touching the new layout.
+    _wipe_legacy_flat_cache(data_path)
+
+    cache_dir = _json_cache_dir(data_path, layer)
+    data_parquet = _json_cache_data_path(cache_dir)
+
+    resolved = _resolve_flatten_schema(p, schema, config_path)
+    _validate_flatten_schema(resolved)
+    fingerprint = _schema_fingerprint(resolved)
+
+    # No-op trapdoor: skip rebuild when target layer already has matching meta.
+    existing_meta = _read_cache_meta(cache_dir)
+    if (
+        existing_meta is not None
+        and existing_meta.get("schema_fingerprint") == fingerprint
+        and existing_meta.get("schema_mode") == schema_mode
+        and data_parquet.exists()
+    ):
+        from haute._polars_utils import read_parquet_metadata
+
+        if layer == _LAYER_WORKING:
+            _mark_working_consulted(data_path)
+        meta = read_parquet_metadata(data_parquet)
+        logger.info(
+            "json_cache_build_noop",
+            layer=layer,
+            data_path=data_path_str,
+            cache_dir=str(cache_dir),
+        )
+        return {
+            "path": str(data_parquet),
+            "data_path": data_path_str,
+            "row_count": meta["row_count"],
+            "column_count": meta["column_count"],
+            "columns": meta["columns"],
+            "size_bytes": meta["size_bytes"],
+            "cached_at": meta["mtime"],
+            "cache_seconds": 0.0,
+        }
+
+    parquet_metadata = _build_parquet_metadata(resolved, schema_mode)
 
     event = threading.Event()
     t0 = time.monotonic()
@@ -1506,27 +1786,26 @@ def build_json_cache(
         _cancel_events[data_path_str] = event
 
     try:
-        resolved = _resolve_flatten_schema(p, schema, config_path)
-        _validate_flatten_schema(resolved)
-
         if p.suffix == ".jsonl":
             _flatten_jsonl_to_cache(
                 p,
                 resolved,
-                cache_path,
+                data_parquet,
                 progress_key=data_path_str,
                 t0=t0,
                 cancel_event=event,
+                parquet_metadata=parquet_metadata,
             )
         else:
             # .json: must be fully loaded (JSON format constraint)
             _flatten_and_write_streaming(
                 _iter_json_records(p),
                 resolved,
-                cache_path,
+                data_parquet,
                 progress_key=data_path_str,
                 t0=t0,
                 cancel_event=event,
+                parquet_metadata=parquet_metadata,
             )
     finally:
         with _flatten_lock:
@@ -1537,14 +1816,16 @@ def build_json_cache(
 
     from haute._polars_utils import read_parquet_metadata
 
-    _write_json_cache_meta(
-        cache_path,
+    _write_cache_meta(
+        cache_dir,
         schema_mode=schema_mode,
         flatten_schema=resolved,
     )
-    meta = read_parquet_metadata(cache_path)
+    if layer == _LAYER_WORKING:
+        _mark_working_consulted(data_path)
+    meta = read_parquet_metadata(data_parquet)
     return {
-        "path": str(cache_path),
+        "path": str(data_parquet),
         "data_path": data_path_str,
         "row_count": meta["row_count"],
         "column_count": meta["column_count"],
@@ -1553,3 +1834,85 @@ def build_json_cache(
         "cached_at": meta["mtime"],
         "cache_seconds": round(elapsed, 2),
     }
+
+
+def mirror_cache_to_committed(data_path: str | Path) -> bool:
+    """Promote `working/<hash>/` → `committed/<hash>/` on Save (DUAL_CACHE.md §4).
+
+    Behaviour (the user's test plan governs):
+      - If the current process has NOT cached this data file (i.e. not in
+        ``_session_consulted_hashes``), this is a no-op. This guards against
+        save inadvertently promoting a stale on-disk working/ from a
+        previous session (cross-restart vulnerability mitigation).
+      - If working/ exists: mirror it byte-for-byte into committed/
+        (test 3 — "save synchronises stable to volatile without changing
+        volatile"). No-op trapdoor: if working/meta.json fingerprint ==
+        committed/meta.json fingerprint, skip the copy.
+      - If working/ does not exist: ensure committed/ also does not exist
+        (test 5 — "save in cache-deleted state removes stable cache").
+
+    Returns True if the on-disk committed/ state changed.
+    """
+    _wipe_legacy_flat_cache(data_path)
+    if not _is_working_consulted(data_path):
+        # Stale on-disk working/ from a previous session; or no cache ever.
+        return False
+
+    working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+    committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
+
+    if not working_dir.exists():
+        if committed_dir.exists():
+            shutil.rmtree(committed_dir)
+            logger.info(
+                "json_cache_committed_cleared",
+                data_path=str(data_path),
+                committed_dir=str(committed_dir),
+            )
+            return True
+        return False
+
+    working_meta = _read_cache_meta(working_dir)
+    committed_meta = (
+        _read_cache_meta(committed_dir) if committed_dir.exists() else None
+    )
+    if (
+        working_meta is not None
+        and committed_meta is not None
+        and working_meta.get("schema_fingerprint")
+        == committed_meta.get("schema_fingerprint")
+        and working_meta.get("schema_mode") == committed_meta.get("schema_mode")
+    ):
+        logger.info(
+            "json_cache_save_noop",
+            data_path=str(data_path),
+            committed_dir=str(committed_dir),
+        )
+        return False
+
+    # Atomic replacement: copytree into a `.tmp` sibling then swap.
+    committed_dir.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = committed_dir.with_name(committed_dir.name + ".tmp")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    shutil.copytree(working_dir, tmp_dir)
+    if committed_dir.exists():
+        backup = committed_dir.with_name(committed_dir.name + ".old")
+        if backup.exists():
+            shutil.rmtree(backup)
+        committed_dir.rename(backup)
+        try:
+            tmp_dir.rename(committed_dir)
+        except BaseException:
+            backup.rename(committed_dir)
+            raise
+        shutil.rmtree(backup, ignore_errors=True)
+    else:
+        tmp_dir.rename(committed_dir)
+    logger.info(
+        "json_cache_committed_mirrored",
+        data_path=str(data_path),
+        working_dir=str(working_dir),
+        committed_dir=str(committed_dir),
+    )
+    return True

--- a/src/haute/_json_flatten.py
+++ b/src/haute/_json_flatten.py
@@ -18,9 +18,12 @@ Array indices are **1-based** (e.g. ``additional_drivers.1.first_name``).
 from __future__ import annotations
 
 import gc
+import hashlib
+import os
+import shutil
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
@@ -1183,11 +1186,6 @@ def flatten_to_frame(
 #     server-startup cleanup) so a future recovery UX can offer to
 #     reinstate it, but the running emitter does not consult it.
 
-import hashlib
-import os
-import shutil
-from collections.abc import Mapping
-
 _CACHE_DIR = ".haute_cache"
 _LAYER_WORKING = "working"
 _LAYER_COMMITTED = "committed"
@@ -1873,14 +1871,11 @@ def mirror_cache_to_committed(data_path: str | Path) -> bool:
         return False
 
     working_meta = _read_cache_meta(working_dir)
-    committed_meta = (
-        _read_cache_meta(committed_dir) if committed_dir.exists() else None
-    )
+    committed_meta = _read_cache_meta(committed_dir) if committed_dir.exists() else None
     if (
         working_meta is not None
         and committed_meta is not None
-        and working_meta.get("schema_fingerprint")
-        == committed_meta.get("schema_fingerprint")
+        and working_meta.get("schema_fingerprint") == committed_meta.get("schema_fingerprint")
         and working_meta.get("schema_mode") == committed_meta.get("schema_mode")
     ):
         logger.info(

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -115,6 +115,7 @@ class SavePipelineService:
             self._write_code(body, graph, py_path, touched)
             self._infer_flatten_schemas(graph)
             self._write_config_files(graph, touched)
+            self._mirror_api_input_caches(graph)
             warnings.extend(
                 self._write_sidecar(py_path, graph, body.sources, body.active_source, touched)
             )
@@ -371,6 +372,50 @@ class SavePipelineService:
                 samples = load_samples(data_path)
                 if samples:
                     cfg["flattenSchema"] = infer_schema(samples)
+
+    # ------------------------------------------------------------------
+    # Dual-cache: mirror working/ → committed/ per API Input node
+    # ------------------------------------------------------------------
+
+    def _mirror_api_input_caches(self, graph: PipelineGraph) -> None:
+        """Promote each API Input node's volatile cache to the committed layer.
+
+        Walks every API Input node backed by a JSON/JSONL data file and
+        invokes :func:`haute._json_flatten.mirror_cache_to_committed`.
+        Mirror semantics (test plan):
+
+        - When working/<hash>/ exists, copy it into committed/<hash>/
+          (no-op trapdoor if fingerprints already match).
+        - When working/<hash>/ does NOT exist *and* this process previously
+          cached the file (delete-then-save flow), remove committed/<hash>/.
+        - When this process has never cached the file, do nothing — avoids
+          promoting a stale on-disk working/ from a previous session.
+
+        Mirror failures are not rolled back through ``_TouchedFile``
+        because the operation is idempotent: a partial state on disk is a
+        valid intermediate that the next save can repair. Logged for the
+        operator to investigate.
+        """
+        from haute._json_flatten import mirror_cache_to_committed
+
+        for node in graph.nodes:
+            if node.data.nodeType != NodeType.API_INPUT:
+                continue
+            cfg = node.data.config
+            path = cfg.get("path", "")
+            if not path.endswith((".json", ".jsonl")):
+                continue
+            data_path = (self._root / path).resolve()
+            if not data_path.is_relative_to(self._root):
+                continue
+            try:
+                mirror_cache_to_committed(str(data_path))
+            except Exception as exc:  # pragma: no cover - logged for operator
+                logger.error(
+                    "json_cache_mirror_failed",
+                    data_path=str(data_path),
+                    error=str(exc),
+                )
 
     # ------------------------------------------------------------------
     # Config file I/O

--- a/src/haute/routes/json_cache.py
+++ b/src/haute/routes/json_cache.py
@@ -132,7 +132,13 @@ async def get_json_cache_progress(path: str) -> JsonCacheProgressResponse:
 
 @router.post("/status", response_model=JsonCacheStatusResponse)
 async def post_json_cache_status(body: JsonCacheBuildRequest) -> JsonCacheStatusResponse:
-    """Check whether a JSON file has been cached as parquet."""
+    """Check whether a JSON file has a valid cache the emitter would consume.
+
+    Dual-layer semantics: returns the layer the emitter would actually read
+    from — `working/` if this process has cached the file (active editing
+    session), else `committed/` — or `cached=False` if neither is valid.
+    The wire shape stays unchanged so the frontend pill behaves as today.
+    """
     data_path = _resolve_data_path(body.path)
     config_path = _resolve_config_path(body.config_path)
     from haute._json_flatten import (
@@ -169,7 +175,7 @@ async def post_json_cache_status(body: JsonCacheBuildRequest) -> JsonCacheStatus
 
 @router.get("/status", response_model=JsonCacheStatusResponse)
 async def get_json_cache_status(path: str) -> JsonCacheStatusResponse:
-    """Check whether a JSON file has been cached as parquet."""
+    """Check whether a JSON file has a valid cache (schema-agnostic)."""
     data_path = _resolve_data_path(path)
     from haute._json_flatten import json_cache_info
 
@@ -181,7 +187,12 @@ async def get_json_cache_status(path: str) -> JsonCacheStatusResponse:
 
 @router.delete("", response_model=JsonCacheStatusResponse)
 async def delete_json_cache(path: str) -> JsonCacheStatusResponse:
-    """Delete the local parquet cache for a JSON file."""
+    """Delete the volatile (working/) cache layer for a JSON file.
+
+    Dual-cache semantics: delete operates on the working/ layer only. The
+    durable committed/ layer is untouched and remains the source of truth
+    until a subsequent save mirrors a (possibly absent) working/ into it.
+    """
     data_path = _resolve_data_path(path)
     from haute._json_flatten import clear_json_cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,25 @@ def _clear_pipeline_dir_cache():
     pipeline_dir.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _clear_dual_cache_session():
+    """Reset the dual-cache consulted-hashes set between tests.
+
+    The set is module-level in ``haute._json_flatten`` — once a test calls
+    ``build_json_cache`` or ``read_json_flat`` for a data file, the hash
+    persists across subsequent tests in the same process. That would let
+    one test's working-layer state spill into another's emitter precedence
+    check, masking regressions or producing flaky failures. Clearing
+    before AND after each test gives the same per-process isolation the
+    other module-level singletons in this conftest get.
+    """
+    from haute._json_flatten import _clear_session
+
+    _clear_session()
+    yield
+    _clear_session()
+
+
 @pytest.fixture()
 def _widen_sandbox_root():
     """Allow tests to load files from temp directories.

--- a/tests/test_dual_cache_behavior.py
+++ b/tests/test_dual_cache_behavior.py
@@ -42,7 +42,6 @@ from haute._json_flatten import (
     mirror_cache_to_committed,
 )
 
-
 # ---------------------------------------------------------------------------
 # Project fixture
 # ---------------------------------------------------------------------------
@@ -59,7 +58,7 @@ _SCHEMA_S2: dict[str, object] = {
 def _write_data_file(path: Path) -> None:
     """Write a small JSONL file with fields covering both S1 and S2 schemas."""
     path.write_text(
-        '\n'.join(
+        "\n".join(
             json.dumps(rec)
             for rec in (
                 {"quote_id": "q-1", "premium": 100.0, "extra": "alpha"},
@@ -286,9 +285,7 @@ class TestSetUp:
         )
 
         # Working and committed parquets are byte-identical after save (mirror).
-        assert (working / "data.parquet").read_bytes() == (
-            committed / "data.parquet"
-        ).read_bytes()
+        assert (working / "data.parquet").read_bytes() == (committed / "data.parquet").read_bytes()
 
 
 # ---------------------------------------------------------------------------
@@ -325,9 +322,7 @@ class TestVolatileTracksSchemaChanges:
         _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
 
         # ASSERT (2.4) — stable cache agrees with the snapshot (last-save state).
-        assert (committed / "data.parquet").read_bytes() == (
-            scratch / "data.parquet"
-        ).read_bytes()
+        assert (committed / "data.parquet").read_bytes() == (scratch / "data.parquet").read_bytes()
         assert _read_meta(committed) == _read_meta(scratch)
 
         # ASSERT (2.5) — volatile cache metadata fingerprint == in-memory S2 fingerprint.
@@ -346,9 +341,7 @@ class TestVolatileTracksSchemaChanges:
 
         # ASSERT (2.7) — volatile and stable disagree.
         assert _read_meta(working) != _read_meta(committed)
-        assert (working / "data.parquet").read_bytes() != (
-            committed / "data.parquet"
-        ).read_bytes()
+        assert (working / "data.parquet").read_bytes() != (committed / "data.parquet").read_bytes()
 
 
 # ---------------------------------------------------------------------------
@@ -389,9 +382,7 @@ class TestSaveMirrors:
         assert _read_meta(working) == _read_meta(scratch_volatile)
 
         # ASSERT (3.4) — committed bytes-equal to working.
-        assert (working / "data.parquet").read_bytes() == (
-            committed / "data.parquet"
-        ).read_bytes()
+        assert (working / "data.parquet").read_bytes() == (committed / "data.parquet").read_bytes()
         assert _read_meta(working) == _read_meta(committed)
 
 
@@ -430,9 +421,7 @@ class TestDeleteOnlyAffectsVolatile:
         # ASSERT (4.2) — working/ does not exist (directory absent).
         assert not working.exists()
         # ASSERT (4.3) — committed/ unchanged.
-        assert (committed / "data.parquet").read_bytes() == (
-            scratch / "data.parquet"
-        ).read_bytes()
+        assert (committed / "data.parquet").read_bytes() == (scratch / "data.parquet").read_bytes()
         assert _read_meta(committed) == _read_meta(scratch)
 
 
@@ -471,9 +460,7 @@ class TestSaveAfterDeletePromotesAbsence:
         _api_save(client)
 
         # ASSERT (5.2) — committed/ removed (save mirrored the absence).
-        assert not committed.exists(), (
-            "Save should propagate the cache-deleted state to committed/"
-        )
+        assert not committed.exists(), "Save should propagate the cache-deleted state to committed/"
         # ASSERT (5.3) — working/ still absent.
         assert not working.exists()
 
@@ -508,9 +495,7 @@ class TestCrossRestartVulnerability:
         committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
         assert b"haute.flatten_schema" in _read_parquet_metadata(working / "data.parquet")
         assert _read_meta(working)["schema_fingerprint"] == _schema_fingerprint(_SCHEMA_S2)
-        assert _read_meta(committed)["schema_fingerprint"] == _schema_fingerprint(
-            project["schema"]
-        )
+        assert _read_meta(committed)["schema_fingerprint"] == _schema_fingerprint(project["schema"])
 
         # Simulate a server restart: working/ on disk survives, but the
         # process-local consulted set is cleared.
@@ -525,9 +510,7 @@ class TestCrossRestartVulnerability:
         # restart (it reloads the saved on-disk config).
         _set_schema_in_config(config_file, project["schema"])
         status = _api_cache_status(client, project["data_rel"], schema=project["schema"])
-        assert status["cached"] is True, (
-            "status with S1 schema should hit committed/ post-restart"
-        )
+        assert status["cached"] is True, "status with S1 schema should hit committed/ post-restart"
         # Status's cache path is in committed/, not working/.
         assert _LAYER_COMMITTED in status["path"], status["path"]
 
@@ -540,9 +523,7 @@ class TestCrossRestartVulnerability:
         # unreachable by the emitter post-restart.
         assert (working / "data.parquet").exists()
         embedded = json.loads(
-            _read_parquet_metadata(working / "data.parquet")[
-                b"haute.flatten_schema"
-            ].decode()
+            _read_parquet_metadata(working / "data.parquet")[b"haute.flatten_schema"].decode()
         )
         assert embedded == _SCHEMA_S2
 

--- a/tests/test_dual_cache_behavior.py
+++ b/tests/test_dual_cache_behavior.py
@@ -1,0 +1,738 @@
+"""Dual-cache behavioural contract tests (working/ vs committed/ layers).
+
+Covers the 8 scenarios from the dual-cache plan:
+
+  1. SET-UP — known state after cache + save: both layers in sync.
+  2. Volatile cache changes with in-session schema edits; stable unchanged.
+  3. Save mirrors working/ → committed/; working/ unchanged.
+  4. Delete only affects volatile (working/); committed/ untouched.
+  5. Save in cache-deleted state removes committed/ (no-cache promotion).
+  6. Cross-restart vulnerability is closed (CACHEING_ACCESS_MODEL.md pattern).
+  7. No-op trapdoors (cache fingerprint match; save fingerprint match).
+  8. Read-precedence at execute time (emitter prefers working/ else committed/).
+
+Setup pattern: each test starts from a fresh project laid out by
+``_setup_project`` (one apiInput JSON node, one cached data file). State
+between tests is reset by the autouse ``_clear_dual_cache_session``
+fixture in conftest.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import textwrap
+from pathlib import Path
+
+import polars as pl
+import pyarrow.parquet as pq
+import pytest
+from fastapi.testclient import TestClient
+
+from haute._json_flatten import (
+    _LAYER_COMMITTED,
+    _LAYER_WORKING,
+    _clear_session,
+    _committed_cache_data_path,
+    _is_working_consulted,
+    _json_cache_dir,
+    _schema_fingerprint,
+    _working_cache_data_path,
+    build_json_cache,
+    mirror_cache_to_committed,
+)
+
+
+# ---------------------------------------------------------------------------
+# Project fixture
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA_S1: dict[str, str] = {"quote_id": "str", "premium": "float"}
+_SCHEMA_S2: dict[str, object] = {
+    "quote_id": "str",
+    "premium": "float",
+    "extra": "str",
+}
+
+
+def _write_data_file(path: Path) -> None:
+    """Write a small JSONL file with fields covering both S1 and S2 schemas."""
+    path.write_text(
+        '\n'.join(
+            json.dumps(rec)
+            for rec in (
+                {"quote_id": "q-1", "premium": 100.0, "extra": "alpha"},
+                {"quote_id": "q-2", "premium": 200.5, "extra": "beta"},
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _setup_project(root: Path, *, schema: dict[str, object]) -> dict[str, object]:
+    """Create a minimal project under *root* with one apiInput node.
+
+    Returns the resolved data and config paths, plus the schema used.
+    """
+    pipeline_dir_path = root / "rating"
+    pipeline_dir_path.mkdir(parents=True, exist_ok=True)
+    config_dir = pipeline_dir_path / "config" / "quote_input"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = root / "data" / "quotes"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    data_file = data_dir / "sample_quote.jsonl"
+    _write_data_file(data_file)
+
+    quotes_config = config_dir / "quotes.json"
+    quotes_config.write_text(
+        json.dumps({"path": "data/quotes/sample_quote.jsonl", "flattenSchema": schema}),
+        encoding="utf-8",
+    )
+
+    pipeline_file = pipeline_dir_path / "main.py"
+    pipeline_file.write_text(
+        textwrap.dedent(
+            '''\
+            """Pipeline: regression"""
+
+            import polars as pl
+            import haute
+
+            pipeline = haute.Pipeline("regression")
+
+
+            @pipeline.api_input(
+                config="config/quote_input/quotes.json",
+                contract="opaque",
+            )
+            def quotes() -> pl.LazyFrame:
+                """quotes node"""
+                from pathlib import Path
+                from haute._json_flatten import read_json_flat
+                return read_json_flat(
+                    Path(__file__).parent.parent
+                    / "data/quotes/sample_quote.jsonl",
+                    config_path="config/quote_input/quotes.json",
+                )
+            '''
+        ),
+        encoding="utf-8",
+    )
+
+    haute_toml = root / "haute.toml"
+    haute_toml.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "regression"
+            pipeline = "rating/main.py"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    return {
+        "data_file": data_file,
+        "data_rel": "data/quotes/sample_quote.jsonl",
+        "config_file": quotes_config,
+        "config_rel": "config/quote_input/quotes.json",
+        "pipeline_file": pipeline_file,
+        "schema": schema,
+    }
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Fresh project + isolated cache dir for each test."""
+    monkeypatch.chdir(tmp_path)
+    info = _setup_project(tmp_path, schema=_SCHEMA_S1)
+
+    from haute.routes._helpers import pipeline_dir as _pd
+
+    _pd.cache_clear()
+    return info
+
+
+@pytest.fixture()
+def client(project: dict[str, object]) -> TestClient:
+    """A TestClient pointed at the project fixture's pipeline."""
+    from haute.server import app
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _api_cache_build(client: TestClient, data_rel: str, schema: dict | None) -> dict:
+    body: dict[str, object] = {"path": data_rel}
+    if schema is not None:
+        body["flatten_schema"] = schema
+    resp = client.post("/api/json-cache/build", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _api_save(client: TestClient) -> dict:
+    """Issue POST /api/pipeline/save for the project pipeline.
+
+    Builds the graph payload by fetching the current parsed graph and
+    re-submitting it. Mirrors the frontend's save flow.
+    """
+    graph_resp = client.get("/api/pipeline")
+    assert graph_resp.status_code == 200, graph_resp.text
+    graph = graph_resp.json()
+    body = {
+        "graph": graph,
+        "sources": graph.get("sources") or ["live"],
+        "active_source": graph.get("active_source") or "live",
+        "source_file": "rating/main.py",
+        "name": "regression",
+        "description": graph.get("description") or "regression",
+    }
+    resp = client.post("/api/pipeline/save", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _api_cache_delete(client: TestClient, data_rel: str) -> dict:
+    resp = client.delete(f"/api/json-cache?path={data_rel}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _api_cache_status(
+    client: TestClient,
+    data_rel: str,
+    *,
+    schema: dict | None = None,
+) -> dict:
+    body: dict[str, object] = {"path": data_rel}
+    if schema is not None:
+        body["flatten_schema"] = schema
+    resp = client.post("/api/json-cache/status", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _read_meta(cache_dir: Path) -> dict | None:
+    meta_path = cache_dir / "meta.json"
+    if not meta_path.exists():
+        return None
+    return json.loads(meta_path.read_text(encoding="utf-8"))
+
+
+def _read_parquet_metadata(parquet_path: Path) -> dict[bytes, bytes]:
+    md = pq.read_metadata(str(parquet_path)).metadata
+    return dict(md) if md else {}
+
+
+def _set_schema_in_config(config_file: Path, schema: dict) -> None:
+    """Rewrite the on-disk apiInput config to use *schema*."""
+    cfg = json.loads(config_file.read_text(encoding="utf-8"))
+    cfg["flattenSchema"] = schema
+    config_file.write_text(json.dumps(cfg), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: SET-UP
+# ---------------------------------------------------------------------------
+
+
+class TestSetUp:
+    """After cache + save the two layers are in sync with the in-memory view."""
+
+    def test_known_state_after_cache_and_save(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+    ) -> None:
+        data_file: Path = project["data_file"]
+        schema = project["schema"]
+
+        # Step 1+2: cache the data.
+        result = _api_cache_build(client, project["data_rel"], schema)
+        assert result["row_count"] == 2
+
+        # Step 3: save.
+        _api_save(client)
+
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+        assert (working / "data.parquet").exists()
+        assert (committed / "data.parquet").exists()
+
+        # Fingerprints in meta.json match the resolved schema.
+        wmeta = _read_meta(working)
+        cmeta = _read_meta(committed)
+        expected_fp = _schema_fingerprint(schema)
+        assert wmeta is not None and wmeta["schema_fingerprint"] == expected_fp
+        assert cmeta is not None and cmeta["schema_fingerprint"] == expected_fp
+
+        # Parquet KV-metadata carries the schema for single-file robustness.
+        pq_meta_w = _read_parquet_metadata(working / "data.parquet")
+        pq_meta_c = _read_parquet_metadata(committed / "data.parquet")
+        assert b"haute.flatten_schema" in pq_meta_w
+        assert b"haute.flatten_schema" in pq_meta_c
+        assert (
+            json.loads(pq_meta_w[b"haute.flatten_schema"].decode())
+            == json.loads(pq_meta_c[b"haute.flatten_schema"].decode())
+            == schema
+        )
+
+        # Working and committed parquets are byte-identical after save (mirror).
+        assert (working / "data.parquet").read_bytes() == (
+            committed / "data.parquet"
+        ).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: volatile changes with schema; stable unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestVolatileTracksSchemaChanges:
+    """Cache after schema edit produces a working/ that diverges from committed/."""
+
+    def test_volatile_reflects_in_memory_stable_reflects_save(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+        schema_s1 = project["schema"]
+
+        # Bring the project to the post-save baseline (test 1's terminal state).
+        _api_cache_build(client, project["data_rel"], schema_s1)
+        _api_save(client)
+
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+
+        # Snapshot the committed layer to a scratch dir for later comparison.
+        scratch = tmp_path / "scratch_stable"
+        shutil.copytree(committed, scratch)
+
+        # Schema edit (simulating an in-session edit).
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+
+        # ASSERT (2.4) — stable cache agrees with the snapshot (last-save state).
+        assert (committed / "data.parquet").read_bytes() == (
+            scratch / "data.parquet"
+        ).read_bytes()
+        assert _read_meta(committed) == _read_meta(scratch)
+
+        # ASSERT (2.5) — volatile cache metadata fingerprint == in-memory S2 fingerprint.
+        wmeta = _read_meta(working)
+        assert wmeta is not None
+        assert wmeta["schema_fingerprint"] == _schema_fingerprint(_SCHEMA_S2)
+
+        # ASSERT (2.6) — parquet footer describes the shape of the cached data.
+        pq_meta = _read_parquet_metadata(working / "data.parquet")
+        assert b"haute.flatten_schema" in pq_meta
+        embedded = json.loads(pq_meta[b"haute.flatten_schema"].decode())
+        assert embedded == _SCHEMA_S2
+        # And the parquet columns match the schema's declared leaves.
+        cols = pl.scan_parquet(working / "data.parquet").collect_schema().names()
+        assert set(cols) == set(_SCHEMA_S2.keys())
+
+        # ASSERT (2.7) — volatile and stable disagree.
+        assert _read_meta(working) != _read_meta(committed)
+        assert (working / "data.parquet").read_bytes() != (
+            committed / "data.parquet"
+        ).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: save mirrors working → committed without changing working
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMirrors:
+    """Save copies working/ into committed/ byte-for-byte; working/ unchanged."""
+
+    def test_save_synchronises_committed_to_working(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+
+        # Snapshot the working layer to a scratch dir before save.
+        scratch_volatile = tmp_path / "scratch_volatile"
+        shutil.copytree(working, scratch_volatile)
+
+        _api_save(client)
+
+        # ASSERT (3.3) — working unchanged.
+        assert (working / "data.parquet").read_bytes() == (
+            scratch_volatile / "data.parquet"
+        ).read_bytes()
+        assert _read_meta(working) == _read_meta(scratch_volatile)
+
+        # ASSERT (3.4) — committed bytes-equal to working.
+        assert (working / "data.parquet").read_bytes() == (
+            committed / "data.parquet"
+        ).read_bytes()
+        assert _read_meta(working) == _read_meta(committed)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: delete only affects volatile
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteOnlyAffectsVolatile:
+    """The DELETE endpoint removes working/ only; committed/ is untouched."""
+
+    def test_delete_removes_working_only(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+        _api_save(client)  # so both layers reflect S2
+
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+
+        # Snapshot committed/ before deletion for the assert.
+        scratch = tmp_path / "scratch_stable"
+        shutil.copytree(committed, scratch)
+
+        _api_cache_delete(client, project["data_rel"])
+
+        # ASSERT (4.2) — working/ does not exist (directory absent).
+        assert not working.exists()
+        # ASSERT (4.3) — committed/ unchanged.
+        assert (committed / "data.parquet").read_bytes() == (
+            scratch / "data.parquet"
+        ).read_bytes()
+        assert _read_meta(committed) == _read_meta(scratch)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: save in cache-deleted state removes committed/
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAfterDeletePromotesAbsence:
+    """Save after delete promotes "no cache" — committed/ becomes empty too."""
+
+    def test_save_after_delete_removes_committed(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+    ) -> None:
+        data_file: Path = project["data_file"]
+
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        assert _is_working_consulted(str(data_file))
+
+        _api_cache_delete(client, project["data_rel"])
+
+        # Delete clears working/ but preserves the consulted flag — the
+        # user is still in the same process and remains authoritative for
+        # this data file. So the next save sees "consulted=True, working
+        # absent" and propagates the absence to committed/.
+        assert _is_working_consulted(str(data_file))
+        assert not working.exists()
+        assert committed.exists()  # delete didn't touch committed/
+
+        _api_save(client)
+
+        # ASSERT (5.2) — committed/ removed (save mirrored the absence).
+        assert not committed.exists(), (
+            "Save should propagate the cache-deleted state to committed/"
+        )
+        # ASSERT (5.3) — working/ still absent.
+        assert not working.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: vulnerability-pattern regression (cross-restart)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossRestartVulnerability:
+    """CACHEING_ACCESS_MODEL.md vulnerability is closed by the dual-cache split."""
+
+    def test_restart_ignores_working_falls_through_to_committed(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+    ) -> None:
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+
+        # Bring the project to a baseline: both layers reflect S1.
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+        assert _is_working_consulted(str(data_file))
+
+        # Edit schema in-memory to S2, re-cache. Working/ now has S2.
+        # Committed/ still has S1.
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+        assert b"haute.flatten_schema" in _read_parquet_metadata(working / "data.parquet")
+        assert _read_meta(working)["schema_fingerprint"] == _schema_fingerprint(_SCHEMA_S2)
+        assert _read_meta(committed)["schema_fingerprint"] == _schema_fingerprint(
+            project["schema"]
+        )
+
+        # Simulate a server restart: working/ on disk survives, but the
+        # process-local consulted set is cleared.
+        _clear_session()
+        assert not _is_working_consulted(str(data_file))
+
+        # ASSERT (7) — status reflects working/ (not consulted, reports cached=False).
+        # The on-disk schema mapping JSON would have to be reverted to S1 for the
+        # editor to show S1; the JSON file currently reflects whatever's in
+        # config_file. The test simulates the editor reading the saved schema
+        # by querying status with S1, which is what the editor would do after a
+        # restart (it reloads the saved on-disk config).
+        _set_schema_in_config(config_file, project["schema"])
+        status = _api_cache_status(client, project["data_rel"], schema=project["schema"])
+        assert status["cached"] is True, (
+            "status with S1 schema should hit committed/ post-restart"
+        )
+        # Status's cache path is in committed/, not working/.
+        assert _LAYER_COMMITTED in status["path"], status["path"]
+
+        # ASSERT (8) — committed/<hash>/data.parquet still has S1.
+        committed_meta = _read_meta(committed)
+        assert committed_meta["schema_fingerprint"] == _schema_fingerprint(project["schema"])
+
+        # ASSERT (9) — working/<hash>/data.parquet still exists on disk (lost
+        # work preserved for potential future recovery), but with S2 contents,
+        # unreachable by the emitter post-restart.
+        assert (working / "data.parquet").exists()
+        embedded = json.loads(
+            _read_parquet_metadata(working / "data.parquet")[
+                b"haute.flatten_schema"
+            ].decode()
+        )
+        assert embedded == _SCHEMA_S2
+
+
+# ---------------------------------------------------------------------------
+# Test 7: no-op trapdoors
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpTrapdoors:
+    """Cache trapdoor (working/) and save trapdoor (committed/) skip rebuilds."""
+
+    def test_cache_noop_when_fingerprint_matches(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+    ) -> None:
+        data_file: Path = project["data_file"]
+
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        working = _json_cache_dir(data_file, _LAYER_WORKING)
+        first_mtime = (working / "data.parquet").stat().st_mtime
+
+        # Re-cache with same schema → no rebuild, mtime unchanged.
+        # The trapdoor uses fingerprint equality, not byte equality, so a
+        # rebuild would touch mtime even if the bytes were identical.
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        assert (working / "data.parquet").stat().st_mtime == first_mtime
+
+        # Change schema → rebuild fires, mtime advances.
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+        assert (working / "data.parquet").stat().st_mtime > first_mtime
+
+    def test_save_noop_when_layers_already_in_sync(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+        tmp_path: Path,
+    ) -> None:
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+        committed = _json_cache_dir(data_file, _LAYER_COMMITTED)
+        first_mtime = (committed / "data.parquet").stat().st_mtime
+
+        # Re-save with no edits in between → cache portion is a no-op.
+        _api_save(client)
+        assert (committed / "data.parquet").stat().st_mtime == first_mtime
+
+        # Edit schema then re-cache then save → committed/ rebuilt (via mirror).
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+        _api_save(client)
+        assert (committed / "data.parquet").stat().st_mtime > first_mtime
+
+
+# ---------------------------------------------------------------------------
+# Test 8: read precedence at execute time
+# ---------------------------------------------------------------------------
+
+
+class TestReadPrecedence:
+    """The emitter prefers working/ if consulted; else falls through to committed/."""
+
+    def test_emitter_reads_working_then_committed_then_raises(
+        self,
+        client: TestClient,
+        project: dict[str, object],
+    ) -> None:
+        from haute._json_flatten import cache_layer_if_valid
+
+        data_file: Path = project["data_file"]
+        config_file: Path = project["config_file"]
+
+        # Both layers populated with S1.
+        _api_cache_build(client, project["data_rel"], project["schema"])
+        _api_save(client)
+
+        result = cache_layer_if_valid(str(data_file), schema=project["schema"])
+        assert result is not None
+        _, layer = result
+        # Working/ is preferred when consulted.
+        assert layer == _LAYER_WORKING
+
+        # Re-cache S2 with the new schema persisted on disk. Working/ has S2,
+        # committed/ still has S1.
+        _set_schema_in_config(config_file, _SCHEMA_S2)
+        _api_cache_build(client, project["data_rel"], _SCHEMA_S2)
+
+        # Emitter for S2 → working/ (which has S2).
+        result_s2 = cache_layer_if_valid(str(data_file), schema=_SCHEMA_S2)
+        assert result_s2 is not None
+        assert result_s2[1] == _LAYER_WORKING
+        assert result_s2[0] == _working_cache_data_path(data_file)
+
+        # Emitter for S1 → working/ S2 fingerprint mismatch, falls through to committed/.
+        result_s1 = cache_layer_if_valid(str(data_file), schema=project["schema"])
+        assert result_s1 is not None
+        assert result_s1[1] == _LAYER_COMMITTED
+        assert result_s1[0] == _committed_cache_data_path(data_file)
+
+        # Delete working/ → emitter falls through to committed/ for S1.
+        # Consulted flag persists across delete; precedence still checks
+        # working/ first (now invalid) before falling through.
+        _api_cache_delete(client, project["data_rel"])
+        result_after = cache_layer_if_valid(str(data_file), schema=project["schema"])
+        assert result_after is not None
+        assert result_after[1] == _LAYER_COMMITTED
+        # S2 has no valid layer (committed/ has S1, working/ is gone).
+        assert cache_layer_if_valid(str(data_file), schema=_SCHEMA_S2) is None
+
+        # Save with deleted cache → committed/ also removed (test 5).
+        _api_save(client)
+        # Now neither layer is valid for any schema.
+        assert cache_layer_if_valid(str(data_file), schema=project["schema"]) is None
+        assert cache_layer_if_valid(str(data_file), schema=_SCHEMA_S2) is None
+
+
+# ---------------------------------------------------------------------------
+# Direct invariants on the mirror function (not requiring a TestClient)
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorDirectInvariants:
+    """Direct tests on mirror_cache_to_committed for tricky edge cases."""
+
+    def test_mirror_noop_when_consulted_set_does_not_contain_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stale on-disk working/ from a previous session is NOT promoted."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+
+        # Pretend a previous session left a working/ behind (no session mark).
+        cache_dir = _json_cache_dir(str(data_file), _LAYER_WORKING)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "data.parquet").write_bytes(b"stale")
+        (cache_dir / "meta.json").write_text(
+            json.dumps({"schema_mode": "inferred", "schema_fingerprint": "deadbeef"})
+        )
+        assert not _is_working_consulted(str(data_file))
+
+        changed = mirror_cache_to_committed(str(data_file))
+
+        assert changed is False
+        # Committed/ stays absent — stale working/ wasn't promoted.
+        assert not _json_cache_dir(str(data_file), _LAYER_COMMITTED).exists()
+
+    def test_mirror_no_op_when_fingerprints_match(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+        mirror_cache_to_committed(str(data_file))
+
+        committed = _json_cache_dir(str(data_file), _LAYER_COMMITTED)
+        first_mtime = (committed / "data.parquet").stat().st_mtime
+
+        changed = mirror_cache_to_committed(str(data_file))
+        assert changed is False
+        assert (committed / "data.parquet").stat().st_mtime == first_mtime
+
+    def test_mirror_removes_committed_when_working_absent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+        mirror_cache_to_committed(str(data_file))
+
+        committed = _json_cache_dir(str(data_file), _LAYER_COMMITTED)
+        working = _json_cache_dir(str(data_file), _LAYER_WORKING)
+        assert committed.exists() and working.exists()
+        assert _is_working_consulted(str(data_file))
+
+        # Simulate the DELETE endpoint: working/ removed, consulted preserved.
+        shutil.rmtree(working)
+
+        changed = mirror_cache_to_committed(str(data_file))
+        assert changed is True
+        assert not committed.exists()

--- a/tests/test_dual_cache_behavior.py
+++ b/tests/test_dual_cache_behavior.py
@@ -30,15 +30,22 @@ import pytest
 from fastapi.testclient import TestClient
 
 from haute._json_flatten import (
+    _CACHE_DIR,
     _LAYER_COMMITTED,
     _LAYER_WORKING,
     _clear_session,
     _committed_cache_data_path,
+    _flatten_and_write,
     _is_working_consulted,
     _json_cache_dir,
+    _mark_working_consulted,
+    _path_hash,
+    _resolve_flatten_schema,
     _schema_fingerprint,
+    _wipe_legacy_flat_cache,
     _working_cache_data_path,
     build_json_cache,
+    cache_layer_if_valid,
     mirror_cache_to_committed,
 )
 
@@ -717,3 +724,309 @@ class TestMirrorDirectInvariants:
         changed = mirror_cache_to_committed(str(data_file))
         assert changed is True
         assert not committed.exists()
+
+
+# ---------------------------------------------------------------------------
+# Branch-coverage tests for dual-cache internals
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLayerValidation:
+    """`build_json_cache(layer=...)` enforces a small enum."""
+
+    def test_unknown_layer_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        with pytest.raises(ValueError, match="Unknown cache layer"):
+            build_json_cache(str(data_file), schema=_SCHEMA_S1, layer="bogus")
+
+    def test_committed_layer_does_not_mark_consulted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`build_json_cache(layer="committed")` writes committed/ but leaves
+        the working-consulted flag unchanged — committed builds shouldn't
+        flip the emitter's precedence."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        assert not _is_working_consulted(str(data_file))
+
+        build_json_cache(str(data_file), schema=_SCHEMA_S1, layer=_LAYER_COMMITTED)
+
+        assert _json_cache_dir(str(data_file), _LAYER_COMMITTED).exists()
+        # Critical assertion: working consulted flag did NOT flip.
+        assert not _is_working_consulted(str(data_file))
+
+    def test_build_noop_for_committed_layer_keeps_consulted_off(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The cache no-op trapdoor inside build_json_cache also respects layer."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1, layer=_LAYER_COMMITTED)
+        _clear_session()  # ensure consulted state is clean before re-build
+        assert not _is_working_consulted(str(data_file))
+
+        # Same schema → no-op trapdoor fires.
+        build_json_cache(str(data_file), schema=_SCHEMA_S1, layer=_LAYER_COMMITTED)
+
+        # The trapdoor still must not flip working-consulted for layer="committed".
+        assert not _is_working_consulted(str(data_file))
+
+
+class TestWipeLegacyFlatCache:
+    """`_wipe_legacy_flat_cache` removes the pre-dual-cache artifacts."""
+
+    def test_returns_false_when_no_legacy_artifacts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        assert _wipe_legacy_flat_cache(tmp_path / "data.jsonl") is False
+
+    def test_removes_legacy_artifacts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        # Place every flavor of legacy artifact that _wipe_legacy_flat_cache
+        # knows about. The function should clear all of them on first touch.
+        cache_root = tmp_path / _CACHE_DIR
+        cache_root.mkdir()
+        stem = f"json_{_path_hash(str(data_file))}"
+        legacy_paths = [
+            cache_root / f"{stem}.parquet",
+            cache_root / f"{stem}.parquet.meta.json",
+            cache_root / f"{stem}.parquet.tmp",
+            cache_root / f"{stem}.raw.parquet",
+            cache_root / f"{stem}.raw.parquet.tmp",
+        ]
+        for p in legacy_paths:
+            p.write_bytes(b"x")
+        assert all(p.exists() for p in legacy_paths)
+
+        assert _wipe_legacy_flat_cache(str(data_file)) is True
+        assert not any(p.exists() for p in legacy_paths)
+
+
+class TestFlattenAndWriteMetadata:
+    """`_flatten_and_write` writes parquet kv-metadata when supplied."""
+
+    def test_embeds_parquet_metadata_when_provided(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache_path = tmp_path / "out.parquet"
+        metadata = {b"haute.flatten_schema": b'{"x":"int"}', b"haute.schema_mode": b"explicit"}
+
+        _flatten_and_write(
+            [{"x": 1}, {"x": 2}],
+            {"x": "int"},
+            cache_path,
+            parquet_metadata=metadata,
+        )
+
+        md = pq.read_metadata(str(cache_path)).metadata or {}
+        assert md.get(b"haute.flatten_schema") == b'{"x":"int"}'
+        assert md.get(b"haute.schema_mode") == b"explicit"
+
+    def test_writes_without_metadata_when_none(self, tmp_path: Path) -> None:
+        """Default path (no metadata) still writes a valid parquet."""
+        cache_path = tmp_path / "out.parquet"
+        _flatten_and_write([{"x": 1}], {"x": "int"}, cache_path)
+        df = pl.read_parquet(cache_path)
+        assert df["x"].to_list() == [1]
+
+
+class TestResolveFlattenSchemaConfigBranches:
+    """`_resolve_flatten_schema` config-path branches."""
+
+    def test_config_without_flatten_schema_falls_through_to_inference(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A config file present but missing ``flattenSchema`` triggers inference."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        config_file = tmp_path / "config.json"
+        # Note: config exists but has no flattenSchema key.
+        config_file.write_text(json.dumps({"path": "data.jsonl"}), encoding="utf-8")
+
+        resolved = _resolve_flatten_schema(data_file, None, str(config_file))
+        # Inference produces a non-empty schema for our 3-column data.
+        assert isinstance(resolved, dict)
+        assert "quote_id" in resolved
+
+    def test_config_missing_on_disk_falls_through_to_inference(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_resolve_flatten_schema`` treats a non-existent config_path as no config."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        missing = tmp_path / "does_not_exist.json"
+
+        resolved = _resolve_flatten_schema(data_file, None, str(missing))
+        assert isinstance(resolved, dict)
+        assert "quote_id" in resolved
+
+
+class TestCacheLayerIfValidBranches:
+    """`cache_layer_if_valid` branches under different (schema, config_path) combos."""
+
+    def test_returns_none_when_explicit_schema_fingerprint_mismatches(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+
+        # Look up with a different schema → fingerprint mismatch → no hit.
+        assert cache_layer_if_valid(str(data_file), schema=_SCHEMA_S2) is None
+
+    def test_returns_none_for_schemaless_lookup_on_explicit_cache(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cache built with an explicit schema is NOT served to a schema-less
+        lookup — only ``inferred``-mode caches answer the schema=None query."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+
+        assert cache_layer_if_valid(str(data_file), schema=None) is None
+
+    def test_inferred_mode_with_config_path_hits_cache(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When config_path is supplied but has no flattenSchema, the
+        resolved mode is "inferred" and a matching inferred-mode cache hits."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"path": "data.jsonl"}), encoding="utf-8")
+        build_json_cache(str(data_file), config_path=str(config_file))
+
+        result = cache_layer_if_valid(str(data_file), config_path=str(config_file))
+        assert result is not None
+        path, layer = result
+        assert layer == _LAYER_WORKING
+        assert path == _working_cache_data_path(data_file)
+
+
+class TestMirrorAtomicSwap:
+    """`mirror_cache_to_committed` cleans up stale `.tmp`/`.old` and rolls back."""
+
+    def test_cleans_up_stale_tmp_and_backup_dirs(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stale .tmp/.old siblings from a prior failed mirror get cleaned up
+        before a fresh rebuild."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+
+        # Set up: working has S1, committed has S2-stale (mismatched fingerprint
+        # so the no-op trapdoor doesn't fire). We then plant stale .tmp/.old.
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+        committed = _json_cache_dir(str(data_file), _LAYER_COMMITTED)
+        committed.mkdir(parents=True, exist_ok=True)
+        (committed / "data.parquet").write_bytes(b"stale-committed")
+        (committed / "meta.json").write_text(
+            json.dumps({"schema_mode": "explicit", "schema_fingerprint": "deadbeef"}),
+            encoding="utf-8",
+        )
+        # Stale .tmp and .old siblings from a previous failed mirror.
+        stale_tmp = committed.with_name(committed.name + ".tmp")
+        stale_backup = committed.with_name(committed.name + ".old")
+        stale_tmp.mkdir()
+        (stale_tmp / "junk").write_bytes(b"stale-tmp")
+        stale_backup.mkdir()
+        (stale_backup / "junk").write_bytes(b"stale-backup")
+
+        changed = mirror_cache_to_committed(str(data_file))
+
+        assert changed is True
+        assert not stale_tmp.exists(), "stale .tmp must be wiped before the new copy"
+        assert not stale_backup.exists(), "stale .old must be wiped before rename"
+        # Committed now mirrors working's S1 content.
+        working = _json_cache_dir(str(data_file), _LAYER_WORKING)
+        assert (committed / "data.parquet").read_bytes() == (working / "data.parquet").read_bytes()
+
+    def test_rolls_back_when_swap_rename_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the final ``tmp_dir → committed_dir`` rename fails, the backup
+        must be restored so committed/ is never lost."""
+        monkeypatch.chdir(tmp_path)
+        data_file = tmp_path / "data.jsonl"
+        _write_data_file(data_file)
+        build_json_cache(str(data_file), schema=_SCHEMA_S1)
+        committed = _json_cache_dir(str(data_file), _LAYER_COMMITTED)
+        committed.mkdir(parents=True, exist_ok=True)
+        (committed / "data.parquet").write_bytes(b"original-committed")
+        (committed / "meta.json").write_text(
+            json.dumps({"schema_mode": "explicit", "schema_fingerprint": "deadbeef"}),
+            encoding="utf-8",
+        )
+        original_bytes = (committed / "data.parquet").read_bytes()
+
+        # Monkeypatch Path.rename so the second rename (tmp_dir → committed_dir)
+        # raises. The function's except-branch must restore the backup.
+        original_rename = Path.rename
+        call_count = {"n": 0}
+
+        def flaky_rename(self: Path, target: Path) -> Path:
+            call_count["n"] += 1
+            # First rename is committed → backup. Second is tmp → committed.
+            if call_count["n"] == 2:
+                raise OSError("simulated rename failure")
+            return original_rename(self, target)
+
+        monkeypatch.setattr(Path, "rename", flaky_rename)
+
+        with pytest.raises(OSError, match="simulated rename failure"):
+            mirror_cache_to_committed(str(data_file))
+
+        # Committed must be restored to its original bytes (rollback worked).
+        assert committed.exists()
+        assert (committed / "data.parquet").read_bytes() == original_bytes
+
+
+class TestMarkAndClearSession:
+    """Direct coverage for `_mark_working_consulted` / `_clear_session`."""
+
+    def test_mark_and_clear_round_trip(self, tmp_path: Path) -> None:
+        data_file = tmp_path / "data.jsonl"
+        data_file.write_text('{"x":1}\n', encoding="utf-8")
+        assert not _is_working_consulted(str(data_file))
+        _mark_working_consulted(str(data_file))
+        assert _is_working_consulted(str(data_file))
+        _clear_session()
+        assert not _is_working_consulted(str(data_file))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -56,6 +56,10 @@ def _isolate_json_cache(tmp_path, monkeypatch, _widen_sandbox_root):
         cache_path = jf._json_cache_path(str(data_path))
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         pl.read_json(data_path).write_parquet(cache_path)
+        # Mark the working layer as consulted so the dual-cache emitter
+        # picks it up; otherwise it falls through to committed/ which is
+        # not populated by this fixture.
+        jf._mark_working_consulted(str(data_path))
 
 
 class TestEndToEnd:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2015,7 +2015,11 @@ class TestApiInputLargeFileGating:
 
     def test_large_file_with_cache_succeeds(self, tmp_path, monkeypatch):
         """Large JSONL files with a valid cache should use the cache directly."""
-        from haute._json_flatten import _LARGE_FILE_THRESHOLD, _json_cache_path
+        from haute._json_flatten import (
+            _LARGE_FILE_THRESHOLD,
+            _json_cache_path,
+            _mark_working_consulted,
+        )
 
         monkeypatch.chdir(tmp_path)
 
@@ -2026,10 +2030,13 @@ class TestApiInputLargeFileGating:
         data_file.write_text(line * lines_needed)
         assert data_file.stat().st_size >= _LARGE_FILE_THRESHOLD
 
-        # Pre-build the cache manually
+        # Pre-build the cache manually. Mark working/ as consulted so the
+        # dual-cache emitter picks it up (cache was not built via the
+        # public build_json_cache path).
         cache_path = _json_cache_path(str(data_file))
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         pl.DataFrame({"x": [1, 2, 3]}).write_parquet(cache_path)
+        _mark_working_consulted(str(data_file))
 
         node = _api_input_node("api", str(data_file))
         _, fn, _ = _build_node_fn(node)

--- a/tests/test_json_cache_routes.py
+++ b/tests/test_json_cache_routes.py
@@ -861,7 +861,7 @@ class TestApiInputCacheEndToEnd:
         # Build the cache normally, then delete just the meta sidecar.
         build_json_cache(info["data_file"], schema=flatten_schema)
         cache_path = _json_cache_path(info["data_file"])
-        meta_path = Path(str(cache_path) + ".meta.json")
+        meta_path = cache_path.parent / "meta.json"
         assert cache_path.exists()
         meta_path.unlink()
 

--- a/tests/test_json_flatten.py
+++ b/tests/test_json_flatten.py
@@ -738,32 +738,38 @@ class TestJsonCache:
         assert ".haute_cache" in str(p1)
 
     def test_cache_invalid_when_missing(self, tmp_path):
-        cache = tmp_path / "missing.parquet"
+        cache_dir = tmp_path / "missing_dir"
         source = tmp_path / "data.json"
         source.write_text("[]")
-        assert not _is_cache_valid(cache, source)
+        assert not _is_cache_valid(cache_dir, source)
 
     def test_cache_valid_when_newer(self, tmp_path):
         source = tmp_path / "data.json"
         source.write_text("[]")
-        cache = tmp_path / "cached.parquet"
-        cache.write_bytes(b"fake")
+        cache_dir = tmp_path / "cache_dir"
+        cache_dir.mkdir()
+        (cache_dir / "data.parquet").write_bytes(b"fake")
         # Ensure cache is newer by touching it
         import os
 
-        os.utime(cache, (cache.stat().st_mtime + 10, cache.stat().st_mtime + 10))
-        assert _is_cache_valid(cache, source)
+        data_parquet = cache_dir / "data.parquet"
+        os.utime(
+            data_parquet,
+            (data_parquet.stat().st_mtime + 10, data_parquet.stat().st_mtime + 10),
+        )
+        assert _is_cache_valid(cache_dir, source)
 
     def test_cache_invalid_when_source_newer(self, tmp_path):
-        cache = tmp_path / "cached.parquet"
-        cache.write_bytes(b"fake")
+        cache_dir = tmp_path / "cache_dir"
+        cache_dir.mkdir()
+        (cache_dir / "data.parquet").write_bytes(b"fake")
         source = tmp_path / "data.json"
         source.write_text("[]")
         # Ensure source is newer
         import os
 
         os.utime(source, (source.stat().st_mtime + 10, source.stat().st_mtime + 10))
-        assert not _is_cache_valid(cache, source)
+        assert not _is_cache_valid(cache_dir, source)
 
     def test_flatten_and_write_creates_parquet(self, tmp_path):
         schema = {"name": "str", "age": "int"}

--- a/tests/test_json_streaming_cache_contracts.py
+++ b/tests/test_json_streaming_cache_contracts.py
@@ -33,10 +33,11 @@ from haute._json_flatten import (
 
 
 def _cache_artifacts(cache_path: Path) -> list[Path]:
+    """Return the on-disk artifacts inside the working/<hash>/ cache dir."""
     raw_path = cache_path.with_suffix(".raw.parquet")
     return [
         cache_path,
-        Path(str(cache_path) + ".meta.json"),
+        cache_path.parent / "meta.json",
         Path(str(cache_path) + ".tmp"),
         raw_path,
         Path(str(raw_path) + ".tmp"),
@@ -182,7 +183,7 @@ def test_explicit_schema_cache_contract_invalidates_same_path_cache(
     assert df.columns == ["x", "y"]
     assert df["y"].to_list() == [2]
 
-    meta_path = Path(str(_json_cache_path(str(data_file))) + ".meta.json")
+    meta_path = _json_cache_path(str(data_file)).parent / "meta.json"
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
     assert meta == {
         "schema_fingerprint": _schema_fingerprint({"x": "int", "y": "int"}),
@@ -230,10 +231,11 @@ def test_build_json_cache_cleans_progress_and_artifacts_when_schema_is_invalid(
 
 
 def test_is_cache_valid_requires_source_file_to_still_exist(tmp_path: Path) -> None:
-    cache_path = tmp_path / "cache.parquet"
-    cache_path.write_bytes(b"stale cache")
+    cache_dir = tmp_path / "cache_dir"
+    cache_dir.mkdir()
+    (cache_dir / "data.parquet").write_bytes(b"stale cache")
 
-    assert not _is_cache_valid(cache_path, tmp_path / "deleted.jsonl")
+    assert not _is_cache_valid(cache_dir, tmp_path / "deleted.jsonl")
 
 
 def test_json_cache_info_returns_none_for_stale_source(

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -266,12 +266,17 @@ class TestExecuteTrace:
                 ]
             )
         )
-        # Pre-cache JSON as parquet (the builder expects this)
-        from haute._json_flatten import _json_cache_path
+        # Pre-cache JSON as parquet (the builder expects this). Writing
+        # directly to the working layer + marking it consulted bypasses
+        # build_json_cache's flatten step, which we want here because the
+        # test injects synthetic column data, not what the data.json would
+        # parse to.
+        from haute._json_flatten import _json_cache_path, _mark_working_consulted
 
         cache_path = _json_cache_path(str(p))
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         pl.DataFrame({"policy_id": [100, 200, 300], "x": [1, 2, 3]}).write_parquet(cache_path)
+        _mark_working_consulted(str(p))
 
         graph = _g(
             {


### PR DESCRIPTION
## Summary

Replaces the single-file JSON parquet cache (`.haute_cache/json_<hash>.parquet`)
with a two-layer scheme under `.haute_cache/{working,committed}/<hash>/`:

- **`working/`** — written by the *Cache as Parquet* button; volatile,
  reflects in-session schema state. Disposable.
- **`committed/`** — written by *Save*, which mirrors `working/` →
  `committed/` (including absence: if `working/<hash>/` doesn't exist,
  `committed/<hash>/` is removed too). The durable contract that survives
  a server restart.

The emitter prefers `working/` for the current process and falls through
to `committed/` after restart, which closes the cross-restart
silent-divergence vulnerability described in the original cacheing
access-model write-up.

Each `data.parquet` embeds its `flatten_schema` and `schema_mode` in
parquet footer kv-metadata under `haute.flatten_schema` and
`haute.schema_mode` (single-file robustness — no schema-wrote/data-failed
race).

No frontend changes: all six `/api/json-cache/*` endpoint shapes and the
save endpoint shape are preserved. The Cache/Save/Delete buttons behave
exactly as today.

## What `Delete` and `Save` do now

| User action | `working/<hash>/` | `committed/<hash>/` |
|---|---|---|
| Cache (button) | written | unchanged |
| Save | unchanged | mirrored from working (or removed if working absent) |
| Delete (button) | removed | unchanged |
| Save after Delete | absent | removed (absence promoted) |

## Migration

Legacy single-file `.haute_cache/json_<hash>.parquet` artifacts are wiped
the first time a dual-cache operation touches that data file. No
automatic conversion — users re-cache via the editor. Logged at INFO.

## Cross-restart vulnerability fix mechanism

`_session_consulted_hashes` is a module-level `set[str]` in
`haute._json_flatten`. `build_json_cache(layer="working")` adds the
data-file's hash; `cache_layer_if_valid` consults `working/` only when
the hash is in the set. The set is empty per Python process, so:

- `working/` on disk after server restart: preserved untouched (no
  startup sweep).
- Emitter post-restart: ignores `working/`, reads `committed/`. The user
  sees the saved schema and no cache; they can re-Cache to repopulate
  `working/`.

This is the minimum mechanism that gives "not consulted after restart"
without on-disk cleanup, keeping the door open for a future recovery UX.

## Tests

- New `tests/test_dual_cache_behavior.py` codifies the 8 scenarios
  (the 5 from the original test plan: setup / volatile-tracks-edits /
  save-mirrors / delete-only-volatile / save-after-delete-clears-committed;
  plus 3 additions: cross-restart vulnerability regression, both
  no-op trapdoors, emitter read precedence).
- Existing cache tests updated for the new path layout
  (`_json_cache_path` is preserved as a working-layer alias to minimise
  churn).
- Full suite: 9790 pass, 9 skipped, 1 failure
  (`test_memory_cap_is_applied_inside_child_process` — pre-existing
  macOS RLIMIT quirk, unrelated to this change).

## Out of scope / known issues

- The executor's `_preview_cache` (`src/haute/executor.py:693`) keys on
  graph fingerprint + execution params, not on `.haute_cache/` disk
  state. So a preview result — success or failure — can be reused across
  a cache-state change that doesn't bump the graph fingerprint. This is
  pre-existing on `main`. The dual-cache split adds new disk-state
  mutations (Save mirroring an absent `working/` into a cleared
  `committed/`) that are additional trigger sequences for the same bug.
  A reviewer exercising the branch via curl won't see it (independent
  process state per call); a user clicking through the editor can.
  Workaround: restart the server. Captured for follow-up; not addressed
  here.

## Reviewer notes

- **Migration is a silent wipe.** No data preservation. Acceptable for
  pre-production state; flagged so it isn't a surprise post-merge.
- **Parquet kv-metadata is now a forward-compat constraint.** Anything
  that rewrites the cache parquet must preserve `haute.flatten_schema`
  and `haute.schema_mode` keys, or readers that rely on them (a future
  deploy-time consumer) will silently lose context.
- **Read `cache_layer_if_valid` together with the
  `_session_consulted_hashes` lifecycle.** The precedence rule and the
  consultation gate are load-bearing for the cross-restart vulnerability
  fix; reading either in isolation will not show why they exist.

## Test plan

- [ ] `pytest tests/test_dual_cache_behavior.py tests/test_json_flatten.py tests/test_json_cache_routes.py tests/test_save_pipeline_integrity.py tests/test_executor.py tests/test_e2e.py -x` → expect 429 pass
- [ ] `git diff main..dual-cache -- frontend/` → expect empty
- [ ] Spot-check parquet metadata embedding: after any successful Cache, `uv run python -c "import pyarrow.parquet as pq; print(pq.read_metadata('.haute_cache/working/json_<hash>/data.parquet').metadata)"` → contains `haute.flatten_schema`
- [ ] Manual: Cache → confirm `working/<hash>/` populated, `committed/<hash>/` absent
- [ ] Manual: Save → confirm `committed/<hash>/` mirrors working bytes
- [ ] Manual: Delete → confirm `working/<hash>/` gone, `committed/<hash>/` unchanged
- [ ] Manual: Save after Delete → confirm both layers absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
