### PR TITLE
save: reject config-sidecar paths that collide case-insensitively

### DIFF
--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -756,7 +756,14 @@ class SavePipelineService:
     def _validate_unique_config_paths_in_graph(graph: PipelineGraph) -> None:
         from haute._config_io import config_path_for_node, has_config_folder
 
-        seen: set[str] = set()
+        # Compare paths casefolded: labels differing only in case (``Foo`` /
+        # ``foo``) sanitize to distinct Python identifiers, but their sidecars
+        # (``Foo.json`` / ``foo.json``) are the SAME file on the
+        # case-insensitive filesystems macOS and Windows default to, where the
+        # second write silently overwrites the first. Rejecting the collision
+        # on every platform keeps a pipeline saved on Linux loadable on a
+        # macOS/Windows checkout.
+        seen: dict[str, str] = {}
         duplicates: set[str] = set()
         for node in graph.nodes:
             nt = node.data.nodeType
@@ -766,19 +773,28 @@ class SavePipelineService:
                 continue
             func_name = _sanitize_func_name(node.data.label)
             rel_path = config_path_for_node(nt, func_name).as_posix()
-            if rel_path in seen:
-                duplicates.add(rel_path)
-            seen.add(rel_path)
+            folded = rel_path.casefold()
+            if folded in seen:
+                duplicates.update((seen[folded], rel_path))
+            else:
+                seen[folded] = rel_path
         SavePipelineService._raise_config_path_conflicts(duplicates)
 
     @staticmethod
     def _merge_config_maps(target: dict[str, str], incoming: dict[str, str]) -> None:
+        # Casefolded comparison for the same reason as
+        # ``_validate_unique_config_paths_in_graph``: a parent node and a
+        # submodel child whose sidecar paths differ only in case would
+        # silently clobber each other on a case-insensitive filesystem.
         duplicates: set[str] = set()
+        folded_target = {key.casefold(): key for key in target}
         for rel_path, content in incoming.items():
-            if rel_path in target:
-                duplicates.add(rel_path)
+            folded = rel_path.casefold()
+            if folded in folded_target:
+                duplicates.update((folded_target[folded], rel_path))
                 continue
             target[rel_path] = content
+            folded_target[folded] = rel_path
         SavePipelineService._raise_config_path_conflicts(duplicates)
 
     @staticmethod
@@ -789,8 +805,11 @@ class SavePipelineService:
         raise HTTPException(
             status_code=400,
             detail=(
-                "Duplicate config sidecar path detected while saving nested "
-                f"submodels: {formatted}. Rename one of the nodes before saving."
+                f"Duplicate config sidecar path detected: {formatted}. "
+                "Sidecar filenames are compared case-insensitively, because "
+                "case-insensitive filesystems (macOS, Windows) treat names "
+                "differing only in case as the same file. Rename one of the "
+                "nodes before saving."
             ),
         )
 

--- a/tests/test_pipeline_runtime_path_validation.py
+++ b/tests/test_pipeline_runtime_path_validation.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import HTTPException
 
 from haute._types import GraphNode, NodeData, NodeType, PipelineGraph
+from haute.routes._save_pipeline import SavePipelineService
 from haute.routes.pipeline import _validate_runtime_input_paths
 
 
