### PR TITLE
Edge-joins feature + CODE_REVIEW remediation W0-W1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - run: uv sync --group dev --locked
 
       - name: Cross-platform path and debt smoke
-        run: uv run pytest tests/test_path_resolution.py tests/test_pipeline_runtime_path_validation.py tests/test_test_debt.py -q
+        run: uv run pytest tests/test_path_resolution.py tests/test_pipeline_runtime_path_validation.py tests/test_test_debt.py tests/test_file_ops.py -q
 
   mutation-config-smoke:
     runs-on: ubuntu-latest

--- a/REMEDIATION_PLAN.md
+++ b/REMEDIATION_PLAN.md
@@ -1,0 +1,188 @@
+# CODE_REVIEW.md remediation tracker
+
+Working through every finding in [`CODE_REVIEW.md`](./CODE_REVIEW.md), in dependency order, as a
+sequence of wave PRs. Each item: failing test first, then the fix (one developer + one independent
+reviewer per item); each wave ends with a fresh audit team over the whole diff; a cross-wave
+holistic review runs after each merge before the next wave starts. Coverage and CI gates are never
+lowered. Items the review marked *partially verified* / *needs repro* start with a repro spike —
+no repro means the item is closed with a note, not speculatively "fixed".
+
+Severity tags below: **[C]** critical, **[H]** high, **[M]** medium, **[L]** low.
+
+## Delivery
+
+- **W0 + W1** land on `code-review` (the unmerged edge-join feature lives here; C1 blocks its merge).
+  Draft PR `code-review` → `main` opens at W0 start so every push gets the full CI matrix.
+- **W2 onward**: one branch + PR per wave, off `main`, sequential where files overlap.
+- **ALGO_VERSION bumps exactly twice**: W1 (3→4, edge handles) and W2 (4→5, encoder unification).
+
+## Wave 0 — Rails
+
+- [ ] 0.1 Draft PR `code-review`→`main` (CI matrix baseline)
+- [ ] 0.2 **[H]** e2e reset guard: assert `rev-parse --show-toplevel` == e2e root + `GIT_CEILING_DIRECTORIES` before destructive git ops (`frontend/e2e/projectIsolation.ts:19`)
+- [ ] 0.3 **[H]** Add `tests/test_file_ops.py` to platform-smoke CI selection (`.github/workflows/ci.yml`)
+- [ ] 0.4 Baseline both preflight legs + e2e green; fix pre-existing failures; snapshot coverage
+- [ ] 0.5 This tracker committed
+
+## Wave 1 — Edge-join / multi-port blockers (on `code-review`)
+
+- [ ] 1.1 **[C1]** Edge-join codegen writes raw frontend node ids → reload fails (`_codegen_builders.py:1044`, `_edge_join.py`); remap to sanitized names + round-trip test (id ≠ sanitized(label))
+- [ ] 1.2 **[C3]** Edge `sourceHandle`/`targetHandle` into graph fingerprint; ALGO_VERSION 3→4 (`_cache.py:145`)
+- [ ] 1.3 **[H]** Port rename destroys edges per keystroke → stable port id, rebind on rename (`App.tsx:322`, `utils/apiInputPorts.ts:74`)
+- [ ] 1.4 **[H]** Frontend manufactures `port_N`/`label__N` handles backend rejects → surface validation (`apiInputPorts.ts:74`)
+- [ ] 1.5 **[H]** apiInput path inputs lose focus per keystroke → stable keys, raw edit state (`ApiInputEditor.tsx:488,591`)
+- [ ] 1.6 **[H]** Undo granularity on edge-reconciliation path (one entry per rename)
+- [ ] 1.7 **[M]** Edge-join `_right` suffix poisons trace matching + first edge-join trace tests (`_trace_correlation.py:305`)
+- [ ] 1.8 **[H]** Join-semantics runtime matrix: suffix/validate/coalesce/semi/anti/full/cross (`tests/test_edge_join.py`)
+
+## Wave 2 — Cache, fingerprint & JSON-cache integrity
+
+- [ ] 2.1 **[C2]** `committed/` mirror never populated → mark working-consulted on production build; HTTP build→save→restart test (`_json_flatten.py:106,255`)
+- [ ] 2.2 **[C4]** Preview cache keys: add dataSource/externalFile/model-artifact signatures via `_runtime_path_fingerprint` + stat-gated memo (`executor.py:891`)
+- [ ] 2.3 **[C4/M]** Trace cache key: add JSON-cache state signature + same file/model extras (`trace.py:314`)
+- [ ] 2.4 **[H]** JSON-cache validity records data-file signature (`_json_shred.py:413`)
+- [ ] 2.5 **[H]** Emit-true zero-selected-columns wedge: one shared emitting predicate (`_json_shred.py:441,618`)
+- [ ] 2.6 **[M]** Atomic + serialized JSON-cache build (`_json_shred.py:456`)
+- [ ] 2.7 **[H]** Count + surface records dropped on shape mismatch (`_json_shred.py:151,281`)
+- [ ] 2.8 **[H]** Reject JSON ints as epoch-day dates (`_json_shred.py:341`)
+- [ ] 2.9 **[M]** Trace cache byte budget (`trace.py:210`)
+- [ ] 2.10 **[M]** Never evict the artifact being stored (`_dataframe_execution_cache.py:465`)
+- [ ] 2.11 **[M]** Chunk whitelist: per-construct chunked==full proof or de-whitelist `fill_null(strategy)`/`is_in(df)` (`chunking.py:421`)
+- [ ] 2.12 **[M]** Projection respects renames (`projection.py:839`)
+- [ ] 2.13 **[L→here]** Unify the two canonical-JSON encoders; ALGO_VERSION 4→5 (`_cache.py` vs `_dataframe_execution_cache.py`)
+
+## Wave 3a — Rating / metrics / trace-number correctness
+
+- [ ] 3a.1 **[C6]** Gini + Lorenz tie aggregation; row-permutation property tests (`modelling/_metrics.py:80,625`)
+- [ ] 3a.2 **[C8]** Waterfall: delta from consecutive outputs, implied factor, reconciliation assert; tests via `execute_trace` (`_trace_waterfall.py:113`)
+- [ ] 3a.3 **[H]** Rating neutral-fill on missing level → default fail-loud, opt-in neutral, miss counters (`_rating.py:359`) — **breaking, release note**
+- [ ] 3a.4 **[H]** Float-vs-string factor keys normalized — same PR as `_trace_enrichment.py:131` `str()` mirror (`_rating.py:292`)
+- [ ] 3a.5 **[H]** Banding codegen gets a real `apply_banding_from_config` body + standalone-run + parse-back tests (`_codegen_builders.py:334`)
+
+## Wave 3b — Optimiser correctness
+
+- [ ] 3b.1 **[C7]** `_validate_and_project` rejects NaN/inf in objective/constraint/scenario columns, names the column (`_optimiser_service.py:4077`)
+- [ ] 3b.2 **[H]** Composite factor groups: multi-column join or save-time reject (`_builders.py:1546`)
+- [ ] 3b.3 **[H]** Ratebook apply/detail pinned against real `RatebookResult`; real-solver integration tests; implement detail or gate UI (`routes/optimiser.py:1204,933`)
+- [ ] 3b.4 **[M]** Single-quote solve `std()` crash (`_optimiser_service.py:1117`)
+- [ ] 3b.5 **[M]** Unseen factor levels rated 1.0 on apply → fail loud (`_builders.py:1565`)
+- [ ] 3b.6 **[M]** Frontier budget 100k vs library cap 10k (`_optimiser_limits.py:14`)
+- [ ] 3b.7 **[M]** `/estimate` cost vs docstring (`optimiser.py:154`)
+- [ ] 3b.8 **[M]** Real-solver numerical/constraint suite replacing drifted mocks
+
+## Wave 4a — Scoring / serving correctness
+
+- [ ] 4a.1 **[H]** Pyfunc named-DataFrame contract; real pyfunc fixture replaces MagicMock (`_mlflow_io.py:897`)
+- [ ] 4a.2 **[H]** Eager scoring: collect once, no positional splice over re-executed plan (`_model_scorer.py:524`)
+- [ ] 4a.3 **[H]** Deployed scorer caches model+contract by `(path, task)` (`deploy/_scorer.py:578`)
+- [ ] 4a.4 **[H]** CatBoost SHAP Poisson/Tweedie repro → `RawFormulaVal` if confirmed (`_model_explainability.py:101`)
+- [ ] 4a.5 **[M]** Multiclass `predict_proba` labeling (`_mlflow_io.py:917`)
+- [ ] 4a.6 **[M]** Drop unconditional Float32 cast for pyfunc (`_mlflow_io.py:888`)
+- [ ] 4a.7 **[M]** Serialize concurrent model download/load (`_mlflow_io.py:530`)
+- [ ] 4a.8 **[M]** Databricks: retry truncation fails loud; per-fetch tmp paths; zero-row schema (`_databricks_io.py:284,266,326`)
+
+## Wave 4b — Training lifecycle
+
+- [ ] 4b.1 **[H]** GLM config keys no longer merged into CatBoost params (`routes/_train_service.py:465`)
+- [ ] 4b.2 **[H]** GLM export shares one config→kwargs builder with `_train_service` (`modelling/_export.py:36`)
+- [ ] 4b.3 **[H]** No fabricated SE/p on fallback — omit + diagnostics error (`modelling/_rustystats.py:332`)
+- [ ] 4b.4 **[M]** `head(N)` downsample → seeded sample (`_train_service.py:880`) — release note
+- [ ] 4b.5 **[M]** Temporal split: explicit null-date policy (`_split.py:268`)
+- [ ] 4b.6 **[M]** Split parquet cleanup on failure/cancel (`_training_job.py:1186`)
+- [ ] 4b.7 **[M]** GPU cancel: join fit thread, clean train_dir (`_algorithms.py:466`)
+- [ ] 4b.8 **[M]** MLflow log button: correct signature + GLM artifacts (`routes/modelling.py:318`)
+- [ ] 4b.9 **[M]** Per-model `feature_contract.json` (`_training_job.py:1263`)
+- [ ] 4b.10 **[M]** PDP failures surfaced (`_metrics.py:759`)
+- [ ] 4b.11 **[M]** Non-finite metric-row filtering counted + surfaced (`_metrics.py:34`)
+
+## Wave 5 — Codegen/parser round-trip safety
+
+- [ ] 5.1 **[C5]** AST-based `_unwrap_chain_assignment` (`_code_extraction.py:252`)
+- [ ] 5.2 **[M]** Idempotent brace sanitization (`_codegen_builders.py:178`)
+- [ ] 5.3 **[M]** Escape pipeline name in module docstring (`codegen.py:660`)
+- [ ] 5.4 **[M]** String-aware paren scanner (`codegen.py:197`)
+- [ ] 5.5 **[M]** Non-literal decorator kwargs: serialize or reject, never `ast.dump` (`_ast_helpers.py:48`)
+- [ ] 5.6 **[M]** Preserve external-file imports (`_code_extraction.py:544`)
+- [ ] 5.7 **[M]** Regex fallback handles multi-arg `connect()` (`_parser_regex.py:42`)
+- [ ] 5.8 **Capstone**: corpus + hypothesis round-trip property test (`tests/test_codegen_roundtrip_property.py`) — parse∘codegen semantic identity + byte-idempotence with adversarial strings
+
+## Wave 6 — Work-loss protection: git + live sync
+
+- [ ] 6.1 **[C9]** `revert_to` auto-commits/stashes before tag+reset; `delete_branch` backup tag before `-D` (`_git.py:649,806`)
+- [ ] 6.2 **[C10]** Frontend: filter foreign `source_file`, identity check, dirty-state banner, reconnect resync; watcher parses only discovery-positive files (`useWebSocketSync.ts:101`, `server.py:356`)
+- [ ] 6.3 **[M]** Push failures surfaced + `pushed` field (`_git.py:546+`)
+- [ ] 6.4 **[M]** Protected branches enforced server-side, configurable (`_git.py:37`)
+- [ ] 6.5 **[H]** Submodel drill-in save gated/redirected; no silent truncation (`useSubmodelNavigation.ts`, `usePipelineAPI.ts:581`)
+- [ ] 6.6 **[H]** Ctrl+Z/Escape gated by `isTyping` (`useKeyboardShortcuts.ts:49`)
+- [ ] 6.7 **[M]** git subprocess `encoding="utf-8"` + platform-smoke test (`_git.py:122`)
+- [ ] 6.8 **[M]** `.gitignore` exact-line check (`cli/_init_cmd.py:497`)
+- [ ] 6.9 ~~`haute init` root `main.py` deletion~~ — **by design** (uv init stub; pipeline `main.py` lives in the rating folder). Only assert init scaffolds the rating-folder `main.py`
+
+## Wave 7 — Boundary fidelity & UI trust
+
+- [ ] 7.1 **[H]** Int64 |v|>2^53 → JSON string; trace row-match + frontend display same PR (`_json_safe.py:16`, `trace.py:227`)
+- [ ] 7.2 **[H]** NaN/±inf → explicit sentinels, distinct from null end-to-end (`_json_safe.py:14`)
+- [ ] 7.3 **[H]** Preview results via raw setter; `_`-keys out of persisted fingerprint (`usePipelineAPI.ts:390,442,562`)
+- [ ] 7.4 **[H]** Timeout aborts → typed timeout error (`api/client.ts:266`, `usePipelineAPI.ts:449`)
+- [ ] 7.5 **[H]** ScenarioExpander min/max commit-on-blur (`ScenarioExpanderEditor.tsx:130`)
+- [ ] 7.6 **[H]** TwoWayGrid paste failure toasts offending cell (`rating/TwoWayGrid.tsx:131`)
+- [ ] 7.7 **[H]** Trace conditional uses backend taken-branch index (`CalculationHero.tsx:462`)
+- [ ] 7.8 **[M]** Trace correlation surfaces duplicate/relaxed-match ambiguity (`_trace_correlation.py:203`)
+- [ ] 7.9 **[M]** Relevance pruning keeps branches feeding later modifications (`trace.py:794`)
+- [ ] 7.10 **[M]** Full-precision affordance in trace panels (`StepCard.tsx:21`)
+- [ ] 7.11 **[M]** Error toasts persist; cache-status error ≠ "not cached"; root ErrorBoundary; LossTab guard (`Toast.tsx:31`, `CacheFetchButton.tsx:94`, `main.tsx`, `LossTab.tsx:70`)
+
+## Wave 8a — Server robustness + deploy
+
+- [ ] 8a.1 **[M]** Save/submodel/`/infer` off the event loop; `sample_size` bounds I/O (`routes/pipeline.py:341`, `json_cache.py:447`)
+- [ ] 8a.2 **[M]** WS send stall closes socket instead of permanent mute (`routes/_helpers.py:375`)
+- [ ] 8a.3 **[M]** Submodel routes use save allowlist + rollback (`submodel.py:90`)
+- [ ] 8a.4 **[M]** Preview 504 releases admission only when thread ends (`pipeline.py:666`)
+- [ ] 8a.5 **[M]** Job store evicts stuck "running" jobs (`_job_store.py:94`)
+- [ ] 8a.6 **[M/L]** RAM estimate: strings + join columns; log 4GiB fallback (`_ram_estimate.py:350,101`)
+- [ ] 8a.7 **[M]** Pin haute/polars/fastapi in generated Dockerfile (`deploy/_container.py:448`)
+- [ ] 8a.8 **[M]** Build the advertised expected-output/tolerance deploy validation (`deploy/_validators.py`)
+- [ ] 8a.9 **[M]** Impact compares predictions, not envelopes; zero-baseline % guard (`deploy/_impact.py:147,188`)
+- [ ] 8a.10 **[M]** Single deploy validation + shipment-resolution path (`cli/_deploy.py:132`)
+- [ ] 8a.11 **[M]** Smoke exits non-zero on unsupported transports (`cli/_smoke.py:77`) — release note
+
+## Wave 8b — Security bundle (isolated PR)
+
+- [ ] 8b.1 Endpoint-level cross-origin repro tests for `/preview`/`/trace`/`/sink`
+- [ ] 8b.2 **[H]** TrustedHost localhost allowlist; per-session token on `/api/*` + WS; WS Origin check before accept (`server.py:215`)
+- [ ] 8b.3 **[H]** Sink path confinement via existing `validate_safe_path` (`executor.py:1418`, helper at `routes/_helpers.py:78`)
+- [ ] 8b.4 e2e token wiring same PR; documented escape hatch; release note
+
+## Wave 9 — Maintainability
+
+- [ ] 9.1 **[L]** Delete dead code: `_build_input_kwargs` machinery, `save_node_config`
+- [ ] 9.2 **[L]** RestrictedUnpickler dot-anchoring + tighter allowlist; honest `_sandbox` docstring (`_sandbox.py:346`)
+- [ ] 9.3 **[L]** Replace tautological test (`apiInputPorts.test.ts:172`)
+- [ ] 9.4 **[L]** Move planning docs out of the mkdocs tree (`docs/EDGE_JOIN_*.md` + `*_PLAN.md`)
+- [ ] 9.5 **[L]** Ruff B/PT/S incrementally; mypy strictness step-up
+- [ ] 9.6 **[L]** Cheap per-PR frontend benchmark gate
+- [ ] 9.7 **[L]** Shared chart scaffold across modelling tabs
+
+## Dropped
+
+- Model-card "Holdout" mislabel — already fixed; tests pin it (review verification correction).
+- `_graph_utils` vs `graph_utils` — deliberate facade (review verification correction).
+- `haute init` root `main.py` deletion — by design: uv init stub removed; pipeline `main.py` lives in the rating folder.
+
+## PR log
+
+| Wave | PR | Status |
+|---|---|---|
+| W0+W1 | (draft) `code-review` → `main` | open |
+
+## Behavior-change log (release notes)
+
+| Wave | Change |
+|---|---|
+| W1/W2 | One-time cache invalidation on upgrade (ALGO_VERSION 3→4, 4→5) |
+| W3a | Rating neutral-fill default flips to fail-loud (opt-in flag); waterfall arithmetic corrected |
+| W3b | Non-finite optimiser inputs / composite groups / frontier budgets now error with contract messages |
+| W4b | Seeded sampling replaces head(N) downsample; fabricated GLM SE/p no longer rendered |
+| W6 | Auto-backup commits/tags in history; protected-branch ops rejected server-side; external-change banner |
+| W7 | JSON payloads: big ints as strings, NaN/inf as sentinels (consumer-visible) |
+| W8a/b | Smoke non-zero exit on unsupported transports; localhost session token (escape hatch documented); pinned Dockerfile |

--- a/REMEDIATION_PLAN.md
+++ b/REMEDIATION_PLAN.md
@@ -30,14 +30,17 @@ Severity tags below: **[C]** critical, **[H]** high, **[M]** medium, **[L]** low
 
 ## Wave 1 — Edge-join / multi-port blockers (on `code-review`)
 
-- [ ] 1.1 **[C1]** Edge-join codegen writes raw frontend node ids → reload fails (`_codegen_builders.py:1044`, `_edge_join.py`); remap to sanitized names + round-trip test (id ≠ sanitized(label))
-- [ ] 1.2 **[C3]** Edge `sourceHandle`/`targetHandle` into graph fingerprint; ALGO_VERSION 3→4 (`_cache.py:145`)
-- [ ] 1.3 **[H]** Port rename destroys edges per keystroke → stable port id, rebind on rename (`App.tsx:322`, `utils/apiInputPorts.ts:74`)
-- [ ] 1.4 **[H]** Frontend manufactures `port_N`/`label__N` handles backend rejects → surface validation (`apiInputPorts.ts:74`)
-- [ ] 1.5 **[H]** apiInput path inputs lose focus per keystroke → stable keys, raw edit state (`ApiInputEditor.tsx:488,591`)
-- [ ] 1.6 **[H]** Undo granularity on edge-reconciliation path (one entry per rename)
-- [ ] 1.7 **[M]** Edge-join `_right` suffix poisons trace matching + first edge-join trace tests (`_trace_correlation.py:305`)
-- [ ] 1.8 **[H]** Join-semantics runtime matrix: suffix/validate/coalesce/semi/anti/full/cross (`tests/test_edge_join.py`)
+- [x] 1.1 **[C1]** Edge-join codegen wrote raw frontend node ids → reload failed; remapped to role-ordered sanitized names + round-trip test (id ≠ sanitized(label)); submodel-boundary variant fixed too — `0765ba6f`
+- [x] 1.2 **[C3]** Edge handles in graph fingerprint (JSON-array serialization); ALGO_VERSION 3→4; class audit: single digest site; executor-level stale-serve proof — `91c8d9d5`
+- [x] 1.3 **[H]** Port rename: contract is handle==raw label end-to-end, so labels commit atomically on blur/Enter and the same commit migrates edges (guarded) then reconciles — edges survive renames — `74b8561f`
+- [x] 1.4 **[H]** `port_N`/`label__N` synthesis removed; blank/duplicate/sanitised-collision labels surface inline validation (astral code-point parity incl.) and render no handle; empty-path commit no longer silently drops tables — `74b8561f`
+- [x] 1.5 **[H]** apiInput path inputs keep focus; paths commit on blur (PathInput); silent readV2 table-drop window closed — `f76de368`
+- [x] 1.6 **[H]** One undo entry per committed rename (rebind via setEdgesRaw inside the setNodes snapshot); deterministic pin — closed by 1.3 construction — `74b8561f`
+- [x] 1.7 **[M]** Edge-join right-parent trace correlation returned decoy rows (left-value poisoning); suffix-aware mapping from build_edge_join_kwargs; first 12 edge-join trace tests — `1ef97d32`
+- [x] 1.8 **[H]** Runtime join-semantics matrix 27→76 tests: how×on/leftOn-rightOn/coalesce/validate/suffix/dtype through both production surfaces; no runtime bugs found — `e32fd90b`
+- [x] 1.9 **[H, found in review]** Column-name inputs: blank commit silently dropped the row via readV2; now CommittedTextInput with blank+per-table-duplicate validation mirroring `_api_input_schema.py:328-343` — `74b8561f`
+
+W1 notes for later waves: preview `_columns` enrichment pushes its own history entries after any config commit (live-confirmed twice; belongs to item 7.3's preview-setter rework). Tracker item 9.3 (apiInputPorts tautological test) was completed early inside 1.3/1.4.
 
 ## Wave 2 — Cache, fingerprint & JSON-cache integrity
 

--- a/REMEDIATION_PLAN.md
+++ b/REMEDIATION_PLAN.md
@@ -21,10 +21,11 @@ Severity tags below: **[C]** critical, **[H]** high, **[M]** medium, **[L]** low
 - [x] 0.1 Draft PR `code-review`→`main` (CI matrix baseline) — [#22](https://github.com/PricingFrontier/haute/pull/22)
 - [x] 0.2 **[H]** e2e reset guard: assert `rev-parse --show-toplevel` == e2e root + `GIT_CEILING_DIRECTORIES` (+ `GIT_DIR`/`GIT_WORK_TREE` stripped) before destructive git ops — `ea2bacdc`
 - [x] 0.3 **[H]** `tests/test_file_ops.py` on platform-smoke CI selection — `4bd18ffa`, CI-verified on windows-latest
-- [ ] 0.4 Baseline both preflight legs + e2e green; fix pre-existing failures; snapshot coverage
+- [x] 0.4 Baseline both preflight legs + e2e green; fix pre-existing failures; snapshot coverage
   - [x] backend leg green local (9842 passed, 91.09%, 18 critical gates) + CI ×3 Python; coverage snapshotted
   - [x] frontend leg: `useEdgeHandlers.ts` critical gate fixed with 14 behavioral tests — `4f011cb8`; CI green
-  - [ ] local e2e: Windows-deterministic stuck-preview defect (preview success dropped on mid-flight `structuralVersion` bump → panel stranded "Running…") — fix in review
+  - [x] local e2e: Windows-deterministic stuck-preview defect fixed (in-flight previews terminalize on mid-flight `structuralVersion` drift) — `11c06dbc`; 15/15 e2e local, CI run 27275208625
+  - [x] W0 wave audit: pass (sole finding was this tracker line)
 - [x] 0.5 This tracker committed — `fdb45da2`
 
 ## Wave 1 — Edge-join / multi-port blockers (on `code-review`)

--- a/REMEDIATION_PLAN.md
+++ b/REMEDIATION_PLAN.md
@@ -18,11 +18,14 @@ Severity tags below: **[C]** critical, **[H]** high, **[M]** medium, **[L]** low
 
 ## Wave 0 — Rails
 
-- [ ] 0.1 Draft PR `code-review`→`main` (CI matrix baseline)
-- [ ] 0.2 **[H]** e2e reset guard: assert `rev-parse --show-toplevel` == e2e root + `GIT_CEILING_DIRECTORIES` before destructive git ops (`frontend/e2e/projectIsolation.ts:19`)
-- [ ] 0.3 **[H]** Add `tests/test_file_ops.py` to platform-smoke CI selection (`.github/workflows/ci.yml`)
+- [x] 0.1 Draft PR `code-review`→`main` (CI matrix baseline) — [#22](https://github.com/PricingFrontier/haute/pull/22)
+- [x] 0.2 **[H]** e2e reset guard: assert `rev-parse --show-toplevel` == e2e root + `GIT_CEILING_DIRECTORIES` (+ `GIT_DIR`/`GIT_WORK_TREE` stripped) before destructive git ops — `ea2bacdc`
+- [x] 0.3 **[H]** `tests/test_file_ops.py` on platform-smoke CI selection — `4bd18ffa`, CI-verified on windows-latest
 - [ ] 0.4 Baseline both preflight legs + e2e green; fix pre-existing failures; snapshot coverage
-- [ ] 0.5 This tracker committed
+  - [x] backend leg green local (9842 passed, 91.09%, 18 critical gates) + CI ×3 Python; coverage snapshotted
+  - [x] frontend leg: `useEdgeHandlers.ts` critical gate fixed with 14 behavioral tests — `4f011cb8`; CI green
+  - [ ] local e2e: Windows-deterministic stuck-preview defect (preview success dropped on mid-flight `structuralVersion` bump → panel stranded "Running…") — fix in review
+- [x] 0.5 This tracker committed — `fdb45da2`
 
 ## Wave 1 — Edge-join / multi-port blockers (on `code-review`)
 

--- a/frontend/e2e/__tests__/projectIsolation.test.ts
+++ b/frontend/e2e/__tests__/projectIsolation.test.ts
@@ -1,0 +1,136 @@
+import { resolve } from "node:path"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const execFileSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock("node:child_process", () => ({
+  default: { execFileSync: execFileSyncMock },
+  execFileSync: execFileSyncMock,
+}))
+
+import { e2eProjectRoot, repoRoot, resetE2eProject } from "../projectIsolation"
+
+const realPlatform = process.platform
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  })
+}
+
+function mockGit({
+  toplevel,
+  branches = "main\n",
+}: {
+  toplevel: string
+  branches?: string
+}): void {
+  execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+    if (args[0] === "rev-parse") return `${toplevel}\n`
+    if (args[0] === "for-each-ref") return branches
+    return ""
+  })
+}
+
+function gitCalls(): string[][] {
+  return execFileSyncMock.mock.calls.map((call) => call[1] as string[])
+}
+
+function fullResetSequence(branchDeletes: string[][]): string[][] {
+  return [
+    ["rev-parse", "--show-toplevel"],
+    ["switch", "--force", "main"],
+    ["reset", "--hard", "main"],
+    ["for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+    ...branchDeletes,
+    ["clean", "-fdx"],
+  ]
+}
+
+describe("resetE2eProject", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    stubPlatform(realPlatform)
+    vi.unstubAllEnvs()
+  })
+
+  it("verifies the toplevel before running the destructive sequence", () => {
+    mockGit({ toplevel: e2eProjectRoot, branches: "main\nfeature-a\nfeature-b\n" })
+
+    resetE2eProject()
+
+    expect(gitCalls()).toEqual(
+      fullResetSequence([
+        ["branch", "-D", "feature-a"],
+        ["branch", "-D", "feature-b"],
+      ]),
+    )
+    expect(execFileSyncMock.mock.calls.every((call) => call[0] === "git")).toBe(true)
+  })
+
+  it("throws before issuing any destructive command when the toplevel is the parent repo", () => {
+    const reportedToplevel = repoRoot.replaceAll("\\", "/")
+    mockGit({ toplevel: reportedToplevel })
+
+    let message = ""
+    try {
+      resetE2eProject()
+    } catch (error) {
+      message = (error as Error).message
+    }
+
+    expect(message).toContain(reportedToplevel)
+    expect(message).toContain(e2eProjectRoot)
+    expect(gitCalls()).toEqual([["rev-parse", "--show-toplevel"]])
+  })
+
+  it("throws without issuing destructive commands when rev-parse finds no repository", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("fatal: not a git repository (or any of the parent directories): .git")
+    })
+
+    expect(() => resetE2eProject()).toThrow(e2eProjectRoot)
+    expect(gitCalls()).toEqual([["rev-parse", "--show-toplevel"]])
+  })
+
+  it("accepts a matching toplevel reported with forward slashes", () => {
+    mockGit({ toplevel: e2eProjectRoot.replaceAll("\\", "/") })
+
+    resetE2eProject()
+
+    expect(gitCalls()).toEqual(fullResetSequence([]))
+  })
+
+  it("accepts a matching toplevel that differs only by case on win32", () => {
+    stubPlatform("win32")
+    mockGit({ toplevel: e2eProjectRoot.toUpperCase().replaceAll("\\", "/") })
+
+    resetE2eProject()
+
+    expect(gitCalls()).toEqual(fullResetSequence([]))
+  })
+
+  it("pins cwd and GIT_CEILING_DIRECTORIES on every git invocation", () => {
+    vi.stubEnv("GIT_DIR", resolve(repoRoot, ".git"))
+    vi.stubEnv("GIT_WORK_TREE", repoRoot)
+    mockGit({ toplevel: e2eProjectRoot, branches: "main\nstale\n" })
+
+    resetE2eProject()
+
+    expect(execFileSyncMock.mock.calls.length).toBeGreaterThanOrEqual(5)
+    for (const call of execFileSyncMock.mock.calls) {
+      const options = call[2] as { cwd?: string; env?: Record<string, string | undefined> }
+      expect(options.cwd).toBe(e2eProjectRoot)
+      expect(options.env?.GIT_CEILING_DIRECTORIES).toBe(resolve(e2eProjectRoot, ".."))
+      expect(options.env).not.toHaveProperty("GIT_DIR")
+      expect(options.env).not.toHaveProperty("GIT_WORK_TREE")
+    }
+  })
+})

