### PR TITLE
perf: VC sidebar — content-addressed git caches + panel refresh short-circuit

### DIFF
--- a/frontend/src/panels/GitPanel.tsx
+++ b/frontend/src/panels/GitPanel.tsx
@@ -20,6 +20,10 @@ import { computeGitGraphLayout, computeRailRuns, railWidth } from "./gitgraph/la
 import type { RailModel, RailRow, RailRowGeom, RowDescriptor } from "./gitgraph/layout"
 import { GraphRailCell, GraphRailHeader, GraphRailOverlay } from "./gitgraph/GraphCell"
 import { recordSwitch } from "../utils/vcHistory"
+import {
+  readBranchHistory, writeBranchHistory, readGraphCache, writeGraphCache,
+  readMilestoneSaves, writeMilestoneSaves, serializePayload,
+} from "./gitPanelCache"
 
 /** Minimal branch shape the in-row spawn chips need — satisfied by both the
  *  graph payload's branches and the legacy GitManagedBranch fallback. */
@@ -69,8 +73,22 @@ export default function GitPanel({ onClose }: GitPanelProps) {
   // Open the read-only side-by-side comparison on a version (S11).
   const openComparison = useGitStore((s) => s.openComparison)
 
-  const [milestones, setMilestones] = useState<GitMilestoneEntry[]>([])
-  const [pending, setPending] = useState<GitLedgerSave[]>([])
+  const workingBranch = status?.working_branch ?? null
+  const peeking = viewBranch !== null && viewBranch !== workingBranch
+  // The branch whose history the panel shows: the peeked branch, else the
+  // current working branch (null before the first status load).
+  const branchKey = viewBranch ?? workingBranch
+
+  // Session-cache hydration (stale-while-revalidate): a branch viewed earlier
+  // this session paints synchronously from the module-level cache — no
+  // "Loading version history…" flash on remount. refresh() still always runs
+  // and revalidates; the unchanged-payload short-circuit below makes an
+  // unchanged revalidate invisible, and changed data swaps in when it lands.
+  const [seed] = useState(() => (branchKey !== null ? (readBranchHistory(branchKey) ?? null) : null))
+  const [graphSeed] = useState(() => readGraphCache())
+
+  const [milestones, setMilestones] = useState<GitMilestoneEntry[]>(seed?.milestones ?? [])
+  const [pending, setPending] = useState<GitLedgerSave[]>(seed?.pending ?? [])
   const [expanded, setExpanded] = useState<ExpandState>({})
   const [loading, setLoading] = useState(false)
   // Selected commit sha — a save (clicked) or a milestone (just committed).
@@ -79,7 +97,7 @@ export default function GitPanel({ onClose }: GitPanelProps) {
   const [selectedSha, setSelectedSha] = useState<string | null>(null)
   // Working branches keyed by the commit they were spawned from, so a milestone
   // or save can back-link to the branch(es) it spawned (S38).
-  const [forkBranches, setForkBranches] = useState<GitManagedBranch[]>([])
+  const [forkBranches, setForkBranches] = useState<GitManagedBranch[]>(seed?.forkBranches ?? [])
   // Right-click "new branch from here" (S38): the anchor is the menu position +
   // fork point; the draft is the naming step once an option is picked.
   const [forkAnchor, setForkAnchor] = useState<
@@ -88,27 +106,49 @@ export default function GitPanel({ onClose }: GitPanelProps) {
   const [forkDraft, setForkDraft] = useState<{ sha: string; move: boolean; name: string; x: number; y: number } | null>(null)
   const [forking, setForking] = useState(false)
   // Whole-forest topology for the graph rail (A-5): fetched best-effort
-  // alongside refresh(); null (never loaded) means no rail.
-  const [graph, setGraph] = useState<GitGraphResponse | null>(null)
+  // alongside refresh(); null (never loaded) means no rail. Hydrated from the
+  // session cache so a remount paints list + rail together.
+  const [graph, setGraph] = useState<GitGraphResponse | null>(graphSeed?.graph ?? null)
   // Refresh generation for the fire-and-forget graph fetch: a stale response
   // must never overwrite a fresher one.
   const graphGeneration = useRef(0)
   // The branch the loaded milestone/pending rows belong to. During a peek's
   // one-round-trip window the rows still show the PREVIOUS branch — the rail
   // holds off (renders nothing) until this catches up with the view.
-  const [rowsBranch, setRowsBranch] = useState<string | null>(null)
+  const [rowsBranch, setRowsBranch] = useState<string | null>(seed !== null ? branchKey : null)
   // Context menus on the rail (feedback round 2): a milestone dot offers the
   // commit actions, a lane line offers its branch's actions.
   const [dotMenu, setDotMenu] = useState<{ sha: string; x: number; y: number } | null>(null)
   const [laneMenu, setLaneMenu] = useState<{ branch: string; x: number; y: number } | null>(null)
   const [switching, setSwitching] = useState(false)
 
-  const workingBranch = status?.working_branch ?? null
-  const peeking = viewBranch !== null && viewBranch !== workingBranch
-
   // ---------------------------------------------------------------------------
   // Data
   // ---------------------------------------------------------------------------
+
+  // Serializations of the last APPLIED payloads, keyed by the branch they were
+  // applied for: a byte-identical refetch skips its setState entirely, so a
+  // no-op refresh preserves every array identity → zero row/rail re-render
+  // (the rail layout memos and the two-pass measure never re-fire).
+  const applied = useRef<{
+    branch: string | null
+    milestones: string | null
+    pending: string | null
+    forks: string | null
+  }>({
+    branch: seed !== null ? branchKey : null,
+    milestones: seed?.milestonesJson ?? null,
+    pending: seed?.pendingJson ?? null,
+    forks: seed?.forkBranchesJson ?? null,
+  })
+  const appliedGraphJson = useRef<string | null>(graphSeed?.json ?? null)
+
+  // True when rows for the viewed branch are already on screen (cache
+  // hydration or an earlier refresh): the rows-with-rail gate in refresh()
+  // only helps the cold first paint, so it is skipped in that case.
+  const hasRowsOnScreen = useRef(false)
+  hasRowsOnScreen.current =
+    milestones.length > 0 && rowsBranch !== null && rowsBranch === branchKey
 
   const refresh = useCallback(async (): Promise<
     { milestones: GitMilestoneEntry[]; pending: GitLedgerSave[] } | null
@@ -122,7 +162,15 @@ export default function GitPanel({ onClose }: GitPanelProps) {
     const generation = ++graphGeneration.current
     const graphSettled = getGitGraph(50).then(
       (g) => {
-        if (generation === graphGeneration.current) setGraph(g)
+        if (generation !== graphGeneration.current) return
+        const json = serializePayload(g)
+        writeGraphCache(g, json)
+        // Byte-identical graph → keep the previous object identity so the
+        // rail layout memo never recomputes.
+        if (json !== appliedGraphJson.current) {
+          appliedGraphJson.current = json
+          setGraph(g)
+        }
       },
       () => {},
     )
@@ -132,14 +180,39 @@ export default function GitPanel({ onClose }: GitPanelProps) {
         getPendingSaves(viewBranch),
         getWorkingBranches(),
       ])
+      const resolvedBranch = viewBranch ?? ms.working_branch
+      const forks = wb.branches.filter((b) => b.forked_from)
+      const msJson = serializePayload(ms.entries)
+      const psJson = serializePayload(ps.saves)
+      const fbJson = serializePayload(forks)
+      // Always snapshot the successful response for cross-remount hydration —
+      // permissive by design, because a hydrated mount always revalidates.
+      // (resolvedBranch is null only when the backend reports no working
+      // branch; nothing useful to key a cache entry on then.)
+      if (resolvedBranch !== null) {
+        writeBranchHistory(resolvedBranch, {
+          milestones: ms.entries, milestonesJson: msJson,
+          pending: ps.saves, pendingJson: psJson,
+          forkBranches: forks, forkBranchesJson: fbJson,
+        })
+      }
       // Land the rows WITH the rail rather than a beat before it: hold the
       // row commit until the graph settles or 250ms passes, whichever is
       // sooner, so a peek doesn't paint the list and then pop the tree in.
-      await Promise.race([graphSettled, new Promise((r) => setTimeout(r, 250))])
-      setMilestones(ms.entries)
-      setPending(ps.saves)
-      setRowsBranch(viewBranch ?? ms.working_branch)
-      setForkBranches(wb.branches.filter((b) => b.forked_from))
+      // Only worth it on a cold paint — with hydrated rows already on screen
+      // the gate would just delay the reconcile.
+      if (!hasRowsOnScreen.current) {
+        await Promise.race([graphSettled, new Promise((r) => setTimeout(r, 250))])
+      }
+      // Unchanged-payload short-circuit: skip each setState whose payload is
+      // byte-identical to the one already applied for this branch.
+      const a = applied.current
+      const sameBranch = a.branch === resolvedBranch
+      if (!(sameBranch && a.milestones === msJson)) setMilestones(ms.entries)
+      if (!(sameBranch && a.pending === psJson)) setPending(ps.saves)
+      if (!(sameBranch && a.forks === fbJson)) setForkBranches(forks)
+      applied.current = { branch: resolvedBranch, milestones: msJson, pending: psJson, forks: fbJson }
+      setRowsBranch(resolvedBranch)
       // NB: don't clear `expanded` here — that would collapse a milestone the
       // user opened on every auto-refresh. Expansion is reset only on a peek
       // change (the effect below), where the milestones genuinely differ.
@@ -158,21 +231,51 @@ export default function GitPanel({ onClose }: GitPanelProps) {
   const peekingRef = useRef(peeking)
   peekingRef.current = peeking
 
+  // A milestone's folded saves are content-addressed by its merge sha
+  // (immutable), so responses are cached module-wide: re-expanding a
+  // previously expanded milestone costs no fetch, across remounts too.
+  const loadMilestoneSaves = useCallback(async (sha: string): Promise<GitLedgerSave[]> => {
+    const cached = readMilestoneSaves(sha)
+    if (cached !== undefined) return cached
+    const res = await getMilestoneSaves(sha)
+    writeMilestoneSaves(sha, res.saves)
+    return res.saves
+  }, [])
+
   useEffect(() => {
     loadStatus()
     refresh()
   }, [loadStatus, refresh])
 
   // Peeking a different branch shows a different history — reset expansion and
-  // clear the selection (it referred to the previous branch's save). Also clear
-  // the row data so the previous branch's list never lingers while the new one
-  // loads: the panel shows its normal loading state until refresh() lands.
+  // clear the selection (it referred to the previous branch's save). The row
+  // data hydrates from the session cache when this branch was viewed before
+  // (stale-while-revalidate: the refresh effect above revalidates, and the
+  // short-circuit makes an unchanged revalidate invisible); otherwise it is
+  // cleared so the previous branch's list never lingers while the new one
+  // loads, and the panel shows its normal loading state until refresh() lands.
   useEffect(() => {
     setExpanded({})
     setSelectedSha(null)
-    setMilestones([])
-    setPending([])
-    setRowsBranch(null)
+    const key = viewBranch ?? (useGitStore.getState().status?.working_branch ?? null)
+    const cached = key !== null ? readBranchHistory(key) : undefined
+    if (cached !== undefined) {
+      applied.current = {
+        branch: key,
+        milestones: cached.milestonesJson,
+        pending: cached.pendingJson,
+        forks: cached.forkBranchesJson,
+      }
+      setMilestones(cached.milestones)
+      setPending(cached.pending)
+      setForkBranches(cached.forkBranches)
+      setRowsBranch(key)
+    } else {
+      applied.current = { branch: null, milestones: null, pending: null, forks: null }
+      setMilestones([])
+      setPending([])
+      setRowsBranch(null)
+    }
   }, [viewBranch])
 
   // Auto-refresh after a SAVE elsewhere. The new save is shown by the refetch
@@ -214,15 +317,15 @@ export default function GitPanel({ onClose }: GitPanelProps) {
       if (res.milestones.length > 0) {
         const top = res.milestones[0]
         try {
-          const saves = await getMilestoneSaves(top.sha)
-          setExpanded((prev) => ({ ...prev, [top.sha]: saves.saves }))
-          if (saves.saves.length > 0) setSelectedSha(saves.saves[0].sha)
+          const saves = await loadMilestoneSaves(top.sha)
+          setExpanded((prev) => ({ ...prev, [top.sha]: saves }))
+          if (saves.length > 0) setSelectedSha(saves[0].sha)
         } catch {
           // Best-effort: leave the milestone collapsed if its saves won't load.
         }
       }
     })
-  }, [selectLatestSaveNonce, refresh])
+  }, [selectLatestSaveNonce, refresh, loadMilestoneSaves])
 
   // Select a SPECIFIC commit (the compared version, when the toolbar indicator is
   // clicked while comparing): a pending save or a milestone is selected directly;
