### PR TITLE
Fix eager-path OUTPUT contract check (flat apiInput→OUTPUT) + de-flake rmse_perfect

### DIFF
--- a/src/haute/_execute_lazy.py
+++ b/src/haute/_execute_lazy.py
@@ -1835,10 +1835,31 @@ def _execute_eager_core(
                     # Key per-edge by (source, sourceHandle) so the union
                     # picks up the right frame's columns for multi-frame
                     # consumers (commit 4).
-                    edge_cache_keys = [(e.source, e.sourceHandle) for e in incoming_edges_for_node]
-                    upstream_cols: frozenset[str] = frozenset().union(
-                        *(column_cache[k] for k in edge_cache_keys if k in column_cache)
-                    )
+                    #
+                    # A single-frame source stores its columns under
+                    # ``(source, None)`` (see the ``column_cache[(nid, None)]``
+                    # write below). When the consuming edge carries a non-null
+                    # ``sourceHandle`` — an OUTPUT-editor edge names its
+                    # ``source_port``, and a flat apiInput → OUTPUT edge is
+                    # wired with the handle set — the ``(source, handle)`` key
+                    # misses. Fall back to the actual input frame's schema
+                    # (``collect_schema()``, no data collect) rather than
+                    # treating the upstream as column-less, mirroring the lazy
+                    # path's cache-miss fallback in ``_build_lazy_node``.
+                    # ``input_lfs`` is edge-aligned here: every parent is
+                    # present and non-None past the missing/failed guards above.
+                    upstream_col_sets: list[frozenset[str]] = []
+                    for edge, input_lf in zip(incoming_edges_for_node, input_lfs, strict=True):
+                        cache_key = (edge.source, edge.sourceHandle)
+                        cols = column_cache.get(cache_key)
+                        if cols is None:
+                            cols = frozenset(input_lf.collect_schema().names())
+                            column_cache[cache_key] = cols
+                        upstream_col_sets.append(cols)
+                    # ``.union(*[])`` is ``frozenset()``, so the empty case
+                    # (no incoming edges) needs no special handling — though
+                    # it cannot occur here: an empty ``input_lfs`` raises above.
+                    upstream_cols: frozenset[str] = frozenset().union(*upstream_col_sets)
                     _assert_inputs_satisfy_contract(node, contract, upstream_cols)  # type: ignore[arg-type]
 
                 if enforce_contracts:

--- a/tests/test_apiinput_flat_output_dry_run.py
+++ b/tests/test_apiinput_flat_output_dry_run.py
@@ -1,0 +1,175 @@
+"""Flat (CSV/parquet) apiInput wired straight into an OUTPUT node.
+
+Regression for the eager-path column-contract failure: a FLAT apiInput is a
+single-frame source, so the executor stores its columns under
+``column_cache[(source, None)]``. An OUTPUT-editor edge names its
+``source_port``, so the edge carries a non-null ``sourceHandle`` and the
+consumer's input-contract check looked the cache up under
+``(source, sourceHandle)`` — a miss — and collapsed the upstream column set to
+``frozenset()``. The dry-run route surfaced that as::
+
+    ContractMismatchError: Input columns required by the node's contract are
+    missing from the upstream frame. (... missing=['customer_id','premium'],
+    upstream_columns=[])
+
+The fix makes the eager input-contract check fall back to the actual input
+frame's schema on a cache-key miss — the same fallback the lazy path already
+uses. This is independent of the flat-apiInput path-anchoring class: the tests
+here use an ABSOLUTE data path, so path resolution is never in play.
+
+The project uses the canonical nested layout (``haute.toml`` →
+``rating/main.py``, ``data/`` at the project root), launched with cwd at the
+project root, matching how a real haute install runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from haute._execution_admission import create_admitted_execution_context
+from haute._execution_context import ExecutionProfile
+from haute._sandbox import _get_project_root, set_project_root
+from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
+from haute.executor import _preview_cache, execute_graph
+
+_CSV = "customer_id,premium\n1,100.0\n2,200.0\n"
+_EXPECTED_DOCUMENT = [
+    {"customer_id": 1, "premium": 100.0},
+    {"customer_id": 2, "premium": 200.0},
+]
+_OUTPUT_MAPPING = [
+    {
+        "source_port": "src",
+        "source_column": "customer_id",
+        "output_path": "$[:].customer_id",
+    },
+    {
+        "source_port": "src",
+        "source_column": "premium",
+        "output_path": "$[:].premium",
+    },
+]
+
+
+@pytest.fixture()
+def nested_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Canonical nested layout: haute.toml → rating/main.py, data/ at root.
+
+    cwd is the project root, mirroring a real launch. The apiInput data file
+    is written with an ABSOLUTE path so the flat-apiInput path-anchoring class
+    (a separate bug) can never interfere with this contract-boundary check.
+    """
+    (tmp_path / "haute.toml").write_text('[project]\nname = "main"\npipeline = "rating/main.py"\n')
+    (tmp_path / "rating").mkdir()
+    (tmp_path / "rating" / "main.py").write_text("# pipeline entry\n")
+    (tmp_path / "data").mkdir()
+    monkeypatch.chdir(tmp_path)
+    original = _get_project_root()
+    set_project_root(tmp_path)
+    _preview_cache.invalidate()
+    yield tmp_path
+    set_project_root(original)
+    _preview_cache.invalidate()
+
+
+def _flat_api_node(csv_path: Path) -> GraphNode:
+    return GraphNode(
+        id="src",
+        data=NodeData(
+            label="src",
+            nodeType=NodeType.API_INPUT,
+            config={"sourceType": "flat_file", "path": str(csv_path)},
+        ),
+    )
+
+
+def _output_node() -> GraphNode:
+    return GraphNode(
+        id="out",
+        data=NodeData(
+            label="out",
+            nodeType=NodeType.OUTPUT,
+            config={"outputMapping": _OUTPUT_MAPPING, "outputFormat": "json"},
+        ),
+    )
+
+
+def _flat_to_output_graph(csv_path: Path) -> PipelineGraph:
+    return PipelineGraph(
+        nodes=[_flat_api_node(csv_path), _output_node()],
+        # The OUTPUT editor names its source_port, so the edge carries a
+        # non-null sourceHandle — the exact shape that triggered the miss.
+        edges=[GraphEdge(id="e", source="src", target="out", sourceHandle="src")],
+    )
+
+
+def test_flat_apiinput_to_output_executes_via_execute_graph(nested_project: Path) -> None:
+    """Executor-level regression: a flat apiInput reached through a non-null
+    ``sourceHandle`` edge no longer fails the OUTPUT input-contract check.
+
+    Pins the general class (single-frame source + named-port edge), not just
+    the route. Pre-fix this raised ``ContractMismatchError`` with
+    ``upstream_columns=[]``.
+    """
+    csv_path = nested_project / "data" / "customers.csv"
+    csv_path.write_text(_CSV)
+
+    graph = _flat_to_output_graph(csv_path)
+    context = create_admitted_execution_context(
+        operation="flat_output_regression",
+        profile=ExecutionProfile.PREVIEW_EAGER,
+    )
+    results = execute_graph(
+        graph,
+        target_node_id="out",
+        target_preview_only=True,
+        execution_context=context,
+    )
+    assert results["out"].status == "ok", results["out"].error
+    assert results["out"].preview == _EXPECTED_DOCUMENT
+    assert results["out"].row_count == 2
+
+
+def test_flat_apiinput_to_output_dry_run_route(nested_project: Path) -> None:
+    """End-to-end through ``POST /api/output-assemble/dry-run`` — the exact
+    route the OUTPUT editor calls, and the one that surfaced the failure as a
+    422. The volatile mapping is supplied on the request; the graph's OUTPUT
+    config is left empty so the route's config-swap is exercised too.
+    """
+    from haute.server import app
+
+    csv_path = nested_project / "data" / "customers.csv"
+    csv_path.write_text(_CSV)
+
+    graph = {
+        "nodes": [
+            {
+                "id": "src",
+                "data": {
+                    "label": "src",
+                    "nodeType": NodeType.API_INPUT.value,
+                    "config": {"sourceType": "flat_file", "path": str(csv_path)},
+                },
+            },
+            {
+                "id": "out",
+                "data": {"label": "out", "nodeType": NodeType.OUTPUT.value, "config": {}},
+            },
+        ],
+        "edges": [{"id": "e", "source": "src", "target": "out", "sourceHandle": "src"}],
+    }
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(
+        "/api/output-assemble/dry-run",
+        json={"graph": graph, "node_id": "out", "output_mapping": _OUTPUT_MAPPING},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["status"] == "ok", payload.get("error")
+    assert payload["document"] == _EXPECTED_DOCUMENT
+    assert payload["row_count"] == 2

--- a/tests/test_modelling.py
+++ b/tests/test_modelling.py
@@ -651,7 +651,15 @@ class TestComputeMetrics:
         yp = np.array(y_pred)
         result = compute_metrics(yt, yp, None, [metric])
         expected = getattr(sk_metrics, sklearn_fn)(yt, yp, **sklearn_kwargs)
-        assert result[metric] == pytest.approx(expected, rel=1e-6)
+        # Pin an explicit abs floor for the zero-expected case (rmse_perfect:
+        # y_true == y_pred).  Against a 0.0 expected, rel=1e-6 collapses to a
+        # tolerance of 0 and approx falls back to its 1e-12 default floor — the
+        # same knife edge the sibling perfect-case deviance asserts already
+        # avoid with an explicit abs (see TestDevianceMetrics).  Today _rmse
+        # returns bit-exact 0.0 for identical inputs, but the explicit floor
+        # keeps this robust to any future numerically-inexact reformulation.
+        # abs=1e-9 is negligible for the nonzero cases (rel dominates there).
+        assert result[metric] == pytest.approx(expected, rel=1e-6, abs=1e-9)
 
     def test_gini_perfect_ranking(self):
         """Perfect ranking gives Gini = 1.0."""


### PR DESCRIPTION
Two ready, independently-reviewed fixes landed together onto `main` — cherry-picked with original authorship preserved; no file overlap between them.

## 1. Fix eager-path contract check for single-frame source via named-port edge (`c3ae00bc`, cherry-pick of `8326087d`)

A flat (CSV/parquet) apiInput wired straight into an OUTPUT node could not be previewed: the OUTPUT column-contract check hard-failed at execute time with `ContractMismatchError … upstream_columns=[]`. Root cause is a `column_cache` key mismatch in the eager execution path (`_execute_eager_core`): a single-frame source stores its columns under `(nid, None)` but a consumer reached via an OUTPUT-editor-wired edge looks up `(nid, "<port>")`, misses, and the upstream column set collapses to empty. The fix mirrors the lazy path's existing cache-miss fallback: read the input frame's schema via `collect_schema()` (no data collect) and cache it. The check stays enforced; the cache-hit path is unchanged.

- `src/haute/_execute_lazy.py` (+29/−4)
- `tests/test_apiinput_flat_output_dry_run.py` (+175): drives the graph both through `execute_graph` and end-to-end through `/api/output-assemble/dry-run` (the exact route that surfaced the 422).

## 2. De-flake `rmse_perfect`: absolute tolerance floor on a zero-expected metric assert (`69bc388d`, cherry-pick of `2a047806`)

Test-only. `test_core_metric_against_sklearn[rmse_perfect]` compared a bit-exact 0.0 against `pytest.approx(0.0, rel=1e-6)`, where the relative tolerance collapses to zero. Restores the explicit absolute floor (`abs=1e-9`) that the file's sibling zero-expected deviance asserts already pin. The four nonzero params are unchanged (rel dominates).

- `tests/test_modelling.py` (+9/−1)

## Verification

- Both cherry-picks are byte-identical to the reviewed originals (`git patch-id --stable` match); authorship preserved (original author + Claude co-author trailers).
- Fail-without/pass-with proven for the contract fix: both new regression tests fail on pristine main with the exact `ContractMismatchError … upstream_columns=[]`, and pass on this branch.
- Full local `scripts/preflight.sh`: ruff green, frontend green, backend green **except** two pre-existing `tests/test_git_engine.py` identity tests that fail only on macOS (git synthesizes a committer identity from username+hostname, defeating the tests' blank-identity premise) — they fail identically on `main` before this change, pass in GitHub CI, and are unrelated to this diff.
- Validation is tests-only: backend behaviour is asserted through `execute_graph` and the `/api/output-assemble/dry-run` TestClient route, not a live-server pipeline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
