### PR TITLE
ci: exclude fable-Review/ from ruff (unblocks main preflight)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,14 +108,16 @@ packages = ["src/haute"]
 line-length = 100
 target-version = "py311"
 # Root-level generated/demo pipelines are arbitrary user code; keep repo lint
-# focused on the package, tests, docs tooling, and scripts. review/ is the
-# read-only engineering-audit deliverable (findings + runnable repro evidence)
-# — its scripts are point-in-time evidence, not package code.
+# focused on the package, tests, docs tooling, and scripts. review/ and
+# fable-Review/ are read-only engineering-audit deliverables (findings +
+# runnable repro evidence) — their scripts are point-in-time evidence, not
+# package code.
 extend-exclude = [
     "modules/",
     "rating/",
     "outputs/",
     "review/",
+    "fable-Review/",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
## What

`ruff check .` / `ruff format .` (run by `scripts/preflight.sh`, the `backend` CI job) fail on the repro scripts under `fable-Review/tracing/repros/*.py` — `F401` unused imports, `E501` long lines, and format drift — breaking the backend preflight gate for **every** PR that merges into `main`.

## Why

PR #29 (`code-fixes`) committed the engineering-audit deliverable to **`fable-Review/`**, but `[tool.ruff] extend-exclude` only listed **`review/`** — the exact convention its own comment describes ("read-only engineering-audit deliverable … point-in-time evidence, not package code"). The deliverable landed under a different directory name, so its repro scripts get linted as package code.

## Fix

Add `fable-Review/` to `extend-exclude` alongside `review/`. One-line config change; no package code touched.

Verified locally on the full tree (off `main` @ `01266e3c`):
- `uv run ruff check .` → **All checks passed!**
- `uv run ruff format --check .` → **509 files already formatted**

Unblocks main's preflight for all open PRs (including #30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