@@ -245,9 +348,9 @@ export default function GitPanel({ onClose }: GitPanelProps) {
       }
       for (const m of res.milestones) {
         try {
-          const saves = await getMilestoneSaves(m.sha)
-          if (saves.saves.some((s) => s.sha === target)) {
-            setExpanded((prev) => ({ ...prev, [m.sha]: saves.saves }))
+          const saves = await loadMilestoneSaves(m.sha)
+          if (saves.some((s) => s.sha === target)) {
+            setExpanded((prev) => ({ ...prev, [m.sha]: saves }))
             setSelectedSha(target)
             return
           }
@@ -256,7 +359,7 @@ export default function GitPanel({ onClose }: GitPanelProps) {
         }
       }
     })
-  }, [selectSaveNonce, refresh])
+  }, [selectSaveNonce, refresh, loadMilestoneSaves])
 
   const toggleExpand = useCallback(
     async (sha: string) => {
@@ -268,13 +371,20 @@ export default function GitPanel({ onClose }: GitPanelProps) {
         })
         return
       }
+      // Cache hit (sha-immutable): expand synchronously, no fetch, no
+      // "loading" placeholder row.
+      const cached = readMilestoneSaves(sha)
+      if (cached !== undefined) {
+        setExpanded((prev) => ({ ...prev, [sha]: cached }))
+        return
+      }
       setExpanded((prev) => ({ ...prev, [sha]: "loading" }))
       try {
-        const res = await getMilestoneSaves(sha)
+        const saves = await loadMilestoneSaves(sha)
         // Only land the result if this expansion is still the pending one — a
         // collapse (key deleted) or a refresh (map cleared) between request and
         // response must not resurrect a milestone the user moved on from.
-        setExpanded((prev) => (prev[sha] === "loading" ? { ...prev, [sha]: res.saves } : prev))
+        setExpanded((prev) => (prev[sha] === "loading" ? { ...prev, [sha]: saves } : prev))
       } catch (err) {
         const detail = err instanceof Error ? err.message : "unknown error"
         addToast("error", `Failed to load the saves in this milestone: ${detail}`)
@@ -286,7 +396,7 @@ export default function GitPanel({ onClose }: GitPanelProps) {
         })
       }
     },
-    [expanded, addToast],
+    [expanded, addToast, loadMilestoneSaves],
   )
 
   // The row context menu. ALWAYS preventDefault (never fall through to the

--- a/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
+import GitPanel from "../GitPanel"
+import { clearGitPanelCaches } from "../gitPanelCache"
+import useGitStore from "../../stores/useGitStore"
+import type { GitWorkingBranchResponse } from "../../api/types"
+
+// Perf behaviours of the Version Control panel:
+//  (a) a byte-identical refresh applies NO state (row/rail identity preserved,
+//      rail layout not recomputed),
+//  (b) a changed payload does apply,
+//  (c) a remount hydrates from the module-level session cache (no loading
+//      flash) and reconciles when the revalidate lands changed data,
+//  (d) milestone saves are cached by their immutable merge sha — re-expanding
+//      never refetches, across remounts too.
+
+const mockGetWorkingBranch = vi.fn()
+const mockGetMilestones = vi.fn()
+const mockGetMilestoneSaves = vi.fn()
+const mockGetPendingSaves = vi.fn()
+const mockCreateWorkingBranch = vi.fn()
+const mockGetWorkingBranches = vi.fn()
+const mockGetGitGraph = vi.fn()
+const mockSetWorkingBranch = vi.fn()
+
+vi.mock("../../api/client", () => ({
+  getWorkingBranch: (...a: unknown[]) => mockGetWorkingBranch(...a),
+  getMilestones: (...a: unknown[]) => mockGetMilestones(...a),
+  getMilestoneSaves: (...a: unknown[]) => mockGetMilestoneSaves(...a),
+  getPendingSaves: (...a: unknown[]) => mockGetPendingSaves(...a),
+  getWorkingBranches: (...a: unknown[]) => mockGetWorkingBranches(...a),
+  getGitGraph: (...a: unknown[]) => mockGetGitGraph(...a),
+  setWorkingBranch: (...a: unknown[]) => mockSetWorkingBranch(...a),
+  createWorkingBranch: (...a: unknown[]) => mockCreateWorkingBranch(...a),
+  gitArchiveBranch: vi.fn(),
+  gitDeleteBranch: vi.fn(),
+  restoreBranch: vi.fn(),
+  undeleteBranch: vi.fn(),
+  getGitPrefs: vi.fn(() => Promise.resolve({ skip_switch_confirm: false })),
+  setGitPrefs: vi.fn(),
+  getGitRemotes: vi.fn(() => Promise.resolve({ remotes: [], working_branch: null })),
+  gitPush: vi.fn(),
+}))
+
+// Counts rail layout recomputations: the layout memo only re-runs when the
+// graph/rows state identities actually change, so a short-circuited refresh
+// must leave this untouched. The factory wraps the real implementation.
+const layoutSpy = vi.fn()
+vi.mock("../gitgraph/layout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gitgraph/layout")>()
+  return {
+    ...actual,
+    computeGitGraphLayout: (
+      ...args: Parameters<typeof actual.computeGitGraphLayout>
+    ) => {
+      layoutSpy()
+      return actual.computeGitGraphLayout(...args)
+    },
+  }
+})
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const readyStatus: GitWorkingBranchResponse = {
+  working_branch: "pricing-dev",
+  current_branch: "pricing-dev-save",
+  state: "ready",
+  eligible_branches: [],
+  identity_set: true,
+  user_name: "Nick",
+  user_email: "n@example.com",
+  last_save_sha: "abc12345",
+  errors: [],
+}
+
+// Frozen timestamps so structuredClone copies stay byte-identical across calls.
+const T = "2026-07-08T10:00:00.000Z"
+
+const milestonesPayload = {
+  working_branch: "pricing-dev",
+  entries: [
+    { sha: "m1full", short_sha: "m1abc", message: "First milestone", timestamp: T, version_label: "1.0" },
+    { sha: "m2full", short_sha: "m2def", message: "Second milestone", timestamp: T, version_label: null },
+  ],
+}
+
+const graphTwoBranch = {
+  working_branch: "pricing-dev",
+  order: ["pricing-dev", "pricing/nick/spur"],
+  branches: [
+    {
+      name: "pricing-dev", is_archived: false, is_current: true, tip_sha: "m1full",
+      fork_point_sha: null, fork_of: null, forked_from: null,
+      fork_source_sha: null, fork_credit_sha: null, truncated: false,
+      entries: [
+        { sha: "m1full", short_sha: "m1abc", message: "First milestone", timestamp: T, version_label: "1.0", is_root: false, parents: ["m2full", "s2"] },
+        { sha: "m2full", short_sha: "m2def", message: "Second milestone", timestamp: T, version_label: null, is_root: true, parents: [] },
+      ],
+    },
+    {
+      name: "pricing/nick/spur", is_archived: false, is_current: false, tip_sha: "b1full",
+      fork_point_sha: "m2full", fork_of: "pricing-dev", forked_from: null,
+      fork_source_sha: null, fork_credit_sha: null, truncated: false,
+      entries: [
+        { sha: "b1full", short_sha: "b1abcd", message: "Spur milestone", timestamp: T, version_label: null, is_root: false, parents: ["m2full", "s9"] },
+        { sha: "m2full", short_sha: "m2def", message: "Second milestone", timestamp: T, version_label: null, is_root: true, parents: [] },
+      ],
+    },
+  ],
+}
+
+const emptyGraph = { working_branch: null, order: [], branches: [] }
+
+/** Waits for an in-flight refresh cycle to finish (the toolbar refresh button
+ *  is disabled while `loading`). */
+const waitForRefreshSettled = async () => {
+  await waitFor(() => expect(screen.getByTestId("git-panel-refresh")).not.toBeDisabled())
+}
+
+describe("GitPanel session cache + unchanged-payload short-circuit", () => {
+  const defaultProps = { onClose: vi.fn() }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearGitPanelCaches()
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, selectLatestSaveNonce: 0, selectSaveNonce: 0, selectSaveTarget: null, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    mockGetWorkingBranch.mockResolvedValue(readyStatus)
+    mockSetWorkingBranch.mockResolvedValue({})
+    // Fresh, deep-equal object per call: proves the short-circuit works on
+    // byte-identical CONTENT, not on accidental object identity.
+    mockGetMilestones.mockImplementation(() => Promise.resolve(structuredClone(milestonesPayload)))
+    mockGetPendingSaves.mockImplementation(() => Promise.resolve({ saves: [] }))
+    mockGetMilestoneSaves.mockResolvedValue({ saves: [] })
+    mockCreateWorkingBranch.mockResolvedValue({ working_branch: "x", moved: false, switched: false, last_save_sha: null })
+    mockGetWorkingBranches.mockImplementation(() => Promise.resolve({ current: "pricing-dev", branches: [] }))
+    mockGetGitGraph.mockImplementation(() => Promise.resolve(structuredClone(graphTwoBranch)))
+  })
+
+  afterEach(cleanup)
+
+  it("(a) a byte-identical refresh applies no state: rail layout untouched, row nodes stable", async () => {
+    render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-graph-rail").length).toBeGreaterThan(0))
+    await waitForRefreshSettled()
+
+    const layoutCallsAfterMount = layoutSpy.mock.calls.length
+    const rowBefore = screen.getAllByTestId("git-panel-milestone")[0]
+
+    // A save elsewhere bumps the history nonce → refresh refetches; every
+    // payload comes back byte-identical (fresh clones, same content).
+    useGitStore.getState().notifyHistoryChanged()
+    await waitFor(() => expect(mockGetMilestones).toHaveBeenCalledTimes(2))
+    await waitForRefreshSettled()
+
+    // No rail layout recompute and the row DOM node survives untouched: the
+    // short-circuit skipped every setState, so all memo inputs kept identity.
+    expect(layoutSpy.mock.calls.length).toBe(layoutCallsAfterMount)
+    expect(screen.getAllByTestId("git-panel-milestone")[0]).toBe(rowBefore)
+  })
+
+  it("(b) a changed payload does apply", async () => {
+    render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+    await waitForRefreshSettled()
+    const layoutCallsAfterMount = layoutSpy.mock.calls.length
+
+    mockGetMilestones.mockImplementation(() => Promise.resolve({
+      working_branch: "pricing-dev",
+      entries: [
+        { sha: "m3full", short_sha: "m3abc", message: "Third milestone", timestamp: T, version_label: null },
+        ...structuredClone(milestonesPayload.entries),
+      ],
+    }))
+    useGitStore.getState().notifyHistoryChanged()
+
+    await waitFor(() => expect(screen.getByText("Third milestone")).toBeInTheDocument())
+    expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(3)
+    // The rows changed, so the rail layout DID recompute this time.
+    await waitFor(() => expect(layoutSpy.mock.calls.length).toBeGreaterThan(layoutCallsAfterMount))
+  })
+
+  it("(c) a warm remount paints cached rows synchronously, then reconciles the changed revalidate", async () => {
+    // Status present in the store (the toolbar loads it at startup) — it
+    // resolves the cache key for the current working branch.
+    useGitStore.setState({ status: readyStatus })
+
+    const first = render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+    await waitForRefreshSettled()
+    first.unmount()
+
+    // Second mount: hold the milestones fetch open — hydration must not wait.
+    let resolveMilestones!: (value: unknown) => void
+    mockGetMilestones.mockImplementation(
+      () => new Promise((resolve) => { resolveMilestones = resolve }),
+    )
+    render(<GitPanel {...defaultProps} />)
+
+    // Immediately on first paint: cached rows, no loading placeholder.
+    expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2)
+    expect(screen.getByText("First milestone")).toBeInTheDocument()
+    expect(screen.queryByTestId("git-panel-loading")).not.toBeInTheDocument()
+
+    // The revalidate lands CHANGED data → it swaps in.
+    resolveMilestones({
+      working_branch: "pricing-dev",
+      entries: [
+        { sha: "m9full", short_sha: "m9abc", message: "Rebuilt milestone", timestamp: T, version_label: null },
+      ],
+    })
+    await waitFor(() => expect(screen.getByText("Rebuilt milestone")).toBeInTheDocument())
+    expect(screen.queryByText("First milestone")).not.toBeInTheDocument()
+    expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(1)
+  })
+
+  it("(c2) a warm remount with an UNCHANGED revalidate keeps the cached rows as-is", async () => {
+    useGitStore.setState({ status: readyStatus })
+
+    const first = render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+    await waitForRefreshSettled()
+    first.unmount()
+
+    render(<GitPanel {...defaultProps} />)
+    expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2)
+    const rowBefore = screen.getAllByTestId("git-panel-milestone")[0]
+
+    // Revalidate settles byte-identical → nothing re-applies.
+    await waitForRefreshSettled()
+    expect(screen.getAllByTestId("git-panel-milestone")[0]).toBe(rowBefore)
+    expect(screen.getByText("First milestone")).toBeInTheDocument()
+  })
+
+  it("(d) milestone saves are sha-cached: re-expanding never refetches, across remounts too", async () => {
+    mockGetGitGraph.mockResolvedValue(structuredClone(emptyGraph))
+    mockGetMilestoneSaves.mockResolvedValue({
+      saves: [{ sha: "s1", short_sha: "s1abc", message: "folded save", timestamp: T, files: [] }],
+    })
+
+    const first = render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+
+    // First expand fetches once.
+    fireEvent.click(screen.getAllByTestId("git-panel-milestone")[0])
+    await waitFor(() => expect(screen.getByTestId("git-panel-save")).toBeInTheDocument())
+    expect(mockGetMilestoneSaves).toHaveBeenCalledTimes(1)
+    expect(mockGetMilestoneSaves).toHaveBeenCalledWith("m1full")
+
+    // Collapse + re-expand: served from the sha cache, no second call and no
+    // "Loading saves…" placeholder.
+    fireEvent.click(screen.getAllByTestId("git-panel-milestone")[0])
+    await waitFor(() => expect(screen.queryByTestId("git-panel-save")).not.toBeInTheDocument())
+    fireEvent.click(screen.getAllByTestId("git-panel-milestone")[0])
+    expect(screen.getByTestId("git-panel-save")).toBeInTheDocument()
+    expect(screen.queryByText("Loading saves…")).not.toBeInTheDocument()
+    expect(mockGetMilestoneSaves).toHaveBeenCalledTimes(1)
+
+    // The cache is module-level: a fresh mount's expansion also skips the fetch.
+    first.unmount()
+    render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+    fireEvent.click(screen.getAllByTestId("git-panel-milestone")[0])
+    expect(screen.getByTestId("git-panel-save")).toBeInTheDocument()
+    expect(mockGetMilestoneSaves).toHaveBeenCalledTimes(1)
+  })
+
+  it("peeking an uncached branch still clears the rows (no stale carry-over)", async () => {
+    render(<GitPanel {...defaultProps} />)
+    await waitFor(() => expect(screen.getAllByTestId("git-panel-milestone")).toHaveLength(2))
+    await waitForRefreshSettled()
+
+    // Peek a branch never viewed this session, holding its fetch open: the
+    // previous branch's rows must vanish (cold path unchanged by the cache).
+    mockGetMilestones.mockImplementation(() => new Promise(() => {}))
+    useGitStore.getState().setPeekBranch("pricing/nick/never-seen")
+    await waitFor(() => expect(screen.queryAllByTestId("git-panel-milestone")).toHaveLength(0))
+  })
+})

