### PR TITLE
apiInput read-gate: surface malformed persisted schema entries

### DIFF
--- a/frontend/e2e/persistence/api-input-render-gate.spec.ts
+++ b/frontend/e2e/persistence/api-input-render-gate.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Render-gate e2e for the v2-native apiInput editor.
+ *
+ * Guards the `readV2` render-gate fix: structurally-incomplete persisted
+ * entries (a table with a blank `path`, a column with a blank `name`/`path`,
+ * a table with a blank `label`) must SURFACE in the editor for repair —
+ * never be silently dropped on read or masked. Before the fix, `readV2`
+ * did `if (!path) continue` / `if (!cname || !cpath) continue`, so such an
+ * entry vanished on read and was re-serialised away on the next edit (silent
+ * data loss); a blank `label` was coerced to the path (masked as valid).
+ *
+ * Per AGENTS.md §UI Test Assertions: drive the real browser, seed the
+ * persisted config on disk, and read what the editor actually renders.
+ *
+ * NB: the editor renders rows from the CONFIG (classifyConfig → readV2),
+ * independent of whether the paths resolve against the sample data — so the
+ * fixture paths need only be grammar-valid `[:]`, not present in
+ * sample_quote.json. The companion unit suite is
+ * `src/__tests__/editors/apiInputSchemaReadGate.test.ts`.
+ */
+import { writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { expect, test } from "@playwright/test"
+
+import { e2eProjectRoot, resetE2eProject } from "../projectIsolation"
+
+const quotesConfigPath = resolve(
+  e2eProjectRoot,
+  "rating",
+  "config",
+  "quote_input",
+  "quotes.json",
+)
+
+/** A v2 column with the inference defaults; name/path are the variables. */
+function col(name: string, path: string, type = "str") {
+  return { name, path, type, status: "Inferred", selected: true, levels: null }
+}
+
+function table(
+  path: string,
+  label: string,
+  columns: ReturnType<typeof col>[],
+) {
+  return { path, label, displayPath: null, emit: true, row_id_column: null, columns }
+}
+
+/** All-valid baseline: 2 well-formed tables, no blanks. */
+const CONTROL_CONFIG = {
+  path: "data/quotes/sample_quote.json",
+  contract: "opaque",
+  tables: [
+    table("$[:]", "quotes", [
+      col("quote_id", "$[:].quote_id"),
+      col("premium_amount", "$[:].premium_amount", "float"),
+    ]),
+    table("$[:].claims[:]", "claims", [
+      col("amount", "$[:].claims[:].amount", "float"),
+      col("claim_date", "$[:].claims[:].claim_date"),
+    ]),
+  ],
+}
+
+/**
+ * The baseline plus one of each "incomplete entry". Table/column indices are
+ * load-bearing for the testid assertions below:
+ *   table 0 "quotes": col 0 valid · col 1 blank NAME · col 2 blank PATH
+ *   table 1 "claims": valid
+ *   table 2 "orphan_no_path": blank table PATH (whole table dropped pre-fix)
+ *   table 3: blank LABEL, path intact (label masked as path pre-fix)
+ */
+const RENDER_GATE_CONFIG = {
+  path: "data/quotes/sample_quote.json",
+  contract: "opaque",
+  tables: [
+    table("$[:]", "quotes", [
+      col("quote_id", "$[:].quote_id"),
+      col("", "$[:].premium_amount", "float"), // blank NAME, path intact
+      col("channel", ""), // blank PATH, name intact
+    ]),
+    table("$[:].claims[:]", "claims", [
+      col("amount", "$[:].claims[:].amount", "float"),
+    ]),
+    table("", "orphan_no_path", []), // blank table PATH
+    table("$[:].addons[:]", "", [
+      col("addon_code", "$[:].addons[:].code"),
+    ]), // blank LABEL, path intact
+  ],
+}
+
+function seedConfig(config: unknown): void {
+  writeFileSync(quotesConfigPath, JSON.stringify(config, null, 2) + "\n", "utf8")
+}
+
+async function openQuotesEditor(page: import("@playwright/test").Page) {
+  await page.goto("/")
+  await expect(
+    page.getByRole("toolbar", { name: /pipeline toolbar/i }),
+  ).toBeVisible()
+  await page.getByTestId("rf__node-quotes").click()
+  const editor = page.getByTestId("api-input-editor")
+  await expect(editor).toBeVisible()
+  return editor
+}
+
+test.describe("apiInput v2 render-gate (persistence layer)", () => {
+  test.beforeEach(() => {
+    resetE2eProject()
+  })
+
+  test("keeps and flags every incomplete persisted entry (no silent drop)", async ({
+    page,
+  }) => {
+    seedConfig(RENDER_GATE_CONFIG)
+    const editor = await openQuotesEditor(page)
+
+    // 1. KEEP: all four tables render — none dropped. (Pre-fix the blank-path
+    //    "orphan_no_path" table and the two blank columns would have vanished.)
+    await expect(page.getByTestId(/^api-input-table-\d+$/)).toHaveCount(4)
+
+    // 2. KEEP the blanks verbatim at their persisted positions.
+    await expect(page.getByTestId("api-input-table-0-col-1-name")).toHaveValue("")
+    await expect(page.getByTestId("api-input-table-0-col-1-path")).toHaveValue(
+      "$[:].premium_amount",
+    )
+    await expect(page.getByTestId("api-input-table-0-col-2-name")).toHaveValue(
+      "channel",
+    )
+    await expect(page.getByTestId("api-input-table-0-col-2-path")).toHaveValue("")
+    await expect(page.getByTestId("api-input-table-2-path")).toHaveValue("")
+    // Blank label kept verbatim — NOT coerced to its (valid) path.
+    await expect(page.getByTestId("api-input-table-3-label")).toHaveValue("")
+    await expect(page.getByTestId("api-input-table-3-path")).toHaveValue(
+      "$[:].addons[:]",
+    )
+
+    // 3. FLAG: each blank surfaces its inline validation error (idle
+    //    validation — no interaction needed).
+    await expect(
+      editor.getByText("this column is invalid and can't be saved", {
+        exact: false,
+      }),
+      "blank column name + blank column path are both flagged",
+    ).toHaveCount(2)
+    await expect(
+      editor.getByText("this table is invalid and can't be saved", {
+        exact: false,
+      }),
+      "blank table path is flagged",
+    ).toHaveCount(1)
+    await expect(
+      editor.getByText("it names this table's frame", { exact: false }),
+      "blank label is flagged (and not masked as the path)",
+    ).toHaveCount(1)
+  })
+
+  test("a fully valid config renders no validation errors (control)", async ({
+    page,
+  }) => {
+    seedConfig(CONTROL_CONFIG)
+    const editor = await openQuotesEditor(page)
+
+    await expect(page.getByTestId(/^api-input-table-\d+$/)).toHaveCount(2)
+    // No blank-field validation messages for a well-formed config — proves the
+    // errors above are caused by the anomalies, not spurious flagging.
+    await expect(
+      editor.getByText("is invalid and can't be saved", { exact: false }),
+    ).toHaveCount(0)
+    await expect(
+      editor.getByText("it names this table's frame", { exact: false }),
+    ).toHaveCount(0)
+  })
+})

--- a/frontend/e2e/persistence/api-input-v2-native.spec.ts
+++ b/frontend/e2e/persistence/api-input-v2-native.spec.ts
@@ -109,8 +109,11 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
         "infer responds 200",
       ).toBe(200)
 
