### PR TITLE
lint: enable ruff PLW1514 + pathlib (PTH) platform subset; pin LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
+# Declared line-ending posture: normalize every text file to LF in the repo
+# and in the working tree on all platforms. `text=auto` lets git auto-detect
+# text vs binary; `eol=lf` pins the checkout ending so a Windows clone does
+# not introduce CRLF, which would break byte-identity fixtures and make
+# cross-platform codegen output diverge.
+* text=auto eol=lf
+
 # Byte-identity / golden test fixtures must check out with LF endings on
 # every platform. Without this, a Windows checkout with autocrlf would
 # rewrite these files to CRLF, breaking the byte-for-byte OUTPUT-fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,11 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
+# Preview mode is enabled solely to activate the explicitly-named preview rule
+# PLW1514 (in select below). explicit-preview-rules keeps every *other* preview
+# rule off, so nothing else from preview leaks into the lint gate.
+preview = true
+explicit-preview-rules = true
 select = [
     "E",
     "F",
@@ -139,6 +144,26 @@ select = [
     "B012",
     "PT013",
     "S506",
+    # Require an explicit encoding on every text open/read/write. Without one,
+    # Python falls back to the platform's locale encoding, so a file written as
+    # UTF-8 on Linux/macOS and read back under cp1252 on Windows silently
+    # mangles non-ASCII bytes. (Preview rule; enabled via the flags above.)
+    "PLW1514",
+    # Pathlib migration -- platform portability. Prefer pathlib.Path over
+    # os.path string ops so a filesystem path stays a Path object, keeping the
+    # str(path) vs path.as_posix() serialization choice explicit at each call
+    # site. The bug class this guards against: str(Path(...)) renders with
+    # backslash separators on Windows, and a backslash path leaked into
+    # generated Python source is misread as an escape sequence. Scope is the
+    # portable subset below only; the open()/getcwd/abspath-class PTH rules are
+    # deliberately excluded.
+    "PTH101",  # os.chmod          -> Path.chmod
+    "PTH110",  # os.path.exists    -> Path.exists
+    "PTH116",  # os.stat           -> Path.stat
+    "PTH118",  # os.path.join      -> Path(...) / ...
+    "PTH119",  # os.path.basename  -> Path.name
+    "PTH120",  # os.path.dirname   -> Path.parent
+    "PTH201",  # Path(".") / Path("") -> Path()
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/run_frontend_e2e_server.py
+++ b/scripts/run_frontend_e2e_server.py
@@ -240,7 +240,7 @@ def _reset_project_dir() -> None:
     if E2E_PROJECT_DIR.exists():
 
         def _retry_remove_readonly(func: object, path: str, _exc_info: object) -> None:
-            os.chmod(path, stat.S_IWRITE)
+            Path(path).chmod(stat.S_IWRITE)
             func(path)
 
         shutil.rmtree(E2E_PROJECT_DIR, onerror=_retry_remove_readonly)

--- a/src/haute/_execution_context.py
+++ b/src/haute/_execution_context.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 EXECUTION_METRICS_SCHEMA_VERSION = 1
@@ -573,7 +574,7 @@ def current_rss_bytes() -> int | None:
 
 def _linux_current_rss_bytes() -> int | None:
     status_path = "/proc/self/status"
-    if not os.path.exists(status_path):
+    if not Path(status_path).exists():
         return None
     try:
         with open(status_path, encoding="utf-8") as fh:

--- a/src/haute/_project.py
+++ b/src/haute/_project.py
@@ -158,7 +158,7 @@ def _looks_like_pipeline_file(candidate: Path) -> bool:
     if candidate.name in _NOT_A_PIPELINE or candidate.suffix != ".py":
         return False
     try:
-        text = candidate.read_text(errors="replace")
+        text = candidate.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
     return "haute.Pipeline" in text

--- a/src/haute/_ram_estimate.py
+++ b/src/haute/_ram_estimate.py
@@ -64,7 +64,7 @@ def available_ram_bytes() -> int:
     windows_error: str | None = None
 
     try:
-        with open("/proc/meminfo") as f:
+        with open("/proc/meminfo", encoding="utf-8") as f:
             for line in f:
                 if line.startswith("MemAvailable:"):
                     return int(line.split()[1]) * 1024

--- a/src/haute/_stat_gated_cache.py
+++ b/src/haute/_stat_gated_cache.py
@@ -27,9 +27,9 @@ threads and must be treated as immutable by callers.
 
 from __future__ import annotations
 
-import os
 import threading
 from collections.abc import Callable, Hashable
+from pathlib import Path
 from typing import Generic, TypeVar
 
 K = TypeVar("K", bound=Hashable)
@@ -53,7 +53,7 @@ class StatGatedCache(Generic[K, V]):
         cached (and returned) if the gate held.
         """
         for _ in range(2):
-            stat_result = os.stat(path)
+            stat_result = Path(path).stat()
             gate = (stat_result.st_mtime_ns, stat_result.st_size)
             with self._lock:
                 entry = self._entries.get(key)
@@ -68,7 +68,7 @@ class StatGatedCache(Generic[K, V]):
                     if entry is not None and (entry[0], entry[1]) == gate:
                         return entry[2]
                 value = loader()
-                after = os.stat(path)
+                after = Path(path).stat()
                 if (after.st_mtime_ns, after.st_size) != gate:
                     continue
                 with self._lock:

--- a/src/haute/cli/_impact.py
+++ b/src/haute/cli/_impact.py
@@ -169,7 +169,7 @@ def handle_impact(config: ImpactConfig) -> None:
     # Platform-specific CI summary integration
     github_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if github_summary:
-        with open(github_summary, "a") as f:
+        with open(github_summary, "a", encoding="utf-8") as f:
             f.write(md)
         click.echo("  \u2192 Report written to GitHub Step Summary")
 

--- a/src/haute/deploy/_model_code.py
+++ b/src/haute/deploy/_model_code.py
@@ -19,7 +19,7 @@ class HauteModel(mlflow.pyfunc.PythonModel):  # type: ignore[name-defined]
     def load_context(self, context: PythonModelContext) -> None:
         """Called once when the model is loaded for serving."""
         manifest_path = Path(context.artifacts["deploy_manifest"])
-        self._manifest = json.loads(manifest_path.read_text())
+        self._manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         self._graph = PipelineGraph.model_validate(self._manifest["pruned_graph"])
         self._input_node_ids = self._manifest["input_node_ids"]
         self._output_node_id = self._manifest["output_node_id"]

--- a/src/haute/deploy/_schema.py
+++ b/src/haute/deploy/_schema.py
@@ -116,7 +116,7 @@ def infer_output_schema(
     cache_path = Path(_SCHEMA_CACHE_FILE)
     if cache_path.exists():
         try:
-            cached = _json.loads(cache_path.read_text())
+            cached = _json.loads(cache_path.read_text(encoding="utf-8"))
             if cached.get("fingerprint") == fp:
                 logger.info("output_schema_cache_hit", fingerprint=fp[:8])
                 return dict(cached["schema"])
@@ -166,7 +166,7 @@ def infer_output_schema(
     # propagate rather than be masked by a bare ``except: pass``.
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_text(_json.dumps({"fingerprint": fp, "schema": schema}))
+        cache_path.write_text(_json.dumps({"fingerprint": fp, "schema": schema}), encoding="utf-8")
     except OSError as exc:
         logger.warning("output_schema_cache_write_failed", path=str(cache_path), error=str(exc))
 

--- a/src/haute/modelling/_algorithms.py
+++ b/src/haute/modelling/_algorithms.py
@@ -34,7 +34,7 @@ def _get_rss_mb() -> float:
     # Linux — /proc/self/status gives current (not peak) RSS
     if sys.platform == "linux":
         try:
-            with open("/proc/self/status") as f:
+            with open("/proc/self/status", encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("VmRSS:"):
                         return int(line.split()[1]) / 1024  # kB → MB
@@ -103,7 +103,7 @@ def _mem_checkpoint(label: str) -> None:
 
     ts = time.strftime("%H:%M:%S")
     entry = f"[{ts}] {label:<45} RSS={rss_mb:>9.1f} MB   Avail={avail_mb:>9.1f} MB\n"
-    with open(_MEM_LOG, "a") as f:
+    with open(_MEM_LOG, "a", encoding="utf-8") as f:
         f.write(entry)
         f.flush()
         try:
@@ -380,15 +380,15 @@ def _run_gpu_fit_with_metric_polling(
     )
     worker.start()
 
-    metric_path = os.path.join(train_dir, "learn_error.tsv")
+    metric_path = Path(train_dir) / "learn_error.tsv"
     last_seen = 0  # number of data lines already processed
 
     def _poll_metric_file() -> None:
         nonlocal last_seen
         try:
-            if not os.path.exists(metric_path):
+            if not metric_path.exists():
                 return
-            with open(metric_path) as mf:
+            with open(metric_path, encoding="utf-8") as mf:
                 lines = mf.readlines()
         except OSError:
             return  # metric file mid-write — pick it up on the next poll

--- a/src/haute/modelling/_mlflow_log.py
+++ b/src/haute/modelling/_mlflow_log.py
@@ -145,6 +145,7 @@ def build_run_url(
 def _log_json_artifact(mlflow: Any, data: Any, prefix: str, artifact_dir: str) -> None:
     """Write *data* to a temp JSON file and log it as an MLflow artifact."""
     with tempfile.NamedTemporaryFile(
+        encoding="utf-8",
         mode="w",
         suffix=".json",
         prefix=f"{prefix}_",
@@ -565,6 +566,7 @@ def _log_model_card(
         metadata=metadata,
     )
     with tempfile.NamedTemporaryFile(
+        encoding="utf-8",
         mode="w",
         suffix=".html",
         prefix="model_card_",

--- a/src/haute/modelling/_training_job.py
+++ b/src/haute/modelling/_training_job.py
@@ -1266,7 +1266,7 @@ class TrainingJob:
         gc.collect()
 
         # Clean up split parquet
-        if split_result.owns_tmp and os.path.exists(data_path):
+        if split_result.owns_tmp and Path(data_path).exists():
             os.unlink(data_path)
 
         return _MetricsResult(

--- a/src/haute/routes/_optimiser_service.py
+++ b/src/haute/routes/_optimiser_service.py
@@ -4794,7 +4794,7 @@ class OptimiserSolveService:
             )
             raise HTTPException(status_code=400, detail=detail) from exc
         finally:
-            if os.path.exists(tmp_path):
+            if Path(tmp_path).exists():
                 try:
                     os.unlink(tmp_path)
                 except Exception as cleanup_exc:

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -964,7 +964,7 @@ class TrainService:
             _malloc_trim()
             _mem_checkpoint("sunk to temp parquet")
         except ExecutionMemoryLimitExceededError as exc:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
             logger.warning(
                 "pipeline_exec_memory_limited",
@@ -978,7 +978,7 @@ class TrainService:
             )
             raise _memory_limit_http_exception(exc) from None
         except BoundedMemoryUnsupportedError as exc:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
             error_msg = f"Pipeline cannot run in bounded streaming mode: {exc}"
             logger.warning(
@@ -993,11 +993,11 @@ class TrainService:
             )
             raise HTTPException(status_code=422, detail=error_msg) from None
         except HTTPException:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
             raise
         except Exception as exc:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
             error_msg = f"Pipeline execution failed: {exc}"
             logger.error("pipeline_exec_failed", error=str(exc), node_id=body.node_id)
@@ -1226,14 +1226,14 @@ class TrainService:
                     )
                 self._training_jobs.release(job_id)
                 execution_context.release_admission()
-                if os.path.exists(tmp_parquet):
+                if Path(tmp_parquet).exists():
                     os.unlink(tmp_parquet)
 
         try:
             thread = threading.Thread(target=_train_background, daemon=True)
             thread.start()
         except Exception as exc:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
             logger.error("training_worker_start_failed", error=str(exc), node_id=node_id)
             self._lifecycle.transition(

--- a/tests/test_algorithms_coverage.py
+++ b/tests/test_algorithms_coverage.py
@@ -7,9 +7,9 @@ CatBoost, and MLflow dependencies.
 
 from __future__ import annotations
 
-import os
 import sys
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
@@ -1333,8 +1333,8 @@ class TestGPUOnIterationPath:
 
         def fake_fit(pool: Any, **kwargs: Any) -> None:
             # Simulate CatBoost writing learn_error.tsv
-            metric_path = os.path.join(real_tempdir, "learn_error.tsv")
-            with open(metric_path, "w") as f:
+            metric_path = Path(real_tempdir) / "learn_error.tsv"
+            with open(metric_path, "w", encoding="utf-8") as f:
                 f.write("iter\tRMSE\n")
                 f.write("0\t0.5\n")
                 f.write("1\t0.4\n")

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -284,9 +284,7 @@ class TestServe:
         else:
             # On Windows, shutil.which("npm") returns the full path
             # e.g. "C:\Program Files\nodejs\npm.cmd"
-            import os
-
-            npm_basename = os.path.basename(cmd[0]).lower()
+            npm_basename = Path(cmd[0]).name.lower()
             assert npm_basename.startswith("npm"), f"Expected npm as first arg, got: {cmd}"
 
     def test_dev_mode_opens_browser_after_backend_is_ready_when_flag_not_set(

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1281,7 +1281,7 @@ class TestDeployToContainer:
         mock_build.return_value = ContainerBuildResult(
             image_tag="m:v",
             manifest_path=Path("m.json"),
-            build_dir=Path("."),
+            build_dir=Path(),
             model_name="m",
             model_version=1,
         )

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -274,7 +274,7 @@ class TestBundler:
         )
 
         with pytest.raises(FileNotFoundError, match="[Aa]rtifact.*not found"):
-            collect_artifacts(graph, [], Path("."))
+            collect_artifacts(graph, [], Path())
 
     def test_collect_model_score_artifact(self, tmp_path, monkeypatch):
         """MODEL_SCORE nodes download .cbm from MLflow and include in artifacts."""
@@ -327,7 +327,7 @@ class TestBundler:
             }
         )
 
-        artifacts = collect_artifacts(graph, [], Path("."))
+        artifacts = collect_artifacts(graph, [], Path())
         assert len(artifacts) == 0
 
     def test_external_file_no_path_skipped(self):
@@ -348,7 +348,7 @@ class TestBundler:
             }
         )
 
-        artifacts = collect_artifacts(graph, [], Path("."))
+        artifacts = collect_artifacts(graph, [], Path())
         assert len(artifacts) == 0
 
     def test_datasource_not_input_collects_artifact(self, tmp_path):
@@ -512,7 +512,7 @@ class TestBundler:
             }
         )
 
-        artifacts = collect_artifacts(graph, [], Path("."))
+        artifacts = collect_artifacts(graph, [], Path())
         assert len(artifacts) == 0
 
     def test_registered_model_resolve_error_propagates(self):
@@ -542,7 +542,7 @@ class TestBundler:
             side_effect=ValueError("No versions found for registered model 'nonexistent-model'."),
         ):
             with pytest.raises(ValueError, match="No versions found"):
-                collect_artifacts(graph, [], Path("."))
+                collect_artifacts(graph, [], Path())
 
     def test_mixed_run_and_registered_models(self, tmp_path, monkeypatch):
         """Pipeline with both run-based and registered MODEL_SCORE nodes."""
@@ -1434,7 +1434,7 @@ class TestModelsFromCode:
 
         from haute.deploy._mlflow import _MODEL_CODE_PATH
 
-        source = Path(_MODEL_CODE_PATH).read_text()
+        source = Path(_MODEL_CODE_PATH).read_text(encoding="utf-8")
         assert "set_model(" in source
 
     def test_log_model_receives_file_path(self, deploy_pipeline_file: Path) -> None:

--- a/tests/test_git_state_coverage.py
+++ b/tests/test_git_state_coverage.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text)
+    path.write_text(text, encoding="utf-8")
 
 
 class TestReadPrefsFallbacks:

--- a/tests/test_mlflow_log.py
+++ b/tests/test_mlflow_log.py
@@ -1044,7 +1044,6 @@ class TestConfigureMlflowTracking:
 class TestLogJsonArtifact:
     def test_writes_and_cleans_up(self) -> None:
         """_log_json_artifact should write JSON, log it, and delete the file."""
-        import os
 
         mock_mlflow = MagicMock()
         from haute.modelling._mlflow_log import _log_json_artifact
@@ -1053,7 +1052,7 @@ class TestLogJsonArtifact:
         mock_mlflow.log_artifact.assert_called_once()
         logged_path = mock_mlflow.log_artifact.call_args[0][0]
         # File should have been cleaned up
-        assert not os.path.exists(logged_path)
+        assert not Path(logged_path).exists()
 
     def test_cleans_up_on_error(self) -> None:
         """Even if log_artifact raises, the temp file should be cleaned up."""
@@ -1070,7 +1069,6 @@ class TestLogJsonArtifact:
 class TestLogModelCard:
     def test_generates_and_logs_html(self) -> None:
         """_log_model_card should generate HTML and log as artifact."""
-        import os
 
         mock_mlflow = MagicMock()
         from haute.modelling._mlflow_log import _log_model_card
@@ -1088,4 +1086,4 @@ class TestLogModelCard:
         args = mock_mlflow.log_artifact.call_args
         assert args[0][1] == "model_card"
         # Temp file should be cleaned up
-        assert not os.path.exists(args[0][0])
+        assert not Path(args[0][0]).exists()

--- a/tests/test_model_scorer.py
+++ b/tests/test_model_scorer.py
@@ -534,7 +534,7 @@ class TestSinkToTemp:
         lf = pl.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}).lazy()
         path = _sink_to_temp(lf)
         try:
-            assert os.path.exists(path)
+            assert Path(path).exists()
             assert path.endswith(".parquet")
             df = pl.read_parquet(path)
             assert len(df) == 3

--- a/tests/test_model_scorer_contracts.py
+++ b/tests/test_model_scorer_contracts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -179,6 +178,6 @@ def test_score_from_config_rejects_symlink_escape(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="outside project root"):
         score_from_config(
             pl.DataFrame({"a": [1.0]}).lazy(),
-            config=os.path.join("config", "model_scoring", "score.json"),
+            config=str(Path("config") / "model_scoring" / "score.json"),
             base_dir=str(tmp_path),
         )

--- a/tests/test_optimiser_apply.py
+++ b/tests/test_optimiser_apply.py
@@ -7,6 +7,7 @@ artifact caching, and deploy bundling/scoring.
 import json
 import os
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -61,7 +62,7 @@ def _make_ratebook_artifact(version: str = "rb_v1") -> dict:
 def _write_artifact(artifact: dict) -> str:
     fd, path = tempfile.mkstemp(suffix=".json")
     os.close(fd)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(artifact, f)
     return path
 
@@ -1159,7 +1160,7 @@ class TestBundler:
                 ],
                 edges=[],
             )
-            artifacts = collect_artifacts(graph, [], pipeline_dir=os.path.dirname(path))
+            artifacts = collect_artifacts(graph, [], pipeline_dir=Path(path).parent)
             assert len(artifacts) == 1
             key = list(artifacts.keys())[0]
             assert key.startswith("apply_1__")

--- a/tests/test_optimiser_routes.py
+++ b/tests/test_optimiser_routes.py
@@ -8771,7 +8771,7 @@ class TestApplyLambdasUnit:
         assert resp.status_code == 200
         mock_solver.solve.assert_called_once()
         assert mock_solver.solve.call_args.kwargs["lambdas"] == {"volume": 0.7}
-        saved = json_mod.loads(Path(out_path).read_text())
+        saved = json_mod.loads(Path(out_path).read_text(encoding="utf-8"))
         assert saved["total_objective"] == 222.0
         assert saved["total_constraints"] == {"volume": 0.97}
         assert saved["factor_tables"] == _expected_region_factor_tables()
@@ -9271,7 +9271,7 @@ class TestSaveResultUnit:
         data = resp.json()
         assert data["status"] == "ok"
 
-        saved = json_mod.loads(Path(out_path).read_text())
+        saved = json_mod.loads(Path(out_path).read_text(encoding="utf-8"))
         assert saved["lambdas"] == {"volume": 0.5}
         assert saved["total_objective"] == 100.0
         assert saved["converged"] is True
@@ -9307,7 +9307,7 @@ class TestSaveResultUnit:
         )
 
         assert resp.status_code == 200
-        saved = json_mod.loads(Path(out_path).read_text())
+        saved = json_mod.loads(Path(out_path).read_text(encoding="utf-8"))
         assert saved["total_objective"] == 222.0
         assert saved["total_constraints"] == {"volume": 0.97}
         assert saved["factor_tables"] == _expected_region_factor_tables()
@@ -10307,7 +10307,9 @@ class TestMlflowLogExtended:
         def capture_artifact(path: str) -> None:
             artifact_path = Path(path)
             if artifact_path.suffix == ".json":
-                logged_json[artifact_path.name] = json_mod.loads(artifact_path.read_text())
+                logged_json[artifact_path.name] = json_mod.loads(
+                    artifact_path.read_text(encoding="utf-8")
+                )
 
         mock_mlflow.log_artifact.side_effect = capture_artifact
 
@@ -12146,9 +12148,8 @@ class TestBuildGrid:
         # Temp file should be cleaned up
         build_call_args = mock_build.call_args
         parquet_path = build_call_args[0][0]
-        import os
 
-        assert not os.path.exists(parquet_path)
+        assert not Path(parquet_path).exists()
 
     def test_build_grid_without_chunk_size_uses_default_chunked_builder(self, tmp_path):
         """Without explicit chunk_size, derive rows from the setup byte budget."""

--- a/tests/test_optimiser_routes_critical_edges.py
+++ b/tests/test_optimiser_routes_critical_edges.py
@@ -982,7 +982,7 @@ def test_mlflow_log_ratebook_falls_back_to_solve_result_factor_tables(
         # asks mlflow to log it; capture the file content so we can
         # inspect what would have shipped to MLflow.
         if artifact_path.endswith("optimiser_result.json"):
-            captured_payloads.append(Path(artifact_path).read_text())
+            captured_payloads.append(Path(artifact_path).read_text(encoding="utf-8"))
 
     fake_mlflow = MagicMock()
     fake_run = MagicMock()

--- a/tests/test_parser_helpers_split.py
+++ b/tests/test_parser_helpers_split.py
@@ -701,7 +701,7 @@ class TestGodFileIsGone:
         import haute._parser_helpers as facade
 
         facade_path = Path(facade.__file__)
-        line_count = facade_path.read_text().count("\n")
+        line_count = facade_path.read_text(encoding="utf-8").count("\n")
 
         # The old file was 1011 lines.  A facade module should be well
         # under 300 lines (room for imports, __all__, docstring, and

--- a/tests/test_partial_failure.py
+++ b/tests/test_partial_failure.py
@@ -224,14 +224,14 @@ class TestPermissionDenied:
         py_file = read_only_dir / "pipeline.py"
         py_file.write_text("# placeholder")
 
-        os.chmod(read_only_dir, stat.S_IRUSR | stat.S_IXUSR)
+        read_only_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
         try:
             svc = SavePipelineService(read_only_dir)
             req = _make_save_request("pipeline.py")
             with pytest.raises((OSError, PermissionError)):
                 svc.save(req)
         finally:
-            os.chmod(read_only_dir, stat.S_IRWXU)
+            read_only_dir.chmod(stat.S_IRWXU)
 
     def test_save_sidecar_to_readonly_file_succeeds_via_atomic_replace(
         self, tmp_path: Path
@@ -258,7 +258,7 @@ class TestPermissionDenied:
         sidecar = py_path.with_suffix(".haute.json")
         sidecar.write_text('{"original": true}')
         if sys.platform != "win32":
-            os.chmod(sidecar, stat.S_IRUSR)
+            sidecar.chmod(stat.S_IRUSR)
 
         graph = _simple_graph()
         try:
@@ -273,7 +273,7 @@ class TestPermissionDenied:
         finally:
             if sys.platform != "win32":
                 # Restore writable so tmp_path cleanup doesn't choke.
-                os.chmod(sidecar, stat.S_IRWXU)
+                sidecar.chmod(stat.S_IRWXU)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="chmod semantics differ on Windows")
     def test_save_sidecar_to_readonly_dir_raises(self, tmp_path: Path) -> None:
@@ -292,13 +292,13 @@ class TestPermissionDenied:
         py_path = project / "pipeline.py"
         py_path.write_text("# placeholder")
 
-        os.chmod(project, stat.S_IRUSR | stat.S_IXUSR)
+        project.chmod(stat.S_IRUSR | stat.S_IXUSR)
         graph = _simple_graph()
         try:
             with pytest.raises((PermissionError, OSError)):
                 save_sidecar(py_path, graph)
         finally:
-            os.chmod(project, stat.S_IRWXU)
+            project.chmod(stat.S_IRWXU)
 
 
 # ===================================================================
@@ -329,19 +329,19 @@ class TestTempFileCleanupOnCrash:
         checkpoint_dir = tmp_path / "haute_train_ckpt_test"
         checkpoint_dir.mkdir()
 
-        assert os.path.exists(tmp_parquet)
+        assert Path(tmp_parquet).exists()
 
         # Replicate the exact cleanup pattern from _execute_and_sink
         try:
             raise RuntimeError("Simulated OOM in _execute_lazy")
         except Exception:
-            if os.path.exists(tmp_parquet):
+            if Path(tmp_parquet).exists():
                 os.unlink(tmp_parquet)
         finally:
             if checkpoint_dir and checkpoint_dir.exists():
                 shutil.rmtree(checkpoint_dir, ignore_errors=True)
 
-        assert not os.path.exists(tmp_parquet), "Temp parquet leaked after exception"
+        assert not Path(tmp_parquet).exists(), "Temp parquet leaked after exception"
         assert not checkpoint_dir.exists(), "Checkpoint dir leaked after exception"
 
     def test_checkpoint_dir_cleaned_on_exception(self, tmp_path: Path) -> None:
@@ -383,7 +383,7 @@ class TestTempFileCleanupOnCrash:
         except ValueError:
             pass
         finally:
-            if os.path.exists(str(tmp_parquet)):
+            if tmp_parquet.exists():
                 os.unlink(str(tmp_parquet))
 
         assert not tmp_parquet.exists(), "Parquet not cleaned after training failure"

--- a/tests/test_path_traversal_advanced.py
+++ b/tests/test_path_traversal_advanced.py
@@ -29,7 +29,7 @@ import pytest
 def _write_json(path: Path, data: dict) -> None:
     """Write a dict as JSON to the given path, creating parents."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data))
+    path.write_text(json.dumps(data), encoding="utf-8")
 
 
 # =========================================================================

--- a/tests/test_polars_utils.py
+++ b/tests/test_polars_utils.py
@@ -49,7 +49,7 @@ def _manual_write_csv(self: pl.DataFrame, path, **_kw) -> None:
     import csv
 
     cols = self.columns
-    with open(str(path), "w", newline="") as f:
+    with open(str(path), "w", encoding="utf-8", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(cols)
         for row in self.iter_rows():

--- a/tests/test_train_service_coverage.py
+++ b/tests/test_train_service_coverage.py
@@ -754,11 +754,30 @@ class TestExecuteAndSinkCleanupAbsentPaths:
         return store, service, job_id, _source_only_request()
 
     def _run_with_absent_paths(self, service, body, job_id, lazy_side_effect):
-        """Run _execute_and_sink with os.path.exists forced False (temp gone) and
-        mkdtemp pointed at a non-existent dir (checkpoint dir absent)."""
+        """Run _execute_and_sink with the temp parquet absent, exercising the
+        cleanup guards' skip-unlink arms.
+
+        The training temp parquet is deleted the instant mkstemp hands it back,
+        so the ``if Path(tmp_parquet).exists()`` guards are naturally False
+        without mocking pathlib globally. Only the ``haute_train_`` temp is
+        special-cased; the dataframe-cache machinery's own mkstemp temps are
+        delegated to the real implementation untouched. os.path.exists stays
+        globally False (as before) to keep that machinery off real filesystem
+        I/O, and os.unlink is mocked as the belt-and-braces assertion target."""
         import tempfile as _tempfile
 
         ckpt_missing = "/nonexistent/haute_ckpt_absent"
+        real_mkstemp = _tempfile.mkstemp
+        real_unlink = os.unlink  # capture before the with-block mocks os.unlink
+
+        def _mkstemp_training_absent(*a, **k):
+            fd, path = real_mkstemp(*a, **k)
+            if k.get("prefix") == "haute_train_":
+                # Drop the training temp immediately so the cleanup guards see it
+                # as already gone; the fd stays valid for the caller's os.close.
+                real_unlink(path)
+            return fd, path
+
         p1, p2, p3, p4, p5 = _patch_execute_env()
         with (
             patch(
@@ -766,6 +785,7 @@ class TestExecuteAndSinkCleanupAbsentPaths:
                 side_effect=lazy_side_effect,
             ),
             patch("haute.routes._train_service.os.path.exists", return_value=False),
+            patch.object(_tempfile, "mkstemp", side_effect=_mkstemp_training_absent),
             patch.object(_tempfile, "mkdtemp", return_value=ckpt_missing),
             patch("haute.routes._train_service.os.unlink") as mock_unlink,
             p1,
@@ -1225,7 +1245,7 @@ class TestLaunchBackgroundWorker:
         store, service, job_id = self._service_and_job()
         context = _training_execution_context()
         tmp_parquet = str(tmp_path / "train.parquet")
-        Path(tmp_parquet).write_text("x")
+        Path(tmp_parquet).write_text("x", encoding="utf-8")
 
         cap = _train_service._MAX_TRAIN_LOSS_HISTORY
 
@@ -1319,7 +1339,7 @@ class TestLaunchBackgroundWorker:
         store, service, job_id = self._service_and_job()
         context = _training_execution_context()
         tmp_parquet = str(tmp_path / "train.parquet")
-        Path(tmp_parquet).write_text("x")
+        Path(tmp_parquet).write_text("x", encoding="utf-8")
 
         class FakeJob:
             def run(self, *a, **k):
@@ -1357,7 +1377,7 @@ class TestLaunchBackgroundWorker:
         store, service, job_id = self._service_and_job()
         context = _training_execution_context()
         tmp_parquet = str(tmp_path / "train.parquet")
-        Path(tmp_parquet).write_text("x")
+        Path(tmp_parquet).write_text("x", encoding="utf-8")
 
         class FakeJob:
             def run(self, *a, **k):
@@ -1392,7 +1412,7 @@ class TestLaunchBackgroundWorker:
         store, service, job_id = self._service_and_job()
         context = _training_execution_context()
         tmp_parquet = str(tmp_path / "train.parquet")
-        Path(tmp_parquet).write_text("x")
+        Path(tmp_parquet).write_text("x", encoding="utf-8")
 
         class FakeJob:
             def run(self, *a, **k):

--- a/tests/test_v2_codec_and_shred.py
+++ b/tests/test_v2_codec_and_shred.py
@@ -471,7 +471,7 @@ def test_shred_to_buffers_two_columns_from_same_source_get_same_values() -> None
 
 
 def _write_rating_json(path: Path) -> None:
-    path.write_text(json.dumps(_rating_records()))
+    path.write_text(json.dumps(_rating_records()), encoding="utf-8")
 
 
 def test_build_per_port_cache_writes_one_parquet_per_emit_table(tmp_path: Path) -> None:

--- a/tests/test_v2_object_nesting_inference.py
+++ b/tests/test_v2_object_nesting_inference.py
@@ -359,7 +359,7 @@ class TestDataModelObjectEmbeddingIgnoresBranching:
     """
 
     def test_object_wrappers_add_no_tables_only_arrays_do(self, tmp_path: Path) -> None:
-        original = json.loads(_DATA_MODEL_EXAMPLE.read_text())
+        original = json.loads(_DATA_MODEL_EXAMPLE.read_text(encoding="utf-8"))
         base_paths = _table_paths(infer_v2_schema_from_data(_write(tmp_path / "a", original)))
         assert base_paths == {
             "$[:]",


### PR DESCRIPTION
## What

Platform-portability lint hardening across the Python package, tests, and scripts — one wide but mechanical sweep bundling three changes.

### 1. `PLW1514` — require an explicit encoding on text I/O
Enabled via ruff **preview mode** with `explicit-preview-rules = true`, so *only* this one preview rule activates (every other preview rule stays off). Adds `encoding="utf-8"` to **29** `open` / `read_text` / `write_text` / `NamedTemporaryFile` sites. Without an explicit encoding, Python falls back to the platform locale encoding — a file written UTF-8 on Linux/macOS and read back under cp1252 on Windows silently corrupts non-ASCII bytes.

### 2. `PTH` — pathlib for the portable `os.path` subset
Enabled `PTH101, PTH110, PTH116, PTH118, PTH119, PTH120, PTH201` and rewrote **38** sites (`os.path.exists` → `Path.exists`, `os.chmod` → `Path.chmod`, `os.stat` → `Path.stat`, `os.path.join` → `Path(...) / ...`, `os.path.basename` → `Path.name`, `os.path.dirname` → `Path.parent`, `Path(".")` → `Path()`). A `select`-block comment documents the requirement and the WHY: keeping filesystem paths as `Path` objects makes the `str(path)` vs `path.as_posix()` serialization choice explicit at the call site — the Windows codegen bug class where a backslash path leaks into generated Python source and is read back as an escape. The `open()` / `getcwd` / `abspath`-class PTH rules are deliberately left out of scope.

One coverage test (`test_train_service_coverage.py::TestExecuteAndSinkCleanupAbsentPaths`) mocked `os.path.exists` to exercise `_train_service`'s temp-cleanup guards; since those guards now call `Path.exists`, the helper was updated to make the temp parquet genuinely absent (delete it right after `mkstemp`, delegating the cache machinery's own temps to the real implementation) so the same skip-unlink branches are still covered. It was the only test affected.

### 3. `.gitattributes` — declared LF line-ending posture
Added `* text=auto eol=lf` so future checkouts/commits normalize to LF on every platform. The existing `tests/fixtures/**/*.json text eol=lf` pin is retained. The index was already entirely LF (2260 LF / 6 binary / 9 empty, **0 CRLF**), so this adds no working-tree churn — no repo-wide `--renormalize` was run.

## Verification (macOS; full suite runs locally)
- `uv run ruff check .` — clean (before the fixes it surfaced exactly the 29 PLW1514 + 38 PTH findings; 0 after).
- `uv run ruff format --check .` — clean.
- `uv run mypy src/haute/` — clean (147 source files).
- `uv run pytest` full suite — **green: 12285 passed, 26 skipped, 2 xfailed**, identical to the pre-change baseline, under the `--cov-fail-under=90` global coverage gate (total coverage 92.70%).

## ⚠️ Merge ordering — read before merging
This is a **repo-wide sweep touching 33 files** (12 `src/`, 19 `tests/`, 1 `scripts/`, plus `pyproject.toml` and `.gitattributes`) and is **maximally conflict-prone with any in-flight PR**. It should merge **only after the in-flight PR queue has cleared**, and a **`git rebase origin/main` immediately before merge** is required to reconcile against whatever landed first. Please do not merge this ahead of narrower branches — let those land, then rebase this on top.