--- a/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
 import GitPanel from "../GitPanel"
+import { clearGitPanelCaches } from "../gitPanelCache"
 import useGitStore from "../../stores/useGitStore"
 
 // Mirror of GitPanel.test.tsx's client mock — the panel reads working-branch
@@ -58,6 +59,9 @@ describe("GitPanel — uncovered fork/view/peek paths", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // The panel's session caches are module-level (they survive remounts by
+    // design) — reset them so tests stay independent.
+    clearGitPanelCaches()
     useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, selectLatestSaveNonce: 0, selectSaveNonce: 0, selectSaveTarget: null, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestones.mockResolvedValue(milestones)

--- a/frontend/src/panels/__tests__/GitPanel.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
 import GitPanel from "../GitPanel"
+import { clearGitPanelCaches } from "../gitPanelCache"
 import useGitStore from "../../stores/useGitStore"
 import useGraphStore from "../../stores/useGraphStore"
 import useToastStore from "../../stores/useToastStore"
@@ -119,6 +120,9 @@ describe("GitPanel", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // The panel's session caches are module-level (they survive remounts by
+    // design) — reset them so tests stay independent.
+    clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
     useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, selectLatestSaveNonce: 0, selectSaveNonce: 0, selectSaveTarget: null, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     // Switches record undoable VC entries on the graph store's history stacks.

--- a/frontend/src/panels/__tests__/gitPanelCache.test.ts
+++ b/frontend/src/panels/__tests__/gitPanelCache.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  BRANCH_HISTORY_CAP,
+  MILESTONE_SAVES_CAP,
+  clearGitPanelCaches,
+  readBranchHistory,
+  readGraphCache,
+  readMilestoneSaves,
+  serializePayload,
+  writeBranchHistory,
+  writeGraphCache,
+  writeMilestoneSaves,
+} from "../gitPanelCache"
+import type { BranchHistoryEntry } from "../gitPanelCache"
+import type { GitGraphResponse, GitLedgerSave } from "../../api/types"
+
+const save = (sha: string): GitLedgerSave => ({
+  sha,
+  short_sha: sha.slice(0, 6),
+  message: `save ${sha}`,
+  timestamp: "2026-07-08T00:00:00Z",
+  files: [],
+})
+
+const entryFor = (branch: string): BranchHistoryEntry => {
+  const milestones = [
+    { sha: `${branch}-m1`, short_sha: "m1", message: "m1", timestamp: "2026-07-08T00:00:00Z", version_label: null },
+  ]
+  const pending: GitLedgerSave[] = []
+  return {
+    milestones,
+    milestonesJson: serializePayload(milestones),
+    pending,
+    pendingJson: serializePayload(pending),
+    forkBranches: [],
+    forkBranchesJson: serializePayload([]),
+  }
+}
+
+describe("gitPanelCache", () => {
+  beforeEach(clearGitPanelCaches)
+
+  it("serializePayload round-trips identical payloads to identical strings", () => {
+    const a = { entries: [save("abc")], working_branch: "b" }
+    const b = structuredClone(a)
+    expect(a).not.toBe(b)
+    expect(serializePayload(a)).toBe(serializePayload(b))
+    expect(serializePayload(a)).not.toBe(serializePayload({ ...a, working_branch: "c" }))
+  })
+
+  it("stores and returns a branch history entry by branch name", () => {
+    const entry = entryFor("pricing-dev")
+    writeBranchHistory("pricing-dev", entry)
+    expect(readBranchHistory("pricing-dev")).toBe(entry)
+    expect(readBranchHistory("unknown")).toBeUndefined()
+  })
+
+  it("evicts the least-recently-used branch past the cap", () => {
+    for (let i = 0; i < BRANCH_HISTORY_CAP; i++) {
+      writeBranchHistory(`b${i}`, entryFor(`b${i}`))
+    }
+    // Touch b0 so it is no longer the oldest, then overflow by one.
+    expect(readBranchHistory("b0")).toBeDefined()
+    writeBranchHistory("overflow", entryFor("overflow"))
+    // b1 (now the least-recently-used) was evicted; b0 and the newcomer stay.
+    expect(readBranchHistory("b1")).toBeUndefined()
+    expect(readBranchHistory("b0")).toBeDefined()
+    expect(readBranchHistory("overflow")).toBeDefined()
+  })
+
+  it("rewriting an existing branch does not evict anything", () => {
+    for (let i = 0; i < BRANCH_HISTORY_CAP; i++) {
+      writeBranchHistory(`b${i}`, entryFor(`b${i}`))
+    }
+    writeBranchHistory("b3", entryFor("b3"))
+    for (let i = 0; i < BRANCH_HISTORY_CAP; i++) {
+      expect(readBranchHistory(`b${i}`)).toBeDefined()
+    }
+  })
+
+  it("caches milestone saves by sha with an LRU bound", () => {
+    for (let i = 0; i < MILESTONE_SAVES_CAP; i++) {
+      writeMilestoneSaves(`sha${i}`, [save(`sha${i}`)])
+    }
+    expect(readMilestoneSaves("sha0")).toBeDefined() // touch → most recent
+    writeMilestoneSaves("overflow", [save("overflow")])
+    expect(readMilestoneSaves("sha1")).toBeUndefined() // evicted
+    expect(readMilestoneSaves("sha0")).toBeDefined()
+    expect(readMilestoneSaves("overflow")).toEqual([save("overflow")])
+  })
+
+  it("holds a single whole-forest graph payload", () => {
+    expect(readGraphCache()).toBeNull()
+    const graph: GitGraphResponse = { working_branch: null, order: [], branches: [] }
+    const json = serializePayload(graph)
+    writeGraphCache(graph, json)
+    expect(readGraphCache()).toEqual({ graph, json })
+  })
+
+  it("clearGitPanelCaches empties everything", () => {
+    writeBranchHistory("b", entryFor("b"))
+    writeMilestoneSaves("sha", [save("sha")])
+    writeGraphCache({ working_branch: null, order: [], branches: [] }, "{}")
+    clearGitPanelCaches()
+    expect(readBranchHistory("b")).toBeUndefined()
+    expect(readMilestoneSaves("sha")).toBeUndefined()
+    expect(readGraphCache()).toBeNull()
+  })
+})

--- a/frontend/src/panels/gitPanelCache.ts
+++ b/frontend/src/panels/gitPanelCache.ts
@@ -1,0 +1,106 @@
+/**
+ * Session-lived caches for the Version Control panel (GitPanel).
+ *
+ * The panel is conditionally mounted, so every open remounts it — without a
+ * cache each open refetched four endpoints from scratch behind a "Loading
+ * version history…" flash. These module-level maps survive remounts so a
+ * branch viewed once this session paints instantly, stale-while-revalidate:
+ * GitPanel ALWAYS refetches after hydrating, and byte-identical responses are
+ * short-circuited (via the stored serializations) so an unchanged revalidate
+ * applies no state at all. Staleness is therefore bounded by one round trip,
+ * which is why the cache can be permissive about invalidation.
+ *
+ * Bounds: the per-branch history cache keeps the last BRANCH_HISTORY_CAP
+ * branches; the milestone-saves cache keeps MILESTONE_SAVES_CAP entries.
+ * A milestone's folded saves are content-addressed by its merge sha
+ * (immutable), so that cache never revalidates. Pending saves are NOT
+ * sha-addressed and are only ever cached as part of a branch's history
+ * snapshot. Both maps evict least-recently-used. Nothing here is durable —
+ * per-tab, per-session only.
+ */
+import type {
+  GitGraphResponse,
+  GitLedgerSave,
+  GitManagedBranch,
+  GitMilestoneEntry,
+} from "../api/types"
+
+export const BRANCH_HISTORY_CAP = 8
+export const MILESTONE_SAVES_CAP = 64
+
+/** One branch's last-seen history payloads plus their serializations (the
+ *  serializations feed GitPanel's unchanged-payload short-circuit). */
+export interface BranchHistoryEntry {
+  milestones: GitMilestoneEntry[]
+  milestonesJson: string
+  pending: GitLedgerSave[]
+  pendingJson: string
+  forkBranches: GitManagedBranch[]
+  forkBranchesJson: string
+}
+
+/** Cheap stable serialization for payload equality. Responses are parsed
+ *  JSON from one backend serializer, so key order is stable and stringify
+ *  round-trips byte-identical payloads to identical strings. */
+export function serializePayload(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+// Map preserves insertion order → oldest entry is the first key. Reads
+// re-insert (touch) so "oldest" means least-recently-used.
+const branchHistory = new Map<string, BranchHistoryEntry>()
+const milestoneSaves = new Map<string, GitLedgerSave[]>()
+
+// The graph endpoint returns the WHOLE forest (it is not branch-scoped), so a
+// single slot serves every branch's hydration.
+let graphCache: { graph: GitGraphResponse; json: string } | null = null
+
+function touch<K, V>(map: Map<K, V>, key: K): V | undefined {
+  const value = map.get(key)
+  if (value !== undefined) {
+    map.delete(key)
+    map.set(key, value)
+  }
+  return value
+}
+
+function put<K, V>(map: Map<K, V>, key: K, value: V, cap: number): void {
+  map.delete(key)
+  map.set(key, value)
+  while (map.size > cap) {
+    const oldest = map.keys().next().value
+    if (oldest === undefined) break
+    map.delete(oldest)
+  }
+}
+
+export function readBranchHistory(branch: string): BranchHistoryEntry | undefined {
+  return touch(branchHistory, branch)
+}
+
+export function writeBranchHistory(branch: string, entry: BranchHistoryEntry): void {
+  put(branchHistory, branch, entry, BRANCH_HISTORY_CAP)
+}
+
+export function readGraphCache(): { graph: GitGraphResponse; json: string } | null {
+  return graphCache
+}
+
+export function writeGraphCache(graph: GitGraphResponse, json: string): void {
+  graphCache = { graph, json }
+}
+
+export function readMilestoneSaves(sha: string): GitLedgerSave[] | undefined {
+  return touch(milestoneSaves, sha)
+}
+
+export function writeMilestoneSaves(sha: string, saves: GitLedgerSave[]): void {
+  put(milestoneSaves, sha, saves, MILESTONE_SAVES_CAP)
+}
+
+/** Test hook: module-level state leaks across tests without this. */
+export function clearGitPanelCaches(): void {
+  branchHistory.clear()
+  milestoneSaves.clear()
+  graphCache = null
+}

--- a/src/haute/_git.py
+++ b/src/haute/_git.py
@@ -21,7 +21,6 @@ import time
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import TypeVar
 
 from haute._logging import get_logger
 from haute.errors import HauteError
@@ -223,6 +222,25 @@ def _run_git_ok(*args: str, cwd: Path | None = None) -> tuple[bool, str]:
         cwd=cwd or Path.cwd(),
     )
     return result.returncode == 0, result.stdout.strip()
+
+
+def _run_git_rc(*args: str, cwd: Path | None = None) -> tuple[int, str]:
+    """Run a git command and return (returncode, stdout).  Never raises.
+
+    Exists alongside :func:`_run_git_ok` for callers that must distinguish a
+    SEMANTIC non-zero exit from a real failure — ``merge-base --is-ancestor``
+    exits 1 for "not an ancestor" (a valid, cacheable answer) but >1 for an
+    unreadable object (which must never be cached).
+    """
+    cmd = ["git"] + list(args)
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=cwd or Path.cwd(),
+    )
+    return result.returncode, result.stdout.strip()
 
 
 def _should_fetch(remote: str, cwd: Path | None = None, kind: str = "deploy") -> bool:
@@ -538,49 +556,83 @@ def list_branches(cwd: Path | None = None) -> GitBranchListResponse:
     Uses ``%(ahead-behind:<default>)`` (git 2.35+) to get commit counts
     in a single subprocess call instead of one per branch.
     """
+    return _list_branches_with_tips(cwd=cwd)[0]
+
+
+def _list_branches_with_tips(
+    cwd: Path | None = None, *, with_counts: bool = True
+) -> tuple[GitBranchListResponse, dict[str, str]]:
+    """:func:`list_branches` plus a ``{short ref name: tip SHA}`` map covering
+    EVERY local head (ledgers and archived pairs included), read from the same
+    single ``for-each-ref`` call via ``%(objectname)``.
+
+    The graph and branch-manager paths key their content-addressed caches by
+    these tips instead of issuing per-branch ``rev-parse`` subprocesses — refs
+    are resolved to SHAs exactly once per request, here.
+
+    ``with_counts=False`` drops ``%(ahead-behind:)`` from the format — the one
+    per-branch-EXPENSIVE atom in it (git walks each ref's history to count) —
+    for the sidebar read paths (graph, branch manager, working-branch status),
+    none of which consume ``commit_count``; it is reported as 0 there. The
+    current/user-slug reads stay: ``is_yours`` drives the yours-first sort,
+    which IS consumed (the branch-manager render order and the startup modal's
+    ``eligible[0]`` preselection follow it)."""
     _assert_git_repo(cwd)
 
     current = _get_current_branch(cwd)
     default = _get_default_branch(cwd)
     user_slug = _get_user_slug(cwd)
 
-    # Try the fast path first: %(ahead-behind:ref) gives "ahead behind"
-    # counts in one subprocess call (git ≥ 2.35).
-    ok, raw = _run_git_ok(
-        "for-each-ref",
-        "--sort=-committerdate",
-        f"--format=%(refname:short)\t%(committerdate:iso-strict)\t%(ahead-behind:{default})",
-        "refs/heads/",
-        cwd=cwd,
-    )
-
-    if not ok or not raw:
-        # Fallback for very old git: no ahead-behind support.
+    cheap_format = "%(refname:short)\t%(objectname)\t%(committerdate:iso-strict)"
+    if with_counts:
+        # Try the fast path first: %(ahead-behind:ref) gives "ahead behind"
+        # counts in one subprocess call (git ≥ 2.35).
         ok, raw = _run_git_ok(
             "for-each-ref",
             "--sort=-committerdate",
-            "--format=%(refname:short)\t%(committerdate:iso-strict)",
+            f"--format={cheap_format}\t%(ahead-behind:{default})",
+            "refs/heads/",
+            cwd=cwd,
+        )
+        if not ok or not raw:
+            # Fallback for very old git: no ahead-behind support.
+            ok, raw = _run_git_ok(
+                "for-each-ref",
+                "--sort=-committerdate",
+                f"--format={cheap_format}",
+                "refs/heads/",
+                cwd=cwd,
+            )
+    else:
+        # The 3-field shape is also the very-old-git fallback — one attempt.
+        ok, raw = _run_git_ok(
+            "for-each-ref",
+            "--sort=-committerdate",
+            f"--format={cheap_format}",
             "refs/heads/",
             cwd=cwd,
         )
 
     branches: list[GitBranchItem] = []
+    tips: dict[str, str] = {}
     if ok and raw:
         for line in raw.splitlines():
             parts = line.split("\t")
-            if len(parts) < 2:
+            if len(parts) < 3:
                 continue
 
             name = parts[0]
-            commit_time = parts[1]
+            tip_sha = parts[1]
+            commit_time = parts[2]
+            tips[name] = tip_sha
 
             # Parse ahead-behind if available (format: "ahead behind")
             commit_count = 0
-            if len(parts) >= 3:
-                ab = parts[2].split()
+            if len(parts) >= 4:
+                ab = parts[3].split()
                 if len(ab) == 2 and ab[0].isdigit():
                     commit_count = int(ab[0])
-            else:
+            elif with_counts:
                 # Slow fallback: one subprocess per branch
                 ok_count, count_str = _run_git_ok(
                     "rev-list",
@@ -612,7 +664,7 @@ def list_branches(cwd: Path | None = None) -> GitBranchListResponse:
 
     branches.sort(key=sort_key)
 
-    return GitBranchListResponse(current=current, branches=branches)
+    return GitBranchListResponse(current=current, branches=branches), tips
 
 
 # ---------------------------------------------------------------------------
@@ -691,14 +743,116 @@ def _tree_of(ref: str, cwd: Path | None = None) -> str:
     return _run_git("rev-parse", f"{ref}^{{tree}}", cwd=cwd).strip()
 
 
+# ---------------------------------------------------------------------------
+# Content-addressed caches — a full commit SHA names an immutable object, so
+# any pure derivation from full SHAs (ancestry, merge-base, parents, the
+# first-parent spine, a windowed log) is itself immutable and can be cached
+# forever with no invalidation story. Ref names are NOT invariant, so only
+# full-40-hex-SHA arguments take the cached path (anything else falls through
+# to a live subprocess), and TAG-derived data (version labels) is never cached
+# here — tags move independently of the commits they point at. Failures
+# (unreadable ref/object) are never cached: each inner cached function raises
+# ``GitError`` on failure and ``functools.lru_cache`` does not memoise a call
+# that raises; the public wrappers catch and keep the old failure semantics.
+# Keys include ``str(cwd)`` (the ``_get_default_branch_cached`` precedent) so
+# repos served by one process never share entries.
+# ---------------------------------------------------------------------------
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _is_full_sha(value: str) -> bool:
+    """Whether *value* is a full 40-hex commit SHA (the cacheable key shape)."""
+    return bool(_FULL_SHA_RE.match(value))
+
+
+@lru_cache(maxsize=1024)
+def _merge_base_cached(a: str, b: str, cwd_key: str) -> str:
+    """Cached inner — raises on any failure (incl. no common ancestor) so
+    lru_cache never stores it; only a real base SHA is memoised."""
+    ok, base = _run_git_ok("merge-base", a, b, cwd=Path(cwd_key) if cwd_key else None)
+    if not ok or not base.strip():
+        raise GitError(f"merge-base failed for {a} {b}")
+    return base.strip()
+
+
 def _merge_base(a: str, b: str, cwd: Path | None = None) -> str | None:
+    if _is_full_sha(a) and _is_full_sha(b):
+        try:
+            return _merge_base_cached(a, b, str(cwd) if cwd else "")
+        except GitError:
+            return None
     ok, base = _run_git_ok("merge-base", a, b, cwd=cwd)
     return base.strip() if ok and base.strip() else None
 
 
+@lru_cache(maxsize=4096)
+def _is_ancestor_cached(ancestor: str, descendant: str, cwd_key: str) -> bool:
+    """Cached inner — exit 0/1 are the two valid (immutable) answers; any other
+    exit is an unreadable object and raises, so it is never memoised."""
+    code, _ = _run_git_rc(
+        "merge-base",
+        "--is-ancestor",
+        ancestor,
+        descendant,
+        cwd=Path(cwd_key) if cwd_key else None,
+    )
+    if code == 0:
+        return True
+    if code == 1:
+        return False
+    raise GitError(f"merge-base --is-ancestor failed for {ancestor} {descendant}")
+
+
 def _is_ancestor(ancestor: str, descendant: str, cwd: Path | None = None) -> bool:
+    if _is_full_sha(ancestor) and _is_full_sha(descendant):
+        try:
+            return _is_ancestor_cached(ancestor, descendant, str(cwd) if cwd else "")
+        except GitError:
+            return False
     ok, _ = _run_git_ok("merge-base", "--is-ancestor", ancestor, descendant, cwd=cwd)
     return ok
+
+
+@lru_cache(maxsize=64)
+def _first_parent_spine_cached(tip_sha: str, cwd_key: str) -> tuple[str, ...]:
+    """Cached inner — the full first-parent chain below an immutable tip SHA."""
+    ok, raw = _run_git_ok(
+        "rev-list",
+        "--first-parent",
+        tip_sha,
+        "--",
+        cwd=Path(cwd_key) if cwd_key else None,
+    )
+    if not ok or not raw.strip():
+        raise GitError(f"rev-list --first-parent failed for {tip_sha}")
+    return tuple(raw.split())
+
+
+def _first_parent_spine(tip: str, cwd: Path | None = None) -> list[str] | None:
+    """Full first-parent chain of *tip*, newest first; ``None`` when unreadable.
+
+    Cached per (tip SHA, cwd) when *tip* is a full SHA — the spine below a
+    commit is content-addressed, so a branch whose tip hasn't moved costs no
+    subprocess on re-read, and any tip move (fast-forward or rewrite) is a new
+    key and therefore immediately fresh."""
+    if _is_full_sha(tip):
+        try:
+            return list(_first_parent_spine_cached(tip, str(cwd) if cwd else ""))
+        except GitError:
+            return None
+    ok, raw = _run_git_ok("rev-list", "--first-parent", tip, "--", cwd=cwd)
+    return raw.split() if ok and raw.strip() else None
+
+
+def _clear_content_caches() -> None:
+    """Drop every content-addressed cache (test isolation + repo-reset hygiene,
+    alongside ``_get_default_branch_cached.cache_clear()``)."""
+    _merge_base_cached.cache_clear()
+    _is_ancestor_cached.cache_clear()
+    _first_parent_spine_cached.cache_clear()
+    _commit_parents_cached.cache_clear()
+    _graph_log_cached.cache_clear()
 
 
 def resolve_ledger(working: str, cwd: Path | None = None) -> str:
@@ -907,8 +1061,12 @@ def set_identity(
 def _eligible_working_branches(cwd: Path | None = None) -> list[str]:
     """Names choosable as a working branch: not protected, ledger, archived, or
     the repo's default branch (which is deploy-only, like the hardcoded
-    protected set — PROTECTED_BRANCHES being configurable is a later item)."""
-    listing = list_branches(cwd=cwd)
+    protected set — PROTECTED_BRANCHES being configurable is a later item).
+
+    Cheap enumeration (no ahead-behind): only names, archived flags and the
+    yours-first order are consumed — the startup modal preselects the FIRST
+    eligible branch, so the order must match the full listing's."""
+    listing, _ = _list_branches_with_tips(cwd=cwd, with_counts=False)
     default = _get_default_branch(cwd)
     return [
         b.name
@@ -1031,6 +1189,7 @@ def set_working_branch(
                     )
                 _run_git("branch", "-m", "main", cwd=cwd)
                 _get_default_branch_cached.cache_clear()
+                _clear_content_caches()
 
             _run_git("add", "-A", cwd=cwd)
             # If nothing was staged (empty working tree) use --allow-empty so we
@@ -1494,7 +1653,12 @@ def working_milestones(
 ) -> GitMilestonesResponse:
     """Milestone history (first-parent chain, newest first, with version-label
     tags). Defaults to the clone's working branch; pass *branch* to peek at
-    another branch's history without switching to it."""
+    another branch's history without switching to it.
+
+    Shares the graph rail's cached windowed log (keyed by the resolved tip
+    SHA): one ``git log`` per (tip, limit) ever, then a warm page costs the
+    tip resolve plus the per-request batched tag read only. Version labels
+    are applied after retrieval — tags move independently of tips."""
     _assert_git_repo(cwd)
     from haute._git_state import read_working_branch
 
@@ -1503,36 +1667,37 @@ def working_milestones(
         working: str | None = branch
     else:
         working = read_working_branch(project_root)
-    if working is None or _rev_parse(working, cwd=cwd) is None:
+    if working is None:
+        return GitMilestonesResponse(working_branch=working, entries=[])
+    tip = _rev_parse(working, cwd=cwd)
+    if tip is None:
         return GitMilestonesResponse(working_branch=working, entries=[])
 
     # First-parent walk = the milestone spine (skips the ledger's per-save
     # commits, which hang off each merge's second parent).
-    ok, raw = _run_git_ok(
-        "log",
-        "--first-parent",
-        f"--max-count={limit}",
-        "--format=%H\t%h\t%s\t%aI",
-        working,
-        cwd=cwd,
-    )
-    entries: list[GitMilestoneEntry] = []
-    if ok and raw:
-        for line in raw.splitlines():
-            parts = line.split("\t", 3)
-            if len(parts) < 4:
-                continue
-            sha, short_sha, message, timestamp = parts
-            entries.append(
-                GitMilestoneEntry(
-                    sha=sha,
-                    short_sha=short_sha,
-                    message=message,
-                    timestamp=timestamp,
-                    version_label=_version_label_for(sha, cwd=cwd),
-                )
-            )
-    _mark_root_entry(entries, cwd=cwd)
+    try:
+        rows = _graph_log_cached(tip, limit, str(cwd) if cwd else "")
+    except GitError:
+        return GitMilestonesResponse(working_branch=working, entries=[])
+
+    # ONE batched tag read for the whole page instead of a per-row
+    # ``tag --points-at`` (the N+1 that dominated this endpoint).
+    labels = _version_label_map(cwd=cwd)
+    entries = [
+        GitMilestoneEntry(
+            sha=sha,
+            short_sha=short_sha,
+            message=message,
+            timestamp=timestamp,
+            version_label=labels.get(sha),
+            # Truncation-aware root tagging for free from the row's %P: only a
+            # genuinely parentless commit is flagged, and a first-parent walk
+            # can only ever end (not pass through) one — so this fires for the
+            # oldest entry of an untruncated page and never for a windowed cut.
+            is_root=not parents,
+        )
+        for sha, short_sha, parents, timestamp, message in rows
+    ]
     return GitMilestonesResponse(working_branch=working, entries=entries)
 
 
@@ -1566,20 +1731,6 @@ def _is_root_commit(sha: str, cwd: Path | None = None) -> bool:
     line is ``"<sha> <parent1> <parent2>..."`` — a root has no trailing shas."""
     ok, raw = _run_git_ok("rev-list", "--parents", "-n", "1", sha, cwd=cwd)
     return ok and len(raw.split()) <= 1