-      // After Infer, tables should be present. Count via testid prefix.
-      const tableRows = page.locator('[data-testid^="api-input-table-"]')
+      // After Infer, tables should be present. Match the row container
+      // testid exactly (api-input-table-<ti>) — a prefix selector would
+      // also count every child element (-emit, -label, -col-0-name, …)
+      // and pass with a single table.
+      const tableRows = page.getByTestId(/^api-input-table-\d+$/)
       const tableCount = await tableRows.count()
       expect(
         tableCount,
@@ -119,10 +122,15 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
 
       // No indexed-array paths: a column path matching `.<digit>.` is
       // the v1-flatten failure mode (`claims.1.claim_date`). Scan all
-      // column-path inputs.
+      // column-path inputs (api-input-table-<ti>-col-<ci>-path); table-level
+      // path inputs (api-input-table-<ti>-path) have no -col- segment.
       const allColumnPathInputs = page.locator(
-        '[data-testid$="-path"]:not([data-testid*="-table-"])',
+        '[data-testid="api-input-tables"] [data-testid*="-col-"][data-testid$="-path"]',
       )
+      expect(
+        await allColumnPathInputs.count(),
+        "at least one column-path input rendered after Infer (guards the scan below against going vacuous)",
+      ).toBeGreaterThan(0)
       const allPaths = await allColumnPathInputs.evaluateAll((els) =>
         els.map((el) => (el as HTMLInputElement).value),
       )

--- a/frontend/src/__tests__/cssColorTokenization.test.ts
+++ b/frontend/src/__tests__/cssColorTokenization.test.ts
@@ -15,7 +15,7 @@
  *     across `#ef4444`, `#ee4444`, `#ef4445` etc.
  *   - Defeat light/dark-mode overrides which work by re-declaring tokens.
  *
- * This suite pins two properties:
+ * This suite pins three properties:
  *
  *   1. NO hex literals (`#RGB`, `#RRGGBB`, `#RRGGBBAA`) appear outside
  *      the `:root` block.  Inside `:root` they are expected — that's where
@@ -30,6 +30,16 @@
  *      fallback — those are caller-supplied properties whose fallback is
  *      the real token.  We only flag var() calls with no fallback.
  *
+ *   3. Every fallback-less `var(--name)` in live `.ts`/`.tsx` source
+ *      (inline `style={{ ... }}` objects, CSS-in-JS strings) resolves to
+ *      a token declared in index.css.  A dangling reference is worse here
+ *      than in CSS: the declaration is invalid at computed-value time, so
+ *      the property silently becomes its initial value — `transparent`
+ *      backgrounds, `currentColor` borders — with no build error and no
+ *      console warning.  Tokens provided at runtime by something other
+ *      than index.css (caller-set inline properties, Tailwind's @theme
+ *      layer) must carry an inline fallback, same as rule 2.
+ *
  * When this test fails
  * --------------------
  * - "hex literal outside :root" — move the colour to a new token inside
@@ -39,7 +49,7 @@
  *   property is deliberately caller-supplied.
  */
 import { describe, it, expect } from "vitest"
-import { readFileSync } from "node:fs"
+import { readFileSync, readdirSync, statSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -186,6 +196,18 @@ function findVarRefs(css: string): VarRef[] {
   while ((m = openRe.exec(css)) !== null) {
     const name = m[1]
     const offset = m.index
+    // A name truncated by a template interpolation — e.g. the dynamic
+    // `var(--diff-${diffStatus})` in PipelineNode.tsx — is a runtime-
+    // composed token reference: the full name doesn't exist statically,
+    // so declared-ness can't be judged here. Skip it (rules 1/2 still
+    // pin the token family's declarations in index.css itself).
+    // Anchor at the end of the captured NAME, not openRe.lastIndex —
+    // lastIndex sits past the regex's trailing \s* run, and a COMPLETE
+    // static name merely followed by whitespace + `${...}` (e.g.
+    // `var(--bg ${x})`) must still be reported. m[0]'s only trailing
+    // whitespace is that \s* run, so trimEnd() lands exactly at the
+    // name end.
+    if (css.startsWith("${", m.index + m[0].trimEnd().length)) continue
     // Walk forward from the end of the match to find the matching `)`
     // and note whether we pass a comma at depth 0.
     let depth = 1
@@ -227,6 +249,101 @@ function findTokenDeclarations(css: string): Set<string> {
     decls.add(m[2])
   }
   return decls
+}
+
+// ---------------------------------------------------------------------------
+// TS/TSX source scanner (contract property 3)
+// ---------------------------------------------------------------------------
+
+const SRC_ROOT = path.resolve(HERE, "..")
+
+/**
+ * Enumerate live `.ts`/`.tsx` source files under `frontend/src`, skipping
+ * test code (`__tests__/`, `*.test.*`, `*.spec.*`) — test fixtures use
+ * deliberately-fake var() names as examples.
+ */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue
+      out.push(...collectSourceFiles(full))
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(test|spec)\.(ts|tsx)$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+/**
+ * Blank out block comments and whole-line `//` comments so var() examples
+ * in doc comments aren't flagged.  Comments are replaced with whitespace
+ * (newlines preserved) so reported line numbers stay accurate.  Trailing
+ * `//` comments are left in place because the pattern can't be
+ * distinguished from `://` inside string URLs — erring on the side of
+ * scanning too much, which only ever makes the contract stricter.
+ *
+ * The block-comment pass is STRING-AWARE: a `/*` inside a '…', "…" or
+ * `…` literal (e.g. a glob like "src/*") does not open a comment span.
+ * A naive regex pass blanked real code from such a string to the next
+ * comment terminator in the file — the bad direction for this contract,
+ * since a dangling var(--...) in the blanked span went unreported
+ * (false negative). Pinned by the canary test below.
+ */
+function stripComments(text: string): string {
+  let out = ""
+  let i = 0
+  // Current context: inside a block comment, inside a string/template
+  // literal (the quote char), or plain code (null).
+  let mode: '"' | "'" | "`" | "/*" | null = null
+  while (i < text.length) {
+    const ch = text[i]
+    if (mode === "/*") {
+      if (ch === "*" && text[i + 1] === "/") {
+        out += "  "
+        i += 2
+        mode = null
+        continue
+      }
+      out += ch === "\n" ? "\n" : " "
+      i++
+      continue
+    }
+    if (mode !== null) {
+      // Inside a string/template literal — copy verbatim, honouring
+      // escapes so an escaped quote doesn't end the literal.
+      if (ch === "\\") {
+        out += text.slice(i, i + 2)
+        i += 2
+        continue
+      }
+      if (ch === mode) mode = null
+      out += ch
+      i++
+      continue
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      out += "  "
+      i += 2
+      mode = "/*"
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      mode = ch
+      out += ch
+      i++
+      continue
+    }
+    out += ch
+    i++
+  }
+  // Whole-line `//` comments — same regex (and same `://` tradeoff) as
+  // before; a `//` line inside a template literal remains the one known
+  // over-strip, unchanged.
+  return out.replace(/^[ \t]*\/\/.*$/gm, "")
 }
 
 // ---------------------------------------------------------------------------
@@ -306,5 +423,74 @@ describe("index.css — design-token contract", () => {
     ]
     const missing = required.filter((t) => !declared.has(t))
     expect(missing).toEqual([])
+  })
+})
+
+describe("ts/tsx source — design-token contract", () => {
+  it("every fallback-less var(--name) in live source resolves to an index.css token", () => {
+    // Regression guard for the bug class where a component references a
+    // token that was never declared (or was renamed away): the style is
+    // invalid at computed-value time and the property silently falls back
+    // to its initial value — e.g. `background` → transparent, `border-color`
+    // → currentColor.  Caught here: ApiInputEditor's var(--bg)/var(--bg-soft)/
+    // var(--text), and the never-declared --bg-surface / --border-subtle.
+    const declared = findTokenDeclarations(CSS)
+    const offenders: string[] = []
+    const files = collectSourceFiles(SRC_ROOT)
+    for (const file of files) {
+      const text = stripComments(readFileSync(file, "utf8"))
+      const dangling = findVarRefs(text).filter((r) => !r.hasFallback && !declared.has(r.name))
+      for (const d of dangling) {
+        const rel = path.relative(SRC_ROOT, file).split(path.sep).join(path.posix.sep)
+        offenders.push(`  ${rel}:${d.line}  var(${d.name})  — no index.css declaration and no inline fallback`)
+      }
+    }
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found ${offenders.length} dangling var(--...) reference(s) in ts/tsx source. ` +
+          `Declare the token in index.css :root, or add an inline fallback ` +
+          `(var(--name, <fallback>)) if the property is caller-supplied or provided by Tailwind:\n` +
+          offenders.join("\n"),
+      )
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it("skips template-interpolated token names (dynamic refs like var(--diff-${status}))", () => {
+    // Regression: the scanner used to truncate `var(--diff-${diffStatus})`
+    // to the never-declared name `--diff-` and flag it as dangling.
+    const refs = findVarRefs('a { color: var(--diff-${status}); background: var(--real); }')
+    expect(refs.map((r) => r.name)).toEqual(["--real"])
+    // …but a COMPLETE static name merely followed by whitespace + an
+    // interpolation is still reported — only a name TRUNCATED by `${`
+    // is dynamic.
+    const spaced = findVarRefs('a { color: var(--bg ${x}); }')
+    expect(spaced.map((r) => r.name)).toEqual(["--bg"])
+  })
+
+  it("stripComments: a '/*' inside a string literal must not blank following code", () => {
+    // A string-unaware pass would open a comment span at the `/*` in
+    // "src/*" and blank everything up to the next real `*/` — hiding
+    // any dangling var(--...) reference in between (a false NEGATIVE,
+    // the bad direction for this contract).
+    const src = 'const g = "src/*"\nconst c = "var(--canary)"\n/* real comment */\n'
+    expect(stripComments(src)).toContain("--canary")
+  })
+
+  it("scans a non-trivial source tree (smoke — prevents silent scope loss)", () => {
+    // If the walker's filters ever accidentally exclude everything (e.g. a
+    // bad rename of SRC_ROOT), the contract test above would pass vacuously.
+    const files = collectSourceFiles(SRC_ROOT)
+    expect(files.length).toBeGreaterThanOrEqual(50)
+    expect(files.some((f) => f.endsWith(".tsx"))).toBe(true)
+    // ...and prove the var() scanner itself still extracts references. A
+    // broken findVarRefs regex (one that matched nothing) would also make
+    // the contract test above pass vacuously — zero refs found, zero
+    // offenders — so assert the live tree yields a non-trivial ref count.
+    const totalRefs = files.reduce(
+      (n, f) => n + findVarRefs(stripComments(readFileSync(f, "utf8"))).length,
+      0,
+    )
+    expect(totalRefs).toBeGreaterThanOrEqual(50)
   })
 })

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -1201,3 +1201,285 @@ describe("ApiInputEditor — W1.9 column-name validation (blank / duplicate)", (
     expect(screen.queryByTestId("api-input-table-0-col-1-name-error")).toBeNull()
   })
 })
+
+// ─── readV2 render-gate: disk-arriving blanks SURFACE, never vanish ──
+//
+// The W1.x work above closed the INTERACTIVE blank-commit vector (the
+// editor refuses to commit a blank name/path/label). But a blank entry
+// can still arrive from disk — a hand-edited/legacy file, or the residue
+// of the pre-W1.x per-keystroke editor that committed `name:""`. Until
+// `readV2` was fixed it silently dropped those, so the row rendered
+// nowhere (and was re-serialised away on the next edit — see the
+// round-trip suite below). `readV2` now KEEPS them; these tests pin that
+// the editor surfaces every persisted entry with inline validation,
+// WITHOUT any interaction (the 1:1 JSON↔UI render-gate invariant).
+describe("ApiInputEditor — disk-arriving blank entries surface (render-gate)", () => {
+  it("a blank-NAME column from disk renders its row with a visible name error", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true },
+            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", selected: true },
+          ],
+        },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={vi.fn()} />)
+
+    // Both columns surface — the blank one did NOT vanish (1:1 JSON↔UI).
+    expect(screen.getByTestId("api-input-table-0-col-0")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-0-col-1")).toBeTruthy()
+    // …and the blank one is flagged so the user can repair/delete it.
+    expect(screen.getByTestId("api-input-table-0-col-0-name-error")).toBeTruthy()
+    const nameInput = screen.getByTestId("api-input-table-0-col-0-name")
+    expect(nameInput.getAttribute("aria-invalid")).toBe("true")
+  })
+
+  it("a blank-PATH column from disk renders its row with a visible path error", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            { name: "premium", path: "", type: "float", status: "Inferred", selected: true },
+          ],
+        },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={vi.fn()} />)
+
+    expect(screen.getByTestId("api-input-table-0-col-0")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-0-col-0-path-error")).toBeTruthy()
+  })
+
+  it("a blank-PATH table from disk renders its row with a visible path error", () => {
+    const config = {
+      tables: [
+        { path: "", label: "orphan", emit: true, columns: [] },
+        { path: "$[:]", label: "policies", emit: true, columns: [] },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={vi.fn()} />)
+
+    // Both tables surface; the blank-path one is flagged, not suppressed.
+    expect(screen.getByTestId("api-input-table-0")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-1")).toBeTruthy()
+    expect(screen.getByTestId("api-input-table-0-path-error")).toBeTruthy()
+  })
+
+  it("a blank-LABEL table from disk (valid path) surfaces a label error, not a masked path", () => {
+    // The label IS the runtime port name; a blank label is backend-invalid.
+    // readV2 must KEEP `label:""` verbatim (not coerce it to the path),
+    // so validateTableLabel surfaces the error rather than the row looking
+    // valid and the blank being silently rewritten to the path on save.
+    const config = {
+      tables: [
+        { path: "$[:]", label: "", emit: true, columns: [] },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={vi.fn()} />)
+
+    const labelInput = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    // The label was NOT masked as the path "$[:]"; it shows blank…
+    expect(labelInput.value).toBe("")
+    // …with a visible error and aria-invalid, no interaction.
+    expect(screen.getByTestId("api-input-table-0-label-error")).toBeTruthy()
+    expect(labelInput.getAttribute("aria-invalid")).toBe("true")
+  })
+})
+
+// ─── Persistent-boundary regression: blank entry survives a round-trip ──
+//
+// The headline data-loss bug. A blank entry on disk was dropped by
+// readV2, and the editor's NEXT write re-serialised the filtered view
+// (writeV2) — permanently deleting the entry from the persisted config,
+// even though the user never touched it. This drives an UNRELATED edit
+// through a NON-MOCKED handleConfigUpdate (StatefulHarness echoes
+// onUpdate back into config exactly like NodePanel) and asserts the
+// persisted object STILL contains the blank column, with EXACT shape
+// (AGENTS contract §UI Test Assertions: assert at the persistent
+// boundary, exact shape). RED before the readV2 fix; GREEN after.
+//
+// Each test drives the UNRELATED edit through the table-level `emit`
+// checkbox (api-input-table-0-emit). That testid is positionally stable
+// — the *table* is never dropped by the bug — so the click succeeds in
+// BOTH the pre-fix and post-fix worlds, and the RED is driven by the
+// persistence (toEqual) assertion itself rather than an incidental
+// element-not-found. (Toggling a *column* checkbox would vanish pre-fix
+// when the blank row above it is dropped and the indices collapse.)
+describe("ApiInputEditor — blank entry is not lost when an unrelated field is edited", () => {
+  it("a blank-NAME column survives an unrelated edit (persisted config, exact shape)", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            // Residue of the old per-keystroke clear: a real source path
+            // but a blank name. The user is NOT editing this column.
+            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true },
+            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", selected: true },
+          ],
+        },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+
+    // Unrelated, immediate-commit edit: toggle the TABLE's emit.
+    fireEvent.click(screen.getByTestId("api-input-table-0-emit"))
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const persisted = onUpdateSpy.mock.calls.at(-1)![0]
+    expect(persisted).toEqual({
+      path: "",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          displayPath: null,
+          emit: false,
+          row_id_column: null,
+          columns: [
+            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", selected: true, levels: null },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("a blank-PATH column survives an unrelated edit (persisted config, exact shape)", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            { name: "premium", path: "", type: "float", status: "Inferred", selected: true },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true },
+          ],
+        },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+
+    fireEvent.click(screen.getByTestId("api-input-table-0-emit"))
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(onUpdateSpy.mock.calls.at(-1)![0]).toEqual({
+      path: "",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          displayPath: null,
+          emit: false,
+          row_id_column: null,
+          columns: [
+            { name: "premium", path: "", type: "float", status: "Inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("a blank-PATH table survives an unrelated edit on another table (persisted config, exact shape)", () => {
+    // Table-level twin of the column round-trips: the blank-path table is
+    // LAST and we edit the FIRST (valid) table's emit, so the click target
+    // is stable across pre/post-fix and the RED comes from the table being
+    // dropped from the persisted array, not a missing element.
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true },
+          ],
+        },
+        { path: "", label: "orphan", emit: false, columns: [] },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+
+    fireEvent.click(screen.getByTestId("api-input-table-0-emit"))
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(onUpdateSpy.mock.calls.at(-1)![0]).toEqual({
+      path: "",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          displayPath: null,
+          emit: false,
+          row_id_column: null,
+          columns: [
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+          ],
+        },
+        { path: "", label: "orphan", displayPath: null, emit: false, row_id_column: null, columns: [] },
+      ],
+    })
+  })
+
+  it("a blank-LABEL table is not silently rewritten to its path on an unrelated edit", () => {
+    // Distinct mechanism from the drops above: pre-fix readV2 KEPT this
+    // table (its path is valid) but COERCED `label:""` → the path string,
+    // so an unrelated edit re-serialised `label:"$[:]"` — silently
+    // overwriting the persisted blank. The fix keeps `label:""` verbatim.
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "",
+          emit: true,
+          columns: [
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true },
+          ],
+        },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+
+    fireEvent.click(screen.getByTestId("api-input-table-0-emit"))
+
+    expect(onUpdateSpy).toHaveBeenCalledTimes(1)
+    const persisted = onUpdateSpy.mock.calls.at(-1)![0] as { tables: { label: string }[] }
+    // The blank label survived as "" — NOT rewritten to the path "$[:]".
+    expect(persisted.tables[0].label).toBe("")
+    expect(persisted).toEqual({
+      path: "",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:]",
+          label: "",
+          displayPath: null,
+          emit: false,
+          row_id_column: null,
+          columns: [
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/frontend/src/__tests__/editors/apiInputSchemaReadGate.test.ts
+++ b/frontend/src/__tests__/editors/apiInputSchemaReadGate.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Render-gate contract for `readV2` (the v2 apiInput read codec).
+ *
+ * Bug class (silent data loss). `readV2` historically did
+ * `if (!path) continue` for tables and `if (!cname || !cpath) continue`
+ * for columns — silently dropping any persisted entry whose name/path
+ * was blank. Because the editor re-derives its view through
+ * `classifyConfig → readV2` and then re-serialises that view via
+ * `writeV2` on the next edit, a dropped-on-read entry was permanently
+ * deleted from the persisted config on the user's next keystroke
+ * elsewhere. A blank entry could arrive from a hand-edited/legacy file
+ * or as the residue of the old per-keystroke editor that committed
+ * `name:""`. Either way the user had no surface to see or repair it —
+ * a violation of the 1:1 JSON↔UI render-gate invariant (every persisted
+ * entry must surface somewhere visible; greying/erroring is fine,
+ * suppression is not).
+ *
+ * Fix. `readV2` KEEPS such entries by default (the disk/render path);
+ * the editor renders them in an invalid state (inline error) so they
+ * can be repaired or explicitly deleted. The Infer-Tables path — fresh
+ * backend output that was never user-persisted — opts back into dropping
+ * via `{ dropIncomplete: true }`.
+ *
+ * Companion suites: `apiInputSchemaSanitisation.test.ts` (removedTables),
+ * `ApiInputEditor.test.tsx` (the editor surfaces these entries + the
+ * persistent-boundary round-trip), and `tests/test_v2_codec_and_shred.py`
+ * (the backend twin LOUDLY rejects the same blanks rather than dropping).
+ *
+ * Paths use the canonical `[:]` array selector (the only form accepted by
+ * the path grammar); `readV2` itself is grammar-agnostic and passes paths
+ * through verbatim, so these fixtures only assert keep/drop behaviour.
+ */
+import { describe, it, expect } from "vitest"
+
+import { readV2, writeV2 } from "../../panels/editors/apiInputSchema"
+
+/** A column whose source path is intact but whose name was cleared. */
+const BLANK_NAME_COL = {
+  name: "",
+  path: "$[:].policy_id",
+  type: "int",
+  status: "Inferred",
+  selected: true,
+  levels: null,
+}
+
+/** A column whose name is intact but whose source path was cleared. */
+const BLANK_PATH_COL = {
+  name: "premium",
+  path: "",
+  type: "float",
+  status: "Inferred",
+  selected: true,
+  levels: null,
+}
+
+const VALID_COL = {
+  name: "policy_ref",
+  path: "$[:].policy_ref",
+  type: "str",
+  status: "Confirmed",
+  selected: true,
+  levels: null,
+}
+
+function configWith(columns: unknown[]): Record<string, unknown> {
+  return {
+    path: "data/input.json",
+    contract: "opaque",
+    tables: [
+      { path: "$[:]", label: "policies", emit: true, columns },
+    ],
+  }
+}
+
+describe("readV2 render-gate — keeps blank entries by default (no silent drop)", () => {
+  it("keeps a column whose NAME is blank (path intact)", () => {
+    const v2 = readV2(configWith([BLANK_NAME_COL, VALID_COL]))
+    expect(v2.tables[0].columns).toHaveLength(2)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "", path: "$[:].policy_id" })
+  })
+
+  it("keeps a column whose PATH is blank (name intact)", () => {
+    const v2 = readV2(configWith([BLANK_PATH_COL, VALID_COL]))
+    expect(v2.tables[0].columns).toHaveLength(2)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "premium", path: "" })
+  })
+
+  it("keeps a column whose name AND path are both blank", () => {
+    const v2 = readV2(configWith([{ name: "", path: "", type: "str" }, VALID_COL]))
+    expect(v2.tables[0].columns).toHaveLength(2)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "", path: "" })
+  })
+
+  it("keeps a table whose PATH is blank", () => {
+    const config = {
+      tables: [
+        { path: "", label: "orphan", emit: true, columns: [] },
+        { path: "$[:]", label: "policies", emit: true, columns: [] },
+      ],
+    }
+    const v2 = readV2(config)
+    expect(v2.tables).toHaveLength(2)
+    expect(v2.tables[0]).toMatchObject({ path: "", label: "orphan" })
+  })
+
+  it("keeps a blank table LABEL verbatim — does NOT coerce it to the path", () => {
+    // The label is the runtime port name; a blank label is backend-invalid.
+    // Masking it as the path would render the row as valid and silently
+    // rewrite the persisted "" to the path on the next edit.
+    const v2 = readV2({
+      tables: [{ path: "$[:]", label: "", emit: true, columns: [] }],
+    })
+    expect(v2.tables).toHaveLength(1)
+    expect(v2.tables[0].label).toBe("")
+  })
+
+  it("defaults a MISSING label key to the path (inference convention preserved)", () => {
+    // Distinct from a blank label: an omitted label is the inference
+    // convention (label defaults to the table path), not a user-cleared
+    // field, so coercion is correct there.
+    const v2 = readV2({
+      tables: [{ path: "$[:]", emit: true, columns: [] }],
+    })
+    expect(v2.tables[0].label).toBe("$[:]")
+  })
+
+  it("coerces a missing name/path to '' but still KEEPS the entry", () => {
+    // A column object lacking the keys entirely (not even blank strings)
+    // is still a content-bearing persisted entry — surface it, don't drop.
+    const v2 = readV2(configWith([{ type: "int", selected: true }, VALID_COL]))
+    expect(v2.tables[0].columns).toHaveLength(2)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "", path: "" })
+  })
+
+  it("preserves the 1:1 entry count for a config full of blanks", () => {
+    const v2 = readV2(configWith([BLANK_NAME_COL, BLANK_PATH_COL, VALID_COL]))
+    expect(v2.tables[0].columns).toHaveLength(3)
+  })
+
+  it("still drops genuinely non-object entries (null / string) — not content-bearing", () => {
+    const config = {
+      tables: [
+        null,
+        "garbage",
+        { path: "$[:]", label: "policies", emit: true, columns: [null, "x", VALID_COL] },
+      ],
+    }
+    const v2 = readV2(config)
+    expect(v2.tables).toHaveLength(1)
+    expect(v2.tables[0].columns).toHaveLength(1)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "policy_ref" })
+  })
+
+  it("round-trips a blank entry through writeV2 without losing it", () => {
+    // The data-loss mechanism was read→re-serialise dropping the entry.
+    // With the keep behaviour, writeV2(readV2(x)) must retain the blank.
+    const raw = writeV2(readV2(configWith([BLANK_NAME_COL, VALID_COL])))
+    const cols = (raw.tables as Array<{ columns: unknown[] }>)[0].columns
+    expect(cols).toHaveLength(2)
+    expect(cols[0]).toMatchObject({ name: "", path: "$[:].policy_id" })
+  })
+
+  it("does NOT resurrect removedTables while keeping blank entries (sanitisation intact)", () => {
+    const config = {
+      ...configWith([BLANK_NAME_COL]),
+      removedTables: ["dropped_a"],
+    }
+    const v2 = readV2(config)
+    expect(v2).not.toHaveProperty("removedTables")
+    expect(v2.tables[0].columns).toHaveLength(1)
+  })
+})
+
+describe("readV2 { dropIncomplete: true } — infer-path sanitisation drops blanks", () => {
+  it("drops blank-name and blank-path columns", () => {
+    const v2 = readV2(configWith([BLANK_NAME_COL, BLANK_PATH_COL, VALID_COL]), {
+      dropIncomplete: true,
+    })
+    expect(v2.tables[0].columns).toHaveLength(1)
+    expect(v2.tables[0].columns[0]).toMatchObject({ name: "policy_ref" })
+  })
+
+  it("drops blank-path tables", () => {
+    const config = {
+      tables: [
+        { path: "", label: "orphan", emit: true, columns: [] },
+        { path: "$[:]", label: "policies", emit: true, columns: [] },
+      ],
+    }
+    const v2 = readV2(config, { dropIncomplete: true })
+    expect(v2.tables).toHaveLength(1)
+    expect(v2.tables[0]).toMatchObject({ path: "$[:]", label: "policies" })
+  })
+
+  it("drops blank-label tables (symmetric with blank path/name)", () => {
+    const config = {
+      tables: [
+        { path: "$[:].a[:]", label: "", emit: true, columns: [] },
+        { path: "$[:]", label: "policies", emit: true, columns: [] },
+      ],
+    }
+    const v2 = readV2(config, { dropIncomplete: true })
+    expect(v2.tables).toHaveLength(1)
+    expect(v2.tables[0]).toMatchObject({ path: "$[:]", label: "policies" })
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,6 +10,11 @@
   --bg-panel: #141721;
   --bg-input: #0d0f17;
   --bg-hover: #1f2333;
+  /* Card-on-panel surface. Aliases --bg-panel: call sites historically
+     referenced this token without it being declared, so they rendered
+     transparent and showed the panel colour through — this pins that
+     appearance while making the token real (and individually themeable). */
+  --bg-surface: var(--bg-panel);
 
   /* Chrome (header/sidebar) */
   --chrome: #0b0d14;
@@ -188,6 +193,7 @@
   /* Borders */
   --border: rgba(255,255,255,.07);
   --border-bright: rgba(255,255,255,.10);
+  --border-subtle: rgba(255,255,255,.04);
 
   /* Scrollbars — low-alpha white overlays on the dark surface.
      Track is barely visible; thumb is legible; hover brightens it

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -263,8 +263,10 @@ export default function ApiInputEditor({
   // tab-separated `name<TAB>path<TAB>type<TAB>selected` rows (the shape Copy
   // emits). A recognised header row is dropped; pasted columns REPLACE the
   // table's existing columns. Unknown types coerce to "str" (mirroring
-  // readV2); blank-name/path rows are skipped (they'd be dropped on read
-  // anyway). Pasted columns are author-confirmed (status "Confirmed").
+  // readV2); blank-name/path rows are skipped — fresh paste input drops
+  // the incomplete (like the infer path); the render-gate KEEP applies
+  // only to already-persisted entries. Pasted columns are
+  // author-confirmed (status "Confirmed").
   const pasteColumns = (tableIdx: number, grid: string[][]) => {
     const body =
       grid.length > 0 &&
@@ -322,11 +324,17 @@ export default function ApiInputEditor({
     setInferError(null)
     try {
       const result = await inferJsonCacheSchema({ path: currentPath })
-      // Route the raw /infer response through `readV2` so it's
-      // sanitised exactly like every other read path (drops malformed
-      // tables/columns, coerces unknown column types) instead of being
-      // raw-cast into state.
-      const inferred = readV2({ tables: result.tables as unknown[] }).tables
+      // Route the raw /infer response through `readV2` so unknown column
+      // types are coerced instead of being raw-cast into state. Infer is
+      // fresh backend output that was never user-persisted, so it opts
+      // into dropping structurally-incomplete tables/columns via
+      // `{ dropIncomplete: true }` — unlike the disk/render read paths,
+      // which now KEEP blanks so the editor surfaces them for repair
+      // (render-gate invariant) instead of silently deleting them.
+      const inferred = readV2(
+        { tables: result.tables as unknown[] },
+        { dropIncomplete: true },
+      ).tables
       if (v2.tables.length === 0) {
         // First run — nothing to clobber, apply in one click.
         writeBack({ ...v2, tables: inferred })
@@ -616,7 +624,7 @@ function TableBlock({
     <div
       data-testid={testIdPrefix}
       className="px-2 py-2 rounded-md space-y-1.5"
-      style={{ border: "1px solid var(--border)", background: "var(--bg-soft)" }}
+      style={{ border: "1px solid var(--border)", background: "var(--bg-elevated)" }}
     >
       {/* Shared table-actions strip (pushed onto API inputs too): Copy the
           columns as TSV, Share/Save the table's schema as JSON, Save as
@@ -674,9 +682,9 @@ function TableBlock({
           containerClassName="flex-1 min-w-0"
           className="w-full text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
-            background: "var(--bg)",
+            background: "var(--bg-input)",
             border: "1px solid var(--border)",
-            color: "var(--text)",
+            color: "var(--text-primary)",
           }}
         />
         <CommittedTextInput
@@ -688,7 +696,7 @@ function TableBlock({
           containerClassName="flex-1 min-w-0"
           className="w-full text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
-            background: "var(--bg)",
+            background: "var(--bg-input)",
             border: "1px solid var(--border)",
             color: "var(--text-muted)",
           }}
@@ -741,13 +749,14 @@ function TableBlock({
  * W1.9 — column-name validation, mirroring `validate_v2_schema`: blank
  * names are rejected, and names must be unique WITHIN their table
  * (`seen_col_names` resets per table — the same name in two different
- * tables is legal, each table is its own frame). Refusing at the commit
- * boundary also closes the readV2 silent-drop: a committed blank name
- * deleted the column row instantly.
+ * tables is legal, each table is its own frame). This refuses an
+ * INTERACTIVE blank commit; complementarily, `readV2` no longer drops a
+ * blank-name column arriving from disk (it surfaces here with this same
+ * error), so the column can never silently vanish from either direction.
  */
 function columnNameError(candidate: string, otherNames: readonly string[]): string | null {
   if (!candidate.trim()) {
-    return "A name is required — clearing it would delete this column from the schema."
+    return "A name is required — this column is invalid and can't be saved without one."
   }
   if (otherNames.includes(candidate)) {
     return `Duplicate column name: "${candidate}" is already used in this table.`
@@ -783,7 +792,7 @@ function ColumnRow({
         validate={validateName}
         containerClassName="w-32 shrink-0"
         className="w-full px-1 py-0.5 rounded font-mono"
-        style={{ background: "var(--bg)", border: "1px solid var(--border)" }}
+        style={{ background: "var(--bg-input)", border: "1px solid var(--border)" }}
       />
       <CommittedTextInput
         dataTestId={`${testIdPrefix}-path`}
@@ -794,7 +803,7 @@ function ColumnRow({
         containerClassName="flex-1 min-w-0"
         className="w-full px-1 py-0.5 rounded font-mono"
         style={{
-          background: "var(--bg)",
+          background: "var(--bg-input)",
           border: "1px solid var(--border)",
           color: "var(--text-muted)",
         }}
@@ -804,7 +813,7 @@ function ColumnRow({
         value={col.type}
         onChange={(e) => onUpdate({ type: e.target.value as ColumnType })}
         className="px-1 py-0.5 rounded"
-        style={{ background: "var(--bg)", border: "1px solid var(--border)" }}
+        style={{ background: "var(--bg-input)", border: "1px solid var(--border)" }}
       >
         {COLUMN_TYPES.map((t) => (
           <option key={t} value={t}>
@@ -838,8 +847,10 @@ function ColumnRow({
 // boundary — the draft and a visible error stay in place so the user
 // can fix or revert, and nothing destructive ever reaches config. When
 // idle, the committed value itself is validated, so invalid states
-// arriving from disk or an infer-merge surface without any
-// interaction.
+// arriving from disk or an infer-merge surface without any interaction
+// — load-bearing now that `readV2` KEEPS blank-path/blank-name entries
+// (default read path) instead of silently dropping them: the kept entry
+// renders here and this validation is what makes it visible/repairable.
 
 // ─── INPUT path grammar validation ────────────────────────────────
 //
@@ -848,14 +859,15 @@ function ColumnRow({
 // These wrap the shared grammar core (`jsonpath.ts`, the mirror of
 // `_jsonpath.py`): a TABLE path must end at an array `[:]` or be the root array;
 // a COLUMN path must name a leaf (the `$value` reserved leaf is allowed). Blank
-// keeps its destructive-clear message (clearing a path deletes the table/column
-// via readV2), then the grammar decides everything else — so an invalid path is
-// caught in-editor, not as a 422 on save.
+// keeps its dedicated blank-guard message — an interactive clear is refused at
+// the commit boundary, and a blank arriving from disk (which readV2 now KEEPS)
+// is idle-flagged by this same validator — then the grammar decides everything
+// else, so an invalid path is caught in-editor, not as a 422 on save.
 
 /** INPUT table-path validator: blank-guard + the shared table-path grammar. */
 function validateTablePath(candidate: string): string | null {
   if (!candidate.trim()) {
-    return "A path is required — clearing it would delete this table from the schema."
+    return "A path is required — this table is invalid and can't be saved without one."
   }
   return validateInputTablePath(candidate.trim())
 }
@@ -863,7 +875,7 @@ function validateTablePath(candidate: string): string | null {
 /** INPUT column-path validator: blank-guard + the shared column-path grammar. */
 function validateColumnPath(candidate: string): string | null {
   if (!candidate.trim()) {
-    return "A path is required — clearing it would delete this column from the schema."
+    return "A path is required — this column is invalid and can't be saved without one."
   }
   return validateInputColumnPath(candidate.trim())
 }

--- a/frontend/src/panels/editors/FrameTableActions.tsx
+++ b/frontend/src/panels/editors/FrameTableActions.tsx
@@ -243,7 +243,7 @@ export function FrameTableActions({
               onClick={commitPaste}
               disabled={pasteDraft.trim() === ""}
               className="text-[11px] font-semibold px-2 py-0.5 rounded disabled:opacity-40"
-              style={{ background: "var(--accent, var(--text-muted))", color: "var(--text-on-accent, var(--bg))" }}
+              style={{ background: "var(--accent, var(--text-muted))", color: "var(--text-on-accent, var(--bg-input))" }}
             >
               Apply paste
             </button>

--- a/frontend/src/panels/editors/JsonPreview.tsx
+++ b/frontend/src/panels/editors/JsonPreview.tsx
@@ -111,7 +111,7 @@ export function JsonPreview({
     <div
       data-testid={testIdPrefix}
       className="rounded-md"
-      style={{ border: "1px solid var(--border)", background: "var(--bg-soft)" }}
+      style={{ border: "1px solid var(--border)", background: "var(--bg-elevated)" }}
     >
       <div className="flex items-center gap-2 px-2 py-2">
         <button

--- a/frontend/src/panels/editors/OutputEditor.tsx
+++ b/frontend/src/panels/editors/OutputEditor.tsx
@@ -768,7 +768,7 @@ export default function OutputEditor({
           <div
             data-testid="output-frames-table"
             className="rounded-md"
-            style={{ border: "1px solid var(--border)", background: "var(--bg-soft)" }}
+            style={{ border: "1px solid var(--border)", background: "var(--bg-elevated)" }}
           >
             <div className="flex items-center justify-between gap-2 px-2 py-2">
               <button
@@ -1081,7 +1081,7 @@ function FrameBlock({
     <div
       data-testid={testIdPrefix}
       className="rounded-md"
-      style={{ border: "1px solid var(--border)", background: "var(--bg-soft)" }}
+      style={{ border: "1px solid var(--border)", background: "var(--bg-elevated)" }}
     >
       <div className="flex items-center gap-2 px-2 py-2">
         <button

--- a/frontend/src/panels/editors/apiInputSchema.ts
+++ b/frontend/src/panels/editors/apiInputSchema.ts
@@ -86,8 +86,49 @@ export function classifyConfig(
   return { kind: "empty", raw: config ?? {} }
 }
 
-/** Read a v2 config from a generic record. Tolerant of partial shape. */
-export function readV2(config: Record<string, unknown>): ApiInputConfigV2 {
+/** Options for {@link readV2}. */
+export interface ReadV2Options {
+  /**
+   * Whether to DROP structurally-incomplete entries — tables with a
+   * blank `path`, and columns with a blank `name` or `path`.
+   *
+   * - `false` (the **default**, used by every disk/render read path via
+   *   {@link classifyConfig}): such entries are KEPT verbatim. A
+   *   persisted entry that renders nowhere is still active at execute
+   *   time and the user has no surface to repair it — dropping it on
+   *   read and then re-serialising the filtered view on the next edit is
+   *   silent data loss. The editor renders the kept entry in an invalid
+   *   state (inline error) so it can be repaired or explicitly deleted.
+   *   This upholds the 1:1 JSON↔UI render-gate invariant (every
+   *   persisted entry must surface somewhere visible).
+   *
+   * - `true` (used ONLY for the Infer-Tables response): a malformed
+   *   entry there is fresh backend output that was never user-persisted
+   *   state, so discarding it before it reaches config is correct — we
+   *   don't inject errored rows from an inference quirk.
+   *
+   * Asymmetry with the backend twin (`_api_input_schema.py`): the
+   * backend has no read-into-structure step that could drop — it
+   * `validate_v2_schema`-rejects a blank `name`/`path` LOUDLY (raises →
+   * 422). Both sides refuse to silently drop; the frontend surfaces a
+   * persisted blank via render+flag, the backend via loud rejection.
+   */
+  dropIncomplete?: boolean
+}
+
+/**
+ * Read a v2 config from a generic record. Tolerant of partial shape.
+ *
+ * By default KEEPS structurally-incomplete tables/columns (blank
+ * `path`/`name`) so the editor can surface them for repair; pass
+ * `{ dropIncomplete: true }` on the infer path to discard them. See
+ * {@link ReadV2Options.dropIncomplete}.
+ */
+export function readV2(
+  config: Record<string, unknown>,
+  options: ReadV2Options = {},
+): ApiInputConfigV2 {
+  const { dropIncomplete = false } = options
   const rawTables = Array.isArray((config as { tables?: unknown }).tables)
     ? ((config as { tables: unknown[] }).tables as unknown[])
     : []
@@ -96,8 +137,19 @@ export function readV2(config: Record<string, unknown>): ApiInputConfigV2 {
     if (!t || typeof t !== "object") continue
     const tt = t as Record<string, unknown>
     const path = typeof tt.path === "string" ? tt.path : ""
-    if (!path) continue
-    const label = typeof tt.label === "string" && tt.label ? tt.label : path
+    // Keep a blank label verbatim (mirrors `path` below and the column
+    // `name`/`path`) so the editor surfaces it via validateTableLabel.
+    // Only a MISSING label key defaults to `path` — the inference
+    // convention where the label is simply omitted. A persisted `label:
+    // ""` must NOT be masked as the path: it's backend-invalid (the label
+    // is the runtime port name) and would otherwise render as valid and
+    // be silently rewritten to the path on the next edit.
+    const label = typeof tt.label === "string" ? tt.label : path
+    // Drop a structurally-incomplete table (blank path OR blank label)
+    // only on the infer path. On the disk/render path such a table is a
+    // persisted entry that must surface (render-gate invariant) — the
+    // editor flags the blank field (requireNonBlank / validateTableLabel).
+    if (dropIncomplete && (!path || !label)) continue
     const emit = tt.emit === true
     const displayPath = typeof tt.displayPath === "string" ? tt.displayPath : null
     const row_id_column =
@@ -109,7 +161,12 @@ export function readV2(config: Record<string, unknown>): ApiInputConfigV2 {
       const cc = c as Record<string, unknown>
       const cname = typeof cc.name === "string" ? cc.name : ""
       const cpath = typeof cc.path === "string" ? cc.path : ""
-      if (!cname || !cpath) continue
+      // Drop a blank-name/blank-path column only on the infer path. On
+      // the disk/render path it's a persisted entry that must surface
+      // (render-gate invariant) — the editor flags it via columnNameError
+      // / requireNonBlank so the user repairs or deletes it instead of it
+      // silently vanishing (and being re-serialised away on the next edit).
+      if (dropIncomplete && (!cname || !cpath)) continue
       const ctype = (
         typeof cc.type === "string" && ALLOWED_TYPES.has(cc.type as ColumnType)
           ? cc.type

--- a/tests/test_v2_codec_and_shred.py
+++ b/tests/test_v2_codec_and_shred.py
@@ -198,6 +198,38 @@ def test_validate_rejects_missing_label() -> None:
         validate_v2_schema(cfg)
 
 
+# ─── Blank name/path: the backend twin of the frontend readV2 fix ───
+#
+# The frontend `readV2` codec (frontend/src/panels/editors/apiInputSchema.ts)
+# used to SILENTLY DROP tables with a blank `path` and columns with a
+# blank `name`/`path` — silent data loss. The fix makes it KEEP them and
+# surface them for repair. The backend is the mirror: it must never
+# silently drop these either — it rejects them LOUDLY here, so a config
+# the user couldn't repair can never reach cache-build / execute. These
+# pin that loud rejection (contract parity with the editor's validation).
+
+
+def test_validate_rejects_blank_table_path() -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["path"] = ""
+    with pytest.raises(ApiInputSchemaError, match=r"tables\[0\]\.path is missing"):
+        validate_v2_schema(cfg)
+
+
+def test_validate_rejects_blank_column_name() -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["columns"][0]["name"] = ""
+    with pytest.raises(ApiInputSchemaError, match=r"columns\[0\]\.name is missing"):
+        validate_v2_schema(cfg)
+
+
+def test_validate_rejects_blank_column_path() -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["columns"][0]["path"] = ""
+    with pytest.raises(ApiInputSchemaError, match=r"columns\[0\]\.path is missing"):
+        validate_v2_schema(cfg)
+
+
 def test_validate_rejects_duplicate_table_labels() -> None:
     cfg = _minimal_v2()
     cfg["tables"].append(dict(cfg["tables"][0]))


### PR DESCRIPTION
## What & why

`readV2` (the v2 apiInput read codec) silently dropped tables with a blank `path` and columns with a blank `name`/`path` on every read. Because the editor re-derives its view via `classifyConfig → readV2` and re-serialises via `writeV2` on the next edit, a blank entry arriving from a hand-edited or legacy config file was **permanently deleted on the user's next keystroke elsewhere** — with no surface to see or repair it. That violates the 1:1 JSON↔UI render-gate invariant: every persisted entry must surface somewhere visible (greying/erroring is fine; silent suppression is not).

## Changes

- **readV2 render-gate** (`141e74ac`) — `readV2` now KEEPS structurally-incomplete entries by default; the editor's existing validators surface them inline for repair. The Infer-Tables call site opts back into dropping via a new `{ dropIncomplete: true }` option (fresh backend output was never user-persisted state). A persisted blank `label: ""` is kept verbatim (backend-invalid, flagged) rather than masked as the path. Blank-guard messages reworded to the keep-semantics truth — a blank is invalid and unsaveable; nothing is deleted anymore.
- **Design tokens** (`3a34931f`) — the multi-frame token rename left pre-rename names (`--bg`/`--bg-soft`/`--text`) referenced across ApiInputEditor / JsonPreview / OutputEditor / FrameTableActions, and `--bg-surface` / `--border-subtle` were consumed at 20+ sites without ever being declared — silently rendering as their initial values (transparent backgrounds, currentColor borders). Migrated those call sites in place to the canonical tokens (`--bg-input` / `--bg-elevated` / `--text-primary`) and declared the two missing tokens. New `cssColorTokenization` contract: every fallback-less `var(--name)` in live `.ts`/`.tsx` source must resolve to an index.css declaration, so a dangling token fails the suite instead of silently degrading (interpolation-safe and string-literal-aware).
- **e2e** (`9e8f0324`) — apiInput selector hardening (exact row-container testid + non-vacuous column-path scan) and a new render-gate spec that drives a persisted config carrying blank-name/path/label entries through the real browser and asserts every entry surfaces flagged (none silently dropped), with a clean control config.

## Verification
- Frontend vitest **4967/4967** (256 files); `tsc --noEmit` clean; eslint clean.
- Backend `tests/test_v2_codec_and_shred.py` **53/53** — the backend twin loudly 422-rejects the same blanks the frontend now surfaces.
- Adversarial multi-agent review of the diff: 3 confirmed-real findings, all fixed on the branch (scanner whitespace false-negative, string-unaware comment stripping, stale destructive-clear copy).

## Provenance
Reconciled landing vehicle per cross-session coordination: this branch plus fold-ins from the parallel `apiinput-read-gate` WIP snapshot (`43994fd2`) — the backend blank-rejection tests verbatim and the editor test suites with fixtures converted to the canonical `[:]` array selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
