### PR TITLE
De-flake macOS-only git identity-unset tests via user.useConfigOnly

### DIFF
--- a/tests/test_git_engine.py
+++ b/tests/test_git_engine.py
@@ -700,9 +700,16 @@ class TestSetWorkingBranchUnborn:
         subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, capture_output=True)
         (root / "main.py").write_text("x = 1\n")
 
-        # Blank global config prevents any global identity from bleeding in.
+        # Force the seed commit to fail deterministically for missing identity.
+        # An *empty* global config is not enough: with GIT_CONFIG_NOSYSTEM set and
+        # the author/committer env vars cleared, git falls back to auto-detecting an
+        # identity from username+hostname. That succeeds on dev machines (e.g.
+        # "user@host.local") and fails only on CI runners whose hostname yields a
+        # bogus ".(none)" domain — so an empty config makes this test pass in CI but
+        # spuriously fail locally. user.useConfigOnly=true refuses any auto-detected
+        # identity, exercising the raise-path on every machine.
         blank_cfg = tmp_path / "blank.gitconfig"
-        blank_cfg.write_text("")
+        blank_cfg.write_text("[user]\n\tuseConfigOnly = true\n")
         monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(blank_cfg))
         monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
         for var in (
@@ -893,11 +900,22 @@ class TestSetWorkingBranchUnbornNonDefault:
         _git(root, "checkout", "-b", "initial-branch")  # unborn non-default HEAD
         (root / "main.py").write_text("x = 1\n")
 
-        # Blank global/system config so no ambient identity lets the commit succeed.
+        # Force the commit to fail for missing identity on every machine. An empty
+        # global config is not enough — with the author/committer env vars cleared
+        # git auto-detects an identity from username+hostname (succeeds locally,
+        # fails only on CI's ".(none)" hostname). user.useConfigOnly=true refuses
+        # any auto-detected identity, so the raise-path is exercised everywhere.
         blank_cfg = tmp_path / "blank.gitconfig"
-        blank_cfg.write_text("")
+        blank_cfg.write_text("[user]\n\tuseConfigOnly = true\n")
         monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(blank_cfg))
         monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+        for var in (
+            "GIT_AUTHOR_NAME",
+            "GIT_AUTHOR_EMAIL",
+            "GIT_COMMITTER_NAME",
+            "GIT_COMMITTER_EMAIL",
+        ):
+            monkeypatch.delenv(var, raising=False)
 
         with pytest.raises(GitDomainError, match="set your git name and email first"):
             set_working_branch("initial-branch", root, create=True, cwd=root)


### PR DESCRIPTION
## What & why

Two `tests/test_git_engine.py` identity tests fail deterministically on macOS but pass in GitHub CI:

- `TestSetWorkingBranchUnborn::test_identity_unset_raises_clear_domain_error`
- `TestSetWorkingBranchUnbornNonDefault::test_rename_then_commit_failure_leaves_unborn_main`

This is the exact pre-existing failure that #32 had to carve out of its local `scripts/preflight.sh` verification ("two pre-existing `test_git_engine.py` identity tests that fail only on macOS … defeating the tests' blank-identity premise"). Every full local preflight run on the Mac is red because of it, defeating the local landing gate.

Both tests blank the global config (empty `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM=1`, identity env vars cleared) and expect the seed commit inside `set_working_branch` to fail for missing identity. But git falls back to auto-detecting an identity from `username@hostname`: on this Mac that yields a valid-looking `Nicholas Loughlin <nick@Nicholass-MacBook-Air.local>`, so the commit **succeeds** and no `GitDomainError` is raised. CI runners' hostnames resolve to a bogus `.(none)` domain, so auto-detection fails there and the tests pass — a machine-dependent split.

## Changes (`d08e854f`)

- Write `[user]` / `useConfigOnly = true` into the isolation gitconfig instead of leaving it empty. `user.useConfigOnly=true` makes git **refuse** any auto-detected identity, so the seed commit fails for missing identity deterministically on every machine.
- Confirmed by probe that git's stderr under `useConfigOnly` still carries the keywords `_git.py`'s `except GitError` block matches (`Author identity unknown`, `Please tell me who you are`, `user.email`, `user.name`), so haute still translates the failure into the friendly `GitDomainError` both tests' `match=` patterns expect. Without that, haute would re-raise a raw `GitError` and the tests would error rather than pass.
- Mirror the `GIT_AUTHOR_*` / `GIT_COMMITTER_*` `delenv` block from test 1 into test 2, closing a second latent machine-dependency: `useConfigOnly` refuses *config* identity but still honors *env-var* identity, so an ambient `GIT_COMMITTER_EMAIL` could otherwise let test 2's commit spuriously succeed.

## Verification

- Both target tests: pass on macOS (previously failed), and continue to pass in CI — the commit still fails, now via refused identity rather than the `.(none)` hostname, with the same keyword-bearing stderr.
- Full `tests/test_git_engine.py` (197 tests): green locally.
- The fix is strictly more deterministic than the empty-config setup it replaces: it removes the platform dependence entirely rather than relying on the runner's hostname.

## Coordination

Independent, single-file, test-only change off `main` (1 commit, `tests/test_git_engine.py` only). Ready to land in the GAPFILLS batch alongside #30 / #32. Landing this **removes the known-failure carve-out** that #32 (and every future local preflight run) has had to make for these two tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