--- a/frontend/e2e/projectIsolation.ts
+++ b/frontend/e2e/projectIsolation.ts
@@ -8,15 +8,48 @@ const __dirname = dirname(__filename)
 export const repoRoot = resolve(__dirname, "..", "..")
 export const e2eProjectRoot = resolve(repoRoot, ".tmp-e2e-project")
 
+// Ceiling at the e2e root's parent so git can never discover a repository
+// above the temp project (e.g. the real repo) if .tmp-e2e-project/.git vanishes.
+const e2eProjectParent = resolve(e2eProjectRoot, "..")
+
 function runGit(args: string[]): string {
+  // An inherited GIT_DIR / GIT_WORK_TREE bypasses repository discovery entirely,
+  // which would defeat both the ceiling and the toplevel assertion below.
+  const env = { ...process.env, GIT_CEILING_DIRECTORIES: e2eProjectParent }
+  delete env.GIT_DIR
+  delete env.GIT_WORK_TREE
   return execFileSync("git", args, {
     cwd: e2eProjectRoot,
+    env,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   })
 }
 
+function comparablePath(value: string): string {
+  const resolved = resolve(value)
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved
+}
+
+function assertGitToplevelIsE2eProject(): void {
+  let toplevel: string
+  try {
+    toplevel = runGit(["rev-parse", "--show-toplevel"]).trim()
+  } catch (error) {
+    throw new Error(
+      `Refusing to reset e2e project: git found no repository toplevel at ${e2eProjectRoot}`,
+      { cause: error },
+    )
+  }
+  if (comparablePath(toplevel) !== comparablePath(e2eProjectRoot)) {
+    throw new Error(
+      `Refusing to reset e2e project: git toplevel is ${toplevel} but expected ${e2eProjectRoot}`,
+    )
+  }
+}
+
 export function resetE2eProject(): void {
+  assertGitToplevelIsE2eProject()
   runGit(["switch", "--force", "main"])
   runGit(["reset", "--hard", "main"])
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test"
 
 export default defineConfig({
   testDir: "./e2e",
+  // Vitest unit tests for e2e helpers live in e2e/__tests__; keep them out of Playwright.
+  testIgnore: "**/__tests__/**",
   timeout: 60_000,
   expect: {
     timeout: 15_000,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,7 @@ import { NODE_TYPES } from "./utils/nodeTypes"
 import { previewForActiveNode } from "./utils/activePreview"
 import { swapEdgeJoinInputs, type EdgeJoinSwapInputsFailureReason } from "./utils/edgeJoinGraph"
 import { isPipelineConnectionValid } from "./utils/connectionValidation"
-import { reconcileApiInputEdges } from "./utils/apiInputPorts"
+import { applyApiInputConfigChange } from "./utils/apiInputPorts"
 import { shouldUseLiteGraphEffects } from "./utils/graphPerformance"
 import { nodeData } from "./types/node"
 import { PanelLeftOpen } from "lucide-react"
@@ -307,28 +307,48 @@ function FlowEditor() {
 
   const onUpdateNode = useCallback(
     (id: string, data: Record<string, unknown>) => {
+      // Capture the pre-update node BEFORE committing, so apiInput edge
+      // maintenance below can diff old vs new port identities.
+      const prevNode = graphRef.current.nodes.find((n) => n.id === id)
       setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data } : n)))
       setSelectedNode((prev) => (prev && prev.id === id ? { ...prev, data } : prev))
 
-      // Defect 1 — reconcile orphaned outgoing edges when an apiInput's
-      // emit-port set changes (emit-off / table-rename / table-delete /
-      // single↔multi-port transition). An edge whose `sourceHandle` no
-      // longer maps to a rendered port would otherwise persist broken to
-      // disk and only fail at execution time with a backend KeyError.
-      // We prune at edit time and surface a visible, named toast so the
-      // disconnection is never silent.
+      // apiInput edge maintenance (W1.3 / Defect 1) — an apiInput's
+      // handle ids ARE its table labels (the only id space that
+      // round-trips through codegen → save → parse), so a config commit
+      // can change port identities. Two cases, handled in one pass:
+      //  - RENAME (W1.3): the same commit that renames a port rebinds
+      //    the edges bound to the old handle — rename is migration,
+      //    never edge loss.
+      //  - genuine orphaning (emit-off / table-delete / single↔multi
+      //    transition): the edge is pruned with a visible, named toast,
+      //    instead of persisting broken to disk and KeyError-ing at run.
       if (data.nodeType !== NODE_TYPES.API_INPUT) return
       const config = (data.config ?? {}) as Record<string, unknown>
-      const { removed } = reconcileApiInputEdges({
+      const prevConfig = ((prevNode?.data as Record<string, unknown> | undefined)?.config ??
+        {}) as Record<string, unknown>
+      const { rebound, removed } = applyApiInputConfigChange({
         nodeId: id,
-        config,
+        prevConfig,
+        nextConfig: config,
         edges: graphRef.current.edges,
       })
+      if (rebound.length === 0 && removed.length === 0) return
+      const reboundTo = new Map(rebound.map((r) => [r.edge.id, r.to]))
+      const removedIds = new Set(removed.map((r) => r.edge.id))
+      // Raw (history-skipping) on purpose: the `setNodes` above already
+      // snapshotted the pre-commit {nodes, edges}, so applying the edge
+      // consequences raw keeps the whole config commit ONE undo entry —
+      // undoing a rename restores the old label AND its old bindings
+      // atomically, with no per-keystroke or per-phase history churn.
+      setEdgesRaw((eds) =>
+        eds
+          .filter((e) => !removedIds.has(e.id))
+          .map((e) =>
+            reboundTo.has(e.id) ? { ...e, sourceHandle: reboundTo.get(e.id)! } : e,
+          ),
+      )
       if (removed.length === 0) return
-      setEdges((eds) => {
-        const removedIds = new Set(removed.map((r) => r.edge.id))
-        return eds.filter((e) => !removedIds.has(e.id))
-      })
       const ports = removed
         .map((r) => (r.sourceHandle === null ? "the default port" : `port "${r.sourceHandle}"`))
         .join(", ")
@@ -338,7 +358,7 @@ function FlowEditor() {
         `Disconnected ${removed.length} edge${removed.length === 1 ? "" : "s"} from ${label}: ${ports} no longer ${removed.length === 1 ? "exists" : "exist"} after your edit.`,
       )
     },
-    [setNodes, setEdges, graphRef, addToast],
+    [setNodes, setEdgesRaw, graphRef, addToast],
   )
 
   const {

--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -786,6 +786,82 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     })
   })
 
+  it("W1.3: renaming a CONNECTED port keeps its edge — rebound to the new handle in ONE undo entry", async () => {
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeApiInputGraph())
+    // Determinism: the default previewNode mock resolves `columns: []`
+    // (truthy), and usePipelineAPI stashes `_columns` via history-aware
+    // setNodes whenever a preview lands — an asynchronous undo-stack
+    // push that can otherwise land inside this test's measurement
+    // window (observed under coverage instrumentation). Keep every
+    // preview PENDING so the only undo entries this test can observe
+    // are the ones it creates. (beforeEach restores the default mock.)
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    fireEvent.click(await screen.findByText("Quote Source"))
+
+    // Rename the bound 'drivers' port (table index 1) by typing several
+    // characters. The label is the live handle id, so under the old
+    // per-keystroke commit scheme the FIRST keystroke ("driversX" ≠
+    // "drivers") destroyed the edge.
+    const label = (await screen.findByTestId("api-input-table-1-label")) as HTMLInputElement
+    const undoDepthBefore = useGraphStore.getState().undoStack.length
+    label.focus()
+    for (const v of ["driver", "driver_", "driver_risk"]) {
+      fireEvent.change(label, { target: { value: v } })
+      // The edge survives EVERY intermediate keystroke, still bound to
+      // the committed handle — nothing reached the graph yet.
+      expect(useGraphStore.getState().edges).toHaveLength(1)
+      expect(useGraphStore.getState().edges[0].sourceHandle).toBe("drivers")
+    }
+    expect(useGraphStore.getState().undoStack.length).toBe(undoDepthBefore)
+
+    // Blur commits the rename atomically: config + edge rebind together.
+    fireEvent.blur(label)
+    await waitFor(() => {
+      expect(useGraphStore.getState().edges[0].sourceHandle).toBe("driver_risk")
+    })
+    expect(useGraphStore.getState().edges).toHaveLength(1)
+    // Exactly one undo-meaningful commit for the whole rename…
+    expect(useGraphStore.getState().undoStack.length).toBe(undoDepthBefore + 1)
+    // …and no disconnection warning, because nothing was disconnected.
+    expect(useToastStore.getState().toasts.some((t) => t.type === "warning")).toBe(false)
+
+    // Undo restores the old label AND the old binding in one step.
+    useGraphStore.getState().undo()
+    const node = useGraphStore.getState().nodes.find((n) => n.id === "api_0")
+    const tables = (node?.data.config as { tables: { label: string }[] }).tables
+    expect(tables[1].label).toBe("drivers")
+    expect(useGraphStore.getState().edges[0].sourceHandle).toBe("drivers")
+  })
+
+  it("W1.4: blanking a port label in the editor never reaches the graph — no synthesized port, edge intact", async () => {
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeApiInputGraph())
+    // Same determinism guard as the W1.3 test above: keep previews
+    // pending so no async `_columns` stash mutates nodes mid-test.
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    fireEvent.click(await screen.findByText("Quote Source"))
+
+    const label = (await screen.findByTestId("api-input-table-1-label")) as HTMLInputElement
+    label.focus()
+    fireEvent.change(label, { target: { value: "" } })
+    fireEvent.blur(label)
+
+    // The commit was refused with visible validation…
+    expect(await screen.findByTestId("api-input-table-1-label-error")).toBeTruthy()
+    // …config still carries the real label, the edge is untouched, and
+    // no `port_<idx>` identity exists anywhere in the graph.
+    const node = useGraphStore.getState().nodes.find((n) => n.id === "api_0")
+    const tables = (node?.data.config as { tables: { label: string }[] }).tables
+    expect(tables[1].label).toBe("drivers")
+    expect(useGraphStore.getState().edges).toHaveLength(1)
+    expect(useGraphStore.getState().edges[0].sourceHandle).toBe("drivers")
+  })
+
   it("editing a non-port field (column) does NOT prune the still-valid edge", async () => {
     vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeApiInputGraph())
     render(<App />)

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react"
+import { useState } from "react"
 import ApiInputEditor from "../../panels/editors/ApiInputEditor"
 
 afterEach(cleanup)
@@ -547,4 +548,242 @@ describe("ApiInputEditor", () => {
     })
   })
 
+})
+
+// ─── W1.5 — path inputs: focus retention + commit-on-blur ──────────
+//
+// CODE_REVIEW (frontend editors): the TableBlock/ColumnRow React keys
+// embedded the edited path (`${table.path}-${ti}` / `${col.path}-${ci}`),
+// so every keystroke in a path input committed to config, round-tripped
+// through the parent, changed the key, and remounted the row — the
+// input lost focus after each character. Half-typed paths also polluted
+// config (churning structuralVersion; a transiently empty path makes
+// readV2 drop the whole table). These tests need a *stateful* harness
+// that echoes onUpdate back into the config prop, exactly like
+// NodePanel does — a plain vi.fn() onUpdate never round-trips and can
+// never remount, which is why the original suite missed the defect.
+
+/** Echoes onUpdate back into the `config` prop like NodePanel does. */
+function StatefulHarness({
+  initialConfig,
+  onUpdateSpy,
+}: {
+  initialConfig: Record<string, unknown>
+  onUpdateSpy: (keyOrUpdates: string | Record<string, unknown>, value?: unknown) => void
+}) {
+  const [config, setConfig] = useState(initialConfig)
+  return (
+    <ApiInputEditor
+      config={config}
+      onUpdate={(keyOrUpdates: string | Record<string, unknown>, value?: unknown) => {
+        onUpdateSpy(keyOrUpdates, value)
+        setConfig((prev) =>
+          typeof keyOrUpdates === "string"
+            ? { ...prev, [keyOrUpdates]: value }
+            : { ...prev, ...keyOrUpdates },
+        )
+      }}
+      accentColor="#10b981"
+    />
+  )
+}
+
+// No `path` key → no cache button / infer button → no async noise; the
+// tables array alone makes the config v2-shaped.
+const ONE_TABLE_ONE_COL = {
+  tables: [
+    {
+      path: "$[*]",
+      label: "policies",
+      emit: true,
+      columns: [
+        {
+          name: "policy_id",
+          path: "$[*].policy_id",
+          type: "int",
+          status: "Inferred",
+          selected: true,
+        },
+      ],
+    },
+  ],
+}
+
+const TWO_TABLES = {
+  tables: [
+    { path: "$[*]", label: "policies", emit: true, columns: [] },
+    { path: "$[*].drivers[*]", label: "drivers", emit: false, columns: [] },
+  ],
+}
+
+/** Dispatches each progressively-longer value at the CURRENTLY focused
+ * element — like a real user, whose keystrokes land wherever focus is.
+ * Under value-derived keys the first keystroke remounts the row and
+ * focus falls to <body>, so subsequent keystrokes go nowhere. */
+function typeSequence(values: string[]) {
+  for (const v of values) {
+    fireEvent.change(document.activeElement as Element, { target: { value: v } })
+  }
+}
+
+describe("ApiInputEditor — W1.5 path inputs (focus retention, commit discipline)", () => {
+  it("table path input keeps focus and accumulates keystrokes without remounting", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    typeSequence(["$[*].", "$[*].q", "$[*].qu", "$[*].quotes[*]"])
+
+    // Same DOM element — the row was never remounted…
+    expect(screen.getByTestId("api-input-table-0-path")).toBe(input)
+    // …focus never left it…
+    expect(document.activeElement).toBe(input)
+    // …and the keystrokes accumulated into the full string.
+    expect(input.value).toBe("$[*].quotes[*]")
+  })
+
+  it("table path edits do NOT commit per keystroke; blur commits exactly once with the final value", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    typeSequence(["$[*].", "$[*].q", "$[*].qu", "$[*].quotes[*]"])
+
+    // No half-typed path ever reached the config.
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.blur(input)
+
+    // Exactly one commit, carrying only the final value.
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const committedPaths = onUpdateSpy.mock.calls.map(
+      (c) => (c[0] as { tables: { path: string }[] }).tables[0].path,
+    )
+    expect(committedPaths).toEqual(["$[*].quotes[*]"])
+  })
+
+  it("Enter commits the table path exactly once and keeps the element focused", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    typeSequence(["$[*].x", "$[*].xs[*]"])
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { path: string }[] }).tables[0].path,
+    ).toBe("$[*].xs[*]")
+    // Enter commits in place — same element, still focused, showing the
+    // committed value.
+    expect(screen.getByTestId("api-input-table-0-path")).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe("$[*].xs[*]")
+
+    // A later blur must not double-commit the same value.
+    fireEvent.blur(input)
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("column path input keeps focus through a paste-style edit and commits once on blur", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-col-0-path") as HTMLInputElement
+    input.focus()
+    // Paste arrives as a single change event with the full replacement.
+    fireEvent.change(input, { target: { value: "$[*].quote.policy_id" } })
+
+    // No remount, no focus loss, no premature commit.
+    expect(screen.getByTestId("api-input-table-0-col-0-path")).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe("$[*].quote.policy_id")
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.blur(input)
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const arg = onUpdateSpy.mock.calls[0][0] as {
+      tables: { columns: { path: string }[] }[]
+    }
+    expect(arg.tables[0].columns[0].path).toBe("$[*].quote.policy_id")
+  })
+
+  it("blur after editing back to the committed value is a no-op (no churn commit)", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    typeSequence(["$[*].x", "$[*]"])
+    fireEvent.blur(input)
+
+    // The draft equals the committed value — nothing to write; config
+    // (and therefore structuralVersion downstream) must not churn.
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    expect(input.value).toBe("$[*]")
+  })
+
+  it("label and column-name inputs do not share the value-derived-key defect (per-keystroke commits retained, focus kept)", () => {
+    // Evidence for the review's verification pass: keys never embedded
+    // label/name, so these inputs re-render in place. They keep their
+    // original per-keystroke commit behaviour — deliberately unchanged.
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const label = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    label.focus()
+    typeSequence(["policies_a", "policies_ab", "policies_abc"])
+    expect(screen.getByTestId("api-input-table-0-label")).toBe(label)
+    expect(document.activeElement).toBe(label)
+    expect(label.value).toBe("policies_abc")
+    // Per-keystroke commits flowed through — one per change event.
+    expect(onUpdateSpy).toHaveBeenCalledTimes(3)
+
+    onUpdateSpy.mockClear()
+    const name = screen.getByTestId("api-input-table-0-col-0-name") as HTMLInputElement
+    name.focus()
+    typeSequence(["policy_idx", "policy_idxy"])
+    expect(screen.getByTestId("api-input-table-0-col-0-name")).toBe(name)
+    expect(document.activeElement).toBe(name)
+    expect(name.value).toBe("policy_idxy")
+    expect(onUpdateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it("removing the row above an in-progress path edit never leaks the draft into the surviving row", () => {
+    // Positional keys mean the surviving row slides into index 0 and is
+    // adopted by the component instance that held the dead row's draft.
+    // The committed value must win: the stale draft is discarded, never
+    // committed into the row that slid up.
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    // Half-typed draft in table 0's path — deliberately not blurred.
+    fireEvent.change(input, { target: { value: "$[*].HALF" } })
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId("api-input-table-0-remove"))
+
+    // Exactly one commit so far: the removal itself.
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const removal = onUpdateSpy.mock.calls[0][0] as { tables: { path: string }[] }
+    expect(removal.tables.map((t) => t.path)).toEqual(["$[*].drivers[*]"])
+
+    // The surviving row shows ITS OWN committed path, not the dead
+    // row's half-typed draft…
+    const survivor = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    expect(survivor.value).toBe("$[*].drivers[*]")
+
+    // …and blurring it commits nothing (the stale draft is gone).
+    fireEvent.blur(survivor)
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -730,30 +730,39 @@ describe("ApiInputEditor — W1.5 path inputs (focus retention, commit disciplin
     expect(input.value).toBe("$[*]")
   })
 
-  it("label and column-name inputs do not share the value-derived-key defect (per-keystroke commits retained, focus kept)", () => {
-    // Evidence for the review's verification pass: keys never embedded
-    // label/name, so these inputs re-render in place. They keep their
-    // original per-keystroke commit behaviour — deliberately unchanged.
+  it("column-name inputs keep focus while typing and commit atomically on blur", () => {
+    // PIN REVISION (W1.3, then W1.9): this test originally pinned BOTH
+    // the table-label and column-name inputs committing per keystroke
+    // (documenting then-current behaviour). The label half was revised
+    // first (labels are handle ids — see the W1.3/W1.4 suite below).
+    // The column-name half is now deliberately revised too (W1.9):
+    // per-keystroke commits meant backspacing a name to empty committed
+    // `name:""`, and `readV2` (apiInputSchema.ts) silently dropped the
+    // whole column row — instant UI data loss the backend would also
+    // 422 on (blank/duplicate column names are rejected by
+    // `validate_v2_schema`). Column names now commit atomically on
+    // blur/Enter with validation, exactly like labels and paths. The
+    // focus-retention half of the original pin is unchanged.
     const onUpdateSpy = vi.fn()
     render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
 
-    const label = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
-    label.focus()
-    typeSequence(["policies_a", "policies_ab", "policies_abc"])
-    expect(screen.getByTestId("api-input-table-0-label")).toBe(label)
-    expect(document.activeElement).toBe(label)
-    expect(label.value).toBe("policies_abc")
-    // Per-keystroke commits flowed through — one per change event.
-    expect(onUpdateSpy).toHaveBeenCalledTimes(3)
-
-    onUpdateSpy.mockClear()
     const name = screen.getByTestId("api-input-table-0-col-0-name") as HTMLInputElement
     name.focus()
     typeSequence(["policy_idx", "policy_idxy"])
     expect(screen.getByTestId("api-input-table-0-col-0-name")).toBe(name)
     expect(document.activeElement).toBe(name)
     expect(name.value).toBe("policy_idxy")
-    expect(onUpdateSpy).toHaveBeenCalledTimes(2)
+    // No intermediate name ever reached config…
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.blur(name)
+
+    // …blur commits exactly once with the final value.
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { columns: { name: string }[] }[] })
+        .tables[0].columns[0].name,
+    ).toBe("policy_idxy")
   })
 
   it("removing the row above an in-progress path edit never leaks the draft into the surviving row", () => {
@@ -785,5 +794,388 @@ describe("ApiInputEditor — W1.5 path inputs (focus retention, commit disciplin
     // …and blurring it commits nothing (the stale draft is gone).
     fireEvent.blur(survivor)
     expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── W1.3 / W1.4 — port labels: atomic commit + validation ─────────
+//
+// A table label IS the React Flow handle id and the backend port name
+// (`_json_shred` keys runtime frames by raw label; codegen emits it as
+// `connect(..., source_port=label)`). Two consequences:
+//
+//  - W1.3: committing per keystroke made every intermediate string a
+//    live handle id — renaming a CONNECTED port destroyed its edges on
+//    the first keystroke. Labels must commit atomically (blur/Enter).
+//  - W1.4: blank/duplicate labels are hard-rejected by the backend on
+//    save (`validate_v2_schema`), so the editor must refuse to commit
+//    them and show why — never paper over with synthesized handles.
+
+const TWO_EMIT_TABLES = {
+  tables: [
+    {
+      path: "$[*]",
+      label: "policies",
+      emit: true,
+      columns: [
+        { name: "policy_id", path: "$[*].policy_id", type: "int", status: "Inferred", selected: true },
+      ],
+    },
+    {
+      path: "$[*].drivers[*]",
+      label: "drivers",
+      emit: true,
+      columns: [
+        { name: "driver_id", path: "$[*].drivers[*].driver_id", type: "int", status: "Inferred", selected: true },
+      ],
+    },
+  ],
+}
+
+describe("ApiInputEditor — W1.3 port-label commits are atomic", () => {
+  it("typing in a label input does not commit per keystroke; blur commits exactly once with the final value", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    typeSequence(["quotes_a", "quotes_ab", "quotes_abc"])
+
+    // No intermediate label ever became a live handle id.
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    // Focus and accumulation are unaffected by the buffering.
+    expect(screen.getByTestId("api-input-table-0-label")).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe("quotes_abc")
+
+    fireEvent.blur(input)
+
+    // Exactly one commit — one onUpdate, one graph update, one
+    // undo-meaningful entry — carrying only the final label.
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const arg = onUpdateSpy.mock.calls[0][0] as { tables: { label: string }[] }
+    expect(arg.tables.map((t) => t.label)).toEqual(["quotes_abc", "drivers"])
+  })
+
+  it("Enter commits the label exactly once and a later blur does not double-commit", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    typeSequence(["quotes"])
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { label: string }[] }).tables[0].label,
+    ).toBe("quotes")
+    expect(input.value).toBe("quotes")
+
+    fireEvent.blur(input)
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("blur after editing back to the committed label is a no-op (no churn commit)", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    typeSequence(["policiesX", "policies"])
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    expect(input.value).toBe("policies")
+  })
+})
+
+describe("ApiInputEditor — W1.4 label validation (blank / duplicate / sanitised collision)", () => {
+  it("a blanked label shows validation on blur and commits NOTHING (no port_<idx> ever reaches config)", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "" } })
+    fireEvent.blur(input)
+
+    // Refused: the blank label never reached config, so the port and its
+    // edges are untouched and no synthesized handle can exist anywhere.
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    // Visible validation, and the draft is kept so the user sees what
+    // was rejected.
+    expect(screen.getByTestId("api-input-table-0-label-error")).toBeTruthy()
+    expect(input.value).toBe("")
+    expect(input.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("a duplicate label shows validation and refuses to commit (no __<idx> disambiguation)", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "drivers" } })
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    const error = screen.getByTestId("api-input-table-0-label-error")
+    expect(error.textContent).toMatch(/drivers/)
+  })
+
+  it("a sanitised-form collision (backend B2) is rejected before commit", () => {
+    // "drivers.x" sanitises to "drivers_x"; if another table is labelled
+    // "drivers_x" the backend rejects the save (both would write the
+    // same parquet). Surface that here, not as a 422 later.
+    const config = {
+      tables: [
+        { path: "$[*]", label: "policies", emit: true, columns: [] },
+        { path: "$[*].d[*]", label: "drivers_x", emit: true, columns: [] },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "drivers.x" } })
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId("api-input-table-0-label-error").textContent).toMatch(/drivers_x/)
+  })
+
+  it("fixing an invalid draft to a valid label clears the error and commits once", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={TWO_EMIT_TABLES} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "" } })
+    fireEvent.blur(input)
+    expect(screen.getByTestId("api-input-table-0-label-error")).toBeTruthy()
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: "quotes" } })
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { label: string }[] }).tables[0].label,
+    ).toBe("quotes")
+    expect(screen.queryByTestId("api-input-table-0-label-error")).toBeNull()
+  })
+
+  it("an already-committed duplicate (e.g. loaded from disk) surfaces validation without any interaction", () => {
+    // The editor can't prevent invalid configs arriving from legacy
+    // files or an infer-merge; it must SHOW the problem (the backend
+    // will reject the save until it's fixed).
+    const config = {
+      tables: [
+        { path: "$[*]", label: "dup", emit: true, columns: [] },
+        { path: "$[*].b[*]", label: "dup", emit: true, columns: [] },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={vi.fn()} />)
+
+    expect(screen.getByTestId("api-input-table-0-label-error")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-1-label-error")).toBeTruthy()
+  })
+})
+
+describe("ApiInputEditor — blank paths are refused, never silently destructive", () => {
+  // Folded W1.5 follow-up: PathInput committed "" on a deliberate
+  // clear+blur, and `readV2` then silently dropped the whole table (or
+  // column) from config. Invalid editor state must surface as
+  // validation — never as silent data loss.
+
+  it("clearing a TABLE path and blurring refuses the commit, shows validation, and keeps the table", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "" } })
+    fireEvent.blur(input)
+
+    // The destructive commit never happened…
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    // …the table row is still there…
+    expect(screen.getByTestId("api-input-table-0")).toBeTruthy()
+    // …and the user can see why the clear was refused.
+    expect(screen.getByTestId("api-input-table-0-path-error")).toBeTruthy()
+  })
+
+  it("clearing a COLUMN path and blurring refuses the commit and keeps the column", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-col-0-path") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "   " } })
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId("api-input-table-0-col-0")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-0-col-0-path-error")).toBeTruthy()
+  })
+
+  it("typing a real path after a refused clear commits normally and clears the error", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const input = screen.getByTestId("api-input-table-0-path") as HTMLInputElement
+    input.focus()
+    fireEvent.change(input, { target: { value: "" } })
+    fireEvent.blur(input)
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.change(input, { target: { value: "$[*].quotes[*]" } })
+    fireEvent.blur(input)
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { path: string }[] }).tables[0].path,
+    ).toBe("$[*].quotes[*]")
+    expect(screen.queryByTestId("api-input-table-0-path-error")).toBeNull()
+  })
+})
+
+// ─── W1.9 — column names: atomic commit + validation ───────────────
+//
+// Same destructive class as the blank-path defect: column-name inputs
+// committed per keystroke, so backspacing a name to empty committed
+// `name:""` → `readV2` (apiInputSchema.ts) dropped the column row
+// INSTANTLY (silent UI data loss; the backend would also 422 the save —
+// `validate_v2_schema` rejects blank column names and duplicate names
+// WITHIN a table, see `seen_col_names` scoped per table). Names now
+// commit on blur/Enter and invalid candidates are refused with visible
+// validation.
+
+const TWO_COLS_AND_SECOND_TABLE = {
+  tables: [
+    {
+      path: "$[*]",
+      label: "policies",
+      emit: true,
+      columns: [
+        { name: "policy_id", path: "$[*].policy_id", type: "int", status: "Inferred", selected: true },
+        { name: "premium", path: "$[*].premium", type: "float", status: "Inferred", selected: true },
+      ],
+    },
+    {
+      path: "$[*].drivers[*]",
+      label: "drivers",
+      emit: true,
+      columns: [
+        { name: "driver_id", path: "$[*].drivers[*].driver_id", type: "int", status: "Inferred", selected: true },
+      ],
+    },
+  ],
+}
+
+describe("ApiInputEditor — W1.9 column-name validation (blank / duplicate)", () => {
+  it("backspacing a name to empty never deletes the column: commit refused, row survives, error shown", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const name = screen.getByTestId("api-input-table-0-col-0-name") as HTMLInputElement
+    name.focus()
+    // Backspace the committed "policy_id" down to nothing, then blur.
+    typeSequence(["policy_i", "policy", "p", ""])
+    fireEvent.blur(name)
+
+    // Nothing destructive reached config…
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    // …the column row is still there…
+    expect(screen.getByTestId("api-input-table-0-col-0")).toBeTruthy()
+    // …with a visible reason for the refusal.
+    expect(screen.getByTestId("api-input-table-0-col-0-name-error")).toBeTruthy()
+    expect(name.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("a duplicate name within the SAME table is refused with visible validation", () => {
+    const onUpdateSpy = vi.fn()
+    render(
+      <StatefulHarness initialConfig={TWO_COLS_AND_SECOND_TABLE} onUpdateSpy={onUpdateSpy} />,
+    )
+
+    const name = screen.getByTestId("api-input-table-0-col-1-name") as HTMLInputElement
+    name.focus()
+    fireEvent.change(name, { target: { value: "policy_id" } })
+    fireEvent.blur(name)
+
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByTestId("api-input-table-0-col-1-name-error").textContent,
+    ).toMatch(/policy_id/)
+  })
+
+  it("the duplicate rule is scoped PER TABLE, exactly like the backend's seen_col_names", () => {
+    // `validate_v2_schema` resets its `seen_col_names` set per table:
+    // the same column name in two DIFFERENT tables is legal (each table
+    // is its own frame). The editor must not over-reject.
+    const onUpdateSpy = vi.fn()
+    render(
+      <StatefulHarness initialConfig={TWO_COLS_AND_SECOND_TABLE} onUpdateSpy={onUpdateSpy} />,
+    )
+
+    // Rename drivers.driver_id → policy_id: collides with a name in
+    // table 0, but NOT within its own table → commits cleanly.
+    const name = screen.getByTestId("api-input-table-1-col-0-name") as HTMLInputElement
+    name.focus()
+    fireEvent.change(name, { target: { value: "policy_id" } })
+    fireEvent.blur(name)
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const arg = onUpdateSpy.mock.calls[0][0] as {
+      tables: { columns: { name: string }[] }[]
+    }
+    expect(arg.tables[1].columns[0].name).toBe("policy_id")
+    expect(screen.queryByTestId("api-input-table-1-col-0-name-error")).toBeNull()
+  })
+
+  it("a valid rename commits exactly once on Enter, and a later blur does not double-commit", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={ONE_TABLE_ONE_COL} onUpdateSpy={onUpdateSpy} />)
+
+    const name = screen.getByTestId("api-input-table-0-col-0-name") as HTMLInputElement
+    name.focus()
+    typeSequence(["policy_ref"])
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(name, { key: "Enter" })
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { columns: { name: string }[] }[] })
+        .tables[0].columns[0].name,
+    ).toBe("policy_ref")
+
+    fireEvent.blur(name)
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("fixing an invalid name draft to a valid one clears the error and commits once", () => {
+    const onUpdateSpy = vi.fn()
+    render(
+      <StatefulHarness initialConfig={TWO_COLS_AND_SECOND_TABLE} onUpdateSpy={onUpdateSpy} />,
+    )
+
+    const name = screen.getByTestId("api-input-table-0-col-1-name") as HTMLInputElement
+    name.focus()
+    fireEvent.change(name, { target: { value: "policy_id" } })
+    fireEvent.blur(name)
+    expect(screen.getByTestId("api-input-table-0-col-1-name-error")).toBeTruthy()
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+
+    fireEvent.change(name, { target: { value: "policy_id_2" } })
+    fireEvent.blur(name)
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (onUpdateSpy.mock.calls[0][0] as { tables: { columns: { name: string }[] }[] })
+        .tables[0].columns[1].name,
+    ).toBe("policy_id_2")
+    expect(screen.queryByTestId("api-input-table-0-col-1-name-error")).toBeNull()
   })
 })