@@ -99,6 +100,88 @@ def test_validate_runtime_input_paths_rejects_model_score_escape(
 
     assert exc_info.value.status_code == 403
     assert "outside the project root" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Case-only config-sidecar collisions.
+#
+# Node labels differing only in case ("Foo" / "foo") sanitize to distinct
+# Python identifiers, but their config sidecars (config/<type>/Foo.json vs
+# config/<type>/foo.json) are the SAME file on the case-insensitive
+# filesystems macOS and Windows default to — the second write would silently
+# overwrite the first. The save-time guard therefore rejects the collision on
+# every platform. These tests live in this file because it runs on the
+# macOS/Windows platform-smoke CI leg, i.e. on real case-insensitive
+# filesystems.
+# ---------------------------------------------------------------------------
+
+
+def _config_node(node_id: str, label: str) -> GraphNode:
+    return GraphNode(
+        id=node_id,
+        data=NodeData(
+            label=label,
+            nodeType=NodeType.DATA_SOURCE,
+            config={"path": f"{node_id}.csv"},
+        ),
+    )
+
+
+def test_case_only_label_collision_rejected_before_any_config_write(
+    tmp_path: Path,
+) -> None:
+    """Two same-type nodes whose labels differ only in case must not save."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(
+        nodes=[_config_node("a", "Foo"), _config_node("b", "foo")],
+        edges=[],
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_config_files(graph)
+
+    assert exc_info.value.status_code == 400
+    assert "Duplicate config sidecar path" in exc_info.value.detail
+    assert "config/data_source/Foo.json" in exc_info.value.detail
+    assert "config/data_source/foo.json" in exc_info.value.detail
+    # Rejected before any write: neither casing reached the disk.
+    assert not (tmp_path / "config").exists()
+
+
+def test_case_only_collision_between_parent_and_submodel_rejected(
+    tmp_path: Path,
+) -> None:
+    """A submodel child colliding case-only with a parent node must not save."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(nodes=[_config_node("parent", "Shared")], edges=[])
+    child = _config_node("child", "shared")
+    graph.submodels = {
+        "pricing": {
+            "file": "modules/pricing.py",
+            "graph": {"nodes": [child.model_dump(mode="json")], "edges": []},
+        }
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_config_files(graph)
+
+    assert exc_info.value.status_code == 400
+    assert "Duplicate config sidecar path" in exc_info.value.detail
+    assert not (tmp_path / "config").exists()
+
+
+def test_distinct_labels_still_write_one_sidecar_each(tmp_path: Path) -> None:
+    """The casefold guard must not over-trigger on genuinely distinct names."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(
+        nodes=[_config_node("a", "Foo"), _config_node("b", "Bar")],
+        edges=[],
+    )
+
+    svc._write_config_files(graph)
+
+    assert (tmp_path / "config" / "data_source" / "Foo.json").is_file()
+    assert (tmp_path / "config" / "data_source" / "Bar.json").is_file()
 
 
 def test_validate_runtime_input_paths_checks_optimiser_apply_file_mode_only() -> None:


### PR DESCRIPTION
## Bug

Two same-type nodes whose labels differ **only in case** (`Foo` / `foo`) silently corrupt each other's saved config on macOS/Windows:

- `_sanitize_func_name` preserves case, so `Foo` and `foo` are **distinct Python identifiers** — the function-name collision guard correctly passes them.
- Their config sidecars are `config/<type>/Foo.json` and `config/<type>/foo.json` — **distinct strings**, so the dedicated config-path duplicate guard (a case-sensitive `set[str]` membership check) also passed them.
- On the case-insensitive filesystems macOS and Windows default to, those are the **same file**: the save loop wrote both, the second overwrote the first, and one node's config was lost with **no error at save time or ever after** (both nodes then load the surviving, wrong config).

Reproduced end-to-end on macOS before the fix: both save-time guards passed, `collect_node_configs` returned 2 entries, both were written, **1 file survived** holding the wrong node's payload.

This is a platform divergence of exactly the class the platform workstream targets: the same pipeline works on Linux (two distinct files) and silently loses data when saved on a macOS/Windows checkout.

## Fix

Both save-time config-path guards in `SavePipelineService` now compare sidecar rel-paths **casefolded**:

- `_validate_unique_config_paths_in_graph` — flat-graph duplicates,
- `_merge_config_maps` — parent vs embedded-submodel duplicates,

and `_raise_config_path_conflicts`'s message now names **both colliding casings** and explains the case-insensitivity rationale (the `"Duplicate config sidecar path"` prefix asserted by existing tests is unchanged).

The collision is rejected on **every** platform, not just case-insensitive ones — a pipeline saved on Linux must stay loadable on a macOS/Windows checkout. False positives are not possible for genuinely-distinct files: sanitized names are pure ASCII (`_sanitize_func_name` hex-encodes non-ASCII), so `casefold()` is exactly ASCII case folding — the same equivalence APFS/NTFS apply.

## Tests

Three characterization tests in `tests/test_pipeline_runtime_path_validation.py` — chosen because that file runs on the **macOS + Windows platform-smoke CI leg** (no CI change needed), i.e. against real case-insensitive filesystems:

1. flat-graph case-only collision → HTTP 400 naming both casings, rejected **before any write**;
2. parent/submodel case-only collision → HTTP 400, nothing written;
3. genuinely distinct labels (`Foo`/`Bar`) still write one sidecar each (guard doesn't over-trigger).

They are deterministic on case-sensitive filesystems too (the guard rejects everywhere), so the Linux backend legs stay green.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- `uv run mypy src/haute/` — clean (147 source files).
- `uv run pytest` full suite — **12298 passed, 26 skipped, 2 xfailed** under the `--cov-fail-under=90` gate (coverage 92.71%).
- Adversarial review (subagent, verdict **SOUND-WITH-NITS**, merge-approved):
  - **No false positives possible:** `_sanitize_func_name` output is provably pure ASCII `[A-Za-z0-9_]` (probed ß, ẞ, İ, ı, Kelvin K, Å, µ, ﬁ — all hex-encoded lowercase), so `casefold()` here is exactly the ASCII folding APFS/NTFS apply; every rejected pair really is one file on macOS/Windows.
  - **No unguarded sidecar writers:** the only config-sidecar write path is `_write_config_files` → `_stage_write`, which routes through both fixed guards.
  - **Legacy escape confirmed:** a pre-existing on-disk collision doesn't brick saving — `_compute_disk_prev_config_files` catches the guard's rejection and degrades safely, so users can rename their way out.
  - **No message-contract dependence:** zero repo hits for the old wording; frontend displays `err.detail` verbatim (no parsing).

## Known adjacent gap (pre-existing, follow-up queued)

The review probe-confirmed a sibling bug this PR deliberately does **not** cover: a case-only **rename** of a single node (`Foo` → `FOO`) still loses its config on macOS/Windows, via `_remove_stale_config_files`'s case-sensitive prev/current diff (save writes `FOO.json` — the same file — then stale cleanup unlinks `Foo.json`). No collision exists in any single graph, so the save-time guards here cannot see it. It is recoverable from git history via the VC ledger and is queued as its own follow-up with a repro and fix direction (casefold the stale diff).

Origin: D4b follow-up from the platform-lint sweep (#41). Authoring the planned case-collision characterization test exposed this as a live bug, so the PR carries the fix plus the tests rather than a characterization of broken behaviour.
