### PR TITLE
Add OS junk-file ignores to the root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,6 +253,19 @@ src/haute/static/
 # data
 /data
 
+# macOS system files
+.DS_Store
+.DS_Store?
+._*
+
+# Windows system files
+# Zone.Identifier files are NTFS alternate data streams created when files are
+# downloaded from the internet on Windows. They're invisible on Windows but
+# appear as literal files with colons in their names on Mac/Linux.
+*:Zone.Identifier
+Thumbs.db
+Desktop.ini
+
 # Internal docs - not for public repos
 WTW_RADAR_REPORT.md
 CLAUDE.md


### PR DESCRIPTION
## Summary
- Root .gitignore now ignores macOS junk files (.DS_Store, .DS_Store?, ._*) and Windows junk files (*:Zone.Identifier NTFS-stream artefacts, Thumbs.db, Desktop.ini), repo-wide.
- Recovered verbatim from baddcf62 (nick-dev, 2026-03-02) — the junk-file block is the only part of that commit that never reached main. Deliberately excluded: the price-contour comment-out, the lightningcss lockfile removal and the uv-workspace stanza (obsolete or since solved on main), and the .claude/ ignore (already on main via 8521db8e).
- Until now the only cover was the .DS_Store entry in frontend/.gitignore, scoped to the frontend tree.

## Verification
- `git check-ignore -v`: all five pattern families match at the root and in subdirectories.
- `git ls-files -i -c --exclude-standard`: empty before and after — no tracked file becomes newly ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)