--- a/frontend/src/__tests__/nodes/ApiInputHandles.test.tsx
+++ b/frontend/src/__tests__/nodes/ApiInputHandles.test.tsx
@@ -137,3 +137,72 @@ describe("apiInput multi-port Handles (commit 6)", () => {
     expect(sourceHandles).toHaveLength(1)
   })
 })
+
+// ─── W1.4 — handle ids are NEVER synthesized ─────────────────────────
+//
+// The backend keys runtime ports by the raw table label and hard-rejects
+// blank/duplicate labels on save (`validate_v2_schema`). A synthesized
+// `port_<idx>` / `label__<idx>` handle is therefore an id the executor
+// can never resolve — an edge bound to one KeyErrors at run time. Tables
+// with invalid labels get NO handle; the editor surfaces the validation.
+
+function sourceHandleIds(container: HTMLElement): (string | null)[] {
+  return Array.from(
+    container.querySelectorAll('.react-flow__handle[data-handlepos="right"]'),
+  ).map((h) => h.getAttribute("data-handleid"))
+}
+
+describe("apiInput Handles never synthesize ids (W1.4)", () => {
+  afterEach(cleanup)
+
+  it("a blank-label emit table renders NO handle — no port_<idx> fallback", () => {
+    const { container } = renderNode({
+      path: "data/quotes.json",
+      tables: [
+        { path: "$[*]", label: "", emit: true, columns: [{ name: "a", selected: true }] },
+        {
+          path: "$[*].drivers[*]",
+          label: "drivers",
+          emit: true,
+          columns: [{ name: "b", selected: true }],
+        },
+      ],
+    })
+    const ids = sourceHandleIds(container)
+    expect(ids).toEqual(["drivers"])
+    expect(ids.some((id) => id?.startsWith("port_"))).toBe(false)
+  })
+
+  it("duplicate labels render ONE handle (first occurrence) — no __<idx> disambiguation", () => {
+    const { container } = renderNode({
+      path: "data/quotes.json",
+      tables: [
+        { path: "$[*]", label: "dup", emit: true, columns: [{ name: "a", selected: true }] },
+        {
+          path: "$[*].b[*]",
+          label: "dup",
+          emit: true,
+          columns: [{ name: "b", selected: true }],
+        },
+      ],
+    })
+    const ids = sourceHandleIds(container)
+    expect(ids).toEqual(["dup"])
+  })
+
+  it("all-blank labels fall back to the single default handle (no bindable fiction)", () => {
+    // Backend-invalid config (only reachable from legacy disk files —
+    // the editor refuses blank label commits). Nothing portlike is
+    // invented for it.
+    const { container } = renderNode({
+      path: "data/quotes.json",
+      tables: [
+        { path: "$[*]", label: "", emit: true, columns: [{ name: "a", selected: true }] },
+        { path: "$[*].b[*]", label: " ", emit: true, columns: [{ name: "b", selected: true }] },
+      ],
+    })
+    const ids = sourceHandleIds(container)
+    expect(ids).toHaveLength(1)
+    expect(ids.some((id) => id?.startsWith("port_") || id?.includes("__"))).toBe(false)
+  })
+})

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, cleanup, act } from "@testing-library/react"
 import type { Node, Edge } from "@xyflow/react"
 import useEdgeHandlers from "../useEdgeHandlers"
+import useToastStore from "../../stores/useToastStore"
 import { NODE_TYPES } from "../../utils/nodeTypes"
 import { DEFAULT_TARGET_HANDLE } from "../../utils/flowHandles"
 
@@ -1117,6 +1118,22 @@ describe("useEdgeHandlers", () => {
     )
   })
 
+  it("onDragOver enables dropping by preventing default and signalling a move", () => {
+    const params = makeParams()
+    const { result } = renderHook(() => useEdgeHandlers(params))
+    const event = {
+      preventDefault: vi.fn(),
+      dataTransfer: { dropEffect: "none" },
+    } as unknown as React.DragEvent
+
+    act(() => {
+      result.current.onDragOver(event)
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(event.dataTransfer.dropEffect).toBe("move")
+  })
+
   it("onDrop creates a new node from shared node metadata and drag config", () => {
     const params = makeParams()
     const { result } = renderHook(() => useEdgeHandlers(params))
@@ -1179,5 +1196,431 @@ describe("useEdgeHandlers", () => {
       result.current.onDrop(event)
     })
     expect(params.setNodes).not.toHaveBeenCalled()
+  })
+})
+
+describe("useEdgeHandlers edge-join failures and multi-port handles", () => {
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [], _toastCounter: 0 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it("onConnectEnd ignores connection endings that never had a source node", () => {
+    const params = makeParams()
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(mouseUpEvent, {
+        isValid: null,
+        fromNode: null,
+        fromHandle: null,
+        toNode: null,
+        toHandle: null,
+      } as never)
+    })
+
+    expect(params.setEdges).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.findEdgeIdAtPoint).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts).toEqual([])
+  })
+
+  it("onConnectEnd fails loudly when a touch ending carries no pointer coordinates", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "base", position: { x: 300, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "lookup", position: { x: 0, y: 160 }, data: { label: "Lookup", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+    const touchEndWithoutPoints = { touches: [], changedTouches: [] } as unknown as TouchEvent
+
+    expect(() => {
+      act(() => {
+        result.current.onConnectEnd(
+          touchEndWithoutPoints,
+          {
+            isValid: true,
+            fromNode: { id: "lookup" },
+            fromHandle: { id: "lookup_out", type: "source" },
+            toNode: { id: "base" },
+            toHandle: { id: "base_out", type: "source" },
+          } as never,
+        )
+      })
+    }).toThrow("Connection end touch event did not include pointer coordinates")
+
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+  })
+
+  it("onConnectEnd rejects a third edgeJoin input when legacy edges occupy no role handles", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "join1", data: { label: "Edge Join 1", nodeType: NODE_TYPES.EDGE_JOIN, config: {} } } as unknown as Node,
+    ]
+    // Legacy/imported graphs can hold edges whose targetHandle never went
+    // through the role-handle migration; neither occupies "base" or "join".
+    params.graphRef.current.edges = [
+      { id: "e-a-join", source: "a", target: "join1", sourceHandle: null, targetHandle: null } as Edge,
+      { id: "e-b-join", source: "b", target: "join1", sourceHandle: null, targetHandle: null } as Edge,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({ from: "c", to: "join1", toHandleId: "join" }),
+      )
+    })
+
+    expect(params.setEdges).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({ type: "error", text: "Edge join nodes accept exactly two inputs" }),
+    ])
+  })
+
+  it("onConnectEnd seeds role config on an edgeJoin node that has no config object", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "join1", data: { label: "Edge Join 1", nodeType: NODE_TYPES.EDGE_JOIN } } as unknown as Node,
+      { id: "quotes", data: { label: "Quotes", nodeType: NODE_TYPES.POLARS, config: {} } } as unknown as Node,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({ from: "quotes", to: "join1", toHandleId: "base" }),
+      )
+    })
+
+    expect(params.pushSnapshot).toHaveBeenCalledOnce()
+    expect(params.setNodesRaw).toHaveBeenCalledOnce()
+    expect(params.setEdgesRaw).toHaveBeenCalledOnce()
+    const nextNodes = params.setNodesRaw.mock.calls[0][0] as Node[]
+    expect(nextNodes.find((n) => n.id === "join1")?.data.config).toEqual({ baseInput: "quotes" })
+    const nextEdges = params.setEdgesRaw.mock.calls[0][0] as Edge[]
+    expect(nextEdges).toEqual([
+      expect.objectContaining({ source: "quotes", target: "join1", targetHandle: "base" }),
+    ])
+  })
+
+  it("onConnectEnd rejects dropping a node's own output onto its outgoing edge as a self-join", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "a", position: { x: 0, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "b", position: { x: 300, y: 0 }, data: { label: "Downstream", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    params.graphRef.current.edges = [
+      { id: "e_ab", source: "a", target: "b", sourceHandle: null, targetHandle: null } as Edge,
+    ]
+    params.findEdgeIdAtPoint.mockReturnValue("e_ab")
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        { clientX: 200, clientY: 150 } as MouseEvent,
+        {
+          isValid: null,
+          fromNode: { id: "a" },
+          fromHandle: { id: "a_out", type: "source" },
+          toNode: null,
+        } as never,
+      )
+    })
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "error",
+        text: "Edge join rejected: choose a different dataframe to join",
+      }),
+    ])
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.setSelectedNode).not.toHaveBeenCalled()
+    expect(params.clearTrace).not.toHaveBeenCalled()
+    expect(params.cancelPreview).not.toHaveBeenCalled()
+    // Self-join is detected before an id is minted, so no id is burnt.
+    expect(params.nodeIdCounter.current).toBe(0)
+  })
+
+  it("onConnectEnd rejects an edge drop that would create a cycle", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "a", position: { x: 0, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "b", position: { x: 300, y: 0 }, data: { label: "Downstream", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    params.graphRef.current.edges = [
+      { id: "e_ab", source: "a", target: "b", sourceHandle: null, targetHandle: null } as Edge,
+    ]
+    params.findEdgeIdAtPoint.mockReturnValue("e_ab")
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    // Dragging the downstream node's output onto the edge feeding it would
+    // route b -> join -> b.
+    act(() => {
+      result.current.onConnectEnd(
+        { clientX: 200, clientY: 150 } as MouseEvent,
+        {
+          isValid: null,
+          fromNode: { id: "b" },
+          fromHandle: { id: "b_out", type: "source" },
+          toNode: null,
+        } as never,
+      )
+    })
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "error",
+        text: "Edge join rejected: that connection would create a cycle",
+      }),
+    ])
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.setSelectedNode).not.toHaveBeenCalled()
+  })
+
+  it("onConnectEnd rejects joining a node's two outputs together as a self-join", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "split", position: { x: 0, y: 0 }, data: { label: "Split", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        {
+          isValid: true,
+          fromNode: { id: "split" },
+          fromHandle: { id: "out_a", type: "source" },
+          toNode: { id: "split" },
+          toHandle: { id: "out_b", type: "source" },
+        } as never,
+      )
+    })
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "error",
+        text: "Edge join rejected: choose a different dataframe to join",
+      }),
+    ])
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.setSelectedNode).not.toHaveBeenCalled()
+    expect(params.lastSelectedNodeRef.current).toBeNull()
+  })
+
+  it("onConnectEnd rejects a source-to-source join from a node that is no longer in the graph", () => {
+    const params = makeParams()
+    // Simulates a stale drag finishing after a websocket refresh removed
+    // the dragged node from graphRef.
+    params.graphRef.current.nodes = [
+      { id: "base", position: { x: 300, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        {
+          isValid: true,
+          fromNode: { id: "ghost" },
+          fromHandle: { id: "ghost_out", type: "source" },
+          toNode: { id: "base" },
+          toHandle: { id: "base_out", type: "source" },
+        } as never,
+      )
+    })
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "error",
+        text: "Edge join rejected: source node is no longer available",
+      }),
+    ])
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+  })
+
+  it("onConnectEnd stores null source handles when joining two default outputs", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "base", position: { x: 300, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "lookup", position: { x: 0, y: 160 }, data: { label: "Lookup", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        {
+          isValid: true,
+          fromNode: { id: "lookup" },
+          fromHandle: { id: null, type: "source" },
+          toNode: { id: "base" },
+          toHandle: { id: null, type: "source" },
+        } as never,
+      )
+    })
+
+    expect(params.pushSnapshot).toHaveBeenCalledOnce()
+    const nextNodes = params.setNodesRaw.mock.calls[0][0] as Node[]
+    expect(nextNodes.find((node) => node.id === "edgeJoin_1")).toMatchObject({
+      data: { config: { baseInput: "base", joinInput: "lookup" } },
+    })
+    const nextEdges = params.setEdgesRaw.mock.calls[0][0] as Edge[]
+    expect(nextEdges).toEqual([
+      expect.objectContaining({
+        source: "base",
+        target: "edgeJoin_1",
+        sourceHandle: null,
+        targetHandle: "base",
+      }),
+      expect.objectContaining({
+        source: "lookup",
+        target: "edgeJoin_1",
+        sourceHandle: null,
+        targetHandle: "join",
+      }),
+    ])
+  })
+
+  it("onConnectEnd normalises a reverse drag between default handles into a null-handle edge", () => {
+    const params = makeParams()
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({
+          from: "sinkNode",
+          to: "sourceNode",
+          fromHandleId: DEFAULT_TARGET_HANDLE,
+          toHandleId: null,
+          fromHandleType: "target",
+          toHandleType: "source",
+        }),
+      )
+    })
+
+    expect(params.setEdges).toHaveBeenCalledOnce()
+    const updater = params.setEdges.mock.calls[0][0] as (eds: Edge[]) => Edge[]
+    expect(updater([])).toEqual([
+      expect.objectContaining({
+        source: "sourceNode",
+        target: "sinkNode",
+        sourceHandle: null,
+        targetHandle: null,
+      }),
+    ])
+  })
+
+  it("onConnectEnd inserts an edgeJoin from a default source handle dropped on an edge", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "a", position: { x: 0, y: 0 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "b", position: { x: 300, y: 0 }, data: { label: "Downstream", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "c", position: { x: 0, y: 160 }, data: { label: "Lookup", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    params.graphRef.current.edges = [
+      { id: "e_ab", source: "a", target: "b", sourceHandle: null, targetHandle: null } as Edge,
+    ]
+    params.findEdgeIdAtPoint.mockReturnValue("e_ab")
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        { clientX: 200, clientY: 150 } as MouseEvent,
+        {
+          isValid: null,
+          fromNode: { id: "c" },
+          fromHandle: { id: null, type: "source" },
+          toNode: null,
+        } as never,
+      )
+    })
+
+    expect(params.pushSnapshot).toHaveBeenCalledOnce()
+    const nextEdges = params.setEdgesRaw.mock.calls[0][0] as Edge[]
+    expect(nextEdges).toHaveLength(3)
+    expect(nextEdges).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        source: "c",
+        target: "edgeJoin_1",
+        sourceHandle: null,
+        targetHandle: "join",
+      }),
+    ]))
+  })
+
+  it("onConnectEnd consults edge hit-testing and stays inert when no edge is under the pointer", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      { id: "a", position: { x: 0, y: 0 }, data: { label: "A", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+      { id: "b", position: { x: 300, y: 0 }, data: { label: "B", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
+    ]
+    params.graphRef.current.edges = [
+      { id: "e_ab", source: "a", target: "b", sourceHandle: null, targetHandle: null } as Edge,
+    ]
+    params.findEdgeIdAtPoint.mockReturnValue(null)
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        { clientX: 200, clientY: 150 } as MouseEvent,
+        {
+          isValid: null,
+          fromNode: { id: "a" },
+          fromHandle: { id: "a_out", type: "source" },
+          toNode: null,
+        } as never,
+      )
+    })
+
+    expect(params.findEdgeIdAtPoint).toHaveBeenCalledWith({ x: 200, y: 150 })
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts).toEqual([])
+  })
+
+  it("onConnectEnd treats missing edge hit-testing as no edge under the pointer", () => {
+    const { findEdgeIdAtPoint: _omitted, ...params } = makeParams()
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        { clientX: 200, clientY: 150 } as MouseEvent,
+        {
+          isValid: null,
+          fromNode: { id: "a" },
+          fromHandle: { id: "a_out", type: "source" },
+          toNode: null,
+        } as never,
+      )
+    })
+
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
+    expect(params.setNodesRaw).not.toHaveBeenCalled()
+    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.screenToFlowPosition).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts).toEqual([])
   })
 })

--- a/frontend/src/hooks/__tests__/usePipelineAPI.gaps.test.ts
+++ b/frontend/src/hooks/__tests__/usePipelineAPI.gaps.test.ts
@@ -553,7 +553,13 @@ describe("usePipelineAPI — gap tests", () => {
       }, { timeout: 2000 })
     })
 
