### PR TITLE
Comparison view: right-button pan + refit each pane on real size

### DIFF
--- a/frontend/src/components/ComparisonView.tsx
+++ b/frontend/src/components/ComparisonView.tsx
@@ -131,12 +131,34 @@ function ReadonlyCanvas({
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [edges, , onEdgesChange] = useEdgesState(initialEdges)
   const { fitView } = useReactFlow()
+  const wrapperRef = useRef<HTMLDivElement>(null)
 
   // Re-centre the graph when the pane is reshaped (orientation flip).
   useEffect(() => {
     const id = requestAnimationFrame(() => fitView({ padding: 0.2 }))
     return () => cancelAnimationFrame(id)
   }, [refitKey, fitView])
+
+  // Re-fit once the pane actually has its real size. The initial `fitView` prop
+  // and the orientation-refit effect above both run at mount — but in the
+  // vertical (side-by-side) split the first pane's flex-basis width has not
+  // settled yet, so that early fit measures a partial/zero width and clamps onto
+  // the leftmost node (the right pane mounts after layout, so it was fine). A
+  // ResizeObserver refits as soon as the pane reaches a real, non-zero size, then
+  // disconnects so it never fights the user's later pan/zoom.
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      const box = entries[0]?.contentRect
+      if (box && box.width > 0 && box.height > 0) {
+        fitView({ padding: 0.2 })
+        ro.disconnect()
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [fitView])
 
   // Mirror the focused node onto BOTH canvases (the counterpart highlight) via
   // ReactFlow's native `selected` flag, so PipelineNode draws its normal
@@ -146,28 +168,34 @@ function ReadonlyCanvas({
   }, [selectedId, setNodes])
 
   return (
-    <ReactFlow
-      data-testid={testId}
-      nodes={nodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onNodeClick={(_e, n) => onNodeSelect(n.id)}
-      onPaneClick={onPaneClick}
-      nodeTypes={nodeTypes}
-      nodesDraggable={false}
-      nodesConnectable={false}
-      elementsSelectable={false}
-      edgesFocusable={false}
-      deleteKeyCode={null}
-      minZoom={0.1}
-      fitView
-      fitViewOptions={fitViewOptions}
-      proOptions={proOptions}
-      defaultEdgeOptions={defaultEdgeOptions}
-    >
-      <Background variant={BackgroundVariant.Dots} gap={24} size={1} color="rgba(255,255,255,.06)" />
-    </ReactFlow>
+    <div ref={wrapperRef} className="w-full h-full">
+      <ReactFlow
+        data-testid={testId}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={(_e, n) => onNodeSelect(n.id)}
+        onPaneClick={onPaneClick}
+        nodeTypes={nodeTypes}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        edgesFocusable={false}
+        deleteKeyCode={null}
+        // Right-button drag pans, mirroring the main canvas (App.tsx). The pane is
+        // read-only so there's no left-drag marquee-select to mirror — left-drag
+        // is intentionally inert here; only the right button pans.
+        panOnDrag={[2]}
+        minZoom={0.1}
+        fitView
+        fitViewOptions={fitViewOptions}
+        proOptions={proOptions}
+        defaultEdgeOptions={defaultEdgeOptions}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={24} size={1} color="rgba(255,255,255,.06)" />
+      </ReactFlow>
+    </div>
   )
 }
 

--- a/frontend/src/components/__tests__/ComparisonView.test.tsx
+++ b/frontend/src/components/__tests__/ComparisonView.test.tsx
@@ -11,7 +11,7 @@ const mockFitView = vi.fn()
 // so a test can simulate the pane getting its real size after mount.
 const resizeObservers: ResizeObserverCallback[] = []
 class MockResizeObserver {
-  constructor(private cb: ResizeObserverCallback) {
+  constructor(cb: ResizeObserverCallback) {
     resizeObservers.push(cb)
   }
   observe() {}

--- a/frontend/src/components/__tests__/ComparisonView.test.tsx
+++ b/frontend/src/components/__tests__/ComparisonView.test.tsx
@@ -1,6 +1,36 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
+import { render, screen, fireEvent, cleanup, waitFor, within, act } from "@testing-library/react"
 import type React from "react"
+
+// Stable fitView spy so tests can assert the panes re-fit (a fresh vi.fn() per
+// useReactFlow() call would be un-assertable). Prefixed `mock*` so vitest lets
+// the hoisted vi.mock factory below reference it.
+const mockFitView = vi.fn()
+
+// Controllable ResizeObserver (jsdom has none): capture each observer's callback
+// so a test can simulate the pane getting its real size after mount.
+const resizeObservers: ResizeObserverCallback[] = []
+class MockResizeObserver {
+  constructor(private cb: ResizeObserverCallback) {
+    resizeObservers.push(cb)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver)
+
+/** Fire every live ResizeObserver with a contentRect of the given size. */
+function triggerResize(width: number, height: number) {
+  act(() => {
+    for (const cb of resizeObservers) {
+      cb(
+        [{ contentRect: { width, height } } as ResizeObserverEntry],
+        {} as ResizeObserver,
+      )
+    }
+  })
+}
 
 // Lightweight ReactFlow stand-in so the test exercises ComparisonView's own logic
 // (fetch / loading / which graph feeds which canvas / diff classing / node-click
@@ -26,6 +56,7 @@ vi.mock("@xyflow/react", async () => {
       <div
         data-testid={props["data-testid"] as string}
         className={props.className as string}
+        data-pan-on-drag={JSON.stringify(props.panOnDrag)}
         onClick={(e) => {
           if (e.target === e.currentTarget) onPaneClick?.()
         }}
@@ -45,7 +76,7 @@ vi.mock("@xyflow/react", async () => {
     ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     Background: () => null,
     BackgroundVariant: { Dots: "dots" },
-    useReactFlow: () => ({ fitView: vi.fn() }),
+    useReactFlow: () => ({ fitView: mockFitView }),
     useNodesState: (init: unknown) => {
       const [n, setN] = useState(init)
       return [n, setN, vi.fn()]
@@ -112,6 +143,8 @@ function renderView(
 
 beforeEach(() => {
   mockGetCommitPipeline.mockReset()
+  mockFitView.mockClear()
+  resizeObservers.length = 0
   // The current-side breadcrumb fetches context for the working branch's latest
   // save — give the store a last_save_sha so that fetch fires.
   useGitStore.setState({ status: { last_save_sha: "live123" } as never })
@@ -190,6 +223,43 @@ describe("ComparisonView", () => {
     expect(left.getByTestId("cmp-node-shifted")).toHaveAttribute("data-diff", "moved")
     expect(right.getByTestId("cmp-node-shifted")).toHaveAttribute("data-diff", "moved")
     expect(screen.getByTestId("comparison-legend")).toHaveTextContent("Moved 1")
+  })
+
+  it("enables right-button drag-to-pan on both panes (mirrors the main canvas)", async () => {
+    mockGetCommitPipeline.mockResolvedValue({ nodes: [node("a")], edges: [] })
+    renderView({ currentNodes: [node("a")] as never })
+    await waitFor(() =>
+      expect(screen.getByTestId("comparison-canvas-historical")).toBeInTheDocument(),
+    )
+    // panOnDrag={[2]} — the right mouse button (button 2) pans, as App.tsx:793.
+    for (const testId of ["comparison-canvas-historical", "comparison-canvas-current"]) {
+      expect(screen.getByTestId(testId)).toHaveAttribute("data-pan-on-drag", "[2]")
+    }
+  })
+
+  it("re-fits a pane once it gets its real size after mount (vertical-split fit race)", async () => {
+    mockGetCommitPipeline.mockResolvedValue({ nodes: [node("a")], edges: [] })
+    renderView({ currentNodes: [node("a")] as never })
+    await waitFor(() =>
+      expect(screen.getByTestId("comparison-canvas-historical")).toBeInTheDocument(),
+    )
+    // Ignore any mount-time fits (initial prop / orientation rAF); assert the
+    // ResizeObserver refits once the pane reports a real, non-zero size.
+    mockFitView.mockClear()
+    expect(resizeObservers.length).toBeGreaterThan(0) // both panes observe
+    triggerResize(800, 600)
+    expect(mockFitView).toHaveBeenCalled()
+  })
+
+  it("does not re-fit while the pane still has zero width (no premature fit)", async () => {
+    mockGetCommitPipeline.mockResolvedValue({ nodes: [node("a")], edges: [] })
+    renderView({ currentNodes: [node("a")] as never })
+    await waitFor(() =>
+      expect(screen.getByTestId("comparison-canvas-historical")).toBeInTheDocument(),
+    )
+    mockFitView.mockClear()
+    triggerResize(0, 0)
+    expect(mockFitView).not.toHaveBeenCalled()
   })
 
   it("toggles split orientation both ways via the divider button", async () => {


### PR DESCRIPTION
Fixes the two S11 read-only side-by-side comparison-view bugs found during the git graph-rail review (logged in the bugs ledger, deferred by Nick at the time).

Both live in the per-pane React Flow (`ReadonlyCanvas`) in `frontend/src/components/ComparisonView.tsx`.

## BUG 1 — right-click-drag doesn't pan the comparison panes
The main canvas enables right-button pan (`panOnDrag={[2]}`, App.tsx) but the comparison panes never got it, so right-drag fell through. Added `panOnDrag={[2]}`. The panes are read-only (`elementsSelectable`/`nodesDraggable` off), so there's no left-drag marquee-select to mirror — left-drag stays inert; only the right button pans.

## BUG 2 — vertical-split left pane opens over-zoomed on its leftmost node
Each pane's initial `fitView` (and the orientation-refit rAF) runs at mount, but in the vertical split the first pane's `flexBasis` width hasn't settled yet, so that early fit measures a partial/near-zero width and clamps onto the first node; the second pane mounts after layout and was fine. Added a `ResizeObserver` that refits once the pane reaches a real, non-zero size, then disconnects so it never fights the user's later pan/zoom. Robust to the pane getting its width *after* mount (which a wider rAF alone would not fix).

## Tests
Extended `ComparisonView.test.tsx`: asserts `panOnDrag` is present on both panes; a mount-time `ResizeObserver` resize to a real size fires a refit; a zero-size resize does not. Suite green (15/15).

## Verification
- **Live via the Playwright preview MCP** against the seeded e2e git topology:
  - Right-button drag on both panes translates the viewport by exactly the drag delta, zoom unchanged (pure pan).
  - Fresh vertical-split open: left pane briefly caught over-zoomed (~1.41) then corrected by the observer; both panes settle to equal scale (historical 0.145 vs current 0.148, ratio 0.978). No console errors.
- **Frontend gate**: tsc, eslint, vite build, bundle budget green; ComparisonView suite green. (Full vitest run's only failures were pre-existing load-sensitive timeout flakes in unrelated files, each passing in isolation.)
- Pure frontend — no Python touched, so backend/critical-coverage gates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)