### PR TITLE
Fix /api/files 500 on a non-canonical (Windows short-path) cwd

### DIFF
--- a/src/haute/routes/files.py
+++ b/src/haute/routes/files.py
@@ -31,7 +31,13 @@ async def browse_files(
     extensions: str = ".parquet,.csv,.json,.xml",
 ) -> BrowseFilesResponse:
     """Browse files on disk for the file picker UI."""
-    base = Path.cwd()
+    # Resolve the base: ``validate_safe_path`` returns a *resolved* target and
+    # ``iterdir()`` yields resolved children, so an unresolved base would break
+    # the ``relative_to`` calls below wherever cwd differs from its canonical
+    # form — e.g. a Windows 8.3 short path (``C:\Users\RUNNER~1\...``) whose
+    # entries come back long-form. (POSIX ``getcwd`` already resolves symlinks,
+    # which is why this only bit Windows.)
+    base = Path.cwd().resolve()
     target = validate_safe_path(base, dir)
     if not target.is_dir():
         raise HTTPException(status_code=404, detail=f"Directory not found: {dir}")
@@ -144,7 +150,9 @@ async def get_schema(path: str) -> SchemaResponse:
     so concurrent requests on the single async event loop are not
     serialised behind disk I/O.
     """
-    base = Path.cwd()
+    # Resolve the base for the same reason as ``browse_files`` — keep cwd in its
+    # canonical form so path handling is consistent on Windows short paths.
+    base = Path.cwd().resolve()
     target = validate_safe_path(base, path)
     if not target.is_file():
         raise HTTPException(status_code=404, detail=f"File not found: {path}")

--- a/tests/test_files_routes.py
+++ b/tests/test_files_routes.py
@@ -141,6 +141,66 @@ class TestBrowseFilesSize:
         assert item["size"] is None
 
 
+class TestBrowseFilesUnresolvedCwd:
+    """Regression: the file browser must resolve cwd before ``relative_to``.
+
+    Discovered by the ci-lanes ``init-smoke`` lane: on Windows the server cwd
+    can be an 8.3 short path (``C:\\Users\\RUNNER~1\\...``) while ``iterdir()``
+    yields long-form entries, so an unresolved base made ``relative_to`` raise
+    ``ValueError`` → HTTP 500 on ``/api/files``. POSIX ``getcwd`` resolves
+    symlinks so it never bit locally; reproduced cross-platform here by
+    pointing ``Path.cwd`` at a symlink whose ``resolve()`` differs.
+    """
+
+    @staticmethod
+    def _symlinked_project(tmp_path: Path) -> tuple[Path, Path]:
+        real = tmp_path / "real"
+        (real / "data").mkdir(parents=True)
+        (real / "data" / "probe.json").write_text("{}", encoding="utf-8")
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):  # pragma: no cover - privilege-gated
+            pytest.skip("symlinks unavailable on this platform/privilege level")
+        # The symlink path must be genuinely unresolved for the repro to bite.
+        assert link.resolve() == real.resolve()
+        assert link != real
+        return real, link
+
+    def test_browse_with_unresolved_cwd_lists_and_labels_correctly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _real, link = self._symlinked_project(tmp_path)
+        # files.py reads ``Path.cwd()``; make it return the unresolved symlink.
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda _cls: link))
+
+        from haute.server import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/files", params={"dir": "data"})
+
+        assert resp.status_code == 200, resp.text
+        item = next(i for i in resp.json()["items"] if i["name"] == "probe.json")
+        # Path is relative to the resolved base, so it stays clean (no leaked
+        # absolute prefix, no crash).
+        assert item["path"] == str(Path("data") / "probe.json")
+
+    def test_schema_with_unresolved_cwd_reads_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        real, link = self._symlinked_project(tmp_path)
+        (real / "data" / "t.csv").write_text("x\n1\n", encoding="utf-8")
+        monkeypatch.setattr(Path, "cwd", classmethod(lambda _cls: link))
+
+        from haute.server import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/schema", params={"path": "data/t.csv"})
+
+        assert resp.status_code == 200, resp.text
+        assert [c["name"] for c in resp.json()["columns"]] == ["x"]
+
+
 # ───────────────────────────── get_schema ─────────────────────────────
 
 

--- a/tests/test_test_debt.py
+++ b/tests/test_test_debt.py
@@ -193,6 +193,14 @@ _EXPECTED_DEBT_IDS = {
     # See tests/test_config_io_gaps.py::TestConfigPathEscapeGuard
     # ::test_escape_guard_triggers_on_resolved_outside.
     "1e4116d06849b611",
+    # Windows symlink privilege — the file-browser short-path regression test
+    # builds a symlinked project dir so ``Path.cwd()`` differs from its
+    # ``resolve()`` (the cross-platform stand-in for a Windows 8.3 short cwd),
+    # but symlink creation needs a privilege Windows withholds by default
+    # (WinError 1314). Skipped when symlink creation raises, mirroring the
+    # other symlink-guard tests. See tests/test_files_routes.py
+    # ::TestBrowseFilesUnresolvedCwd._symlinked_project.
+    "e29ebc6050519fc5",
 }
 
 _EXPECTED_NON_STRICT_XFAIL_IDS = {


### PR DESCRIPTION
## What & why

`GET /api/files` (and `/api/schema`) returned **HTTP 500** whenever haute's server cwd was a non-canonical path — most concretely a Windows 8.3 short path (`C:\Users\RUNNER~1\...`). `browse_files` kept its own unresolved `base = Path.cwd()` and called `entry.relative_to(base)`, but `validate_safe_path` returns a *resolved* target and `iterdir()` yields *resolved* entries, so `relative_to` raised `ValueError: '...' is not in the subpath of '...'`. POSIX `getcwd` resolves symlinks, so this only ever bit Windows in practice.

This was surfaced by the new `init-smoke` CI lane (from the ci-lanes feature) on its first Windows run — the fresh-install smoke serves from `%TEMP%`, which is an 8.3 short path on GitHub's Windows runners.

## The fix

Resolve the base in `browse_files` and `get_schema` (`base = Path.cwd().resolve()`), so it matches the resolved target/entries. Two lines + explaining comments.

## Wide audit (per the "go wide" ask)

I audited every `Path.cwd()` + `.relative_to(` pair in `src/haute`. **`files.py` is the only real bug** — it is the only site that compares resolved paths against a *locally-recomputed unresolved* base. Every other site is safe, and why:

- `pipeline.py`, `_cache.py`, `discovery.py`, `_helpers.py:881` — **symmetric**: both sides derive from the same unresolved `Path.cwd()`/glob root, so `relative_to` holds regardless of short/long form.
- `_save_pipeline.py:174` — **consistently resolved**: `self._root` is `project_root.resolve()` and `py_path` comes through `validate_safe_path` (also resolved).
- `_save_pipeline.py:204/432`, `executor.py:330` — **guarded**: wrapped in `try/except ValueError` that degrades gracefully.

No behaviour-changing churn applied to the safe sites (their displayed relative paths are used as frontend identifiers; resolving them would flip short→long form on Windows for no correctness gain). Flagging them here so the audit is on record.

## Regression test

`TestBrowseFilesUnresolvedCwd` reproduces the Windows short/long split **cross-platform** by pointing `Path.cwd` at a symlink whose `resolve()` differs, then driving `/api/files` and `/api/schema`. Verified it bites: against the unfixed code it fails with the exact production error (`'...real/data/probe.json' is not in the subpath of '...link'`); with the fix it passes. Skips gracefully where symlinks need privileges.

## Verification

- Full `scripts/preflight.sh --backend-only` green: 12,224 passed, coverage 92.69% (≥90 gate), all critical-coverage gates pass. (One load-sensitive timing flake, `test_pipeline_route_supersession`, passed in isolation — the documented gate-parallel flake class, unrelated.)
- `scripts/preflight.sh --init-smoke` green locally (macOS).
- The regression test was verified to bite: against the unfixed code it fails with the exact production `ValueError`; with the fix it passes.
- The upstream proof is the ci-lanes `init-smoke (windows-latest)` lane, which caught this and will now stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