-
-
-_MilestoneEntryT = TypeVar("_MilestoneEntryT", bound=GitMilestoneEntry)
-
-
-def _mark_root_entry(entries: list[_MilestoneEntryT], cwd: Path | None = None) -> None:
-    """Truncation-aware root tagging, shared by the milestones and graph views.
-
-    The first-parent walk terminates at the repo root (the initial commit); when
-    the chain isn't limit-truncated, that's the last (oldest) entry. Tag it so
-    the UI can show an "init" version chip on the otherwise-unlabelled commit.
-    """
-    if entries and _is_root_commit(entries[-1].sha, cwd=cwd):
-        entries[-1] = entries[-1].model_copy(update={"is_root": True})
 
 
 def _ledger_point(milestone_sha: str, cwd: Path | None = None) -> str:
@@ -1871,8 +2022,24 @@ def _version_label_map(cwd: Path | None = None) -> dict[str, str]:
     return labels
 
 
+@lru_cache(maxsize=1024)
+def _commit_parents_cached(sha: str, cwd_key: str) -> tuple[str, ...]:
+    """Cached inner — a commit's parent list is content-addressed; an empty
+    tuple (root commit) is a valid cached answer, an unreadable object raises
+    and is never memoised."""
+    ok, raw = _run_git_ok("show", "-s", "--format=%P", sha, cwd=Path(cwd_key) if cwd_key else None)
+    if not ok:
+        raise GitError(f"git show failed for {sha}")
+    return tuple(raw.split())
+
+
 def _commit_parents(sha: str, cwd: Path | None = None) -> list[str]:
     """All parent SHAs of one commit (``%P``), ``[]`` when unreadable."""
+    if _is_full_sha(sha):
+        try:
+            return list(_commit_parents_cached(sha, str(cwd) if cwd else ""))
+        except GitError:
+            return []
     ok, raw = _run_git_ok("show", "-s", "--format=%P", sha, cwd=cwd)
     return raw.split() if ok else []
 
@@ -1900,16 +2067,17 @@ def _fork_source_and_credit(
     * ``fork_source`` — X's second parent, when X is a merge AND that commit
       is reachable from the parent's working tip or its ledger tip (the
       ledger may not exist — treated as not-ancestor); else None.
