### PR TITLE
save: survive case-only renames in stale cleanup; casefold codegen dedupe

### DIFF
--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -588,15 +588,31 @@ class SavePipelineService:
         touched: list[_TouchedFile],
     ) -> None:
         """Write generated ``.py`` files through the shared output allowlist."""
-        resolved_targets: set[Path] = set()
+        # Resolve and collision-check every path BEFORE any write, comparing
+        # casefolded for the same reason as the config-sidecar guards:
+        # distinct rel-paths like ``modules/Pricing.py`` / ``modules/pricing.py``
+        # are the SAME file on the case-insensitive filesystems macOS and
+        # Windows default to, where the second write silently overwrites the
+        # first. Rejecting on every platform keeps a pipeline saved on Linux
+        # loadable on a macOS/Windows checkout.
+        resolved: list[tuple[Path, str]] = []
+        seen: dict[str, str] = {}
         for rel_path, code in files.items():
             out_path = self._validate_output_rel_path(rel_path, source_file)
-            if out_path in resolved_targets:
+            folded = str(out_path).casefold()
+            if folded in seen:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Codegen produced duplicate output path: {rel_path}",
+                    detail=(
+                        f"Codegen produced duplicate output path: {seen[folded]!r} "
+                        f"and {rel_path!r} name the same file on the "
+                        "case-insensitive filesystems macOS and Windows "
+                        "default to. Rename one of the modules before saving."
+                    ),
                 )
-            resolved_targets.add(out_path)
+            seen[folded] = rel_path
+            resolved.append((out_path, code))
+        for out_path, code in resolved:
             self._stage_write(out_path, code, touched)
 
     # ------------------------------------------------------------------
@@ -703,9 +719,18 @@ class SavePipelineService:
         self._protected_config_files: set[str] = set(
             self._collect_config_load_errors_recursive(graph)
         )
-        self._raise_config_path_conflicts(
-            set(self._last_config_files) & self._protected_config_files
-        )
+        # Casefolded intersection, consistent with the collision guards below:
+        # a to-be-written path and a protected load-error path differing only
+        # in case are the same file on the case-insensitive filesystems macOS
+        # and Windows default to. (Defence in depth — the per-graph casefold
+        # guard already rejects such graphs upstream.)
+        protected_folded = {rel.casefold(): rel for rel in self._protected_config_files}
+        conflicts: set[str] = set()
+        for rel_path in self._last_config_files:
+            match = protected_folded.get(rel_path.casefold())
+            if match is not None:
+                conflicts.update((match, rel_path))
+        self._raise_config_path_conflicts(conflicts)
         for rel_path, json_content in self._last_config_files.items():
             out_path = (self._pipeline_root / rel_path).resolve()
             if not out_path.is_relative_to(self._pipeline_root):
@@ -840,7 +865,21 @@ class SavePipelineService:
         protected: set[str] = getattr(self, "_protected_config_files", set())
         removed: list[Path] = []
 
-        stale = set(prev) - set(current) - protected
+        # Compute the stale diff casefolded, mirroring the collision guards in
+        # `_validate_unique_config_paths_in_graph` / `_merge_config_maps`:
+        # after a case-only node rename (``Foo`` → ``FOO``), prev's
+        # ``Foo.json`` and current's ``FOO.json`` are the SAME on-disk file on
+        # the case-insensitive filesystems macOS and Windows default to — this
+        # save has just rewritten it in place, so unlinking the prev casing
+        # would delete the freshly written survivor. Protected paths get the
+        # same treatment: a prev path differing only in case from a protected
+        # one names the same file there too. Excluding casefold matches on
+        # every platform means a case-only rename on case-SENSITIVE Linux
+        # leaves the old-cased file behind as harmless residue; data safety on
+        # macOS/Windows wins over Linux tidiness.
+        keep_folded = {rel.casefold() for rel in current}
+        keep_folded.update(rel.casefold() for rel in protected)
+        stale = {rel for rel in prev if rel.casefold() not in keep_folded}
         if not stale:
             return removed
 

--- a/tests/test_pipeline_runtime_path_validation.py
+++ b/tests/test_pipeline_runtime_path_validation.py
@@ -184,6 +184,90 @@ def test_distinct_labels_still_write_one_sidecar_each(tmp_path: Path) -> None:
     assert (tmp_path / "config" / "data_source" / "Bar.json").is_file()
 
 