-    it("ignores in-flight preview results after graph execution context changes", async () => {
+    it("terminalizes in-flight preview results after graph execution context changes without applying graph effects", async () => {
+      // W0 contract: a structuralVersion bump while the response is in
+      // flight must not strand the panel on "loading" — the response still
+      // renders as the panel's terminal state. Graph-coupled effects stay
+      // version-gated: stale columns are never written into the changed
+      // graph (no setNodes/cascade), and no cache entry is created for a
+      // node that is absent from the live graph.
       mockLoad.mockResolvedValue({ nodes: [], edges: [] })
       let resolvePreview!: (value: {
         node_id: string
@@ -567,7 +573,8 @@ describe("usePipelineAPI — gap tests", () => {
         resolvePreview = resolve
       }))
 
-      const { result } = renderHook(() => usePipelineAPI(makeParams()))
+      const params = makeParams()
+      const { result } = renderHook(() => usePipelineAPI(params))
       await waitFor(() => expect(result.current.loading).toBe(false))
 
       act(() => {
@@ -591,7 +598,10 @@ describe("usePipelineAPI — gap tests", () => {
         await Promise.resolve()
       })
 
-      expect(result.current.previewData?.row_count).not.toBe(1)
+      expect(result.current.previewData?.status).toBe("ok")
+      expect(result.current.previewData?.row_count).toBe(1)
+      expect(result.current.previewBusy).toBe(false)
+      expect(params.setNodes).not.toHaveBeenCalled()
       expect(useNodeResultsStore.getState().previews.n1).toBeUndefined()
     })
   })

--- a/frontend/src/hooks/__tests__/usePipelineAPI.previewLifecycle.test.ts
+++ b/frontend/src/hooks/__tests__/usePipelineAPI.previewLifecycle.test.ts
@@ -1,0 +1,277 @@
+/**
+ * W0 baseline — preview responses must reach a terminal state when the
+ * graph's structuralVersion changes while the request is in flight.
+ *
+ * Repro (deterministic on Windows, e2e "real optimiser flow"): clicking the
+ * browser_apply node fires fetchPreview → fetchPreviewImmediate captures
+ * structuralVersion=V and issues the API call. The same click mounts
+ * OptimiserApplyEditor, whose artifact-load effect resolves mid-flight and
+ * mirrors `optimiser_mode` into node config (`onUpdate` → setNodes), bumping
+ * structuralVersion to V+1. The response then arrives, `requestStillCurrent()`
+ * is false, and the entire success envelope is silently dropped — previewData
+ * is stranded on `{status:"loading"}` ("Running..." / "Executing pipeline...")
+ * forever: previewBusy clears, no error surfaces, no retry is issued.
+ *
+ * Terminal-state contract pinned here:
+ *   - superseded by a NEWER request (seq mismatch) → drop; the newer request
+ *     owns the panel (covered by usePipelineAPI.abortStale.test.ts);
+ *   - structuralVersion changed but seq still current → the panel must still
+ *     terminalize (data or error). Graph mutation (column application +
+ *     downstream cascade) stays version-gated so stale columns are never
+ *     written into a restructured graph;
+ *   - node deleted mid-flight → handleDeleteNode already cleared the panel;
+ *     the late response must not resurrect it or re-create cache entries.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, cleanup, act, waitFor } from "@testing-library/react"
+import type { Node, Edge } from "@xyflow/react"
+import usePipelineAPI from "../usePipelineAPI"
+import useToastStore from "../../stores/useToastStore"
+import useSettingsStore from "../../stores/useSettingsStore"
+import useGraphStore from "../../stores/useGraphStore"
+import useNodeResultsStore from "../../stores/useNodeResultsStore"
+
+vi.mock("../../api/client", () => ({
+  loadPipeline: vi.fn(),
+  previewNode: vi.fn(),
+  savePipeline: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number
+    detail?: string
+
+    constructor(message: string, status: number, detail?: string) {
+      super(message)
+      this.name = "ApiError"
+      this.status = status
+      this.detail = detail
+    }
+  },
+}))
+
+vi.mock("../../utils/buildGraph", () => ({
+  resolveGraphFromRefs: vi.fn(() => ({ nodes: [], edges: [], preamble: "" })),
+}))
+
+vi.mock("../../utils/makePreviewData", () => ({
+  makePreviewData: vi.fn((nodeId: string, label: string, opts: Record<string, unknown>) => ({
+    nodeId,
+    nodeLabel: label,
+    status: opts.status || "ok",
+    row_count: opts.row_count ?? 0,
+    column_count: opts.column_count ?? 0,
+    columns: opts.columns ?? [],
+    preview: opts.preview ?? [],
+    error: opts.error ?? null,
+    timing_ms: opts.timing_ms ?? 0,
+    memory_bytes: opts.memory_bytes ?? 0,
+    timings: opts.timings ?? [],
+    memory: opts.memory ?? [],
+    schema_warnings: opts.schema_warnings ?? [],
+  })),
+}))
+
+import { loadPipeline, previewNode } from "../../api/client"
+import { makeNode } from "../../test-utils/factories"
+const mockLoad = vi.mocked(loadPipeline)
+const mockPreview = vi.mocked(previewNode)
+
+type PreviewEnvelope = Awaited<ReturnType<typeof previewNode>>
+
+function makeParams(overrides: Partial<Parameters<typeof usePipelineAPI>[0]> = {}) {
+  return {
+    selectedNode: null as Node | null,
+    graphRef: { current: { nodes: [] as Node[], edges: [] as Edge[] } },
+    parentGraphRef: { current: null },
+    submodelsRef: { current: {} },
+    setNodes: vi.fn(),
+    setNodesRaw: vi.fn(),
+    setEdgesRaw: vi.fn(),
+    setPreamble: vi.fn(),
+    preambleRef: { current: "" },
+    pipelineNameRef: { current: "test" },
+    descriptionRef: { current: "" },
+    sourceFileRef: { current: "test.py" },
+    nodeIdCounter: { current: 0 },
+    ...overrides,
+  }
+}
+
+const okEnvelope: PreviewEnvelope = {
+  node_id: "browser_apply",
+  status: "ok",
+  columns: [
+    { name: "optimal_scenario_value", dtype: "f64" },
+    { name: "__optimiser_version__", dtype: "str" },
+  ],
+  preview: [
+    { optimal_scenario_value: 1.25, __optimiser_version__: "v1" },
+    { optimal_scenario_value: 2.5, __optimiser_version__: "v1" },
+  ],
+  row_count: 2,
+  column_count: 2,
+  node_statuses: { browser_apply: "ok" },
+}
+
+describe("usePipelineAPI — preview lifecycle terminal states (W0)", () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    useToastStore.setState({ toasts: [], _toastCounter: 0 })
+    useSettingsStore.setState({ rowLimit: 1000, activeSource: "live", sources: ["live"] })
+    useGraphStore.setState({
+      nodes: [],
+      edges: [],
+      preamble: "",
+      lastSavedSnapshot: null,
+      undoStack: [],
+      redoStack: [],
+      structuralVersion: 0,
+    })
+    useNodeResultsStore.setState({ previews: {}, columnCache: {} })
+    mockLoad.mockReset()
+    mockPreview.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it("renders a preview response that arrives after a mid-flight structuralVersion bump", async () => {
+    // Catches the W0 hang: the success envelope was dropped by
+    // `requestStillCurrent()` because OptimiserApplyEditor's artifact-load
+    // effect bumped structuralVersion while the request was in flight,
+    // stranding the panel on "Executing pipeline..." with no further
+    // requests and no error.
+    mockLoad.mockResolvedValue({ nodes: [], edges: [] })
+
+    let resolvePreview!: (value: PreviewEnvelope) => void
+    mockPreview.mockImplementation(() => new Promise((resolve) => {
+      resolvePreview = resolve
+    }))
+
+    const applyNode = makeNode("browser_apply", "optimiserApply")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [applyNode], edges: [] }
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { result.current.fetchPreview(applyNode, { debounceMs: 0 }) })
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1))
+    expect(result.current.previewData?.status).toBe("loading")
+
+    // Mid-flight: the apply editor mirrors artifact metadata into node
+    // config (onUpdate → setNodes), which bumps structuralVersion.
+    act(() => {
+      useGraphStore.setState((state) => ({
+        structuralVersion: state.structuralVersion + 1,
+      }))
+    })
+
+    await act(async () => {
+      resolvePreview(okEnvelope)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Terminal state: the response renders instead of stranding "loading".
+    expect(result.current.previewData?.status).toBe("ok")
+    expect(result.current.previewData?.nodeId).toBe("browser_apply")
+    expect(result.current.previewData?.row_count).toBe(2)
+    expect(result.current.previewData?.preview).toEqual(okEnvelope.preview)
+    expect(result.current.previewBusy).toBe(false)
+    // No silent retry: exactly the one request the click issued.
+    expect(mockPreview).toHaveBeenCalledTimes(1)
+
+    // Graph mutation stays version-gated: no column application or
+    // downstream cascade from a response computed against the old graph.
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(result.current.nodeStatuses).toEqual({})
+
+    // The result is cached under the fetch-time version, so the next
+    // preview sees a context mismatch and refetches in the background.
+    const cached = useNodeResultsStore.getState().getPreview("browser_apply")
+    expect(cached?.data.status).toBe("ok")
+    expect(cached?.structuralVersion).toBe(0)
+  })
+
+  it("surfaces a preview failure that arrives after a mid-flight structuralVersion bump", async () => {
+    // Same interleave as above but the backend fails: the panel must show
+    // the error, never an eternal "loading" with no error surfaced.
+    mockLoad.mockResolvedValue({ nodes: [], edges: [] })
+
+    let rejectPreview!: (reason: unknown) => void
+    mockPreview.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectPreview = reject
+    }))
+
+    const applyNode = makeNode("browser_apply", "optimiserApply")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [applyNode], edges: [] }
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { result.current.fetchPreview(applyNode, { debounceMs: 0 }) })
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      useGraphStore.setState((state) => ({
+        structuralVersion: state.structuralVersion + 1,
+      }))
+    })
+
+    await act(async () => {
+      rejectPreview(new Error("optimiser artifact not found"))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.previewData?.status).toBe("error")
+    expect(result.current.previewData?.error).toContain("optimiser artifact not found")
+    expect(result.current.previewBusy).toBe(false)
+  })
+
+  it("does not resurrect the panel or cache for a node deleted while its preview was in flight", async () => {
+    // handleDeleteNode clears previewData to null and removes the node;
+    // the late response must keep that terminal state (no panel for a
+    // node that no longer exists, no orphaned cache entry).
+    mockLoad.mockResolvedValue({ nodes: [], edges: [] })
+
+    let resolvePreview!: (value: PreviewEnvelope) => void
+    mockPreview.mockImplementation(() => new Promise((resolve) => {
+      resolvePreview = resolve
+    }))
+
+    const applyNode = makeNode("browser_apply", "optimiserApply")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [applyNode], edges: [] }
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { result.current.fetchPreview(applyNode, { debounceMs: 0 }) })
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledTimes(1))
+
+    // Delete the node mid-flight: panel cleared, node removed from the
+    // live graph, structuralVersion bumped.
+    params.graphRef.current = { nodes: [], edges: [] }
+    act(() => {
+      result.current.setPreviewData(null)
+      useGraphStore.setState((state) => ({
+        structuralVersion: state.structuralVersion + 1,
+      }))
+    })
+
+    await act(async () => {
+      resolvePreview(okEnvelope)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(result.current.previewData).toBeNull()
+    expect(useNodeResultsStore.getState().getPreview("browser_apply")).toBeNull()
+    expect(result.current.previewBusy).toBe(false)
+  })
+})

--- a/frontend/src/hooks/usePipelineAPI.ts
+++ b/frontend/src/hooks/usePipelineAPI.ts
@@ -427,8 +427,29 @@ export default function usePipelineAPI({
       signal: controller.signal,
     })
       .then((result) => {
-        if (!requestStillCurrent()) return
+        // Superseded by a newer preview request: that request owns the
+        // panel surface and will reach its own terminal state.
+        if (previewRequestSeq.current !== requestId) return
         const preview = resultToPreview(node.id, label, result)
+        if (!requestStillCurrent()) {
+          // The graph changed while this response was in flight (e.g. an
+          // editor mirrored artifact metadata into node config, bumping
+          // structuralVersion). Stale columns must not be written into the
+          // restructured graph, but the panel must still reach a terminal
+          // state — silently dropping the response would strand
+          // "Executing pipeline..." forever with no request in flight and
+          // no error surfaced. Paint only if the panel still shows this
+          // node: a node deleted mid-flight has already had its panel
+          // cleared by handleDeleteNode and must stay cleared.
+          setPreviewData((prev) => (prev?.nodeId === node.id ? preview : prev))
+          if (graphRef.current.nodes.some((n) => n.id === node.id)) {
+            // Tagged with the fetch-time structuralVersion, so the next
+            // preview sees a context mismatch and refetches in the
+            // background instead of trusting this entry.
+            storePreview(node.id, preview, structuralVersion, snapshotSource, snapshotRowLimit)
+          }
+          return
+        }
         setPreviewData(preview)
         // Cache the result for next time
         storePreview(node.id, preview, structuralVersion, snapshotSource, snapshotRowLimit)
@@ -447,10 +468,20 @@ export default function usePipelineAPI({
         }
       })
       .catch((err: unknown) => {
-        if (!requestStillCurrent()) return
+        // Superseded by a newer preview request: that request owns the
+        // panel surface.
+        if (previewRequestSeq.current !== requestId) return
         if (isAbortError(err) || isPreviewSupersededError(err)) return
         const detail = previewErrorDetail(err)
-        setPreviewData(makePreviewData(node.id, label, { status: "error", error: detail }))
+        const failure = makePreviewData(node.id, label, { status: "error", error: detail })
+        if (!requestStillCurrent()) {
+          // Same terminal-state requirement as the success path: a failure
+          // arriving after a mid-flight graph change must surface as an
+          // error, not strand the panel on "loading".
+          setPreviewData((prev) => (prev?.nodeId === node.id ? failure : prev))
+          return
+        }
+        setPreviewData(failure)
         setNodeStatuses({})
       })
       .finally(() => {

--- a/frontend/src/nodes/PipelineNode.tsx
+++ b/frontend/src/nodes/PipelineNode.tsx
@@ -110,9 +110,11 @@ function _SourceHandles({
   // Single source of truth for the port labels — shared with the body
   // label column and the edit-time edge reconciler so the canvas, the
   // editor, and edge validation can never disagree about which ports
-  // exist (see `utils/apiInputPorts`). The util already substitutes
-  // `port_<idx>` for blank labels and `__<idx>` for duplicates (the
-  // defence-in-depth S2 cases) and returns `[]` for the 0/1-emit case.
+  // exist (see `utils/apiInputPorts`). Handle ids are the RAW table
+  // labels (the id space the backend round-trips); blank/duplicate
+  // labels yield NO handle — never a synthesized `port_<idx>`/`__<idx>`
+  // id the executor could not resolve (W1.4). Returns `[]` for the
+  // 0/1-emit case.
   const labels = apiInputEmitPortLabels(config)
   if (labels.length === 0) {
     // Single-port fallback (one or zero emit:true tables, or no tables key):
@@ -219,8 +221,8 @@ function PipelineNode({ id, data: nodeData, selected }: NodeProps<PipelineFlowNo
   // Handles, (b) the body label list, and (c) the
   // `useUpdateNodeInternals` effect that nudges React Flow to re-measure
   // when the topology changes.  Logic mirrors `_SourceHandles`: only
-  // emit:true tables count; missing/blank labels fall back to
-  // `port_<idx>`; duplicates are disambiguated with `__<idx>` suffix.
+  // emit:true tables with a valid (non-blank, non-duplicate) label
+  // count — handle ids are raw labels, never synthesized (W1.4).
   const emitTableLabels = useMemo<string[]>(
     () => (isDeployInput ? apiInputEmitPortLabels(nodeData.config) : []),
     [isDeployInput, nodeData.config],

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useMemo, useState, type CSSProperties } from "react"
 import { Radio, Check, Plus, X } from "lucide-react"
 import { FileBrowser, SchemaPreview } from "./_shared"
 import type { OnUpdateConfig } from "./_shared"
@@ -483,9 +483,13 @@ export default function ApiInputEditor({
               </div>
             )}
             <div className="space-y-2">
+              {/* Positional keys, NOT `${table.path}-${ti}`: rows are only
+                  ever appended/removed (never reordered), and a key derived
+                  from the edited path remounted the row on every committed
+                  path change — dropping focus mid-edit (CODE_REVIEW W1.5). */}
               {v2.tables.map((table, ti) => (
                 <TableBlock
-                  key={`${table.path}-${ti}`}
+                  key={ti}
                   table={table}
                   testIdPrefix={`api-input-table-${ti}`}
                   onUpdate={(patch) => updateTable(ti, patch)}
@@ -565,11 +569,10 @@ function TableBlock({
             color: "var(--text)",
           }}
         />
-        <input
-          data-testid={`${testIdPrefix}-path`}
-          type="text"
+        <PathInput
+          dataTestId={`${testIdPrefix}-path`}
           value={table.path}
-          onChange={(e) => onUpdate({ path: e.target.value })}
+          onCommit={(path) => onUpdate({ path })}
           className="flex-1 text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
             background: "var(--bg)",
@@ -586,9 +589,12 @@ function TableBlock({
         </button>
       </div>
       <div className="pl-3 space-y-1">
+        {/* Positional keys for the same reason as the table rows above:
+            `${col.path}-${ci}` remounted the row (and lost focus) on every
+            committed path edit (CODE_REVIEW W1.5). */}
         {table.columns.map((col, ci) => (
           <ColumnRow
-            key={`${col.path}-${ci}`}
+            key={ci}
             col={col}
             testIdPrefix={`${testIdPrefix}-col-${ci}`}
             onUpdate={(patch) => onUpdateColumn(ci, patch)}
@@ -638,11 +644,10 @@ function ColumnRow({
         className="w-32 px-1 py-0.5 rounded font-mono"
         style={{ background: "var(--bg)", border: "1px solid var(--border)" }}
       />
-      <input
-        data-testid={`${testIdPrefix}-path`}
-        type="text"
+      <PathInput
+        dataTestId={`${testIdPrefix}-path`}
         value={col.path}
-        onChange={(e) => onUpdate({ path: e.target.value })}
+        onCommit={(path) => onUpdate({ path })}
         className="flex-1 px-1 py-0.5 rounded font-mono"
         style={{
           background: "var(--bg)",
@@ -667,5 +672,66 @@ function ColumnRow({
         <X size={10} style={{ color: "var(--text-muted)" }} />
       </button>
     </div>
+  )
+}
+
+// ─── PathInput ────────────────────────────────────────────────────
+//
+// CODE_REVIEW W1.5 — table/column path edits buffer locally and commit
+// on blur or Enter instead of writing to config per keystroke. The old
+// per-keystroke scheme had two coupled defects: (1) the row keys were
+// derived from the path, so each committed keystroke remounted the row
+// and the input lost focus; (2) every half-typed path reached the
+// config, churning structuralVersion downstream — and a transiently
+// empty path made readV2 drop the whole table. Label/name inputs never
+// appeared in a key and keep their original per-keystroke commits.
+
+function PathInput({
+  value,
+  onCommit,
+  dataTestId,
+  className,
+  style,
+}: {
+  /** The committed path from config — the source of truth when idle. */
+  value: string
+  /** Called once per commit boundary (blur / Enter) with the final value. */
+  onCommit: (path: string) => void
+  dataTestId: string
+  className: string
+  style: CSSProperties
+}) {
+  // Raw edit buffer; null = not editing, render the committed value.
+  const [draft, setDraft] = useState<string | null>(null)
+  // External committed-value changes win over a stale draft (React's
+  // adjust-state-on-render pattern). This matters because rows use
+  // positional keys: after removing the row above, this instance is
+  // adopted by the row that slides up, and the dead row's half-typed
+  // draft must never be shown for — or committed into — the survivor.
+  // Same for a confirmed re-infer replacing the tables wholesale.
+  const [lastValue, setLastValue] = useState(value)
+  if (lastValue !== value) {
+    setLastValue(value)
+    setDraft(null)
+  }
+  const commit = () => {
+    // Skip no-op commits: a draft equal to the committed value would
+    // only churn config/structuralVersion without changing anything.
+    if (draft !== null && draft !== value) onCommit(draft)
+    setDraft(null)
+  }
+  return (
+    <input
+      data-testid={dataTestId}
+      type="text"
+      value={draft ?? value}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commit()
+      }}
+      className={className}
+      style={style}
+    />
   )
 }

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -5,6 +5,10 @@ import type { OnUpdateConfig } from "./_shared"
 import { useSchemaFetch } from "../../hooks/useSchemaFetch"
 import { configField } from "../../utils/configField"
 import { withAlpha } from "../../utils/color"
+import {
+  apiInputLabelIssue,
+  apiInputLabelIssueMessage,
+} from "../../utils/apiInputPorts"
 import { CacheFetchButton } from "../../components/CacheFetchButton"
 import {
   buildJsonCache,
@@ -184,6 +188,19 @@ export default function ApiInputEditor({
     }
     writeBack(next)
   }
+  // W1.4 — label validation, mirroring the backend's save-time rules
+  // (`validate_v2_schema`): blank labels, duplicates, and sanitised-form
+  // collisions are hard-rejected there, and the label doubles as the
+  // React Flow handle id / runtime port name. An invalid label must be
+  // refused in the editor with a visible reason — committing it would
+  // create a port identity the backend can never emit.
+  const validateTableLabel = (i: number) => (candidate: string) =>
+    apiInputLabelIssueMessage(
+      apiInputLabelIssue(
+        candidate,
+        v2.tables.filter((_, idx) => idx !== i).map((t) => t.label),
+      ),
+    )
   const updateColumn = (
     tableIdx: number,
     colIdx: number,
@@ -492,6 +509,7 @@ export default function ApiInputEditor({
                   key={ti}
                   table={table}
                   testIdPrefix={`api-input-table-${ti}`}
+                  validateLabel={validateTableLabel(ti)}
                   onUpdate={(patch) => updateTable(ti, patch)}
                   onRemove={() => removeTable(ti)}
                   onAddColumn={() => addColumn(ti)}
@@ -524,6 +542,7 @@ export default function ApiInputEditor({
 function TableBlock({
   table,
   testIdPrefix,
+  validateLabel,
   onUpdate,
   onRemove,
   onAddColumn,
@@ -532,6 +551,7 @@ function TableBlock({
 }: {
   table: ApiInputTableV2
   testIdPrefix: string
+  validateLabel: (candidate: string) => string | null
   onUpdate: (patch: Partial<ApiInputTableV2>) => void
   onRemove: () => void
   onAddColumn: () => void
@@ -544,9 +564,9 @@ function TableBlock({
       className="px-2 py-2 rounded-md space-y-1.5"
       style={{ border: "1px solid var(--border)", background: "var(--bg-soft)" }}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         <label
-          className="flex items-center gap-1 text-[11px]"
+          className="flex items-center gap-1 text-[11px] pt-1"
           title="Emit this table as a data port"
         >
           <input
@@ -557,23 +577,32 @@ function TableBlock({
           />
           emit
         </label>
-        <input
-          data-testid={`${testIdPrefix}-label`}
-          type="text"
+        {/* W1.3/W1.4 — the label IS the port's handle id (raw, end to
+            end through codegen → save → parse). It commits atomically
+            on blur/Enter, and blank/duplicate/collision candidates are
+            refused with visible validation instead of ever reaching
+            config (where a per-keystroke commit used to destroy the
+            edges bound to a connected port). */}
+        <CommittedTextInput
+          dataTestId={`${testIdPrefix}-label`}
           value={table.label}
-          onChange={(e) => onUpdate({ label: e.target.value })}
-          className="flex-1 text-xs font-mono px-1.5 py-0.5 rounded"
+          onCommit={(label) => onUpdate({ label })}
+          validate={validateLabel}
+          containerClassName="flex-1 min-w-0"
+          className="w-full text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
             background: "var(--bg)",
             border: "1px solid var(--border)",
             color: "var(--text)",
           }}
         />
-        <PathInput
+        <CommittedTextInput
           dataTestId={`${testIdPrefix}-path`}
           value={table.path}
           onCommit={(path) => onUpdate({ path })}
-          className="flex-1 text-xs font-mono px-1.5 py-0.5 rounded"
+          validate={requireNonBlank("A path is required — clearing it would delete this table from the schema.")}
+          containerClassName="flex-1 min-w-0"
+          className="w-full text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
             background: "var(--bg)",
             border: "1px solid var(--border)",
@@ -584,6 +613,7 @@ function TableBlock({
           data-testid={`${testIdPrefix}-remove`}
           onClick={onRemove}
           title="Remove table"
+          className="pt-1"
         >
           <X size={12} style={{ color: "var(--text-muted)" }} />
         </button>
@@ -597,6 +627,12 @@ function TableBlock({
             key={ci}
             col={col}
             testIdPrefix={`${testIdPrefix}-col-${ci}`}
+            validateName={(candidate) =>
+              columnNameError(
+                candidate,
+                table.columns.filter((_, i) => i !== ci).map((c) => c.name),
+              )
+            }
             onUpdate={(patch) => onUpdateColumn(ci, patch)}
             onRemove={() => onRemoveColumn(ci)}
           />
@@ -617,38 +653,61 @@ function TableBlock({
 
 // ─── ColumnRow ────────────────────────────────────────────────────
 
+/**
+ * W1.9 — column-name validation, mirroring `validate_v2_schema`: blank
+ * names are rejected, and names must be unique WITHIN their table
+ * (`seen_col_names` resets per table — the same name in two different
+ * tables is legal, each table is its own frame). Refusing at the commit
+ * boundary also closes the readV2 silent-drop: a committed blank name
+ * deleted the column row instantly.
+ */
+function columnNameError(candidate: string, otherNames: readonly string[]): string | null {
+  if (!candidate.trim()) {
+    return "A name is required — clearing it would delete this column from the schema."
+  }
+  if (otherNames.includes(candidate)) {
+    return `Duplicate column name: "${candidate}" is already used in this table.`
+  }
+  return null
+}
+
 function ColumnRow({
   col,
   testIdPrefix,
+  validateName,
   onUpdate,
   onRemove,
 }: {
   col: ApiInputColumnV2
   testIdPrefix: string
+  validateName: (candidate: string) => string | null
   onUpdate: (patch: Partial<ApiInputColumnV2>) => void
   onRemove: () => void
 }) {
   return (
-    <div data-testid={testIdPrefix} className="flex items-center gap-2 text-[11px]">
+    <div data-testid={testIdPrefix} className="flex items-start gap-2 text-[11px]">
       <input
         data-testid={`${testIdPrefix}-selected`}
         type="checkbox"
         checked={col.selected}
         onChange={(e) => onUpdate({ selected: e.target.checked })}
       />
-      <input
-        data-testid={`${testIdPrefix}-name`}
-        type="text"
+      <CommittedTextInput
+        dataTestId={`${testIdPrefix}-name`}
         value={col.name}
-        onChange={(e) => onUpdate({ name: e.target.value })}
-        className="w-32 px-1 py-0.5 rounded font-mono"
+        onCommit={(name) => onUpdate({ name })}
+        validate={validateName}
+        containerClassName="w-32 shrink-0"
+        className="w-full px-1 py-0.5 rounded font-mono"
         style={{ background: "var(--bg)", border: "1px solid var(--border)" }}
       />
-      <PathInput
+      <CommittedTextInput
         dataTestId={`${testIdPrefix}-path`}
         value={col.path}
         onCommit={(path) => onUpdate({ path })}
-        className="flex-1 px-1 py-0.5 rounded font-mono"
+        validate={requireNonBlank("A path is required — clearing it would delete this column from the schema.")}
+        containerClassName="flex-1 min-w-0"
+        className="w-full px-1 py-0.5 rounded font-mono"
         style={{
           background: "var(--bg)",
           border: "1px solid var(--border)",
@@ -675,29 +734,51 @@ function ColumnRow({
   )
 }
 
-// ─── PathInput ────────────────────────────────────────────────────
+// ─── CommittedTextInput ───────────────────────────────────────────
 //
-// CODE_REVIEW W1.5 — table/column path edits buffer locally and commit
-// on blur or Enter instead of writing to config per keystroke. The old
-// per-keystroke scheme had two coupled defects: (1) the row keys were
-// derived from the path, so each committed keystroke remounted the row
-// and the input lost focus; (2) every half-typed path reached the
-// config, churning structuralVersion downstream — and a transiently
-// empty path made readV2 drop the whole table. Label/name inputs never
-// appeared in a key and keep their original per-keystroke commits.
+// CODE_REVIEW W1.5 (paths) + W1.3/W1.4 (labels) — schema-identity text
+// fields buffer locally and commit on blur or Enter instead of writing
+// to config per keystroke. The old per-keystroke scheme had coupled
+// defects: (1) row keys derived from the path remounted the row on
+// each committed keystroke and the input lost focus; (2) every
+// half-typed value reached the config, churning structuralVersion
+// downstream; (3) for LABELS — which double as React Flow handle ids /
+// backend port names — each keystroke was a live port-identity change
+// that destroyed the edges bound to a connected port; (4) a
+// transiently blank path/label silently destroyed config via readV2.
+//
+// `validate` closes (4) for deliberate edits too: an invalid candidate
+// (blank path; blank/duplicate/sanitised-colliding label; blank or
+// per-table-duplicate column name — W1.9) is REFUSED at the commit
+// boundary — the draft and a visible error stay in place so the user
+// can fix or revert, and nothing destructive ever reaches config. When
+// idle, the committed value itself is validated, so invalid states
+// arriving from disk or an infer-merge surface without any
+// interaction.
 
-function PathInput({
+/** Validator for fields where a blank value would destroy config. */
+function requireNonBlank(message: string): (candidate: string) => string | null {
+  return (candidate) => (candidate.trim() ? null : message)
+}
+
+function CommittedTextInput({
   value,
   onCommit,
+  validate,
   dataTestId,
+  containerClassName,
   className,
   style,
 }: {
-  /** The committed path from config — the source of truth when idle. */
+  /** The committed value from config — the source of truth when idle. */
   value: string
   /** Called once per commit boundary (blur / Enter) with the final value. */
-  onCommit: (path: string) => void
+  onCommit: (next: string) => void
+  /** User-facing error for an invalid candidate; null = valid. Invalid
+   * candidates are never committed. */
+  validate: (candidate: string) => string | null
   dataTestId: string
+  containerClassName: string
   className: string
   style: CSSProperties
 }) {
@@ -714,24 +795,47 @@ function PathInput({
     setLastValue(value)
     setDraft(null)
   }
+  const shown = draft ?? value
+  const error = validate(shown)
   const commit = () => {
+    if (draft === null) return
     // Skip no-op commits: a draft equal to the committed value would
     // only churn config/structuralVersion without changing anything.
-    if (draft !== null && draft !== value) onCommit(draft)
+    if (draft === value) {
+      setDraft(null)
+      return
+    }
+    // Refuse invalid commits — keep the draft and the visible error so
+    // the user sees exactly what was rejected and why. Failing loud at
+    // the editor beats a backend 422 at save or a KeyError at run.
+    if (validate(draft) !== null) return
+    onCommit(draft)
     setDraft(null)
   }
   return (
-    <input
-      data-testid={dataTestId}
-      type="text"
-      value={draft ?? value}
-      onChange={(e) => setDraft(e.target.value)}
-      onBlur={commit}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") commit()
-      }}
-      className={className}
-      style={style}
-    />
+    <div className={containerClassName}>
+      <input
+        data-testid={dataTestId}
+        type="text"
+        value={shown}
+        aria-invalid={error !== null ? true : undefined}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit()
+        }}
+        className={className}
+        style={error !== null ? { ...style, border: "1px solid var(--danger-border-strong)" } : style}
+      />
+      {error !== null && (
+        <div
+          data-testid={`${dataTestId}-error`}
+          className="mt-0.5 px-1.5 py-0.5 rounded text-[10px] leading-snug"
+          style={{ background: "var(--danger-soft)", color: "var(--danger-text)" }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/utils/__tests__/apiInputPorts.test.ts
+++ b/frontend/src/utils/__tests__/apiInputPorts.test.ts
@@ -4,17 +4,33 @@
  * `apiInputEmitPortLabels` is the single source of truth for the
  * right-edge port labels an apiInput node exposes (shared by
  * `PipelineNode`'s `_SourceHandles`, its body-label column, and the
- * edge reconciler). `reconcileApiInputEdges` prunes outgoing edges
- * whose `sourceHandle` no longer maps to a rendered port after the
- * user edits the node's emit/label/table set — Defect 1 (orphaned
- * edges on emit-off / rename / delete / single↔multi transitions).
+ * edge reconciler). Port identity is the RAW table label — exactly the
+ * string the backend keys runtime ports by (`_json_shred.shred_v2`),
+ * codegen emits as `connect(..., source_port=...)`, and the parser
+ * restores as `edge.sourceHandle`. The frontend therefore NEVER
+ * synthesizes handle ids (`port_<idx>` / `label__<idx>` are gone —
+ * CODE_REVIEW W1.4): a table whose label is blank or collides with an
+ * earlier one simply has no bindable port, and the editor surfaces the
+ * validation error instead.
+ *
+ * `reconcileApiInputEdges` prunes outgoing edges whose `sourceHandle`
+ * no longer maps to a rendered port. `migrateApiInputEdges` +
+ * `applyApiInputConfigChange` implement CODE_REVIEW W1.3: a committed
+ * label rename REBINDS the edges bound to the old handle in the same
+ * state update — rename is handle migration, never edge loss.
  */
 import { describe, expect, it } from "vitest"
 import {
   apiInputEmitPortLabels,
+  apiInputLabelIssue,
+  apiInputLabelIssueMessage,
+  applyApiInputConfigChange,
+  migrateApiInputEdges,
   reconcileApiInputEdges,
+  sanitiseLabelForFilesystem,
 } from "../apiInputPorts"
-import type { SimpleEdge } from "../../panels/editors/_shared"
+import { buildGraph } from "../buildGraph"
+import type { SimpleEdge, SimpleNode } from "../../panels/editors/_shared"
 
 // A table is a runtime port only if it is emit:true AND has >=1 selected
 // column (matches the backend `load_v2_api_source`), so the helper gives a
@@ -30,6 +46,9 @@ const table = (
   columns,
 })
 
+/** Same table, new label — the path stays put, exactly like a label commit. */
+const renamed = (t: Record<string, unknown>, label: string) => ({ ...t, label })
+
 describe("apiInputEmitPortLabels", () => {
   it("returns [] for a config without a tables key", () => {
     expect(apiInputEmitPortLabels({ path: "x.json" })).toEqual([])
@@ -42,14 +61,35 @@ describe("apiInputEmitPortLabels", () => {
     expect(labels).toEqual(["policies", "vehicles"])
   })
 
-  it("substitutes port_<idx> for missing / blank labels", () => {
+  // W1.4 — the backend keys ports by the raw label and hard-rejects blank
+  // labels (`validate_v2_schema`). A synthesized `port_<idx>` handle could
+  // therefore never resolve at runtime (executor KeyError). Blank-label
+  // tables get NO handle; the editor shows the validation error instead.
+  it("renders no port for a missing / blank label — never synthesizes port_<idx>", () => {
     const labels = apiInputEmitPortLabels({
       tables: [
         { path: "$[*]", emit: true, columns: [{ name: "c", selected: true }] },
         { path: "$[*].b", label: "   ", emit: true, columns: [{ name: "c", selected: true }] },
+        { path: "$[*].c", label: "vehicles", emit: true, columns: [{ name: "c", selected: true }] },
       ],
     })
-    expect(labels).toEqual(["port_0", "port_1"])
+    expect(labels).toEqual(["vehicles"])
+    expect(labels.some((l) => l.startsWith("port_"))).toBe(false)
+  })
+
+  it("falls back to the single default handle when every emit label is blank (nothing bindable is synthesized)", () => {
+    // This config is backend-invalid (validate_v2_schema rejects blank
+    // labels) and unreachable through the editor, which blocks blank
+    // commits; it can only arrive from a legacy disk file. We render the
+    // legacy default handle rather than invent port ids the executor
+    // could never resolve.
+    const labels = apiInputEmitPortLabels({
+      tables: [
+        { path: "$[*]", emit: true, columns: [{ name: "c", selected: true }] },
+        { path: "$[*].b", label: "", emit: true, columns: [{ name: "c", selected: true }] },
+      ],
+    })
+    expect(labels).toEqual([])
   })
 
   it("excludes an emit:true table with no selected columns (matches backend runtime)", () => {
@@ -72,11 +112,88 @@ describe("apiInputEmitPortLabels", () => {
     expect(labels).toEqual([])
   })
 
-  it("disambiguates duplicate labels with a __<idx> suffix", () => {
+  // W1.4 — duplicate labels are rejected by the backend on save, and the
+  // runtime keys ports by raw label, so a synthesized `dup__1` handle
+  // could never exist server-side. Only the first occurrence is a port.
+  it("gives duplicate labels a single port (first occurrence) — never synthesizes __<idx>", () => {
     const labels = apiInputEmitPortLabels({
       tables: [table("dup", true), table("dup", true)],
     })
-    expect(labels).toEqual(["dup", "dup__1"])
+    expect(labels).toEqual(["dup"])
+  })
+})
+
+describe("sanitiseLabelForFilesystem", () => {
+  // Mirrors `haute._api_input_schema.sanitise_label_for_filesystem` so the
+  // editor can pre-empt the backend's B2 (sanitised collision) rejection.
+  it("keeps letters, digits, underscore, hyphen; replaces everything else with _", () => {
+    expect(sanitiseLabelForFilesystem("drivers")).toBe("drivers")
+    expect(sanitiseLabelForFilesystem("Driv-er_9")).toBe("Driv-er_9")
+    expect(sanitiseLabelForFilesystem("a.b c/d")).toBe("a_b_c_d")
+  })
+
+  it("maps the empty label to _unnamed (backend parity)", () => {
+    expect(sanitiseLabelForFilesystem("")).toBe("_unnamed")
+  })
+
+  it("replaces an astral character with ONE underscore (code-point parity with Python)", () => {
+    // Python's regex sees "😀" as one code point → one "_". Without the
+    // `u` flag, JS would see two UTF-16 surrogate units → "x__", and the
+    // editor's collision verdicts would diverge from the backend's B2.
+    expect(sanitiseLabelForFilesystem("x😀")).toBe("x_")
+    // Consequence: "x😀" and "x🎉" DO collide (both sanitise to "x_"),
+    // exactly as the backend reports.
+    expect(apiInputLabelIssue("x😀", ["x🎉"])).toEqual({
+      kind: "sanitised-collision",
+      other: "x🎉",
+      sanitised: "x_",
+    })
+  })
+})
+
+describe("apiInputLabelIssue", () => {
+  it("accepts a unique non-blank label", () => {
+    expect(apiInputLabelIssue("vehicles", ["policies", "drivers"])).toBeNull()
+  })
+
+  it("rejects blank and whitespace-only labels", () => {
+    expect(apiInputLabelIssue("", ["policies"])).toEqual({ kind: "blank" })
+    expect(apiInputLabelIssue("   ", ["policies"])).toEqual({ kind: "blank" })
+  })
+
+  it("rejects an exact duplicate of another table's label", () => {
+    expect(apiInputLabelIssue("drivers", ["policies", "drivers"])).toEqual({
+      kind: "duplicate",
+      other: "drivers",
+    })
+  })
+
+  it("rejects a label whose sanitised form collides with another table's (backend B2)", () => {
+    // "driver.stats" and "driver_stats" both sanitise to "driver_stats":
+    // the backend rejects this pair at save (both would write the same
+    // parquet file), so the editor must surface it before commit.
+    expect(apiInputLabelIssue("driver.stats", ["driver_stats"])).toEqual({
+      kind: "sanitised-collision",
+      other: "driver_stats",
+      sanitised: "driver_stats",
+    })
+  })
+
+  it("is case-sensitive (backend labels are exact strings)", () => {
+    expect(apiInputLabelIssue("Drivers", ["drivers"])).toBeNull()
+  })
+
+  it("produces a user-facing message per issue kind, and null for none", () => {
+    expect(apiInputLabelIssueMessage(null)).toBeNull()
+    expect(apiInputLabelIssueMessage({ kind: "blank" })).toMatch(/required/i)
+    expect(apiInputLabelIssueMessage({ kind: "duplicate", other: "drivers" })).toMatch(/drivers/)
+    expect(
+      apiInputLabelIssueMessage({
+        kind: "sanitised-collision",
+        other: "driver_stats",
+        sanitised: "driver_stats",
+      }),
+    ).toMatch(/driver_stats/)
   })
 })
 
@@ -115,21 +232,7 @@ describe("reconcileApiInputEdges", () => {
     expect(result.removed[0].sourceHandle).toBe("drivers")
   })
 
-  it("removes the edge bound to a renamed port label", () => {
-    // 'policies' renamed to 'quotes'; the second emit table keeps the
-    // node multi-port. Edge still points at the stale 'policies'.
-    const staleEdge = outgoing("policies")
-    const liveEdge = outgoing("drivers")
-    const result = reconcileApiInputEdges({
-      nodeId: "api_1",
-      config: { tables: [table("quotes", true), table("drivers", true)] },
-      edges: [staleEdge, liveEdge],
-    })
-    expect(result.edges).toEqual([liveEdge])
-    expect(result.removed.map((r) => r.edge)).toEqual([staleEdge])
-  })
-
-  it("removes the edge bound to a deleted emit table", () => {
+  it("removes the edge bound to a stale label when its table no longer exists", () => {
     const goneEdge = outgoing("vehicles")
     const liveEdge = outgoing("policies")
     const result = reconcileApiInputEdges({
@@ -156,6 +259,11 @@ describe("reconcileApiInputEdges", () => {
   })
 
   it("ignores edges that do not originate from the node", () => {
+    // Tracker item 9.3: this test previously asserted
+    // `expect(result.edges).toBe(result.edges)` — a tautology. The real
+    // contract it pretended to cover: when no outgoing edge of the node
+    // is orphaned, the INPUT array reference is returned untouched and
+    // foreign edges are never inspected, pruned, or copied.
     const otherEdge: SimpleEdge = {
       id: "e_other",
       source: "other_node",
@@ -163,14 +271,15 @@ describe("reconcileApiInputEdges", () => {
       sourceHandle: "whatever",
       targetHandle: null,
     }
+    const edges = [otherEdge]
     const result = reconcileApiInputEdges({
       nodeId: "api_1",
       config: { tables: [table("policies", true), table("drivers", true)] },
-      edges: [otherEdge],
+      edges,
     })
     expect(result.removed).toEqual([])
-    expect(result.edges).toBe(result.edges)
-    expect(result.edges).toEqual([otherEdge])
+    expect(result.edges).toBe(edges)
+    expect(result.edges[0]).toBe(otherEdge)
   })
 
   it("returns the SAME edges array reference when nothing is orphaned (no churn)", () => {
@@ -182,5 +291,291 @@ describe("reconcileApiInputEdges", () => {
     })
     expect(result.removed).toEqual([])
     expect(result.edges).toBe(edges)
+  })
+})
+
+// ─── W1.3 — rename is migration, never loss ─────────────────────────
+
+const edgeFrom = (
+  source: string,
+  sourceHandle: string | null,
+  id = `e_${source}_${sourceHandle}`,
+): SimpleEdge => ({
+  id,
+  source,
+  target: "polars_2",
+  sourceHandle,
+  targetHandle: null,
+})
+
+describe("migrateApiInputEdges", () => {
+  const prev = { tables: [table("policies", true), table("drivers", true)] }
+
+  it("rebinds outgoing edges from the old label to the new one on an index-stable rename", () => {
+    const next = {
+      tables: [renamed(table("policies", true), "quotes"), table("drivers", true)],
+    }
+    const policiesEdge = edgeFrom("api_1", "policies")
+    const driversEdge = edgeFrom("api_1", "drivers")
+    const { edges, rebound } = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [policiesEdge, driversEdge],
+    })
+    expect(rebound).toEqual([{ edge: policiesEdge, from: "policies", to: "quotes" }])
+    expect(edges.map((e) => e.sourceHandle)).toEqual(["quotes", "drivers"])
+    // The untouched edge keeps its object identity.
+    expect(edges[1]).toBe(driversEdge)
+  })
+
+  it("returns the same edges reference when no port was renamed", () => {
+    const edges = [edgeFrom("api_1", "policies")]
+    const result = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: prev,
+      edges,
+    })
+    expect(result.rebound).toEqual([])
+    expect(result.edges).toBe(edges)
+  })
+
+  it("never touches edges from other nodes, even if their handle matches the old label", () => {
+    const next = {
+      tables: [renamed(table("policies", true), "quotes"), table("drivers", true)],
+    }
+    const foreign = edgeFrom("other_node", "policies")
+    const { edges, rebound } = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [foreign],
+    })
+    expect(rebound).toEqual([])
+    expect(edges).toEqual([foreign])
+  })
+
+  it("does not infer renames across table add/remove (length change → no index identity)", () => {
+    const next = { tables: [renamed(table("policies", true), "quotes")] }
+    const policiesEdge = edgeFrom("api_1", "policies")
+    const { rebound } = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [policiesEdge],
+    })
+    expect(rebound).toEqual([])
+  })
+
+  it("does not infer a rename when the table's path changed too (replaced, not renamed)", () => {
+    const next = {
+      tables: [
+        { ...table("policies", true), path: "$[*].swapped[*]", label: "quotes" },
+        table("drivers", true),
+      ],
+    }
+    const { rebound } = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [edgeFrom("api_1", "policies")],
+    })
+    expect(rebound).toEqual([])
+  })
+
+  it("never rebinds onto a colliding handle (new label duplicates another port)", () => {
+    // "policies" renamed to "drivers" — which the second table already
+    // owns. The editor blocks this commit, but the migration must stay
+    // conservative if such a config ever arrives: no rebinding to an
+    // ambiguous handle. (The reconciler then prunes the stale edge with
+    // a visible toast.)
+    const next = {
+      tables: [renamed(table("policies", true), "drivers"), table("drivers", true)],
+    }
+    const { rebound } = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [edgeFrom("api_1", "policies")],
+    })
+    expect(rebound).toEqual([])
+  })
+
+  it("ignores single-port nodes (edges are bound to the null default handle, not labels)", () => {
+    const singlePrev = { tables: [table("policies", true)] }
+    const singleNext = { tables: [renamed(table("policies", true), "quotes")] }
+    const nullEdge = edgeFrom("api_1", null)
+    const inputEdges = [nullEdge]
+    const result = migrateApiInputEdges({
+      nodeId: "api_1",
+      prevConfig: singlePrev,
+      nextConfig: singleNext,
+      edges: inputEdges,
+    })
+    expect(result.rebound).toEqual([])
+    // The INPUT array reference comes back untouched — no copy, no churn.
+    expect(result.edges).toBe(inputEdges)
+    expect(result.edges[0]).toBe(nullEdge)
+  })
+
+  // ── Duplicate-label ownership guards ──────────────────────────────
+  //
+  // With duplicate labels (pre-existing-invalid configs: the editor
+  // blocks new ones, the backend rejects them on save), only the FIRST
+  // eligible occurrence owns the port — and therefore the bound edges.
+  // The migration must never move edges on behalf of a non-owner, and
+  // must decline entirely when the old label still resolves afterwards.
+
+  it("renaming a LATER duplicate (non-owner) never migrates the owner's edges", () => {
+    // Tables: [dup, dup, drivers] — index 0 owns port "dup". The user
+    // renames index 1 (whose label was never a bindable port).
+    const dupPrev = {
+      tables: [
+        { ...table("dup", true), path: "$[*].a[*]" },
+        { ...table("dup", true), path: "$[*].b[*]" },
+        table("drivers", true),
+      ],
+    }
+    const dupNext = {
+      tables: [
+        { ...table("dup", true), path: "$[*].a[*]" },
+        { ...table("dup", true), path: "$[*].b[*]", label: "fresh" },
+        table("drivers", true),
+      ],
+    }
+    const dupEdge = edgeFrom("api_1", "dup")
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: dupPrev,
+      nextConfig: dupNext,
+      edges: [dupEdge],
+    })
+    // No rebind (index 1 was not the owner of "dup")…
+    expect(result.rebound).toEqual([])
+    // …and the owner's edge still resolves — untouched, not pruned.
+    expect(result.removed).toEqual([])
+    expect(result.edges[0]).toBe(dupEdge)
+  })
+
+  it("renaming the OWNER while a later duplicate survives declines to rebind (old label still resolves)", () => {
+    // Tables: [dup, dup, drivers] — renaming index 0 to "fresh" leaves
+    // "dup" alive as a port (now owned by index 1). Rebinding would
+    // silently move the edge between two different tables; the
+    // migration declines, and the edge keeps resolving against the
+    // surviving "dup" port (so nothing is pruned either).
+    const dupPrev = {
+      tables: [
+        { ...table("dup", true), path: "$[*].a[*]" },
+        { ...table("dup", true), path: "$[*].b[*]" },
+        table("drivers", true),
+      ],
+    }
+    const dupNext = {
+      tables: [
+        { ...table("dup", true), path: "$[*].a[*]", label: "fresh" },
+        { ...table("dup", true), path: "$[*].b[*]" },
+        table("drivers", true),
+      ],
+    }
+    const dupEdge = edgeFrom("api_1", "dup")
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: dupPrev,
+      nextConfig: dupNext,
+      edges: [dupEdge],
+    })
+    expect(result.rebound).toEqual([])
+    expect(result.removed).toEqual([])
+    expect(result.edges[0]).toBe(dupEdge)
+  })
+})
+
+describe("applyApiInputConfigChange", () => {
+  const prev = { tables: [table("policies", true), table("drivers", true)] }
+
+  it("W1.3: a committed rename of a CONNECTED port keeps its edges, rebound to the new handle", () => {
+    const next = {
+      tables: [renamed(table("policies", true), "quotes"), table("drivers", true)],
+    }
+    const policiesEdge = edgeFrom("api_1", "policies")
+    const driversEdge = edgeFrom("api_1", "drivers")
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [policiesEdge, driversEdge],
+    })
+    // NOTHING is removed — rename is migration, not loss.
+    expect(result.removed).toEqual([])
+    expect(result.rebound).toEqual([{ edge: policiesEdge, from: "policies", to: "quotes" }])
+    expect(result.edges.map((e) => e.sourceHandle).sort()).toEqual(["drivers", "quotes"])
+  })
+
+  it("still prunes genuinely orphaned edges (emit toggled off) with the rename machinery in place", () => {
+    const next = { tables: [table("policies", true), table("drivers", false)] }
+    const driversEdge = edgeFrom("api_1", "drivers")
+    const keptNull = edgeFrom("api_1", null, "e_null")
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: next,
+      edges: [driversEdge, keptNull],
+    })
+    expect(result.rebound).toEqual([])
+    expect(result.removed.map((r) => r.edge)).toEqual([driversEdge])
+    // Back to single-port: the null default edge is the only valid one.
+    expect(result.edges).toEqual([keptNull])
+  })
+
+  it("returns the input edges reference untouched when nothing changed", () => {
+    const edges = [edgeFrom("api_1", "policies")]
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: prev,
+      nextConfig: prev,
+      edges,
+    })
+    expect(result.rebound).toEqual([])
+    expect(result.removed).toEqual([])
+    expect(result.edges).toBe(edges)
+  })
+
+  it("round-trip identity: parser-reloaded edges (sourceHandle == raw label) rebind 1:1 to rendered handles", () => {
+    // Save side: codegen emits `connect(..., source_port=edge.sourceHandle)`
+    // verbatim (src/haute/codegen.py). Load side: the parser restores
+    // `sourceHandle = source_port` (src/haute/_graph_builders.py). So a
+    // reloaded graph carries edges whose sourceHandle is the raw table
+    // label — and the frontend must render handles in EXACTLY that space.
+    const config = { tables: [table("policies", true), table("drivers", true)] }
+    const labels = apiInputEmitPortLabels(config)
+    // Raw labels, no transformation of any kind.
+    expect(labels).toEqual(["policies", "drivers"])
+
+    const reloaded = labels.map((label, i) =>
+      edgeFrom("api_1", label, `e_reloaded_${i}`),
+    )
+    // buildGraph forwards edges verbatim to the backend payload — the
+    // frontend never rewrites handles on save.
+    const nodes: SimpleNode[] = [
+      {
+        id: "api_1",
+        type: "apiInput",
+        data: { label: "quotes", description: "", nodeType: "apiInput", config },
+      },
+    ]
+    expect(buildGraph(nodes, reloaded).edges).toBe(reloaded)
+
+    // And reconciliation against the same config keeps every reloaded
+    // edge byte-identical: save → reload is a fixed point.
+    const result = applyApiInputConfigChange({
+      nodeId: "api_1",
+      prevConfig: config,
+      nextConfig: config,
+      edges: reloaded,
+    })
+    expect(result.edges).toBe(reloaded)
+    expect(result.rebound).toEqual([])
+    expect(result.removed).toEqual([])
   })
 })

--- a/frontend/src/utils/apiInputPorts.ts
+++ b/frontend/src/utils/apiInputPorts.ts
@@ -6,23 +6,34 @@
  * node's right edge (see `PipelineNode._SourceHandles`). Downstream
  * edges bind to a port via `edge.sourceHandle` = the table's label.
  *
- * This module is the single source of truth for two derived facts:
+ * ── Port identity contract (W1.3 / W1.4) ───────────────────────────
  *
- *  1. `apiInputEmitPortLabels` — the ordered list of port labels the
- *     node exposes. Mirrors the Handle-rendering rules exactly (only
- *     emit:true tables; `port_<idx>` for blank/missing labels;
- *     `__<idx>` to disambiguate duplicates). `PipelineNode` consumes
- *     it for both the Handles and the body label column, so the editor
- *     and the canvas can never disagree about which ports exist.
+ * The handle id IS the raw table label, end to end:
  *
- *  2. `reconcileApiInputEdges` — given the node's *new* config, finds
- *     outgoing edges whose `sourceHandle` no longer maps to a rendered
- *     port and returns the pruned edge list plus a description of what
- *     was removed. This is the load-bearing fix for Defect 1: emit-off,
- *     table-rename, table-delete, and the single↔multi-port handle
- *     transition all silently orphaned edges before. Pruning at edit
- *     time (with a visible toast at the call site) replaces the
- *     previous failure mode — a backend `KeyError` at execution.
+ *  - runtime ports are keyed by raw label (`_json_shred.shred_v2`);
+ *  - the executor resolves `edge.sourceHandle` against those keys and
+ *    KeyErrors on a miss (`_execute_lazy._resolve_source_frame`);
+ *  - codegen saves the handle verbatim as
+ *    `pipeline.connect(..., source_port=<sourceHandle>)`;
+ *  - the parser restores `sourceHandle = source_port` on reload.
+ *
+ * Two consequences this module enforces:
+ *
+ *  1. The frontend NEVER synthesizes handle ids. Blank labels used to
+ *     fall back to `port_<idx>` and duplicates to `label__<idx>` —
+ *     handles the backend can never emit (it hard-rejects blank and
+ *     duplicate labels in `validate_v2_schema`), so edges bound to them
+ *     were guaranteed executor KeyErrors. A table with an invalid label
+ *     now has NO port; the editor surfaces the validation error
+ *     (`apiInputLabelIssue`) instead of papering over it.
+ *
+ *  2. Renaming a port is handle MIGRATION, never edge loss. Because the
+ *     label is the handle id, a committed rename changes the id — so
+ *     the same state update that commits the rename must rebind the
+ *     edges bound to the old id (`migrateApiInputEdges`). Only edges
+ *     whose port genuinely no longer exists are pruned
+ *     (`reconcileApiInputEdges`), with a visible toast at the call
+ *     site. `applyApiInputConfigChange` composes the two.
  */
 import type { SimpleEdge } from "../panels/editors/_shared"
 
@@ -54,6 +65,17 @@ function emitTables(config: ConfigLike): Array<Record<string, unknown>> {
   )
 }
 
+/** The exact label string of a table, or null when missing/non-string. */
+function rawLabel(table: Record<string, unknown>): string | null {
+  const raw = (table as { label?: unknown }).label
+  return typeof raw === "string" ? raw : null
+}
+
+/** A label can be a port name iff it is a non-blank string (backend floor). */
+function isPortableLabel(label: string | null): label is string {
+  return typeof label === "string" && label.trim().length > 0
+}
+
 /**
  * Ordered list of port labels an apiInput exposes.
  *
@@ -61,24 +83,102 @@ function emitTables(config: ConfigLike): Array<Record<string, unknown>> {
  * (`_json_shred.load_v2_api_source`) so the rendered Handle ids, this
  * list, and the executor's emitted ports are always identical:
  *  - a table counts only if `emit: true` AND it has ≥1 selected column;
- *  - a missing / non-string / blank label falls back to `port_<idx>`;
- *  - a label that collides with an earlier one is suffixed `__<idx>`.
+ *  - the port id is the table's RAW label — never a synthesized stand-in;
+ *  - a missing / non-string / blank label yields NO port (the backend
+ *    rejects such configs on save; the editor shows the error);
+ *  - a label duplicating an earlier port yields NO port for the later
+ *    table (only the first occurrence is bindable).
  *
  * Returns `[]` for configs with zero or one emit:true table — those
  * render the single default Handle (id `null`), which has no label.
+ * (A multi-emit config whose labels are ALL invalid also returns `[]`
+ * and falls back to the default Handle: it is backend-invalid and
+ * unreachable through the editor, and we refuse to invent bindable
+ * port ids for it.)
  */
 export function apiInputEmitPortLabels(config: ConfigLike): string[] {
   const emit = emitTables(config)
   if (emit.length < 2) return []
   const seen = new Set<string>()
-  return emit.map((t, idx) => {
-    const raw = (t as { label?: unknown }).label
-    const candidate = typeof raw === "string" && raw.trim() ? raw : `port_${idx}`
-    const label = seen.has(candidate) ? `${candidate}__${idx}` : candidate
+  const labels: string[] = []
+  for (const t of emit) {
+    const label = rawLabel(t)
+    if (!isPortableLabel(label)) continue
+    if (seen.has(label)) continue
     seen.add(label)
-    return label
-  })
+    labels.push(label)
+  }
+  return labels
 }
+
+// ─── Label validation (mirrors backend `validate_v2_schema`) ─────────
+
+// Filesystem-safe label form — exact mirror of
+// `haute._api_input_schema._FILESYSTEM_SAFE_RE`. The backend derives
+// each port's parquet filename from the sanitised label and rejects
+// (B2) any two labels whose sanitised forms collide. The `u` flag is
+// load-bearing for parity: Python regexes operate on code points, and
+// without it JavaScript matches UTF-16 units — an astral char (e.g. an
+// emoji) would become TWO underscores here but ONE on the backend,
+// silently desynchronising the collision check.
+const FILESYSTEM_SAFE_RE = /[^a-zA-Z0-9_-]/gu
+
+/**
+ * Map a table label to its filesystem-safe parquet-filename stem,
+ * byte-for-byte like `haute._api_input_schema.sanitise_label_for_filesystem`.
+ */
+export function sanitiseLabelForFilesystem(label: string): string {
+  if (!label) return "_unnamed"
+  return label.replace(FILESYSTEM_SAFE_RE, "_")
+}
+
+export type ApiInputLabelIssue =
+  | { kind: "blank" }
+  | { kind: "duplicate"; other: string }
+  | { kind: "sanitised-collision"; other: string; sanitised: string }
+
+/**
+ * Validate a candidate table label against the labels of the node's
+ * OTHER tables. Mirrors the backend's save-time rules
+ * (`validate_v2_schema`): blank labels, exact duplicates, and
+ * sanitised-form collisions (B2) are all rejected there with a 422 —
+ * the editor must surface the same verdict before commit, because a
+ * committed invalid label would otherwise only fail at save/run time.
+ *
+ * The blank check uses `trim()` (slightly stricter than the backend's
+ * non-empty floor): a whitespace-only port name is never intentional.
+ */
+export function apiInputLabelIssue(
+  candidate: string,
+  otherLabels: readonly string[],
+): ApiInputLabelIssue | null {
+  if (!candidate.trim()) return { kind: "blank" }
+  for (const other of otherLabels) {
+    if (other === candidate) return { kind: "duplicate", other }
+  }
+  const sanitised = sanitiseLabelForFilesystem(candidate)
+  for (const other of otherLabels) {
+    if (sanitiseLabelForFilesystem(other) === sanitised) {
+      return { kind: "sanitised-collision", other, sanitised }
+    }
+  }
+  return null
+}
+
+/** User-facing message for a label issue; null passes through. */
+export function apiInputLabelIssueMessage(issue: ApiInputLabelIssue | null): string | null {
+  if (issue === null) return null
+  switch (issue.kind) {
+    case "blank":
+      return "A label is required — it names this table's port."
+    case "duplicate":
+      return `Duplicate label: "${issue.other}" is already used by another table.`
+    case "sanitised-collision":
+      return `Label collides with "${issue.other}": both become "${issue.sanitised}" on disk.`
+  }
+}
+
+// ─── Edge reconciliation ─────────────────────────────────────────────
 
 /**
  * The set of `sourceHandle` values an apiInput's outgoing edges may
@@ -121,6 +221,10 @@ export type ReconcileApiInputEdgesResult<E extends SimpleEdge> = {
  * removal to the user (a toast naming what was disconnected) — pruning
  * silently would just trade one invisible failure for another.
  *
+ * NOTE: renames must be migrated BEFORE pruning (see
+ * `migrateApiInputEdges` / `applyApiInputConfigChange`) — this function
+ * alone cannot distinguish "port renamed" from "port deleted".
+ *
  * Returns the original `edges` array reference untouched when nothing
  * is orphaned, so callers can cheaply skip a state update.
  */
@@ -152,4 +256,168 @@ export function reconcileApiInputEdges<E extends SimpleEdge>({
   // can short-circuit a re-render / snapshot.
   if (removed.length === 0) return { edges, removed }
   return { edges: kept, removed }
+}
+
+// ─── Rename migration (W1.3) ─────────────────────────────────────────
+
+/** The raw tables array of a config (no filtering — index alignment matters). */
+function rawTables(config: ConfigLike): unknown[] {
+  const tables = (config as { tables?: unknown } | null | undefined)?.tables
+  return Array.isArray(tables) ? tables : []
+}
+
+function tableAt(tables: unknown[], i: number): Record<string, unknown> | null {
+  const t = tables[i]
+  return t && typeof t === "object" ? (t as Record<string, unknown>) : null
+}
+
+/**
+ * Which table index OWNS each port label under `config` — the first
+ * emit-eligible table carrying that label (later duplicates are not
+ * ports, matching `apiInputEmitPortLabels`). Also counts eligible
+ * tables per label so collisions can be detected.
+ */
+function portOwnership(config: ConfigLike): {
+  ownerIndexByLabel: Map<string, number>
+  eligibleCountByLabel: Map<string, number>
+} {
+  const tables = rawTables(config)
+  const eligible = new Set(emitTables(config))
+  const ownerIndexByLabel = new Map<string, number>()
+  const eligibleCountByLabel = new Map<string, number>()
+  tables.forEach((t, i) => {
+    if (!t || typeof t !== "object" || !eligible.has(t as Record<string, unknown>)) return
+    const label = rawLabel(t as Record<string, unknown>)
+    if (!isPortableLabel(label)) return
+    if (!ownerIndexByLabel.has(label)) ownerIndexByLabel.set(label, i)
+    eligibleCountByLabel.set(label, (eligibleCountByLabel.get(label) ?? 0) + 1)
+  })
+  return { ownerIndexByLabel, eligibleCountByLabel }
+}
+
+export type ReboundApiInputEdge<E extends SimpleEdge> = {
+  /** The ORIGINAL edge object (pre-rebind). */
+  edge: E
+  from: string
+  to: string
+}
+
+export type MigrateApiInputEdgesResult<E extends SimpleEdge> = {
+  /** Edges with renamed handles rebound. Same reference as the input when nothing changed. */
+  edges: E[]
+  rebound: ReboundApiInputEdge<E>[]
+}
+
+/**
+ * Rebind outgoing edges of `nodeId` across a port RENAME — the W1.3
+ * fix. Because the handle id is the label itself (the only id space
+ * that round-trips through codegen/parse), committing a rename changes
+ * the id; without migration the edges bound to the old id are
+ * indistinguishable from edges to a deleted port and get pruned.
+ *
+ * A rename is recognised conservatively — every guard must hold:
+ *  - prev/next have the SAME number of tables (the editor never
+ *    reorders rows; add/remove changes the length and is not a rename);
+ *  - at index i the `path` is unchanged but the label differs (a
+ *    replaced table — different path — is not a rename);
+ *  - the old label was the port OWNED by table i under prev (a later
+ *    duplicate never owned the bound edges);
+ *  - the old label no longer names ANY port under next (otherwise
+ *    rebinding would hijack edges that still resolve);
+ *  - the new label is owned by table i under next and is UNIQUE there
+ *    (never rebind onto a colliding handle).
+ *
+ * Pure; returns the input `edges` reference when nothing was rebound.
+ */
+export function migrateApiInputEdges<E extends SimpleEdge>({
+  nodeId,
+  prevConfig,
+  nextConfig,
+  edges,
+}: {
+  nodeId: string
+  prevConfig: ConfigLike
+  nextConfig: ConfigLike
+  edges: E[]
+}): MigrateApiInputEdgesResult<E> {
+  const prevTables = rawTables(prevConfig)
+  const nextTables = rawTables(nextConfig)
+  if (prevTables.length === 0 || prevTables.length !== nextTables.length) {
+    return { edges, rebound: [] }
+  }
+
+  const prevOwnership = portOwnership(prevConfig)
+  const nextOwnership = portOwnership(nextConfig)
+
+  const renameByOldLabel = new Map<string, string>()
+  for (let i = 0; i < prevTables.length; i++) {
+    const prevTable = tableAt(prevTables, i)
+    const nextTable = tableAt(nextTables, i)
+    if (!prevTable || !nextTable) continue
+    const prevLabel = rawLabel(prevTable)
+    const nextLabel = rawLabel(nextTable)
+    if (!isPortableLabel(prevLabel) || !isPortableLabel(nextLabel)) continue
+    if (prevLabel === nextLabel) continue
+    // Same table identity: the iteration path must be unchanged.
+    const prevPath = (prevTable as { path?: unknown }).path
+    const nextPath = (nextTable as { path?: unknown }).path
+    if (typeof prevPath !== "string" || prevPath !== nextPath) continue
+    // The old label must have been THIS table's port…
+    if (prevOwnership.ownerIndexByLabel.get(prevLabel) !== i) continue
+    // …and must be gone from the new port set (otherwise ambiguous).
+    if (nextOwnership.ownerIndexByLabel.has(prevLabel)) continue
+    // The new label must be this table's port and collision-free.
+    if (nextOwnership.ownerIndexByLabel.get(nextLabel) !== i) continue
+    if (nextOwnership.eligibleCountByLabel.get(nextLabel) !== 1) continue
+    renameByOldLabel.set(prevLabel, nextLabel)
+  }
+  if (renameByOldLabel.size === 0) return { edges, rebound: [] }
+
+  const rebound: ReboundApiInputEdge<E>[] = []
+  const next = edges.map((edge) => {
+    if (edge.source !== nodeId) return edge
+    const handle = edge.sourceHandle
+    if (typeof handle !== "string") return edge
+    const to = renameByOldLabel.get(handle)
+    if (to === undefined) return edge
+    rebound.push({ edge, from: handle, to })
+    return { ...edge, sourceHandle: to }
+  })
+  if (rebound.length === 0) return { edges, rebound }
+  return { edges: next, rebound }
+}
+
+export type ApplyApiInputConfigChangeResult<E extends SimpleEdge> = {
+  /** Edge list after rename migration AND orphan pruning. Same reference as the input when nothing changed. */
+  edges: E[]
+  rebound: ReboundApiInputEdge<E>[]
+  removed: ReconciledApiInputEdge[]
+}
+
+/**
+ * The single edge-maintenance step for an apiInput config commit:
+ * migrate renames FIRST (so renamed ports keep their edges), then prune
+ * whatever genuinely no longer resolves (emit-off, table delete,
+ * single↔multi transitions). `App.onUpdateNode` applies the result in
+ * the same state update that commits the config, so a rename is one
+ * atomic, undoable operation — never a destroy-and-reconnect.
+ */
+export function applyApiInputConfigChange<E extends SimpleEdge>({
+  nodeId,
+  prevConfig,
+  nextConfig,
+  edges,
+}: {
+  nodeId: string
+  prevConfig: ConfigLike
+  nextConfig: ConfigLike
+  edges: E[]
+}): ApplyApiInputConfigChangeResult<E> {
+  const migration = migrateApiInputEdges({ nodeId, prevConfig, nextConfig, edges })
+  const { edges: pruned, removed } = reconcileApiInputEdges({
+    nodeId,
+    config: nextConfig,
+    edges: migration.edges,
+  })
+  return { edges: pruned, rebound: migration.rebound, removed }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "jsdom",
-    include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+    include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
     setupFiles: ["./src/setupTests.ts"],
     allowOnly: false,
     testTimeout: 30000,

--- a/src/haute/_cache.py
+++ b/src/haute/_cache.py
@@ -30,7 +30,12 @@ logger = get_logger(component="cache")
 # simulate a bump and confirm cache entries do not collide across
 # versions — pinned by
 # ``tests/test_routes_hygiene.py::TestBumpVersionInvalidatesCache``.
-ALGO_VERSION: int = 3
+#
+# v4: edge serialization became port-aware — ``sourceHandle`` /
+# ``targetHandle`` are now part of the digest material, so rewiring
+# which port feeds a consumer invalidates previews/traces/dataframes
+# cached under the old wiring.
+ALGO_VERSION: int = 4
 
 
 @dataclass(frozen=True)
@@ -142,8 +147,25 @@ def _graph_base_fingerprint(graph: PipelineGraph) -> str:
         parts.append(
             f"{n.id}|{n.data.nodeType}|{_json.dumps(canonical_config, sort_keys=True)}",
         )
-    for e in sorted(graph.edges, key=lambda e: (e.source, e.target)):
-        parts.append(f"{e.source}->{e.target}")
+    # Edges: serialize the full wiring — ``sourceHandle``/``targetHandle``
+    # select WHICH PORT of a multi-port node (or which edge-join role)
+    # feeds the consumer, so they are digest material just like the
+    # endpoints.  A compact JSON array is unambiguous by construction:
+    # quoting/escaping rules out separator-content collisions, and the
+    # absent handle (``null``) stays distinct from every real handle
+    # string, including ports literally named ``"None"`` or ``"null"``.
+    # Sorting the serialized lines themselves keeps the digest independent
+    # of edge insertion order with no tie-breaking gap — equal sort keys
+    # imply byte-identical lines.
+    parts.extend(
+        sorted(
+            _json.dumps(
+                [e.source, e.sourceHandle, e.target, e.targetHandle],
+                separators=(",", ":"),
+            )
+            for e in graph.edges
+        ),
+    )
     return content_hash_bytes("\n".join(parts).encode())
 
 

--- a/src/haute/_codegen_builders.py
+++ b/src/haute/_codegen_builders.py
@@ -1039,15 +1039,34 @@ def _gen_edge_join(node: GraphNode, source_names: list[str]) -> str:
             source_names=source_names,
         )
     func_name, description, config = _common_node_fields(node)
-    base_name = source_names[0]
+    base_name, join_name = source_names
     params = _build_params(source_names)
+    missing_roles = [key for key in ("baseInput", "joinInput") if not config.get(key)]
+    if missing_roles:
+        # Unreachable via graph_to_code — `_role_order_node_sources` resolves
+        # roles before dispatch — but guards direct callers against silently
+        # emitting a decorator with no role kwargs to rewrite.
+        raise ConfigError(
+            "edgeJoin codegen requires baseInput and joinInput in config.",
+            node_id=node.id,
+            node_label=node.data.label,
+            missing=missing_roles,
+        )
+    # Role kwargs must name the functions this pass emits, not the raw config
+    # node ids: live canvas ids (e.g. "dataSource_5") do not survive a parse
+    # round-trip, where node ids become sanitized function names, so verbatim
+    # ids would make the saved file unloadable.  `_role_order_node_sources`
+    # has already resolved baseInput/joinInput against the connected node ids
+    # — failing loudly when a role references a missing or unconnected node —
+    # and ordered sources base-first, so source_names[0]/[1] ARE the base and
+    # join nodes' emitted function names.
+    role_names = {"base_input": base_name, "join_input": join_name}
     decorator_args = ", ".join(
-        _format_kwarg_source(key, value)
+        _format_kwarg_source(key, role_names.get(key, value))
         for key, value in edge_join_config_to_decorator_kwargs(config)
     )
     # Keep codegen-time validation without duplicating join semantics in the body.
     build_edge_join_kwargs(config)
-    join_name = source_names[1]
     return (
         f"@pipeline.edge_join({decorator_args})\n"
         f"def {func_name}({params}) -> pl.LazyFrame:\n"

--- a/src/haute/_trace_correlation.py
+++ b/src/haute/_trace_correlation.py
@@ -16,12 +16,15 @@ string/float comparisons for the non-Polars edges of the trace surface.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
 import polars as pl
 
+from haute._edge_join import build_edge_join_kwargs
 from haute._logging import get_logger
+from haute._types import GraphNode, NodeType
 
 logger = get_logger(component="trace_correlation")
 
@@ -231,19 +234,143 @@ def _find_matching_row(
     return None, -1
 
 
+def _edge_join_key_pairs(join_kwargs: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return ``(left_key, right_key)`` column pairs from validated join kwargs.
+
+    ``on=[k]`` pairs ``k`` with itself; ``left_on``/``right_on`` zip
+    positionally (validated to equal lengths by ``build_edge_join_kwargs``).
+    Cross joins have no keys and return an empty list.
+    """
+    on = join_kwargs.get("on")
+    if on is not None:
+        keys = on if isinstance(on, list) else [on]
+        return [(key, key) for key in keys]
+    left_on = join_kwargs.get("left_on")
+    right_on = join_kwargs.get("right_on")
+    if left_on is None or right_on is None:
+        return []
+    left_keys = left_on if isinstance(left_on, list) else [left_on]
+    right_keys = right_on if isinstance(right_on, list) else [right_on]
+    return list(zip(left_keys, right_keys, strict=True))
+
+
+def _edge_join_right_match_row(
+    child_row: dict[str, Any],
+    right_cols: set[str],
+    left_cols: set[str],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the value-match row for an edge-join's JOIN-role (right) parent.
+
+    Polars keeps the BASE (left) frame's copy of every colliding column
+    under its original name and emits the right frame's copy as
+    ``<col><suffix>`` — in every join strategy.  Projecting the child row
+    onto the right parent by *name* therefore discards the right parent's
+    actual values (the suffixed copies) and matches the right frame
+    against LEFT-row values instead, correlating to whichever wrong right
+    row those values happen to hit.
+
+    Provenance rules, derived from the exact kwargs the runtime applied
+    (``build_edge_join_kwargs`` — the same single source of truth
+    ``execute_edge_join`` uses):
+
+    1. ``<col><suffix>`` where ``<col>`` exists in BOTH parents is the
+       right frame's copy of a colliding column → match the parent's
+       ``<col>`` against it.
+    2. An unsuffixed child column that exists ONLY in the right parent is
+       right-provenance → match it under its own name.  If it exists in
+       both parents the child carries the left row's value, which must
+       not be matched against the right frame.
+    3. Join keys: for every ``(left_key, right_key)`` pair the child's
+       left-key value equals the matched right row's right-key value on
+       every row where the right side participated (coalesced ``on``
+       keys, ``left_on``/``right_on`` with differing names, semi/anti
+       joins whose output carries no right columns at all).  Map it onto
+       the parent's right-key column unless rule 1/2 already supplied it.
+
+    Rows where the right side did NOT participate (left-join misses,
+    full-join left-only rows) produce values matching no right row, so
+    correlation fails loudly (step omitted) instead of inventing lineage.
+    """
+    join_kwargs = build_edge_join_kwargs(config)
+    suffix: str = join_kwargs["suffix"]
+    match_row: dict[str, Any] = {}
+    for name, value in child_row.items():
+        if name.endswith(suffix) and len(name) > len(suffix):
+            original = name[: -len(suffix)]
+            if original in right_cols and original in left_cols:
+                match_row[original] = value
+                continue
+        if name in right_cols and name not in left_cols:
+            match_row[name] = value
+    for left_key, right_key in _edge_join_key_pairs(join_kwargs):
+        if right_key in match_row or right_key not in right_cols:
+            continue
+        if left_key in child_row:
+            match_row[right_key] = child_row[left_key]
+    return match_row
+
+
+def _build_parent_match_row(
+    child_row: dict[str, Any],
+    parent_id: str,
+    parent_cols: set[str],
+    child_node: GraphNode | None,
+    eager_outputs: dict[str, pl.DataFrame],
+) -> dict[str, Any]:
+    """Project *child_row* onto *parent_id*'s columns for value matching.
+
+    Generic nodes keep the child columns that exist in the parent —
+    name-faithful provenance.  Edge-join children break that assumption
+    for the JOIN-role parent, where colliding columns were suffixed and
+    the unsuffixed names carry the other parent's values; those are
+    routed through :func:`_edge_join_right_match_row`.  The BASE-role
+    parent's columns survive a join under their original names with the
+    base row's values, so the generic projection remains correct there.
+    """
+    if child_node is not None and child_node.data.nodeType == NodeType.EDGE_JOIN:
+        config = child_node.data.config
+        base_id = config.get("baseInput")
+        join_id = config.get("joinInput")
+        if parent_id == join_id:
+            base_df = eager_outputs.get(base_id) if isinstance(base_id, str) else None
+            if base_df is None:
+                raise ValueError(
+                    f"edge-join node '{child_node.id}' has no materialized output for "
+                    f"its base parent '{base_id}' — cannot correlate the join parent"
+                )
+            return _edge_join_right_match_row(
+                child_row,
+                parent_cols,
+                set(base_df.columns),
+                config,
+            )
+        if parent_id != base_id:
+            raise ValueError(
+                f"node '{parent_id}' is wired as a parent of edge-join "
+                f"'{child_node.id}' but matches neither baseInput ({base_id!r}) "
+                f"nor joinInput ({join_id!r})"
+            )
+    return {c: v for c, v in child_row.items() if c in parent_cols}
+
+
 def _correlate_rows_posthoc(
     eager_outputs: dict[str, pl.DataFrame],
     order: list[str],
     parents_of: dict[str, list[str]],
     target_node_id: str,
     row_index: int,
+    *,
+    node_map: Mapping[str, GraphNode],
 ) -> dict[str, dict[str, Any] | None]:
     """Extract the correct row from each node using post-hoc correlation.
 
     Uses the preview-cached DataFrames directly — no re-execution, no
     injected columns.  Walks backward from the target node and matches
     each parent's row by shared column values with the already-resolved
-    child row.
+    child row.  *node_map* supplies node type and config so that
+    edge-join children can route suffixed/colliding columns to the
+    correct parent (see :func:`_build_parent_match_row`).
 
     Returns a dict mapping node_id → row values (JSON-safe), or None
     for nodes where row correlation failed.
@@ -300,15 +427,23 @@ def _correlate_rows_posthoc(
         child_len = len(child_df) if child_df is not None else 0
 
         # Build a filtered child_row for matching: only include columns
-        # that exist in this parent's DataFrame.  This prevents columns
-        # brought in by a *different* parent (via a join) from confusing
-        # the value matcher.
+        # that exist in this parent's DataFrame, and — when the child is
+        # an edge-join — route suffixed/colliding columns to the parent
+        # they actually came from.  This prevents columns brought in by
+        # a *different* parent (via a join) from confusing the value
+        # matcher.
         parent_cols = set(parent_df.columns)
         if child_row is None:
             result[nid] = None
             row_indices[nid] = -1
             continue
-        match_row = {c: v for c, v in child_row.items() if c in parent_cols}
+        match_row = _build_parent_match_row(
+            child_row,
+            nid,
+            parent_cols,
+            node_map.get(resolved_child_id),
+            eager_outputs,
+        )
 
         # Fast path: same row count → likely 1:1 (with_columns, rename, select).
         # Check if the row at the same position matches on shared columns.

--- a/src/haute/trace.py
+++ b/src/haute/trace.py
@@ -436,6 +436,7 @@ def execute_trace(
             parents_of,
             target_node_id,
             row_index,
+            node_map=node_map,
         )
     else:
         # Target node execution failed — build partial rows from available nodes

--- a/tests/test_caching_correctness.py
+++ b/tests/test_caching_correctness.py
@@ -19,6 +19,14 @@ overwrite does not bump mtime, so the cache serves stale content.  Post-fix,
 both functions must key on the xxh64 **content hash** produced by
 ``haute._hashing.content_hash``.
 
+Code-review remediation W1.2 (finding C3) — ``_graph_base_fingerprint``
+serialised edges as ``"{source}->{target}"`` only, omitting
+``sourceHandle``/``targetHandle``.  Rewiring which PORT of a multi-port
+apiInput (or which edge-join role) feeds a consumer therefore produced an
+identical fingerprint, and the preview/trace/dataframe caches silently
+served the old wiring's data.  Post-fix, both handles are part of the edge
+serialization (see ``TestFingerprintEdgeHandleSensitivity``).
+
 All tests in this module are expected to fail pre-fix and pass post-fix
 (with the exception of the regression-guard tests, which must continue to
 pass post-fix).
@@ -36,7 +44,7 @@ import pytest
 from haute._cache import graph_fingerprint, preamble_imports_utility
 from haute._io import _load_cached, load_external_object
 from haute._optimiser_io import _load_artifact_cached, load_optimiser_artifact
-from haute._types import GraphNode, NodeData, PipelineGraph
+from haute._types import GraphEdge, GraphNode, NodeData, PipelineGraph
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -183,6 +191,114 @@ class TestFingerprintCollisionSafety:
         g_set = _make_graph({"x": {"a"}})
         g_str = _make_graph({"x": "{'a'}"})
         assert graph_fingerprint(g_set) != graph_fingerprint(g_str)
+
+
+def _make_wired_graph(edges: list[GraphEdge]) -> PipelineGraph:
+    """Two-node graph whose only variation across tests is the edge wiring."""
+    return PipelineGraph(
+        nodes=[
+            GraphNode(
+                id="quotes",
+                data=NodeData(label="Quotes", nodeType="apiInput", config={}),
+            ),
+            GraphNode(
+                id="rate",
+                data=NodeData(label="Rate", nodeType="polars", config={}),
+            ),
+        ],
+        edges=edges,
+    )
+
+
+class TestFingerprintEdgeHandleSensitivity:
+    """Rewiring WHICH PORT an edge connects must change the fingerprint.
+
+    ``sourceHandle``/``targetHandle`` select which port of a multi-port
+    apiInput (or which edge-join role) feeds a consumer.  Pre-fix,
+    ``_graph_base_fingerprint`` serialised edges as ``"{source}->{target}"``
+    only, so rewiring port ``policies`` → ``drivers`` between the same two
+    nodes produced an IDENTICAL fingerprint and the preview/trace/dataframe
+    caches silently served the old wiring's data.
+    """
+
+    def test_target_handle_rewire_changes_fingerprint(self) -> None:
+        """Same nodes, same edge endpoints — only ``targetHandle`` differs."""
+        g_policies = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", targetHandle="policies")],
+        )
+        g_drivers = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", targetHandle="drivers")],
+        )
+        assert graph_fingerprint(g_policies) != graph_fingerprint(g_drivers)
+
+    def test_source_handle_rewire_changes_fingerprint(self) -> None:
+        """Same nodes, same edge endpoints — only ``sourceHandle`` differs."""
+        g_policies = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", sourceHandle="policies")],
+        )
+        g_drivers = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", sourceHandle="drivers")],
+        )
+        assert graph_fingerprint(g_policies) != graph_fingerprint(g_drivers)
+
+    @pytest.mark.parametrize("handle_field", ["sourceHandle", "targetHandle"])
+    def test_none_handle_differs_from_named_handle(self, handle_field: str) -> None:
+        """A port-less edge and a port-wired edge are different wirings."""
+        g_none = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate")],
+        )
+        g_named = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", **{handle_field: "policies"})],
+        )
+        assert graph_fingerprint(g_none) != graph_fingerprint(g_named)
+
+    @pytest.mark.parametrize("literal", ["null", "None"])
+    def test_none_handle_differs_from_handle_named_like_null(self, literal: str) -> None:
+        """``None`` must be distinguishable from ANY real handle string.
+
+        A naive ``str(handle)`` interpolation would collide ``None`` with a
+        port literally named ``"None"`` (and a naive JSON-text splice would
+        collide it with ``"null"``).  The serialization must keep the absent
+        handle distinct from both.
+        """
+        g_none = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate")],
+        )
+        g_literal = _make_wired_graph(
+            [GraphEdge(id="e1", source="quotes", target="rate", targetHandle=literal)],
+        )
+        assert graph_fingerprint(g_none) != graph_fingerprint(g_literal)
+
+    def test_edge_insertion_order_is_irrelevant(self) -> None:
+        """Shuffled edge insertion order must not move the fingerprint.
+
+        Uses the edge-join shape — two parallel edges between the SAME node
+        pair where only the handles differ — so the sort cannot fall back on
+        ``(source, target)`` alone to break the tie deterministically.
+        """
+        e_base = GraphEdge(id="e1", source="quotes", target="rate", targetHandle="base")
+        e_join = GraphEdge(id="e2", source="quotes", target="rate", targetHandle="join")
+        e_plain = GraphEdge(id="e3", source="quotes", target="rate")
+
+        fingerprints = {
+            graph_fingerprint(_make_wired_graph(list(order)))
+            for order in (
+                (e_base, e_join, e_plain),
+                (e_join, e_plain, e_base),
+                (e_plain, e_base, e_join),
+            )
+        }
+        assert len(fingerprints) == 1
+
+    def test_algo_version_bumped_for_handle_aware_serialization(self) -> None:
+        """The digest material changed — pre-handle cache entries must be
+        invalidated via an ``ALGO_VERSION`` bump (3 → 4), not left to
+        coincidence.  Guards against reverting the bump while keeping the
+        serialization change.
+        """
+        from haute._cache import ALGO_VERSION
+
+        assert ALGO_VERSION >= 4
 
 
 class TestFingerprintTypeErrorForUnknown:

--- a/tests/test_dataframe_execution_cache.py
+++ b/tests/test_dataframe_execution_cache.py
@@ -13,6 +13,7 @@ from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
 from haute.execution import (
     CacheArtifactTooLargeError,
     DataFrameExecutionCache,
+    DataFrameExecutionCacheKey,
     dataframe_execution_cache_key,
     dataframe_execution_cache_profile,
     dataframe_graph_input_fingerprint,
@@ -27,8 +28,29 @@ def _node(node_id: str, node_type: NodeType = NodeType.POLARS, **config: object)
     )
 
 
-def _edge(source: str, target: str) -> GraphEdge:
-    return GraphEdge(id=f"{source}-{target}", source=source, target=target)
+def _edge(
+    source: str,
+    target: str,
+    *,
+    target_handle: str | None = None,
+) -> GraphEdge:
+    return GraphEdge(
+        id=f"{source}-{target}",
+        source=source,
+        target=target,
+        targetHandle=target_handle,
+    )
+
+
+def _port_wired_graph(target_handle: str) -> PipelineGraph:
+    """Source feeding one consumer port — only the port name varies."""
+    return PipelineGraph(
+        nodes=[
+            _node("source", NodeType.API_INPUT),
+            _node("target", NodeType.POLARS, output="premium"),
+        ],
+        edges=[_edge("source", "target", target_handle=target_handle)],
+    )
 
 
 def _graph(*, mid_multiplier: int = 2, downstream_label: str = "downstream") -> PipelineGraph:
@@ -83,6 +105,30 @@ def test_dataframe_cache_key_uses_upstream_subgraph_not_downstream_edits() -> No
         )
         != base_key
     )
+
+
+def test_dataframe_cache_key_distinguishes_edge_handle_rewire() -> None:
+    """Rewiring port ``policies`` → ``drivers`` between the same two nodes
+    must produce a different cache key (CODE_REVIEW finding C3)."""
+    policies_key = dataframe_execution_cache_key(
+        _port_wired_graph("policies"),
+        node_id="target",
+        namespace="unit",
+        source="batch",
+        profile=ExecutionProfile.LAZY_SINK,
+        input_fingerprint="input:v1",
+    )
+    drivers_key = dataframe_execution_cache_key(
+        _port_wired_graph("drivers"),
+        node_id="target",
+        namespace="unit",
+        source="batch",
+        profile=ExecutionProfile.LAZY_SINK,
+        input_fingerprint="input:v1",
+    )
+
+    assert policies_key.lineage_fingerprint != drivers_key.lineage_fingerprint
+    assert policies_key.cache_key != drivers_key.cache_key
 
 
 def test_dataframe_cache_key_requires_explicit_input_fingerprint() -> None:
@@ -325,6 +371,47 @@ def test_materialize_lazy_frame_with_cache_reuses_cached_artifact(tmp_path: Path
 
     assert second.collect().to_dict(as_series=False) == {"x": [1, 2, 3]}
     assert cache.stats()["entries"] == 1
+
+
+def test_materialize_does_not_serve_stale_artifact_after_handle_rewire(
+    tmp_path: Path,
+) -> None:
+    """Seed the cache under one port wiring, flip the handle, and assert the
+    cache does NOT serve the old wiring's artifact.
+
+    Pre-fix (CODE_REVIEW finding C3) both wirings collided on the same
+    fingerprint, so the second materialize returned the ``policies`` rows
+    for the ``drivers`` wiring — silently wrong pricing inputs.
+    """
+    cache = DataFrameExecutionCache(root=tmp_path, max_entries=4, max_bytes=10_000_000)
+
+    def key_for(target_handle: str) -> DataFrameExecutionCacheKey:
+        return dataframe_execution_cache_key(
+            _port_wired_graph(target_handle),
+            node_id="target",
+            namespace="unit",
+            source="batch",
+            profile=ExecutionProfile.LAZY_SINK,
+            input_fingerprint="input:v1",
+        )
+
+    seeded = materialize_lazy_frame_with_cache(
+        pl.DataFrame({"port": ["policies"]}).lazy(),
+        cache=cache,
+        key=key_for("policies"),
+        profile=ExecutionProfile.LAZY_SINK,
+    )
+    assert seeded.collect().to_dict(as_series=False) == {"port": ["policies"]}
+
+    rewired = materialize_lazy_frame_with_cache(
+        pl.DataFrame({"port": ["drivers"]}).lazy(),
+        cache=cache,
+        key=key_for("drivers"),
+        profile=ExecutionProfile.LAZY_SINK,
+    )
+
+    assert rewired.collect().to_dict(as_series=False) == {"port": ["drivers"]}
+    assert cache.stats()["entries"] == 2
 
 
 def test_materialize_lazy_frame_with_cache_does_not_store_failed_collect(

--- a/tests/test_edge_join.py
+++ b/tests/test_edge_join.py
@@ -9,6 +9,7 @@ import polars as pl
 import pytest
 
 from haute._config_validation import VALID_KEYS, warn_unrecognized_config_keys
+from haute._edge_join import resolve_edge_join_role_indices
 from haute._flatten import flatten_graph
 from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
 from haute.codegen import graph_to_code, graph_to_code_multi
@@ -267,8 +268,163 @@ def test_codegen_emits_edge_join_with_base_first_params_and_connects(tmp_path: P
     assert result.collect()["factor"].to_list() == [1.1]
 
 
-def test_submodel_parent_codegen_preserves_external_edge_join_target_role() -> None:
+def _edge_join_decorator_line(code: str) -> str:
+    return next(line for line in code.splitlines() if line.startswith("@pipeline.edge_join("))
+
+
+def test_edge_join_round_trip_resolves_roles_when_node_ids_differ_from_labels(
+    tmp_path: Path,
+) -> None:
+    """Canvas node ids (e.g. ``dataSource_5``) must not leak into decorator kwargs.
+
+    On reload, parsed node ids are the sanitized function names, so role
+    kwargs emitted verbatim from config would never resolve again — preview
+    breaks and the pipeline cannot re-save after a server restart.
+    """
+    ds_values = [{"name": "region", "value": "N"}]
+    enrich_values = [
+        {"name": "region", "value": "N"},
+        {"name": "factor", "value": "1.1"},
+    ]
     graph = PipelineGraph(
+        nodes=[
+            GraphNode(
+                id="dataSource_5",
+                data=NodeData(
+                    label="Data Source 5",
+                    nodeType=NodeType.CONSTANT,
+                    config={"values": ds_values},
+                ),
+            ),
+            GraphNode(
+                id="polars_2",
+                data=NodeData(
+                    label="Enrich Step",
+                    nodeType=NodeType.CONSTANT,
+                    config={"values": enrich_values},
+                ),
+            ),
+            _edge_join_node(
+                {
+                    "baseInput": "dataSource_5",
+                    "joinInput": "polars_2",
+                    "how": "left",
+                    "on": ["region"],
+                }
+            ),
+        ],
+        edges=[
+            GraphEdge(id="e_enrich_join", source="polars_2", target="join", targetHandle="join"),
+            GraphEdge(id="e_ds_join", source="dataSource_5", target="join", targetHandle="base"),
+        ],
+    )
+
+    code = graph_to_code(graph, pipeline_name="joins")
+
+    constant_dir = tmp_path / "config" / "constant"
+    constant_dir.mkdir(parents=True)
+    (constant_dir / "Data_Source_5.json").write_text(
+        json.dumps({"values": ds_values}),
+        encoding="utf-8",
+    )
+    (constant_dir / "Enrich_Step.json").write_text(
+        json.dumps({"values": enrich_values}),
+        encoding="utf-8",
+    )
+    path = _write_pipeline(tmp_path, code)
+    parsed = parse_pipeline_file(path)
+    parsed_join = parsed.node_map["Join_Rates"]
+    parsed_source_ids = [edge.source for edge in parsed.edges if edge.target == "Join_Rates"]
+
+    # The reloaded roles must resolve against the sanitized node ids.
+    base_index, join_index = resolve_edge_join_role_indices(
+        parsed_join.data.config,
+        parsed_source_ids,
+    )
+    assert parsed_source_ids[base_index] == "Data_Source_5"
+    assert parsed_source_ids[join_index] == "Enrich_Step"
+
+    assert 'base_input="Data_Source_5"' in code
+    assert 'join_input="Enrich_Step"' in code
+    assert "dataSource_5" not in code
+    assert "polars_2" not in code
+    assert parsed_join.data.config["baseInput"] == "Data_Source_5"
+    assert parsed_join.data.config["joinInput"] == "Enrich_Step"
+
+    # Preview off the generated module produces the joined frame.
+    namespace = {"__file__": str(path)}
+    exec(compile(code, str(path), "exec"), namespace)
+    result = namespace["pipeline"].run()
+    assert result.collect()["factor"].to_list() == [1.1]
+
+    # Re-save (second codegen pass) is byte-stable for the decorator kwargs.
+    resaved = graph_to_code(parsed, pipeline_name="joins")
+    assert _edge_join_decorator_line(resaved) == _edge_join_decorator_line(code)
+
+
+def test_edge_join_codegen_fails_loudly_when_role_references_missing_node() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            GraphNode(
+                id="quotes",
+                data=NodeData(label="quotes", nodeType=NodeType.CONSTANT, config={}),
+            ),
+            GraphNode(
+                id="lookup",
+                data=NodeData(label="lookup", nodeType=NodeType.CONSTANT, config={}),
+            ),
+            _edge_join_node(
+                {
+                    "baseInput": "ghost_7",
+                    "joinInput": "lookup",
+                    "how": "left",
+                    "on": ["region"],
+                }
+            ),
+        ],
+        edges=[
+            GraphEdge(id="e_quotes_join", source="quotes", target="join"),
+            GraphEdge(id="e_lookup_join", source="lookup", target="join"),
+        ],
+    )
+
+    with pytest.raises(ConfigError, match="not connected") as exc_info:
+        graph_to_code(graph, pipeline_name="joins")
+    assert exc_info.value.context["missing"] == ["ghost_7"]
+
+
+def test_edge_join_codegen_fails_loudly_when_base_and_join_share_a_node() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            GraphNode(
+                id="quotes",
+                data=NodeData(label="quotes", nodeType=NodeType.CONSTANT, config={}),
+            ),
+            GraphNode(
+                id="lookup",
+                data=NodeData(label="lookup", nodeType=NodeType.CONSTANT, config={}),
+            ),
+            _edge_join_node(
+                {
+                    "baseInput": "quotes",
+                    "joinInput": "quotes",
+                    "how": "left",
+                    "on": ["region"],
+                }
+            ),
+        ],
+        edges=[
+            GraphEdge(id="e_quotes_join", source="quotes", target="join"),
+            GraphEdge(id="e_lookup_join", source="lookup", target="join"),
+        ],
+    )
+
+    with pytest.raises(ConfigError, match="distinct"):
+        graph_to_code(graph, pipeline_name="joins")
+
+
+def _submodel_edge_join_graph() -> PipelineGraph:
+    return PipelineGraph(
         nodes=[
             GraphNode(
                 id="src",
@@ -349,11 +505,27 @@ def test_submodel_parent_codegen_preserves_external_edge_join_target_role() -> N
         },
     )
 
-    files = graph_to_code_multi(graph, pipeline_name="main")
+
+def test_submodel_parent_codegen_preserves_external_edge_join_target_role() -> None:
+    files = graph_to_code_multi(_submodel_edge_join_graph(), pipeline_name="main")
 
     assert 'pipeline.connect("Src", "Join", target_port="base")' in files["main.py"]
     assert "pipeline._apply_edge_join" not in files["modules/rating.py"]
     assert "submodel._apply_edge_join" in files["modules/rating.py"]
+
+
+def test_submodel_edge_join_decorator_kwargs_use_emitted_function_names() -> None:
+    """Cross-boundary roles must also be rewritten to emitted function names.
+
+    The submodel join's ``baseInput`` references the parent graph node id
+    ``src``; the emitted submodel file declares that input as the boundary
+    parameter ``Src``, so the decorator must reference ``Src``/``Lookup``
+    or the submodel file can never be reloaded.
+    """
+    files = graph_to_code_multi(_submodel_edge_join_graph(), pipeline_name="main")
+
+    assert 'base_input="Src"' in files["modules/rating.py"]
+    assert 'join_input="Lookup"' in files["modules/rating.py"]
 
 
 def test_flattening_submodel_restores_external_edge_join_target_role() -> None:

--- a/tests/test_edge_join.py
+++ b/tests/test_edge_join.py
@@ -9,12 +9,15 @@ import polars as pl
 import pytest
 
 from haute._config_validation import VALID_KEYS, warn_unrecognized_config_keys
-from haute._edge_join import resolve_edge_join_role_indices
+from haute._edge_join import (
+    edge_join_config_to_decorator_kwargs,
+    resolve_edge_join_role_indices,
+)
 from haute._flatten import flatten_graph
 from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
 from haute.codegen import graph_to_code, graph_to_code_multi
 from haute.errors import ConfigError
-from haute.executor import _build_node_fn
+from haute.executor import _build_node_fn, execute_graph
 from haute.parser import parse_pipeline_file
 from haute.pipeline import Pipeline
 
@@ -795,3 +798,591 @@ def test_edge_join_builder_invalid_config_fails_loudly(
 ) -> None:
     with pytest.raises(ConfigError, match=message):
         _build_edge_join(config, source_ids=["quotes", "lookup"])
+
+
+# ---------------------------------------------------------------------------
+# Runtime join-semantics matrix
+#
+# Every test below executes the join through BOTH production runtime
+# surfaces and asserts output frames (schema + row values), so the two
+# cannot silently drift:
+#
+#   * builder surface — ``_build_node_fn`` (graph executor / preview /
+#     trace / deploy), which joins LazyFrames and collects downstream;
+#   * pipeline surface — generated-code shape: ``@pipeline.edge_join``
+#     decorator kwargs emitted by ``edge_join_config_to_decorator_kwargs``
+#     with a ``pipeline._apply_edge_join`` body, run via ``pipeline.run()``
+#     (eager DataFrames, ``collect_eager=True``).
+#
+# Row assertions are order-insensitive (sorted row sets): Polars joins do
+# not guarantee row order without ``maintain_order``.
+# ---------------------------------------------------------------------------
+
+
+def _sorted_rows(df: pl.DataFrame) -> list[tuple]:
+    return sorted(df.rows(), key=repr)
+
+
+def _run_builder_edge_join(
+    config: dict,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+) -> pl.DataFrame:
+    """Execute through the graph-executor builder surface (lazy join)."""
+    _, fn, _ = _build_edge_join(
+        {**config, "baseInput": "base_src", "joinInput": "lookup_src"},
+        source_ids=["base_src", "lookup_src"],
+    )
+    return fn(base_df.lazy(), join_df.lazy()).collect()
+
+
+def _run_pipeline_edge_join(
+    config: dict,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+) -> pl.DataFrame:
+    """Execute through the generated-code surface (``pipeline.run()``).
+
+    Decorator kwargs are derived with the same helper codegen uses, and the
+    node body delegates to ``pipeline._apply_edge_join`` exactly like an
+    emitted pipeline file, so this is byte-equivalent to generated code.
+    """
+    pipeline = Pipeline("join_matrix")
+
+    @pipeline.data_source
+    def base_src() -> pl.DataFrame:
+        return base_df
+
+    @pipeline.data_source
+    def lookup_src() -> pl.DataFrame:
+        return join_df
+
+    decorator_kwargs = dict(
+        edge_join_config_to_decorator_kwargs(
+            {**config, "baseInput": "base_src", "joinInput": "lookup_src"}
+        )
+    )
+
+    @pipeline.edge_join(**decorator_kwargs)
+    def joined(base_src: pl.DataFrame, lookup_src: pl.DataFrame) -> pl.DataFrame:
+        return pipeline._apply_edge_join("joined", base_src, lookup_src)
+
+    pipeline.connect("base_src", "joined", target_port="base")
+    pipeline.connect("lookup_src", "joined", target_port="join")
+    return pipeline.run()
+
+
+def _run_edge_join(
+    config: dict,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+) -> pl.DataFrame:
+    """Run both runtime surfaces, assert they agree, and return the frame."""
+    builder_result = _run_builder_edge_join(config, base_df, join_df)
+    pipeline_result = _run_pipeline_edge_join(config, base_df, join_df)
+    assert builder_result.columns == pipeline_result.columns
+    assert builder_result.schema == pipeline_result.schema
+    assert _sorted_rows(builder_result) == _sorted_rows(pipeline_result)
+    return pipeline_result
+
+
+def _assert_edge_join_output(
+    result: pl.DataFrame,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+) -> None:
+    assert result.columns == expected_columns
+    assert _sorted_rows(result) == sorted(expected_rows, key=repr)
+
+
+def _assert_edge_join_raises(
+    config: dict,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    """Assert the failure surfaces loudly through BOTH runtime surfaces."""
+    with pytest.raises(error_type, match=match):
+        _run_builder_edge_join(config, base_df, join_df)
+    with pytest.raises(error_type, match=match):
+        _run_pipeline_edge_join(config, base_df, join_df)
+
+
+# Unmatched rows on both sides: k=1 exists only in base, k=4 only in join,
+# so every strategy below provably produces a different output frame.
+_HOW_BASE = pl.DataFrame({"k": [1, 2, 3], "bv": ["b1", "b2", "b3"]})
+_HOW_JOIN = pl.DataFrame({"k": [2, 3, 4], "jv": ["j2", "j3", "j4"]})
+
+
+@pytest.mark.parametrize(
+    ("how", "expected_columns", "expected_rows"),
+    [
+        ("inner", ["k", "bv", "jv"], [(2, "b2", "j2"), (3, "b3", "j3")]),
+        ("left", ["k", "bv", "jv"], [(1, "b1", None), (2, "b2", "j2"), (3, "b3", "j3")]),
+        ("right", ["bv", "k", "jv"], [("b2", 2, "j2"), ("b3", 3, "j3"), (None, 4, "j4")]),
+        (
+            "full",
+            ["k", "bv", "k_right", "jv"],
+            [
+                (1, "b1", None, None),
+                (2, "b2", 2, "j2"),
+                (3, "b3", 3, "j3"),
+                (None, None, 4, "j4"),
+            ],
+        ),
+        ("semi", ["k", "bv"], [(2, "b2"), (3, "b3")]),
+        ("anti", ["k", "bv"], [(1, "b1")]),
+    ],
+)
+def test_edge_join_runtime_how_matrix_with_unmatched_rows_on_both_sides(
+    how: str,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join({"how": how, "on": ["k"]}, _HOW_BASE, _HOW_JOIN)
+    _assert_edge_join_output(result, expected_columns, expected_rows)
+
+
+def test_edge_join_runtime_cross_join_is_full_product_with_suffixed_collisions() -> None:
+    result = _run_edge_join({"how": "cross"}, _HOW_BASE, _HOW_JOIN)
+    # Cross joins have no keys, so the shared name ``k`` is an ordinary
+    # collision and the right copy gets the default suffix.
+    expected_rows = [
+        (bk, bv, jk, jv)
+        for bk, bv in zip([1, 2, 3], ["b1", "b2", "b3"], strict=True)
+        for jk, jv in zip([2, 3, 4], ["j2", "j3", "j4"], strict=True)
+    ]
+    _assert_edge_join_output(result, ["k", "bv", "k_right", "jv"], expected_rows)
+
+
+def test_edge_join_runtime_semi_join_dedupes_duplicate_right_matches() -> None:
+    dup_join = pl.DataFrame({"k": [2, 2, 3], "jv": ["a", "b", "c"]})
+
+    # The fixture provably multiplies under a plain left join (k=2 twice)…
+    left_result = _run_edge_join({"how": "left", "on": ["k"]}, _HOW_BASE, dup_join)
+    _assert_edge_join_output(
+        left_result,
+        ["k", "bv", "jv"],
+        [(1, "b1", None), (2, "b2", "a"), (2, "b2", "b"), (3, "b3", "c")],
+    )
+
+    # …while semi keeps each matching base row exactly once with no right columns.
+    semi_result = _run_edge_join({"how": "semi", "on": ["k"]}, _HOW_BASE, dup_join)
+    _assert_edge_join_output(semi_result, ["k", "bv"], [(2, "b2"), (3, "b3")])
+
+
+def test_edge_join_runtime_anti_join_keeps_only_unmatched_base_rows() -> None:
+    dup_join = pl.DataFrame({"k": [2, 2, 3], "jv": ["a", "b", "c"]})
+    result = _run_edge_join({"how": "anti", "on": ["k"]}, _HOW_BASE, dup_join)
+    _assert_edge_join_output(result, ["k", "bv"], [(1, "b1")])
+
+
+# -- suffix ------------------------------------------------------------------
+
+_SUFFIX_BASE = pl.DataFrame({"k": [1], "shared": ["L"], "also": ["La"]})
+_SUFFIX_JOIN = pl.DataFrame({"k": [1], "shared": ["R"], "also": ["Ra"]})
+
+
+def test_edge_join_runtime_default_suffix_applies_to_every_colliding_column() -> None:
+    result = _run_edge_join({"how": "inner", "on": ["k"]}, _SUFFIX_BASE, _SUFFIX_JOIN)
+    _assert_edge_join_output(
+        result,
+        ["k", "shared", "also", "shared_right", "also_right"],
+        [(1, "L", "La", "R", "Ra")],
+    )
+
+
+def test_edge_join_runtime_custom_suffix_applies_to_every_colliding_column() -> None:
+    result = _run_edge_join(
+        {"how": "inner", "on": ["k"], "suffix": "_lkp"},
+        _SUFFIX_BASE,
+        _SUFFIX_JOIN,
+    )
+    _assert_edge_join_output(
+        result,
+        ["k", "shared", "also", "shared_lkp", "also_lkp"],
+        [(1, "L", "La", "R", "Ra")],
+    )
+
+
+def test_edge_join_runtime_suffix_untouched_when_no_columns_collide() -> None:
+    result = _run_edge_join({"how": "inner", "on": ["k"], "suffix": "_lkp"}, _HOW_BASE, _HOW_JOIN)
+    _assert_edge_join_output(result, ["k", "bv", "jv"], [(2, "b2", "j2"), (3, "b3", "j3")])
+    assert not any(column.endswith("_lkp") for column in result.columns)
+
+
+# -- coalesce ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("coalesce", "expected_columns", "expected_rows"),
+    [
+        (True, ["k", "bv", "jv"], [(2, "b2", "j2"), (3, "b3", "j3")]),
+        (
+            False,
+            ["k", "bv", "k_right", "jv"],
+            [(2, "b2", 2, "j2"), (3, "b3", 3, "j3")],
+        ),
+    ],
+)
+def test_edge_join_runtime_inner_join_coalesce_controls_key_right_column(
+    coalesce: bool,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join(
+        {"how": "inner", "on": ["k"], "coalesce": coalesce},
+        _HOW_BASE,
+        _HOW_JOIN,
+    )
+    _assert_edge_join_output(result, expected_columns, expected_rows)
+
+
+@pytest.mark.parametrize(
+    ("how", "expected_rows"),
+    [
+        # k_right is null-filled on the unmatched base row (k=1) — observable
+        # only under left, not derivable from the inner or full cases.
+        ("left", [(1, "b1", None, None), (2, "b2", 2, "j2"), (3, "b3", 3, "j3")]),
+        # Column order flips versus the right-join default ["bv", "k", "jv"]:
+        # keeping the base key restores base-frame-first ordering, and the
+        # unmatched join row (k=4) null-fills both base columns.
+        ("right", [(2, "b2", 2, "j2"), (3, "b3", 3, "j3"), (None, None, 4, "j4")]),
+    ],
+)
+def test_edge_join_runtime_left_right_coalesce_false_keeps_null_filled_key_right(
+    how: str,
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join(
+        {"how": how, "on": ["k"], "coalesce": False},
+        _HOW_BASE,
+        _HOW_JOIN,
+    )
+    _assert_edge_join_output(result, ["k", "bv", "k_right", "jv"], expected_rows)
+
+
+@pytest.mark.parametrize("coalesce", [True, False])
+@pytest.mark.parametrize(
+    ("how", "expected_columns", "expected_rows"),
+    [
+        ("semi", ["k", "bv"], [(2, "b2"), (3, "b3")]),
+        ("anti", ["k", "bv"], [(1, "b1")]),
+    ],
+)
+def test_edge_join_runtime_semi_anti_accept_and_ignore_coalesce(
+    how: str,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+    coalesce: bool,
+) -> None:
+    # Pinned Polars semantics: semi/anti emit no right-hand columns, so
+    # there is nothing to coalesce — the flag is accepted and the output
+    # is identical to the unflagged join.
+    result = _run_edge_join(
+        {"how": how, "on": ["k"], "coalesce": coalesce},
+        _HOW_BASE,
+        _HOW_JOIN,
+    )
+    _assert_edge_join_output(result, expected_columns, expected_rows)
+
+
+@pytest.mark.parametrize("coalesce", [True, False])
+def test_edge_join_runtime_cross_join_ignores_coalesce(coalesce: bool) -> None:
+    # Pinned Polars semantics: cross joins are keyless, so coalesce is
+    # accepted and ignored — the full product with suffixed collisions is
+    # unchanged (same spirit as the cross+validate pin).
+    result = _run_edge_join({"how": "cross", "coalesce": coalesce}, _HOW_BASE, _HOW_JOIN)
+    assert result.height == 9
+    assert result.columns == ["k", "bv", "k_right", "jv"]
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_columns", "expected_rows"),
+    [
+        # Polars default for full joins is coalesce=False: both key columns
+        # survive, with nulls marking each side's unmatched rows.
+        (
+            {"how": "full", "on": ["k"]},
+            ["k", "bv", "k_right", "jv"],
+            [
+                (1, "b1", None, None),
+                (2, "b2", 2, "j2"),
+                (3, "b3", 3, "j3"),
+                (None, None, 4, "j4"),
+            ],
+        ),
+        (
+            {"how": "full", "on": ["k"], "coalesce": False},
+            ["k", "bv", "k_right", "jv"],
+            [
+                (1, "b1", None, None),
+                (2, "b2", 2, "j2"),
+                (3, "b3", 3, "j3"),
+                (None, None, 4, "j4"),
+            ],
+        ),
+        # coalesce=True merges both key columns: k carries 4 from the right.
+        (
+            {"how": "full", "on": ["k"], "coalesce": True},
+            ["k", "bv", "jv"],
+            [(1, "b1", None), (2, "b2", "j2"), (3, "b3", "j3"), (4, None, "j4")],
+        ),
+    ],
+    ids=["default", "coalesce_false", "coalesce_true"],
+)
+def test_edge_join_runtime_full_join_coalesce_controls_key_right_presence(
+    config: dict,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join(config, _HOW_BASE, _HOW_JOIN)
+    _assert_edge_join_output(result, expected_columns, expected_rows)
+
+
+# -- leftOn / rightOn ---------------------------------------------------------
+
+_LO_BASE = pl.DataFrame({"lk": [1, 2], "bv": ["b1", "b2"]})
+_RO_JOIN = pl.DataFrame({"rk": [2, 3], "jv": ["j2", "j3"]})
+
+
+@pytest.mark.parametrize(
+    ("how", "expected_columns", "expected_rows"),
+    [
+        ("inner", ["lk", "bv", "jv"], [(2, "b2", "j2")]),
+        ("left", ["lk", "bv", "jv"], [(1, "b1", None), (2, "b2", "j2")]),
+        ("right", ["bv", "rk", "jv"], [("b2", 2, "j2"), (None, 3, "j3")]),
+        (
+            "full",
+            ["lk", "bv", "rk", "jv"],
+            [(1, "b1", None, None), (2, "b2", 2, "j2"), (None, None, 3, "j3")],
+        ),
+        ("semi", ["lk", "bv"], [(2, "b2")]),
+        ("anti", ["lk", "bv"], [(1, "b1")]),
+    ],
+)
+def test_edge_join_runtime_left_on_right_on_matrix_with_differing_key_names(
+    how: str,
+    expected_columns: list[str],
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join(
+        {"how": how, "leftOn": ["lk"], "rightOn": ["rk"]},
+        _LO_BASE,
+        _RO_JOIN,
+    )
+    _assert_edge_join_output(result, expected_columns, expected_rows)
+
+
+def test_edge_join_runtime_full_join_left_on_right_on_coalesce_merges_into_left_key() -> None:
+    result = _run_edge_join(
+        {"how": "full", "leftOn": ["lk"], "rightOn": ["rk"], "coalesce": True},
+        _LO_BASE,
+        _RO_JOIN,
+    )
+    _assert_edge_join_output(
+        result,
+        ["lk", "bv", "jv"],
+        [(1, "b1", None), (2, "b2", "j2"), (3, None, "j3")],
+    )
+
+
+def test_edge_join_runtime_multi_column_left_on_right_on_keys() -> None:
+    base_df = pl.DataFrame({"a": [1, 1], "b": ["x", "y"], "lv": [10, 20]})
+    join_df = pl.DataFrame({"c": [1, 1], "d": ["x", "z"], "rv": [100, 300]})
+    result = _run_edge_join(
+        {"how": "inner", "leftOn": ["a", "b"], "rightOn": ["c", "d"]},
+        base_df,
+        join_df,
+    )
+    _assert_edge_join_output(result, ["a", "b", "lv", "rv"], [(1, "x", 10, 100)])
+
+
+def test_edge_join_runtime_cross_join_rejects_left_on_right_on_keys() -> None:
+    _assert_edge_join_raises(
+        {"how": "cross", "leftOn": ["lk"], "rightOn": ["rk"]},
+        _LO_BASE,
+        _RO_JOIN,
+        ConfigError,
+        "cross joins must not configure join keys",
+    )
+
+
+# -- validate ----------------------------------------------------------------
+
+_UNIQUE_JOIN = pl.DataFrame({"k": [2, 3, 4], "jv": ["j2", "j3", "j4"]})
+_DUP_KEY_BASE = pl.DataFrame({"k": [2, 2], "bv": ["x", "y"]})
+_DUP_KEY_JOIN = pl.DataFrame({"k": [2, 2, 3], "jv": ["a", "b", "c"]})
+
+
+@pytest.mark.parametrize(
+    ("validate", "base_df", "join_df", "expected_rows"),
+    [
+        (
+            "1:1",
+            _HOW_BASE,
+            _UNIQUE_JOIN,
+            [(1, "b1", None), (2, "b2", "j2"), (3, "b3", "j3")],
+        ),
+        (
+            "m:1",
+            _DUP_KEY_BASE,
+            _UNIQUE_JOIN,
+            [(2, "x", "j2"), (2, "y", "j2")],
+        ),
+        (
+            "1:m",
+            _HOW_BASE,
+            _DUP_KEY_JOIN,
+            [(1, "b1", None), (2, "b2", "a"), (2, "b2", "b"), (3, "b3", "c")],
+        ),
+        (
+            "m:m",
+            _DUP_KEY_BASE,
+            _DUP_KEY_JOIN,
+            [(2, "x", "a"), (2, "x", "b"), (2, "y", "a"), (2, "y", "b")],
+        ),
+    ],
+)
+def test_edge_join_runtime_validate_passes_when_relationship_holds(
+    validate: str,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+    expected_rows: list[tuple],
+) -> None:
+    result = _run_edge_join(
+        {"how": "left", "on": ["k"], "validate": validate},
+        base_df,
+        join_df,
+    )
+    _assert_edge_join_output(result, ["k", "bv", "jv"], expected_rows)
+
+
+@pytest.mark.parametrize(
+    ("validate", "base_df", "join_df"),
+    [
+        ("1:1", _HOW_BASE, _DUP_KEY_JOIN),  # right side duplicates k=2
+        ("1:1", _DUP_KEY_BASE, _UNIQUE_JOIN),  # left side duplicates k=2
+        ("m:1", _HOW_BASE, _DUP_KEY_JOIN),  # right side must be unique
+        ("1:m", _DUP_KEY_BASE, _UNIQUE_JOIN),  # left side must be unique
+    ],
+    ids=["1to1_dup_right", "1to1_dup_left", "mto1_dup_right", "1tom_dup_left"],
+)
+def test_edge_join_runtime_validate_violation_fails_loudly(
+    validate: str,
+    base_df: pl.DataFrame,
+    join_df: pl.DataFrame,
+) -> None:
+    _assert_edge_join_raises(
+        {"how": "left", "on": ["k"], "validate": validate},
+        base_df,
+        join_df,
+        pl.exceptions.ComputeError,
+        f"join keys did not fulfill {validate} validation",
+    )
+
+
+def test_edge_join_runtime_validate_rejects_unknown_mode_loudly() -> None:
+    _assert_edge_join_raises(
+        {"how": "left", "on": ["k"], "validate": "bogus"},
+        _HOW_BASE,
+        _HOW_JOIN,
+        ValueError,
+        "must be one of",
+    )
+
+
+@pytest.mark.parametrize("how", ["semi", "anti"])
+def test_edge_join_runtime_validate_unsupported_on_semi_anti_fails_loudly(how: str) -> None:
+    _assert_edge_join_raises(
+        {"how": how, "on": ["k"], "validate": "1:1"},
+        _HOW_BASE,
+        _HOW_JOIN,
+        pl.exceptions.ComputeError,
+        f"validation on a {how.upper()} join is not supported",
+    )
+
+
+def test_edge_join_runtime_cross_join_ignores_validate() -> None:
+    # Pinned Polars semantics: validation describes a key relationship and
+    # cross joins have no keys, so Polars accepts and ignores ``validate``.
+    # If a Polars upgrade starts rejecting it, this test must be revisited
+    # alongside the frontend editor's validate field.
+    result = _run_edge_join({"how": "cross", "validate": "1:1"}, _HOW_BASE, _HOW_JOIN)
+    assert result.height == 9
+    assert result.columns == ["k", "bv", "k_right", "jv"]
+
+
+def test_edge_join_runtime_validate_violation_attributed_to_join_node_in_graph_execution() -> None:
+    """A validate failure must surface as the JOIN node's error, not silently.
+
+    Executes a real graph through ``execute_graph`` (the GUI preview path):
+    both sources succeed, the edge-join node alone reports the Polars
+    validation message.
+    """
+    graph = PipelineGraph(
+        nodes=[
+            GraphNode(
+                id="base_src",
+                data=NodeData(
+                    label="base_src",
+                    nodeType=NodeType.POLARS,
+                    config={"code": 'df = pl.DataFrame({"k": [1, 2, 3], "bv": ["x", "y", "z"]})'},
+                ),
+            ),
+            GraphNode(
+                id="lookup_src",
+                data=NodeData(
+                    label="lookup_src",
+                    nodeType=NodeType.POLARS,
+                    config={"code": 'df = pl.DataFrame({"k": [2, 2, 3], "jv": ["a", "b", "c"]})'},
+                ),
+            ),
+            _edge_join_node(
+                {
+                    "baseInput": "base_src",
+                    "joinInput": "lookup_src",
+                    "how": "left",
+                    "on": ["k"],
+                    "validate": "1:1",
+                }
+            ),
+        ],
+        edges=[
+            GraphEdge(id="e_base", source="base_src", target="join", targetHandle="base"),
+            GraphEdge(id="e_lookup", source="lookup_src", target="join", targetHandle="join"),
+        ],
+    )
+
+    results = execute_graph(graph)
+
+    assert results["base_src"].status == "ok"
+    assert results["lookup_src"].status == "ok"
+    assert results["join"].status == "error"
+    assert "1:1 validation" in (results["join"].error or "")
+
+
+# -- join-key dtype edges ------------------------------------------------------
+
+
+def test_edge_join_runtime_mismatched_key_dtypes_fail_loudly() -> None:
+    # Int keys joined against str keys must error, never silently produce
+    # an empty or wrong frame.
+    str_join = pl.DataFrame({"k": ["1", "2"], "jv": ["a", "b"]})
+    _assert_edge_join_raises(
+        {"how": "inner", "on": ["k"]},
+        _HOW_BASE,
+        str_join,
+        pl.exceptions.SchemaError,
+        "datatypes of join keys don't match",
+    )
+
+
+def test_edge_join_runtime_numeric_key_widths_upcast_to_supertype() -> None:
+    # Pinned Polars semantics: Int64 vs Int32 keys join via the numeric
+    # supertype (a documented cast, not silence — values still match).
+    i32_join = pl.DataFrame({"k": pl.Series([2, 3], dtype=pl.Int32), "jv": ["a", "b"]})
+    result = _run_edge_join({"how": "inner", "on": ["k"]}, _HOW_BASE, i32_join)
+    _assert_edge_join_output(result, ["k", "bv", "jv"], [(2, "b2", "a"), (3, "b3", "b")])
+    assert result.schema["k"] == pl.Int64

--- a/tests/test_trace_edge_join.py
+++ b/tests/test_trace_edge_join.py
@@ -1,0 +1,410 @@
+"""Trace correlation / lineage tests for edge-join nodes.
+
+W1.7 remediation: the post-hoc row correlator projected a join child's
+row onto its parents by column *name* (``_trace_correlation``,
+``match_row`` construction in ``_correlate_rows_posthoc``).  For the
+JOIN-role (right) parent that is wrong twice over: Polars renames the
+right frame's copy of every colliding column to ``<col><suffix>`` (so
+the right parent's actual values were discarded), while the unsuffixed
+``<col>`` in the child carries the BASE (left) frame's value (so left
+values were matched against the right frame — poisoning correlation
+onto whichever wrong right-row the left value happened to hit).
+
+All tests drive ``execute_trace`` end-to-end on real pipeline graphs;
+nothing feeds correlation internals by hand.  Assertions cover the
+trace PATH (which upstream nodes appear) and per-step row VALUES only —
+deliberately nothing about waterfall payloads (rewritten in Wave 3a),
+and no fixture values anywhere near 2**53 (Int64 JSON semantics change
+in Wave 7).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from haute.trace import TraceResult, TraceStep, execute_trace
+from tests.conftest import make_edge, make_graph, make_node, make_source_node
+
+LEFT_ID = "left_src"
+RIGHT_ID = "right_src"
+JOIN_ID = "join"
+
+
+def _edge_join_graph(
+    tmp_path,
+    left_df: pl.DataFrame,
+    right_df: pl.DataFrame,
+    join_config: dict,
+    *,
+    reverse_edges: bool = False,
+):
+    """Two parquet sources feeding one edge-join node."""
+    left_path = tmp_path / "left.parquet"
+    right_path = tmp_path / "right.parquet"
+    left_df.write_parquet(left_path)
+    right_df.write_parquet(right_path)
+    config = {"baseInput": LEFT_ID, "joinInput": RIGHT_ID, **join_config}
+    edges = [make_edge(LEFT_ID, JOIN_ID), make_edge(RIGHT_ID, JOIN_ID)]
+    if reverse_edges:
+        edges.reverse()
+    return make_graph(
+        {
+            "nodes": [
+                make_source_node(LEFT_ID, str(left_path)),
+                make_source_node(RIGHT_ID, str(right_path)),
+                make_node(
+                    {
+                        "id": JOIN_ID,
+                        "data": {
+                            "label": "Join",
+                            "nodeType": "edgeJoin",
+                            "config": config,
+                        },
+                    }
+                ),
+            ],
+            "edges": edges,
+        }
+    )
+
+
+def _step_ids(result: TraceResult) -> list[str]:
+    return [s.node_id for s in result.steps]
+
+
+def _step(result: TraceResult, node_id: str) -> TraceStep:
+    matches = [s for s in result.steps if s.node_id == node_id]
+    assert len(matches) == 1, f"expected exactly one step for {node_id!r}, got {_step_ids(result)}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Inner join — right-parent correlation through the suffix
+# ---------------------------------------------------------------------------
+
+
+class TestInnerJoinRightParentCorrelation:
+    def test_right_parent_row_resolves_through_left_on_right_on_keys(self, tmp_path):
+        """The suffixed copy identifies the right row; the left value must not.
+
+        The right parent deliberately contains a decoy row whose
+        ``premium`` equals the LEFT row's premium.  Correlating with the
+        child's unsuffixed ``premium`` (a left value) locks onto the
+        decoy; the child's ``premium_right`` (the right value) plus the
+        leftOn/rightOn key pair identify the genuinely joined row.
+        """
+        left = pl.DataFrame({"policy": ["P1"], "premium": [100]})
+        right = pl.DataFrame(
+            {
+                "ref": ["P1", "P2"],
+                "premium": [999, 100],
+                "tier": ["gold", "silver"],
+            }
+        )
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "leftOn": "policy", "rightOn": "ref"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert set(_step_ids(result)) == {LEFT_ID, RIGHT_ID, JOIN_ID}
+        assert _step(result, JOIN_ID).output_values == {
+            "policy": "P1",
+            "premium": 100,
+            "premium_right": 999,
+            "tier": "gold",
+        }
+        assert _step(result, LEFT_ID).output_values == {"policy": "P1", "premium": 100}
+        assert _step(result, RIGHT_ID).output_values == {
+            "ref": "P1",
+            "premium": 999,
+            "tier": "gold",
+        }
+
+    def test_right_parent_row_resolves_with_duplicate_join_keys(self, tmp_path):
+        """1:many join — only the suffixed value can pick between key-twins."""
+        left = pl.DataFrame({"key": ["a"], "premium": [100]})
+        right = pl.DataFrame(
+            {
+                "key": ["a", "a"],
+                "premium": [999, 100],
+                "tier": ["gold", "silver"],
+            }
+        )
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "on": "key", "maintainOrder": "left_right"},
+        )
+
+        first = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+        assert _step(first, RIGHT_ID).output_values == {
+            "key": "a",
+            "premium": 999,
+            "tier": "gold",
+        }
+
+        second = execute_trace(graph, row_index=1, target_node_id=JOIN_ID)
+        assert _step(second, RIGHT_ID).output_values == {
+            "key": "a",
+            "premium": 100,
+            "tier": "silver",
+        }
+
+    def test_custom_suffix_resolves_right_parent(self, tmp_path):
+        """Suffix handling must come from the join config, not '_right' lore."""
+        left = pl.DataFrame({"key": ["a"], "premium": [100]})
+        right = pl.DataFrame(
+            {
+                "key": ["a", "a"],
+                "premium": [999, 100],
+                "tier": ["gold", "silver"],
+            }
+        )
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "on": "key", "suffix": "_lookup", "maintainOrder": "left_right"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert _step(result, JOIN_ID).output_values["premium_lookup"] == 999
+        assert _step(result, RIGHT_ID).output_values == {
+            "key": "a",
+            "premium": 999,
+            "tier": "gold",
+        }
+
+    def test_right_parent_resolved_by_coalesced_key_when_values_tie(self, tmp_path):
+        """leftOn/rightOn key lineage: the coalesced key must disambiguate.
+
+        The right parent's non-key values are identical across rows, so
+        only mapping the child's leftOn value onto the parent's rightOn
+        column can identify which right row actually joined.
+        """
+        left = pl.DataFrame({"policy": ["P2"], "amount": [1]})
+        right = pl.DataFrame({"ref": ["P1", "P2"], "factor": [7, 7]})
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "leftOn": "policy", "rightOn": "ref"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert _step(result, LEFT_ID).output_values == {"policy": "P2", "amount": 1}
+        assert _step(result, RIGHT_ID).output_values == {"ref": "P2", "factor": 7}
+
+
+# ---------------------------------------------------------------------------
+# Column-targeted traces — the three provenance cases
+# ---------------------------------------------------------------------------
+
+
+def _single_row_inner_graph(tmp_path):
+    left = pl.DataFrame({"key": ["k1"], "premium": [100], "left_only": ["L"]})
+    right = pl.DataFrame({"key": ["k1"], "premium": [999], "tier": ["gold"]})
+    return _edge_join_graph(tmp_path, left, right, {"how": "inner", "on": "key"})
+
+
+class TestColumnTraces:
+    def test_left_origin_column_keeps_left_lineage_and_prunes_right(self, tmp_path):
+        graph = _single_row_inner_graph(tmp_path)
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID, column="left_only")
+
+        assert set(_step_ids(result)) == {LEFT_ID, JOIN_ID}
+        assert _step(result, LEFT_ID).output_values == {
+            "key": "k1",
+            "premium": 100,
+            "left_only": "L",
+        }
+        assert _step(result, JOIN_ID).output_values["left_only"] == "L"
+
+    def test_suffixed_right_column_traces_to_right_parent_row(self, tmp_path):
+        """Tracing ``premium_right`` must show the RIGHT parent's actual row."""
+        left = pl.DataFrame({"key": ["a"], "premium": [100]})
+        right = pl.DataFrame(
+            {
+                "key": ["a", "a"],
+                "premium": [999, 100],
+                "tier": ["gold", "silver"],
+            }
+        )
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "on": "key", "maintainOrder": "left_right"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID, column="premium_right")
+
+        # Both parents stay in the lineage of a column the join created.
+        assert set(_step_ids(result)) == {LEFT_ID, RIGHT_ID, JOIN_ID}
+        assert _step(result, JOIN_ID).output_values["premium_right"] == 999
+        assert _step(result, RIGHT_ID).output_values == {
+            "key": "a",
+            "premium": 999,
+            "tier": "gold",
+        }
+
+    def test_uncollided_right_column_keeps_right_lineage_and_prunes_left(self, tmp_path):
+        graph = _single_row_inner_graph(tmp_path)
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID, column="tier")
+
+        assert set(_step_ids(result)) == {RIGHT_ID, JOIN_ID}
+        assert _step(result, RIGHT_ID).output_values == {
+            "key": "k1",
+            "premium": 999,
+            "tier": "gold",
+        }
+        assert _step(result, JOIN_ID).output_values["tier"] == "gold"
+
+
+# ---------------------------------------------------------------------------
+# Left join — matched and unmatched rows
+# ---------------------------------------------------------------------------
+
+
+class TestLeftJoin:
+    def test_matched_row_traces_both_parents(self, tmp_path):
+        left = pl.DataFrame({"key": ["a", "z"], "premium": [100, 5]})
+        right = pl.DataFrame({"key": ["a"], "premium": [999], "tier": ["gold"]})
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "left", "on": "key", "maintainOrder": "left"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert set(_step_ids(result)) == {LEFT_ID, RIGHT_ID, JOIN_ID}
+        assert _step(result, JOIN_ID).output_values == {
+            "key": "a",
+            "premium": 100,
+            "premium_right": 999,
+            "tier": "gold",
+        }
+        assert _step(result, LEFT_ID).output_values == {"key": "a", "premium": 100}
+        assert _step(result, RIGHT_ID).output_values == {
+            "key": "a",
+            "premium": 999,
+            "tier": "gold",
+        }
+
+    def test_unmatched_row_omits_right_parent_instead_of_inventing_one(self, tmp_path):
+        """A left-join miss has NO right lineage — never show a spurious row.
+
+        The right parent's only row shares the left row's ``premium`` and
+        a null ``tier`` (matching the join output's null), so value
+        matching on left-provenance columns would lock onto it even
+        though the join never matched it.
+        """
+        left = pl.DataFrame({"key": ["z"], "premium": [5]})
+        right = pl.DataFrame(
+            {
+                "key": ["a"],
+                "premium": [5],
+                "tier": pl.Series("tier", [None], dtype=pl.Utf8),
+            }
+        )
+        graph = _edge_join_graph(tmp_path, left, right, {"how": "left", "on": "key"})
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert RIGHT_ID not in _step_ids(result)
+        assert _step(result, LEFT_ID).output_values == {"key": "z", "premium": 5}
+        assert _step(result, JOIN_ID).output_values == {
+            "key": "z",
+            "premium": 5,
+            "premium_right": None,
+            "tier": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Full join — uncoalesced keys travel through the suffix
+# ---------------------------------------------------------------------------
+
+
+class TestFullJoin:
+    def test_right_only_row_maps_suffixed_key_back_to_right_parent(self, tmp_path):
+        left = pl.DataFrame({"key": ["a"], "left_only": ["L"]})
+        right = pl.DataFrame({"key": ["a", "b"], "tier": ["gold", "silver"]})
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "full", "on": "key", "maintainOrder": "left_right"},
+        )
+
+        result = execute_trace(graph, row_index=1, target_node_id=JOIN_ID)
+
+        # The left frame contributed nothing to this row.
+        assert LEFT_ID not in _step_ids(result)
+        assert _step(result, JOIN_ID).output_values == {
+            "key": None,
+            "left_only": None,
+            "key_right": "b",
+            "tier": "silver",
+        }
+        assert _step(result, RIGHT_ID).output_values == {"key": "b", "tier": "silver"}
+
+    def test_matched_row_traces_both_parents(self, tmp_path):
+        left = pl.DataFrame({"key": ["a"], "left_only": ["L"]})
+        right = pl.DataFrame({"key": ["a", "b"], "tier": ["gold", "silver"]})
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "full", "on": "key", "maintainOrder": "left_right"},
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert set(_step_ids(result)) == {LEFT_ID, RIGHT_ID, JOIN_ID}
+        assert _step(result, LEFT_ID).output_values == {"key": "a", "left_only": "L"}
+        assert _step(result, RIGHT_ID).output_values == {"key": "a", "tier": "gold"}
+
+
+# ---------------------------------------------------------------------------
+# Graph wiring — role resolution must not depend on edge order
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeOrderIndependence:
+    def test_role_resolution_independent_of_edge_order(self, tmp_path):
+        left = pl.DataFrame({"policy": ["P1"], "premium": [100]})
+        right = pl.DataFrame(
+            {
+                "ref": ["P1", "P2"],
+                "premium": [999, 100],
+                "tier": ["gold", "silver"],
+            }
+        )
+        graph = _edge_join_graph(
+            tmp_path,
+            left,
+            right,
+            {"how": "inner", "leftOn": "policy", "rightOn": "ref"},
+            reverse_edges=True,
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id=JOIN_ID)
+
+        assert _step(result, LEFT_ID).output_values == {"policy": "P1", "premium": 100}
+        assert _step(result, RIGHT_ID).output_values == {
+            "ref": "P1",
+            "premium": 999,
+            "tier": "gold",
+        }


### PR DESCRIPTION
This branch carries the edge-join / multi-port feature (commits 76112783, f95a7d73) plus Waves 0-1 of the CODE_REVIEW.md remediation. Tracker: REMEDIATION_PLAN.md.

**Draft until Wave 1 completes** - review finding C1 (edge-join node-id round-trip) is a merge blocker for this branch: edge-joins built from canvas-created nodes fail to reload after a server restart.

Scope:
- **W0 rails**: e2e reset safety guard (toplevel assertion + GIT_CEILING_DIRECTORIES), win32 CI coverage for tests/test_file_ops.py, baseline green + coverage snapshot.
- **W1 blockers**: C1 (codegen role-id remap + round-trip test), C3 (edge handles in graph fingerprint, ALGO_VERSION 3->4), apiInput port-identity cluster (stable port ids, validation surfacing, focus retention), undo granularity, edge-join trace tests + join-semantics matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)