-    * ``fork_credit`` — computed only when ``fork_source`` is set: the first
-      parent-spine commit ABOVE the fork point (walking older → newer) that
-      contains the source save, i.e. the milestone whose fold swallowed it —
-      the row that should visually take credit for the spawn while its fold
-      is collapsed. None when the save is still pending (reachable only via
-      the parent's ledger, folded into no parent milestone yet).
+    * ``fork_credit`` — computed only when ``fork_source`` is set: the OLDEST
+      parent-spine commit ABOVE the fork point that contains the source save,
+      i.e. the milestone whose fold swallowed it — the row that should
+      visually take credit for the spawn while its fold is collapsed. Found
+      by binary search (containment along a first-parent spine is monotone).
+      None when the save is still pending (reachable only via the parent's
+      ledger, folded into no parent milestone yet).
 
     Both spines are the full first-parent chains graph_topology already holds
     in memory, newest first; only the is-ancestor checks (and one ``%P`` read
-    for X) hit git.
+    for X) hit git — both SHA-keyed-cached, so a repeat is free.
     """
     idx = spine.index(fork_point_sha)
     if idx == 0:
@@ -1925,52 +2093,93 @@ def _fork_source_and_credit(
     if not in_parent_history:
         return (None, None)  # the anchoring second parent is the fork's own save
     # The parent spine is newest-first, so everything above the fork point is
-    # the prefix; walk it oldest-first for the EARLIEST fold containing the save.
+    # the prefix; the EARLIEST (oldest) fold containing the save is the credit.
+    # Containment along a first-parent spine is monotone — each newer spine
+    # commit's ancestor set is a superset of its elder's — so contains(source)
+    # is True on a newest-first prefix of the candidates and the boundary is
+    # binary-searchable: O(log n) is-ancestor probes instead of the old
+    # oldest-first linear scan's O(n). The newest-candidate probe repeats the
+    # in_parent_history check above, so it costs nothing (SHA-keyed cache).
     parent_idx = parent_spine.index(fork_point_sha)
-    for candidate in reversed(parent_spine[:parent_idx]):
-        if _is_ancestor(source, candidate, cwd=cwd):
-            return (source, candidate)
-    return (source, None)
+    candidates = parent_spine[:parent_idx]
+    if not candidates or not _is_ancestor(source, candidates[0], cwd=cwd):
+        return (source, None)  # still pending on the parent's ledger
+    lo, hi = 0, len(candidates) - 1
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if _is_ancestor(source, candidates[mid], cwd=cwd):
+            lo = mid
+        else:
+            hi = mid - 1
+    return (source, candidates[lo])
 
 
-def _graph_entries(
-    branch: str, limit: int, labels: dict[str, str], cwd: Path | None = None
-) -> list[GitGraphEntry]:
-    """The newest *limit* spine entries for one branch, with parents and version
-    labels (from the batched *labels* map). The subject %s sits LAST in the
-    format so a tab in it can't shift the fixed columns. Root tagging is read
-    off %P — empty parents IS the root commit, window-truncated or not — so no
-    per-branch rev-list probe."""
+# One parsed windowed-log row: (sha, short sha, parents, timestamp, message).
+_GraphLogRow = tuple[str, str, tuple[str, ...], str, str]
+
+
+def _graph_log_rows(tip: str, limit: int, cwd: Path | None = None) -> tuple[_GraphLogRow, ...]:
+    """Uncached windowed first-parent log below *tip*, parsed. The subject %s
+    sits LAST in the format so a tab in it can't shift the fixed columns.
+    Raises :class:`GitError` when the ref/object is unreadable (so the cached
+    wrapper never memoises a failure)."""
     ok, raw = _run_git_ok(
         "log",
         "--first-parent",
         f"--max-count={limit}",
         "--format=%H%x09%h%x09%P%x09%aI%x09%s",
-        branch,
+        tip,
         "--",
         cwd=cwd,
     )
-    entries: list[GitGraphEntry] = []
-    if not ok or not raw:
-        return entries
+    if not ok:
+        raise GitError(f"git log failed for {tip}")
+    rows: list[_GraphLogRow] = []
     for line in raw.splitlines():
         parts = line.split("\t", 4)
         if len(parts) < 5:
             continue
         sha, short_sha, parents_raw, timestamp, message = parts
-        parents = parents_raw.split()
-        entries.append(
-            GitGraphEntry(
-                sha=sha,
-                short_sha=short_sha,
-                message=message,
-                timestamp=timestamp,
-                version_label=labels.get(sha),
-                parents=parents,
-                is_root=not parents,
-            )
+        rows.append((sha, short_sha, tuple(parents_raw.split()), timestamp, message))
+    return tuple(rows)
+
+
+@lru_cache(maxsize=256)
+def _graph_log_cached(tip_sha: str, limit: int, cwd_key: str) -> tuple[_GraphLogRow, ...]:
+    """Cached inner — the window below an immutable tip SHA. Deliberately
+    stores the PARSED rows, not GitGraphEntry objects: version labels come
+    from tags (mutable) and must be applied per-request after retrieval."""
+    return _graph_log_rows(tip_sha, limit, cwd=Path(cwd_key) if cwd_key else None)
+
+
+def _graph_entries(
+    tip: str, limit: int, labels: dict[str, str], cwd: Path | None = None
+) -> list[GitGraphEntry]:
+    """The newest *limit* spine entries below *tip* (a resolved tip SHA on the
+    graph path — cached per (tip, limit, cwd)), with parents and version labels
+    (from the batched per-request *labels* map, applied AFTER cache retrieval —
+    tags move independently of tips). Root tagging is read off %P — empty
+    parents IS the root commit, window-truncated or not — so no per-branch
+    rev-list probe."""
+    try:
+        if _is_full_sha(tip):
+            rows = _graph_log_cached(tip, limit, str(cwd) if cwd else "")
+        else:
+            rows = _graph_log_rows(tip, limit, cwd=cwd)
+    except GitError:
+        return []
+    return [
+        GitGraphEntry(
+            sha=sha,
+            short_sha=short_sha,
+            message=message,
+            timestamp=timestamp,
+            version_label=labels.get(sha),
+            parents=list(parents),
+            is_root=not parents,
         )
-    return entries
+        for sha, short_sha, parents, timestamp, message in rows
+    ]
 
 
 def graph_topology(
@@ -2004,15 +2213,21 @@ def graph_topology(
 
     # Same enumeration as the branch manager (working pairs only, ledgers
     # implicit, the deploy branch excluded) — but archived pairs stay in.
+    # Refs resolve to tip SHAs once, in the for-each-ref itself; each spine is
+    # then a content-addressed read below its tip (cached, so an unmoved
+    # branch costs no rev-list on refresh). Cheap enumeration: the graph never
+    # reads commit_count, so the per-branch ahead-behind walk is skipped.
+    listing, tips = _list_branches_with_tips(cwd=cwd, with_counts=False)
     spines: dict[str, list[str]] = {}
     archived: dict[str, bool] = {}
-    for b in list_branches(cwd=cwd).branches:
+    for b in listing.branches:
         if branch_category(b.name) != "working" or b.name == default:
             continue
-        ok, raw = _run_git_ok("rev-list", "--first-parent", b.name, "--", cwd=cwd)
-        if not ok or not raw.strip():
+        tip = tips.get(b.name)
+        spine = _first_parent_spine(tip, cwd=cwd) if tip is not None else None
+        if spine is None:
             continue  # unreadable ref — nothing to draw for it
-        spines[b.name] = raw.split()
+        spines[b.name] = spine
         archived[b.name] = b.is_archived
 
     # Deterministic processing order: the CURRENT working branch first — a
@@ -2040,9 +2255,6 @@ def graph_topology(
         attachments[name] = attachment
 
     labels = _version_label_map(cwd=cwd)
-    # Parent ledger tips resolve lazily, once per distinct parent — several
-    # forks off one branch share the lookup (and a missing ledger caches None).
-    ledger_tips: dict[str, str | None] = {}
     branches: list[GitGraphBranch] = []
     for name in order:
         spine = spines[name]
@@ -2050,10 +2262,10 @@ def graph_topology(
         fork_source_sha: str | None = None
         fork_credit_sha: str | None = None
         if fork_point_sha is not None and fork_of is not None:
-            if fork_of not in ledger_tips:
-                ledger_tips[fork_of] = _rev_parse(ledger_name(fork_of), cwd=cwd)
+            # Parent ledger tips come from the same for-each-ref enumeration
+            # (ledgers are local heads too) — no per-fork rev-parse.
             fork_source_sha, fork_credit_sha = _fork_source_and_credit(
-                spine, fork_point_sha, spines[fork_of], ledger_tips[fork_of], cwd=cwd
+                spine, fork_point_sha, spines[fork_of], tips.get(ledger_name(fork_of)), cwd=cwd
             )
         # forks.json passthrough, with the same reachability guard the branch
         # manager applies (a stale entry is dropped, never surfaced dangling).
@@ -2071,7 +2283,7 @@ def graph_topology(
                 fork_credit_sha=fork_credit_sha,
                 forked_from=forked_from,
                 truncated=len(spine) > limit,
-                entries=_graph_entries(name, limit, labels, cwd=cwd),
+                entries=_graph_entries(spine[0], limit, labels, cwd=cwd),
             )
         )
     return GitGraphResponse(working_branch=working, order=order, branches=branches)
@@ -2684,12 +2896,14 @@ def branch_away(remote: str, project_root: Path, cwd: Path | None = None) -> Git
 # ---------------------------------------------------------------------------
 
 
-def _has_unmerged_saves(working: str, cwd: Path | None = None) -> bool:
-    """Whether *working*'s ledger holds saves not yet milestoned into it
-    (i.e. the ledger is ahead of the working branch)."""
-    ledger = ledger_name(working)
-    working_tip = _rev_parse(working, cwd=cwd)
-    ledger_tip = _rev_parse(ledger, cwd=cwd)
+def _has_unmerged_saves(
+    working_tip: str | None, ledger_tip: str | None, cwd: Path | None = None
+) -> bool:
+    """Whether a pair's ledger holds saves not yet milestoned into its working
+    branch (i.e. the ledger is ahead of the working branch). Takes resolved tip
+    SHAs — callers already hold them (from the for-each-ref enumeration or a
+    prior rev-parse), so the merge-base lands in the SHA-keyed cache and an
+    unmoved pair costs no subprocess on re-read."""
     if working_tip is None or ledger_tip is None:
         return False
     return _merge_base(working_tip, ledger_tip, cwd=cwd) != ledger_tip
@@ -2718,7 +2932,13 @@ def working_branches(project_root: Path, cwd: Path | None = None) -> GitWorkingB
     tree_dirty = ok_dirty and bool(dirty_status.strip())
 
     entries: list[GitManagedBranch] = []
-    for b in list_branches(cwd=cwd).branches:
+    # Working AND ledger tips come from the single for-each-ref enumeration
+    # (ledgers are local heads too) — no per-branch rev-parse pair, and the
+    # unmerged-saves merge-base is SHA-keyed-cached. Cheap enumeration: the
+    # manager view never reads commit_count (it does consume the yours-first
+    # ORDER, which the cheap format preserves).
+    listing, tips = _list_branches_with_tips(cwd=cwd, with_counts=False)
+    for b in listing.branches:
         # Working branches only — ledgers (category "ledger") and protected
         # branches are not version lines; the default branch is deploy-only.
         if branch_category(b.name) != "working" or b.name == default:
@@ -2733,7 +2953,9 @@ def working_branches(project_root: Path, cwd: Path | None = None) -> GitWorkingB
                 name=b.name,
                 is_current=is_current,
                 is_archived=b.is_archived,
-                has_unmerged_saves=_has_unmerged_saves(b.name, cwd=cwd),
+                has_unmerged_saves=_has_unmerged_saves(
+                    tips.get(b.name), tips.get(ledger_name(b.name)), cwd=cwd
+                ),
                 has_uncommitted_changes=is_current and tree_dirty,
                 forked_from=forked_from,
             )
@@ -2872,14 +3094,15 @@ def delete_working_pair(
     if working_tip is None:
         raise GitDomainError(f"Branch '{working}' does not exist.")
 
-    if not confirm and _has_unmerged_saves(working, cwd=cwd):
+    ledger = ledger_name(working)
+    ledger_tip = _rev_parse(ledger, cwd=cwd)
+
+    if not confirm and _has_unmerged_saves(working_tip, ledger_tip, cwd=cwd):
         raise GitGuardrailError(
             f"'{working}' has saves that were never committed to a milestone — "
             "deleting it loses them. Confirm to delete anyway."
         )
 
-    ledger = ledger_name(working)
-    ledger_tip = _rev_parse(ledger, cwd=cwd)
     # A confirmed delete is destructive by intent — discard a dirty tree along
     # with the branch rather than refusing (S38: deleting the lineage already
     # dwarfs the uncommitted edits).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,25 @@ def _clear_pipeline_dir_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_git_content_caches():
+    """Reset the SHA-keyed git content caches between tests.
+
+    The caches in ``haute._git`` (_is_ancestor/_merge_base/_commit_parents/
+    _first_parent_spine/_graph_log) are keyed by (full SHA, str(cwd)) and are
+    process-global. tmp_path directories recycle across tests, so without a
+    clear a cached entry from one test's repo could be consulted by another
+    test's repo at the same path. Content-addressing makes a wrong answer
+    nearly impossible (same SHA ⇒ same history), but the isolation is
+    belt-and-braces and keeps per-test subprocess-count assertions honest.
+    """
+    from haute._git import _clear_content_caches
+
+    _clear_content_caches()
+    yield
+    _clear_content_caches()
+
+
+@pytest.fixture(autouse=True)
 def _clear_dual_cache_session():
     """Reset the dual-cache consulted-hashes set between tests.
 