+# ---------------------------------------------------------------------------
+# Case-only collisions across saves (rename) and in codegen output paths.
+#
+# The guards above reject two nodes colliding within ONE graph. A case-only
+# RENAME collides across saves instead: prev's ``Foo.json`` and the new
+# ``FOO.json`` are the same on-disk file on macOS/Windows, so stale cleanup
+# unlinking the prev casing would delete the sidecar the save just wrote.
+# Generated ``modules/<name>.py`` files have the same overwrite hazard as
+# sidecars. Like the guards above, these tests live here because this file
+# runs on the macOS/Windows platform-smoke CI leg.
+# ---------------------------------------------------------------------------
+
+
+def test_case_only_rename_survives_stale_cleanup(tmp_path: Path) -> None:
+    """A case-only node rename must not delete the freshly written sidecar.
+
+    Renaming ``Foo`` → ``FOO`` makes the save write ``FOO.json``, which on
+    the case-insensitive filesystems macOS and Windows default to is the
+    SAME file as prev's ``Foo.json`` — overwritten in place. Treating the
+    prev casing as stale would unlink the survivor, destroying the node's
+    config at the moment it was saved.
+    """
+    svc = SavePipelineService(tmp_path)
+    sidecar_dir = tmp_path / "config" / "data_source"
+    sidecar_dir.mkdir(parents=True)
+    (sidecar_dir / "Foo.json").write_text('{"path": "old.csv"}', encoding="utf-8")
+    svc._prev_config_files = {"config/data_source/Foo.json": '{"path": "old.csv"}'}
+    graph = PipelineGraph(nodes=[_config_node("a", "FOO")], edges=[])
+
+    svc._write_config_files(graph)
+    removed = svc._remove_stale_config_files(graph)
+
+    assert removed == []
+    survivor = sidecar_dir / "FOO.json"
+    assert survivor.is_file()
+    assert "a.csv" in survivor.read_text(encoding="utf-8")
+
+
+def test_genuine_rename_still_removes_stale_sidecar(tmp_path: Path) -> None:
+    """The casefold exclusion must not stop real stale cleanup."""
+    svc = SavePipelineService(tmp_path)
+    sidecar_dir = tmp_path / "config" / "data_source"
+    sidecar_dir.mkdir(parents=True)
+    (sidecar_dir / "Foo.json").write_text('{"path": "old.csv"}', encoding="utf-8")
+    svc._prev_config_files = {"config/data_source/Foo.json": '{"path": "old.csv"}'}
+    graph = PipelineGraph(nodes=[_config_node("a", "Bar")], edges=[])
+
+    svc._write_config_files(graph)
+    removed = svc._remove_stale_config_files(graph)
+
+    assert [path.name for path in removed] == ["Foo.json"]
+    assert not (sidecar_dir / "Foo.json").exists()
+    assert (sidecar_dir / "Bar.json").is_file()
+
+
+def test_codegen_case_only_module_collision_rejected_before_any_write(
+    tmp_path: Path,
+) -> None:
+    """Generated module paths differing only in case must not save."""
+    svc = SavePipelineService(tmp_path)
+    files = {"modules/Pricing.py": "# a", "modules/pricing.py": "# b"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_generated_code_files(files, "main.py", [])
+
+    assert exc_info.value.status_code == 400
+    assert "duplicate output path" in exc_info.value.detail
+    assert "modules/Pricing.py" in exc_info.value.detail
+    assert "modules/pricing.py" in exc_info.value.detail
+    # Rejected before any write: neither casing reached the disk.
+    assert not (tmp_path / "modules").exists()
+
+
+def test_codegen_distinct_module_paths_still_write(tmp_path: Path) -> None:
+    """The casefold guard must not over-trigger on genuinely distinct modules."""
+    svc = SavePipelineService(tmp_path)
+    files = {"modules/pricing.py": "# a", "modules/claims.py": "# b"}
+
+    svc._write_generated_code_files(files, "main.py", [])
+
+    assert (tmp_path / "modules" / "pricing.py").is_file()
+    assert (tmp_path / "modules" / "claims.py").is_file()
+
+
 def test_validate_runtime_input_paths_checks_optimiser_apply_file_mode_only() -> None:
     file_graph = PipelineGraph(
         nodes=[


### PR DESCRIPTION
## What

Fixes a data-loss bug that survived PR #42: on the case-insensitive filesystems macOS and Windows default to, renaming a node only by case (`Foo` → `FOO`) destroyed its config sidecar at save time. The save writes `config/<type>/FOO.json` — the SAME on-disk file as the old `Foo.json`, overwritten in place — and `_remove_stale_config_files` then computed the stale diff with case-SENSITIVE string sets, decided `Foo.json` was stale, and unlinked the freshly written survivor (pruning the emptied `config/` tree with it). The PR #42 save-time guards cannot see this: a single renamed node never collides with anything in the graph — the loss happens in stale cleanup, across saves.

## The fix

- `_remove_stale_config_files`: the stale diff now excludes any prev rel-path whose `casefold()` matches a casefolded current (or protected) path, mirroring the PR #42 collision guards. Deliberate trade-off, noted in the code comment: on case-SENSITIVE Linux a case-only rename now leaves the old-cased sidecar behind as harmless residue — data safety on macOS/Windows wins.
- `_write_generated_code_files` (same class, flagged in the PR #42 review): the duplicate-output-path guard deduped resolved codegen paths case-sensitively, so submodels `Pricing`/`pricing` would silently overwrite each other's `modules/<name>.py`. It now compares casefolded and resolves every path before any write, so the 400 rejection (naming both casings) leaves no partial output.
- `_write_config_files`: the written-vs-protected config intersection now intersects casefolded too (defence in depth — the per-graph guard already rejects such graphs upstream).

## Verification

- Reproduced the bug first: both new bug tests were run against the unfixed code and failed exactly as reported (stale cleanup unlinked the survivor on APFS; codegen case-collision did not raise).
- Four characterization tests added to `tests/test_pipeline_runtime_path_validation.py` (runs on the macOS/Windows platform-smoke CI leg, i.e. against real case-insensitive filesystems): the rename survivor outlives stale cleanup, a genuine rename still cleans up, a case-only codegen collision is rejected before any write, and distinct module names still write one file each.
- Full suite: 12302 passed, 26 skipped, 2 xfailed. `ruff check` and `mypy` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)