--- a/tests/test_git_content_caches.py
+++ b/tests/test_git_content_caches.py
@@ -1,0 +1,578 @@
+"""Tests for the SHA-keyed content caches behind the VC sidebar read paths.
+
+Covers the perf fix in ``haute._git``: the batched milestones label map (the
+old per-row ``tag --points-at`` N+1), the content-addressed lru caches
+(_is_ancestor/_merge_base/_commit_parents/_first_parent_spine/_graph_log),
+the fork-credit binary search, and the tips-threaded ``working_branches`` /
+``graph_topology`` paths. Freshness is proven by mutation (new commits AND a
+non-fast-forward rewrite), staleness-immunity by tip-keying; the subprocess
+regression tests spy on the ``_run_git*`` entry points and pin hard bounds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import haute._git as git_mod
+from haute._git import (
+    _commit_parents,
+    _first_parent_spine,
+    _fork_source_and_credit,
+    _graph_entries,
+    _is_ancestor,
+    _merge_base,
+    _version_label_for,
+    commit_milestone,
+    commit_save,
+    create_working_branch,
+    graph_topology,
+    set_working_branch,
+    working_branches,
+    working_milestones,
+)
+from tests._git_helpers import git_run as _git
+from tests._git_helpers import init_repo as _init_repo
+
+WORKING = "pricing-dev"
+LEDGER = "pricing-dev-save"
+
+_FAKE_SHA = "0" * 40  # full-SHA shaped, never a real object
+
+
+def _save(repo: Path, working: str, content: str) -> str:
+    (repo / "fixture.txt").write_text(f"{content}\n", encoding="utf-8")
+    sha = commit_save(["fixture.txt"], working, cwd=repo, message=f"Save {content}")
+    assert sha is not None
+    return sha
+
+
+def _milestone(repo: Path, message: str, label: str | None = None) -> str:
+    return commit_milestone(message, repo, version_label=label, cwd=repo).sha
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A pipeline repo with the engine's working pair adopted (HEAD on ledger)."""
+    root = tmp_path / "pipeline_repo"
+    root.mkdir()
+    _init_repo(root, user="Test Actuary")
+    _git(root, "checkout", "-b", WORKING)
+    set_working_branch(WORKING, root, cwd=root)
+    return root
+
+
+@pytest.fixture
+def git_spy(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Count every git subprocess launched through the module's entry points.
+
+    ``_run_git`` / ``_run_git_ok`` / ``_run_git_rc`` each run their own
+    ``subprocess.run`` (no delegation between them), so wrapping all three
+    counts each git launch exactly once.
+    """
+    counts = {"n": 0}
+    real_run, real_ok, real_rc = git_mod._run_git, git_mod._run_git_ok, git_mod._run_git_rc
+
+    def spy_run(*args, **kwargs):
+        counts["n"] += 1
+        return real_run(*args, **kwargs)
+
+    def spy_ok(*args, **kwargs):
+        counts["n"] += 1
+        return real_ok(*args, **kwargs)
+
+    def spy_rc(*args, **kwargs):
+        counts["n"] += 1
+        return real_rc(*args, **kwargs)
+
+    monkeypatch.setattr(git_mod, "_run_git", spy_run)
+    monkeypatch.setattr(git_mod, "_run_git_ok", spy_ok)
+    monkeypatch.setattr(git_mod, "_run_git_rc", spy_rc)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# (a) Milestones label correctness — the batched map must match the old
+#     per-row ``tag --points-at`` behaviour exactly.
+# ---------------------------------------------------------------------------
+
+
+class TestMilestoneLabels:
+    def test_labels_match_per_row_lookup(self, repo: Path) -> None:
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1", label="v1.0")
+        _save(repo, WORKING, "m2")
+        m2 = _milestone(repo, "Milestone 2")  # untagged
+        _save(repo, WORKING, "m3")
+        m3 = _milestone(repo, "Milestone 3", label="v2.0")
+        # A second tag on m3's commit — first by refname order must win, the
+        # same first-line semantics the old per-row lookup had.
+        _git(repo, "tag", "version/v2.1", m3)
+
+        entries = working_milestones(repo, cwd=repo).entries
+        by_sha = {e.sha: e for e in entries}
+        assert by_sha[m1].version_label == "v1.0"
+        assert by_sha[m2].version_label is None
+        assert by_sha[m3].version_label == "v2.0"
+        # Field-for-field equivalence with the old behaviour (the per-sha
+        # helper still backs commit_context) for EVERY returned row.
+        for e in entries:
+            assert e.version_label == _version_label_for(e.sha, cwd=repo)
+        # Root entry tagging is unaffected by the batching.
+        assert entries[-1].is_root is True
+        assert [e.sha for e in entries[:3]] == [m3, m2, m1]
+
+    def test_unresolvable_branch_returns_empty(self, repo: Path) -> None:
+        res = working_milestones(repo, cwd=repo, branch="pricing-ghost")
+        assert res.working_branch == "pricing-ghost"
+        assert res.entries == []
+
+    def test_unreadable_log_degrades_empty_and_is_not_cached(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _save(repo, WORKING, "m1")
+        _milestone(repo, "Milestone 1")
+
+        real_ok = git_mod._run_git_ok
+
+        def failing_log(*args, **kwargs):
+            if args and args[0] == "log":
+                return (False, "")
+            return real_ok(*args, **kwargs)
+
+        monkeypatch.setattr(git_mod, "_run_git_ok", failing_log)
+        assert working_milestones(repo, cwd=repo).entries == []
+        # The failure was never memoised: with git healthy again, the same
+        # (tip, limit) key serves the real page.
+        monkeypatch.undo()
+        assert len(working_milestones(repo, cwd=repo).entries) == 2
+
+
+# ---------------------------------------------------------------------------
+# (b) Cache freshness — identical repeats, then mutations (fast-forward AND
+#     non-fast-forward) must be visible immediately: everything re-keys on the
+#     tip SHA resolved per request, nothing stales.
+# ---------------------------------------------------------------------------
+
+
+class TestCacheFreshness:
+    def test_repeat_calls_identical(self, repo: Path) -> None:
+        _save(repo, WORKING, "m1")
+        _milestone(repo, "Milestone 1", label="v1.0")
+        _save(repo, WORKING, "pending")
+
+        first = (
+            graph_topology(repo, cwd=repo).model_dump(),
+            working_milestones(repo, cwd=repo).model_dump(),
+            working_branches(repo, cwd=repo).model_dump(),
+        )
+        second = (
+            graph_topology(repo, cwd=repo).model_dump(),
+            working_milestones(repo, cwd=repo).model_dump(),
+            working_branches(repo, cwd=repo).model_dump(),
+        )
+        assert first == second
+
+    def test_new_commit_visible_immediately(self, repo: Path) -> None:
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+        graph_topology(repo, cwd=repo)  # warm every cache
+        working_milestones(repo, cwd=repo)
+        assert not working_branches(repo, cwd=repo).branches[0].has_unmerged_saves
+
+        _save(repo, WORKING, "m2")  # pending save moves the LEDGER tip
+        assert working_branches(repo, cwd=repo).branches[0].has_unmerged_saves
+        m2 = _milestone(repo, "Milestone 2", label="v9.9")  # moves the working tip
+
+        graph = graph_topology(repo, cwd=repo)
+        branch = next(b for b in graph.branches if b.name == WORKING)
+        assert branch.tip_sha == m2
+        assert branch.entries[0].sha == m2
+        assert branch.entries[0].version_label == "v9.9"
+        milestones = working_milestones(repo, cwd=repo).entries
+        assert milestones[0].sha == m2
+        assert milestones[1].sha == m1
+        assert not working_branches(repo, cwd=repo).branches[0].has_unmerged_saves
+
+    def test_non_fast_forward_rewrite_visible_immediately(self, repo: Path) -> None:
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+        _save(repo, WORKING, "m2")
+        m2 = _milestone(repo, "Milestone 2")
+        graph_topology(repo, cwd=repo)  # warm every cache at tip m2
+        working_milestones(repo, cwd=repo)
+        assert not working_branches(repo, cwd=repo).branches[0].has_unmerged_saves
+
+        # Non-fast-forward: rewrite the working tip back to m1 (the ledger
+        # stays at m2's fold, so it is no longer merged into the working tip).
+        _git(repo, "branch", "-f", WORKING, m1)
+
+        graph = graph_topology(repo, cwd=repo)
+        branch = next(b for b in graph.branches if b.name == WORKING)
+        assert branch.tip_sha == m1
+        assert branch.entries[0].sha == m1
+        assert m2 not in [e.sha for e in branch.entries]
+        assert working_milestones(repo, cwd=repo).entries[0].sha == m1
+        assert working_branches(repo, cwd=repo).branches[0].has_unmerged_saves
+
+    def test_new_tag_visible_immediately(self, repo: Path) -> None:
+        """Tags are mutable independently of tips — labels must never be served
+        from a commit-keyed cache."""
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+        graph = graph_topology(repo, cwd=repo)  # warm the windowed-log cache
+        assert working_milestones(repo, cwd=repo).entries[0].version_label is None
+        branch = next(b for b in graph.branches if b.name == WORKING)
+        assert branch.entries[0].version_label is None
+
+        _git(repo, "tag", "-a", "version/v1.5", "-m", "v1.5", m1)
+
+        assert working_milestones(repo, cwd=repo).entries[0].version_label == "v1.5"
+        graph = graph_topology(repo, cwd=repo)  # same tip SHA → cached log rows
+        branch = next(b for b in graph.branches if b.name == WORKING)
+        assert branch.entries[0].version_label == "v1.5"
+
+
+# ---------------------------------------------------------------------------
+# (c) Subprocess-count regression — the N+1s must stay dead.
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessCounts:
+    def test_milestones_constant_git_calls(self, repo: Path, git_spy: dict[str, int]) -> None:
+        """O(1) git calls regardless of entry count — repo-check, tip resolve,
+        one (cached) log, one batched tag read; never one per row — and a warm
+        page (shared with the graph's windowed-log cache) skips the log too."""
+        for i in range(21):  # > the default page size of 20
+            _save(repo, WORKING, f"m{i}")
+            _milestone(repo, f"Milestone {i}", label=f"v{i}.0")
+
+        git_spy["n"] = 0
+        response = working_milestones(repo, cwd=repo)
+        cold_count = git_spy["n"]
+        assert len(response.entries) == 20
+        # Truncated page: the oldest entry still has parents — no root chip.
+        assert response.entries[-1].is_root is False
+        assert cold_count <= 4  # measured: 4 (repo check, rev-parse, log, tag map)
+
+        git_spy["n"] = 0
+        warm = working_milestones(repo, cwd=repo)
+        assert warm.model_dump() == response.model_dump()
+        assert git_spy["n"] <= 3  # measured: 3 — the windowed log is cache-served
+
+    def test_graph_second_call_is_cheap(self, repo: Path, git_spy: dict[str, int]) -> None:
+        for i in range(5):
+            _save(repo, WORKING, f"m{i}")
+            _milestone(repo, f"Milestone {i}")
+        _save(repo, WORKING, "s-fork")
+        fork_source = _save(repo, WORKING, "s-fork2")
+        create_working_branch("pricing-fork", repo, at=fork_source, cwd=repo)
+        _save(repo, WORKING, "s-post")
+        _milestone(repo, "Milestone folds fork source")
+
+        git_spy["n"] = 0
+        first = graph_topology(repo, cwd=repo)
+        first_count = git_spy["n"]
+
+        git_spy["n"] = 0
+        second = graph_topology(repo, cwd=repo)
+        second_count = git_spy["n"]
+
+        assert second.model_dump() == first.model_dump()
+        # Unchanged repo: every spine, windowed log, ancestry probe and parent
+        # read is served from the SHA-keyed caches; what remains is the fixed
+        # per-request work (repo check, current branch, user slug, one
+        # for-each-ref, one tag read) plus the forks.json reachability probe.
+        assert second_count <= 8  # measured: 7 (first call: 15)
+        assert second_count <= first_count - 6  # the content reads all went away
+
+    def test_working_branches_second_call_is_cheap(
+        self, repo: Path, git_spy: dict[str, int]
+    ) -> None:
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+        for name in ("pricing-a", "pricing-b", "pricing-c"):
+            create_working_branch(name, repo, at=m1, cwd=repo)
+
+        git_spy["n"] = 0
+        first = working_branches(repo, cwd=repo)
+        first_count = git_spy["n"]
+
+        git_spy["n"] = 0
+        second = working_branches(repo, cwd=repo)
+        second_count = git_spy["n"]
+
+        assert second.model_dump() == first.model_dump()
+        assert len(second.branches) == 4
+        # Second call: zero per-branch subprocesses (tips come from the single
+        # for-each-ref; every unmerged-saves merge-base is cache-served) — the
+        # count is the fixed request overhead + one reachability probe per
+        # forks.json entry, i.e. O(1) amortized per branch.
+        assert second_count <= first_count - len(second.branches)
+        assert second_count <= 10  # measured: 9 (first call: 13)
+
+
+# ---------------------------------------------------------------------------
+# (d) Fork-credit binary search — identical semantics to the linear scan.
+# ---------------------------------------------------------------------------
+
+
+def _linear_credit(source: str, parent_spine: list[str], fork_point: str, cwd: Path) -> str | None:
+    """The pre-optimisation oldest-first linear scan, kept as the oracle."""
+    parent_idx = parent_spine.index(fork_point)
+    for candidate in reversed(parent_spine[:parent_idx]):
+        if _is_ancestor(source, candidate, cwd=cwd):
+            return candidate
+    return None
+
+
+class TestForkCredit:
+    def _seed_fork_at_save(self, repo: Path) -> tuple[str, str, str]:
+        """work: M1..M3, fork crystallized at pending save S, then M4..M6 on
+        work (M4 folds S). Returns (fork source save, fold milestone M4, fork name)."""
+        for i in range(1, 4):
+            _save(repo, WORKING, f"m{i}")
+            _milestone(repo, f"Milestone {i}")
+        source = _save(repo, WORKING, "spawn-source")
+        create_working_branch("pricing-fork", repo, at=source, cwd=repo)
+        _save(repo, WORKING, "m4")
+        fold = _milestone(repo, "Milestone 4")  # folds the spawn source
+        for i in range(5, 7):
+            _save(repo, WORKING, f"m{i}")
+            _milestone(repo, f"Milestone {i}")
+        return source, fold, "pricing-fork"
+
+    def test_binary_search_matches_linear_scan(self, repo: Path) -> None:
+        source, fold, fork = self._seed_fork_at_save(repo)
+        graph = graph_topology(repo, cwd=repo)
+        branch = next(b for b in graph.branches if b.name == fork)
+        assert branch.fork_source_sha == source
+        # The credit is the OLDEST parent milestone containing the source —
+        # several commits below the parent tip — and must equal the linear
+        # scan's answer exactly.
+        parent = next(b for b in graph.branches if b.name == WORKING)
+        parent_spine = _first_parent_spine(parent.tip_sha, cwd=repo)
+        assert parent_spine is not None
+        assert branch.fork_credit_sha == fold
+        assert branch.fork_credit_sha == _linear_credit(
+            source, parent_spine, branch.fork_point_sha, repo
+        )
+
+    def test_pending_source_has_no_credit(self, repo: Path) -> None:
+        """Fork at a pending save the parent never milestones: the source is
+        reachable only via the parent's ledger → credit None (both scans)."""
+        _save(repo, WORKING, "m1")
+        _milestone(repo, "Milestone 1")
+        source = _save(repo, WORKING, "still-pending")
+        create_working_branch("pricing-fork", repo, at=source, cwd=repo)
+
+        graph = graph_topology(repo, cwd=repo)
+        branch = next(b for b in graph.branches if b.name == "pricing-fork")
+        assert branch.fork_source_sha == source
+        assert branch.fork_credit_sha is None
+
+    def test_credit_mid_spine_binary_boundary(self, tmp_path: Path) -> None:
+        """Out-of-engine parent history where the crediting fold sits MID-spine
+        (candidates below it don't contain the source), driving the binary
+        search through its shrink-right branch; the linear oracle agrees.
+
+        Engine-built histories always credit the oldest candidate (the first
+        milestone after a spawn folds the whole ledger), so this boundary is
+        only reachable in foreign repos — which the endpoint must tolerate.
+        """
+        repo = tmp_path / "foreign"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.name", "Test Actuary")
+        _git(repo, "config", "user.email", "test@example.com")
+
+        def commit(msg: str) -> str:
+            (repo / "f.txt").write_text(f"{msg}\n", encoding="utf-8")
+            _git(repo, "add", "f.txt")
+            _git(repo, "commit", "-m", msg)
+            return _git(repo, "rev-parse", "HEAD")
+
+        commit("R")
+        c1 = commit("C1")
+        c2 = commit("C2")
+        _git(repo, "checkout", "-b", "side")
+        s = commit("S")  # the fork source: child of C2, so C1/C2 don't contain it
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "--no-ff", "-m", "C3", "side")  # C3 contains S
+        c3 = _git(repo, "rev-parse", "HEAD")
+        c4 = commit("C4")
+        # The fork's anchoring merge X: parents [C1, S] via plumbing.
+        tree = _git(repo, "rev-parse", f"{c1}^{{tree}}")
+        x = _git(repo, "commit-tree", tree, "-p", c1, "-p", s, "-m", "X")
+
+        spine = [x, c1, _git(repo, "rev-list", "--max-parents=0", c1)]
+        parent_spine = _first_parent_spine(c4, cwd=repo)
+        assert parent_spine == [c4, c3, c2, c1, parent_spine[-1]]
+
+        got = _fork_source_and_credit(spine, c1, parent_spine, None, cwd=repo)
+        assert got == (s, c3)  # candidates [C4, C3, C2]: True, True, False
+        assert _linear_credit(s, parent_spine, c1, repo) == c3
+
+        # A plain (non-merge) oldest own commit means nothing was folded at
+        # the spawn — no source, no credit.
+        y = _git(repo, "commit-tree", tree, "-p", c1, "-m", "Y")
+        assert _fork_source_and_credit([y, c1], c1, parent_spine, None, cwd=repo) == (None, None)
+
+    def test_no_candidate_contains_source(self, repo: Path) -> None:
+        """Candidates exist above the fork point but none contains the source
+        (it is pending on the parent ledger) — the newest-candidate probe must
+        short-circuit to None, matching the linear scan."""
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+        source = _save(repo, WORKING, "pending-source")
+        create_working_branch("pricing-fork", repo, at=source, cwd=repo)
+        # A sibling line advanced past m1 WITHOUT folding the pending source.
+        create_working_branch("pricing-sib", repo, at=m1, cwd=repo)
+        set_working_branch("pricing-sib", repo, cwd=repo)
+        _save(repo, "pricing-sib", "sib1")
+        sib_tip = _milestone(repo, "Sibling 1")
+
+        fork_tip = _git(repo, "rev-parse", "pricing-fork")
+        spine = _first_parent_spine(fork_tip, cwd=repo)
+        parent_spine = _first_parent_spine(sib_tip, cwd=repo)
+        ledger_tip = _git(repo, "rev-parse", LEDGER)
+        assert spine is not None and parent_spine is not None
+        assert m1 in parent_spine  # the shared fork point, with sib_tip above it
+
+        got = _fork_source_and_credit(spine, m1, parent_spine, ledger_tip, cwd=repo)
+        assert got == (source, None)
+        assert _linear_credit(source, parent_spine, m1, repo) is None
+
+
+# ---------------------------------------------------------------------------
+# Old-git fallback — no %(ahead-behind) support: the fallback for-each-ref
+# must still thread tips through, and the per-branch rev-list count still fires.
+# ---------------------------------------------------------------------------
+
+
+class TestListBranchesFallback:
+    def test_fallback_format_still_threads_tips(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _save(repo, WORKING, "m1")
+        m1 = _milestone(repo, "Milestone 1")
+
+        real_ok = git_mod._run_git_ok
+
+        def no_ahead_behind(*args, **kwargs):
+            if args and args[0] == "for-each-ref" and any("ahead-behind" in a for a in args):
+                return (False, "")  # a git too old for %(ahead-behind)
+            return real_ok(*args, **kwargs)
+
+        monkeypatch.setattr(git_mod, "_run_git_ok", no_ahead_behind)
+
+        listing, tips = git_mod._list_branches_with_tips(cwd=repo)
+        assert tips[WORKING] == m1
+        assert tips[LEDGER] == _git(repo, "rev-parse", LEDGER)
+        by_name = {b.name: b for b in listing.branches}
+        # The slow per-branch rev-list fallback still computes ahead counts.
+        assert by_name[WORKING].commit_count == 2  # milestone merge + its save
+        assert by_name["main"].commit_count == 0
+
+        graph = graph_topology(repo, cwd=repo)
+        assert next(b for b in graph.branches if b.name == WORKING).tip_sha == m1
+
+    def test_cheap_variant_matches_full_except_counts(self, repo: Path) -> None:
+        """with_counts=False must be behaviourally identical for everything the
+        sidebar paths consume: same tips map, same names, same yours-first
+        ORDER (the startup modal preselects eligible[0]), same flags — only
+        commit_count is skipped (reported 0)."""
+        _save(repo, WORKING, "m1")
+        _milestone(repo, "Milestone 1")
+        create_working_branch("pricing-other", repo, at=None, cwd=repo)
+
+        full, full_tips = git_mod._list_branches_with_tips(cwd=repo)
+        cheap, cheap_tips = git_mod._list_branches_with_tips(cwd=repo, with_counts=False)
+
+        assert cheap_tips == full_tips
+        assert cheap.current == full.current
+        assert [b.name for b in cheap.branches] == [b.name for b in full.branches]
+        for c, f in zip(cheap.branches, full.branches):
+            assert c.model_dump(exclude={"commit_count"}) == f.model_dump(exclude={"commit_count"})
+            assert c.commit_count == 0
+        # The full format really does carry counts the cheap one skips.
+        assert next(b for b in full.branches if b.name == WORKING).commit_count > 0
+
+    def test_malformed_ref_line_is_skipped(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_ok = git_mod._run_git_ok
+
+        def with_garbage_line(*args, **kwargs):
+            ok, out = real_ok(*args, **kwargs)
+            if args and args[0] == "for-each-ref" and ok:
+                out = f"garbage-no-tabs\n{out}"
+            return ok, out
+
+        monkeypatch.setattr(git_mod, "_run_git_ok", with_garbage_line)
+        listing, tips = git_mod._list_branches_with_tips(cwd=repo)
+        assert "garbage-no-tabs" not in tips
+        assert "garbage-no-tabs" not in {b.name for b in listing.branches}
+        assert WORKING in tips
+
+
+# ---------------------------------------------------------------------------
+# Cache-helper unit coverage — guards, failure bypasses, uncached fallbacks.
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHelpers:
+    def test_non_sha_args_take_uncached_path(self, repo: Path) -> None:
+        head = _git(repo, "rev-parse", "HEAD")
+        assert _is_ancestor("main", WORKING, cwd=repo) is True
+        assert _merge_base("main", WORKING, cwd=repo) == _git(repo, "rev-parse", "main")
+        assert _commit_parents("HEAD", cwd=repo) == _commit_parents(head, cwd=repo)
+        spine = _first_parent_spine(WORKING, cwd=repo)
+        assert spine is not None and spine[0] == _git(repo, "rev-parse", WORKING)
+
+    def test_failures_are_not_cached(self, repo: Path) -> None:
+        head = _git(repo, "rev-parse", "HEAD")
+        # Unreadable full-SHA-shaped object: old failure semantics preserved…
+        assert _is_ancestor(_FAKE_SHA, head, cwd=repo) is False
+        assert _merge_base(_FAKE_SHA, head, cwd=repo) is None
+        assert _commit_parents(_FAKE_SHA, cwd=repo) == []
+        assert _first_parent_spine(_FAKE_SHA, cwd=repo) is None
+        assert _graph_entries(_FAKE_SHA, 10, {}, cwd=repo) == []
+        # …and none of the failures was memoised.
+        assert git_mod._is_ancestor_cached.cache_info().currsize == 0
+        assert git_mod._merge_base_cached.cache_info().currsize == 0
+        assert git_mod._commit_parents_cached.cache_info().currsize == 0
+        assert git_mod._first_parent_spine_cached.cache_info().currsize == 0
+        assert git_mod._graph_log_cached.cache_info().currsize == 0
+
+    def test_graph_entries_uncached_ref_path(self, repo: Path) -> None:
+        """A ref-name tip (not a full SHA) renders identically but bypasses the
+        windowed-log cache."""
+        _save(repo, WORKING, "m1")
+        _milestone(repo, "Milestone 1", label="v1.0")
+        labels = git_mod._version_label_map(cwd=repo)
+        tip = _git(repo, "rev-parse", WORKING)
+        by_ref = _graph_entries(WORKING, 10, labels, cwd=repo)
+        by_sha = _graph_entries(tip, 10, labels, cwd=repo)
+        assert [e.model_dump() for e in by_ref] == [e.model_dump() for e in by_sha]
+        assert git_mod._graph_log_cached.cache_info().currsize == 1  # SHA call only
+
+    def test_clear_content_caches_empties_everything(self, repo: Path) -> None:
+        head = _git(repo, "rev-parse", "HEAD")
+        main = _git(repo, "rev-parse", "main")
+        _is_ancestor(main, head, cwd=repo)
+        _merge_base(main, head, cwd=repo)
+        _commit_parents(head, cwd=repo)
+        _first_parent_spine(head, cwd=repo)
+        _graph_entries(head, 10, {}, cwd=repo)
+        assert git_mod._is_ancestor_cached.cache_info().currsize == 1
+        git_mod._clear_content_caches()
+        for cache in (
+            git_mod._is_ancestor_cached,
+            git_mod._merge_base_cached,
+            git_mod._commit_parents_cached,
+            git_mod._first_parent_spine_cached,
+            git_mod._graph_log_cached,
+        ):
+            assert cache.cache_info().currsize == 0


### PR DESCRIPTION
## What

The version-control sidebar re-derived everything from git on every panel open and every save — dozens of subprocess forks per refresh with no caching, plus a full row/rail re-render even when nothing changed. This PR makes the backend read paths content-addressed and the panel refresh idempotent.

**Backend** (`src/haute/_git.py`):
- Refs resolve to tip SHAs once per request (the `for-each-ref` enumeration now carries `%(objectname)`); every pure derivation from a full SHA — first-parent spines, windowed logs, ancestry, merge-bases, parents — is LRU-cached with no invalidation story (a moved tip is a new key; non-fast-forward rewrites are covered by construction and by test).
- Milestones: batched `version/` tag map replaces the per-row `git tag --points-at` N+1; the page reuses the graph's cached log window.
- Fork-credit resolution: binary search over the monotone containment prefix replaces an O(n) `merge-base --is-ancestor` scan (latent multi-second worst case for deep forks).
- `working_branches` drops its 3-subprocesses-per-branch pattern; sidebar paths use a cheap enumeration without `ahead-behind` (nothing on them consumes it).

**Frontend** (`frontend/src/panels/GitPanel.tsx`, new `gitPanelCache.ts`):
- Byte-identical refetches skip their `setState` entirely — a no-op refresh causes zero row/rail re-render and no layout re-measure.
- A session-lived cache hydrates reopened panels synchronously (stale-while-revalidate); the 250ms rows-with-rail gate only runs on cold paints.
- Milestone-save expansions are cached by the milestone's immutable merge SHA.

## Measured (1000-commit / 10-branch probe repo)

| | before | after (warm) |
|---|---|---|
| refresh, serial backend work | ~2.1s | ~265ms |
| perceived (endpoints parallel) | ~0.9–1.3s | ~60–76ms |
| refresh with unchanged data | full re-render | no re-render |
| panel reopen | loading flash + refetch | instant paint |

Warm cost is flat in history size.

## Verification

- Full `scripts/preflight.sh` green (backend global + per-file critical coverage, `_git.py` 93.76%/83.14%; TypeScript, ESLint, frontend build/bundle/benchmark gates; 5097 frontend tests), re-run backend-only on the final tree.
- New tests: label-batching equivalence, tip-keyed freshness under fast-forward AND non-FF rewrites, tag-after-cache freshness, fork-credit binary-search equivalence vs a linear oracle, spy-asserted subprocess-count bounds (e.g. milestones ≤3 warm calls), panel referential-stability/warm-remount/sha-cache tests.
- 8-angle adversarial review with per-finding verification: no confirmed bugs; two bounded ≤250ms timing nuances accepted and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)