### PR TITLE
serve: fail fast with actionable error when frontend build is missing

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/setup-worktree.sh
+#
+# Set up frontend assets in a fresh haute worktree. Idempotent — re-running
+# is a no-op once frontend/node_modules and src/haute/static/ exist.
+#
+# Run from anywhere; it resolves the repo root from its own location.
+# `haute serve` points here when it detects a source checkout with no
+# built frontend.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -d frontend/node_modules && -f src/haute/static/index.html ]]; then
+  echo "[setup-worktree] frontend already set up at $REPO_ROOT/frontend; nothing to do"
+  exit 0
+fi
+
+echo "[setup-worktree] worktree: $REPO_ROOT"
+
+if [[ ! -d frontend/node_modules ]]; then
+  echo "[setup-worktree] installing npm deps..."
+  (cd frontend && npm install)
+fi
+
+if [[ ! -f src/haute/static/index.html ]]; then
+  echo "[setup-worktree] building frontend..."
+  (cd frontend && npm run build)
+fi
+
+echo "[setup-worktree] done. 'uv run haute serve' will work now."

--- a/src/haute/cli/_serve.py
+++ b/src/haute/cli/_serve.py
@@ -474,27 +474,65 @@ def _run_dev_mode(config: ServeConfig, frontend_dir: Path) -> None:
         vite_proc.terminate()
 
 
+def _source_checkout_root() -> Path | None:
+    """Return the repo root when haute is running from a source checkout.
+
+    A source checkout (editable install, fresh git worktree) keeps the
+    package at ``<root>/src/haute`` with ``frontend/package.json`` two
+    levels up.  A wheel install lives in ``site-packages`` with no such
+    sibling, so PyPI users are never told to build the frontend — their
+    assets ship prebuilt inside the package.
+    """
+    import haute
+
+    root = Path(haute.__file__).resolve().parent.parent.parent
+    if (root / "frontend" / "package.json").is_file():
+        return root
+    return None
+
+
+def _missing_static_message(static_dir: Path) -> str:
+    """Build the fail-fast error for a missing/incomplete frontend build."""
+    root = _source_checkout_root()
+    if root is None:
+        return (
+            f"Error: no built frontend found at {static_dir}.\n"
+            "The installed haute package is missing its bundled UI assets — "
+            "try reinstalling haute."
+        )
+    return (
+        f"Error: no built frontend found at {static_dir}.\n"
+        "This is a haute source checkout (fresh worktree?) whose UI has not "
+        "been built yet. Build it with:\n"
+        "\n"
+        f"    cd {root / 'frontend'} && npm install && npm run build\n"
+        "\n"
+        "or run the idempotent provisioning script:\n"
+        "\n"
+        f"    {root / 'scripts' / 'setup-worktree.sh'}\n"
+        "\n"
+        "(Once frontend/node_modules exists, 'haute serve' starts dev mode "
+        "instead and serves the UI via Vite without a build.)"
+    )
+
+
 def _run_prod_mode(config: ServeConfig) -> None:
     """Serve the pre-built static frontend from uvicorn.
 
-    Fails loudly when no ``STATIC_DIR`` is present — the user needs to
-    either build the frontend or install ``node_modules`` for dev
-    mode, and a silent fallback would be worse than an actionable
-    error.
+    Fails loudly when ``STATIC_DIR`` is missing or holds an incomplete
+    build — the user needs to either build the frontend or install
+    ``node_modules`` for dev mode, and a silent fallback (or the opaque
+    ``RuntimeError`` uvicorn raises mounting an empty ``assets/``)
+    would be worse than an actionable error.
     """
     import uvicorn
 
-    from haute.server import STATIC_DIR
+    from haute.server import STATIC_DIR, static_build_ready
 
     ensure_local_session_token_env()
 
-    if not STATIC_DIR.exists():
-        click.echo(
-            "Error: No built frontend found. "
-            "Run 'npm run build' in frontend/ first, or "
-            "install node_modules for dev mode.",
-            err=True,
-        )
+    if not static_build_ready(STATIC_DIR):
+        click.echo(_missing_static_message(STATIC_DIR), err=True)
         raise SystemExit(1)
 
     if not config.no_browser:

--- a/src/haute/server.py
+++ b/src/haute/server.py
@@ -75,6 +75,21 @@ mimetypes.add_type("application/javascript", ".js")
 mimetypes.add_type("text/css", ".css")
 
 STATIC_DIR = Path(__file__).parent / "static"
+
+
+def static_build_ready(static_dir: Path) -> bool:
+    """Return ``True`` iff *static_dir* holds a complete frontend build.
+
+    A bare ``static_dir.exists()`` check is not enough: an empty or
+    partial directory (interrupted ``npm run build``, hand-created dir)
+    would pass it, then mounting ``assets/`` raises ``RuntimeError`` at
+    import and ``index.html`` reads 500 at request time.  Requiring the
+    two artefacts every Vite build produces keeps a broken tree on the
+    dev-mode/fail-fast path instead.
+    """
+    return (static_dir / "index.html").is_file() and (static_dir / "assets").is_dir()
+
+
 logger = get_logger(component="server")
 
 _watcher_task: asyncio.Task | None = None
@@ -417,7 +432,7 @@ app.add_middleware(
 )
 
 # CORS for dev mode — Vite dev server (port 5173) talks to FastAPI (port 8000)
-if not STATIC_DIR.exists():
+if not static_build_ready(STATIC_DIR):
     from fastapi.middleware.cors import CORSMiddleware
 
     app.add_middleware(
@@ -457,7 +472,7 @@ app.include_router(git_router)
 # API / WebSocket 404 guard — must be registered BEFORE serve_spa
 # ---------------------------------------------------------------------------
 # Starlette matches routes in registration order.  The SPA catch-all
-# ``serve_spa`` (inside ``if STATIC_DIR.exists()``) returns index.html for
+# ``serve_spa`` (inside ``if static_build_ready(STATIC_DIR)``) returns index.html for
 # every unmatched GET, including /api/* and /ws/* paths.  When those paths
 # don't exist, the browser receives ``200 text/html <!doctype html>`` and
 # ``res.json()`` throws ``Unexpected token '<'``.  Registering these guards
@@ -749,7 +764,7 @@ async def _file_watcher() -> None:
 # Static file serving (built React frontend)
 # ---------------------------------------------------------------------------
 
-if STATIC_DIR.exists():
+if static_build_ready(STATIC_DIR):
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
 
     def _serve_index_html() -> HTMLResponse:

--- a/tests/test_cli_cleanup.py
+++ b/tests/test_cli_cleanup.py
@@ -396,6 +396,8 @@ class TestFindFrontendDirRaisesWhenAbsent:
         monkeypatch.chdir(tmp_path)
         static = tmp_path / "static"
         static.mkdir()
+        (static / "index.html").write_text("<html></html>")
+        (static / "assets").mkdir()
 
         with (
             patch(

--- a/tests/test_cli_fail_loudly.py
+++ b/tests/test_cli_fail_loudly.py
@@ -460,6 +460,8 @@ class TestServePortConflictDetection:
         monkeypatch.chdir(tmp_path)
         static = tmp_path / "static"
         static.mkdir()
+        (static / "index.html").write_text("<html></html>")
+        (static / "assets").mkdir()
         port = bound_socket
 
         # uvicorn.run must never be called — the pre-flight check must fire first.
@@ -505,6 +507,8 @@ class TestServePortConflictDetection:
         monkeypatch.chdir(tmp_path)
         static = tmp_path / "static"
         static.mkdir()
+        (static / "index.html").write_text("<html></html>")
+        (static / "assets").mkdir()
 
         # Pick a port that's currently free.
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -23,6 +23,20 @@ def _serve_port_available():
         yield
 
 
+def _built_static_dir(tmp_path: Path) -> Path:
+    """Create a complete fake frontend build (index.html + assets/).
+
+    Prod mode now checks build completeness, not bare directory
+    existence, so tests that want to reach ``uvicorn.run`` must fake
+    both artefacts.
+    """
+    static = tmp_path / "static"
+    static.mkdir()
+    (static / "index.html").write_text("<html></html>")
+    (static / "assets").mkdir()
+    return static
+
+
 class TestServe:
     def test_prod_mode_no_static_fails(
         self,
@@ -44,6 +58,100 @@ class TestServe:
 
         assert result.exit_code == 1
         assert "frontend" in result.output.lower() or "npm" in result.output.lower()
+
+    def test_prod_mode_empty_static_dir_fails(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty static/ (fresh worktree, interrupted build) must fail fast.
+
+        Before the completeness check, a bare directory passed the
+        ``exists()`` gate and uvicorn crashed with an opaque
+        ``RuntimeError`` mounting the missing ``assets/`` subdirectory.
+        """
+        monkeypatch.chdir(tmp_path)
+        static = tmp_path / "static"
+        static.mkdir()
+
+        with (
+            patch(
+                "haute.cli._serve._find_frontend_dir",
+                side_effect=FileNotFoundError("no frontend/ anywhere"),
+            ),
+            patch("haute.server.STATIC_DIR", static),
+            patch("uvicorn.run") as mock_run,
+        ):
+            result = runner.invoke(cli, ["serve", "--no-browser"])
+
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+
+    def test_prod_mode_source_checkout_error_names_build_steps(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """In a source checkout the error must be actionable: npm steps + script."""
+        monkeypatch.chdir(tmp_path)
+        repo_root = tmp_path / "checkout"
+        (repo_root / "frontend").mkdir(parents=True)
+        (repo_root / "frontend" / "package.json").write_text("{}")
+
+        with (
+            patch(
+                "haute.cli._serve._find_frontend_dir",
+                side_effect=FileNotFoundError("no frontend/ anywhere"),
+            ),
+            patch("haute.cli._serve._source_checkout_root", return_value=repo_root),
+            patch("haute.server.STATIC_DIR", tmp_path / "nonexistent"),
+        ):
+            result = runner.invoke(cli, ["serve", "--no-browser"])
+
+        assert result.exit_code == 1
+        assert "npm install" in result.output
+        assert "npm run build" in result.output
+        assert "setup-worktree.sh" in result.output
+        assert str(repo_root / "frontend") in result.output
+
+    def test_prod_mode_wheel_install_error_omits_build_steps(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A wheel install with broken assets should say reinstall, not npm."""
+        monkeypatch.chdir(tmp_path)
+
+        with (
+            patch(
+                "haute.cli._serve._find_frontend_dir",
+                side_effect=FileNotFoundError("no frontend/ anywhere"),
+            ),
+            patch("haute.cli._serve._source_checkout_root", return_value=None),
+            patch("haute.server.STATIC_DIR", tmp_path / "nonexistent"),
+        ):
+            result = runner.invoke(cli, ["serve", "--no-browser"])
+
+        assert result.exit_code == 1
+        assert "reinstall" in result.output.lower()
+        assert "npm" not in result.output
+
+    def test_source_checkout_root_detection(self, tmp_path: Path) -> None:
+        """Detection keys off frontend/package.json two levels above the package."""
+        pkg = tmp_path / "src" / "haute"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("")
+        fake_haute = MagicMock(__file__=str(pkg / "__init__.py"))
+
+        with patch.dict("sys.modules", {"haute": fake_haute}):
+            assert serve_mod._source_checkout_root() is None
+            frontend = tmp_path / "frontend"
+            frontend.mkdir()
+            (frontend / "package.json").write_text("{}")
+            assert serve_mod._source_checkout_root() == tmp_path
 
     def test_ipv6_loopback_uses_ipv6_probe_socket(self) -> None:
         """The port probe must match IPv6 hosts such as ``::1``."""
@@ -201,8 +309,7 @@ class TestServe:
     ) -> None:
         """Prod mode should serve from built static directory."""
         monkeypatch.chdir(tmp_path)
-        static = tmp_path / "static"
-        static.mkdir()
+        static = _built_static_dir(tmp_path)
 
         with (
             patch(
@@ -231,8 +338,7 @@ class TestServe:
         :func:`uvicorn.run`, not exercise real socket binding.
         """
         monkeypatch.chdir(tmp_path)
-        static = tmp_path / "static"
-        static.mkdir()
+        static = _built_static_dir(tmp_path)
 
         with (
             patch(
@@ -324,8 +430,7 @@ class TestServe:
     ) -> None:
         """Prod mode without --no-browser should schedule _open_browser."""
         monkeypatch.chdir(tmp_path)
-        static = tmp_path / "static"
-        static.mkdir()
+        static = _built_static_dir(tmp_path)
 
         mock_timer = MagicMock()
 
@@ -356,8 +461,7 @@ class TestServe:
     ) -> None:
         """Prod mode browser URL should reflect custom host/port."""
         monkeypatch.chdir(tmp_path)
-        static = tmp_path / "static"
-        static.mkdir()
+        static = _built_static_dir(tmp_path)
 
         mock_timer = MagicMock()
 

--- a/tests/test_host_binding.py
+++ b/tests/test_host_binding.py
@@ -51,14 +51,17 @@ def _serve_port_available():
 
 
 def _fake_static_dir(tmp_path: Path) -> Path:
-    """Create a static directory so ``handle_serve`` can reach ``uvicorn.run``.
+    """Create a complete static build so ``handle_serve`` reaches ``uvicorn.run``.
 
-    The ``serve`` prod-mode branch exits early with "No built frontend
-    found" when ``STATIC_DIR`` is missing; a host-binding test only
-    cares about the host/port selection and must get past that gate.
+    The ``serve`` prod-mode branch exits early with "no built frontend
+    found" when ``STATIC_DIR`` is missing ``index.html`` or ``assets/``;
+    a host-binding test only cares about the host/port selection and
+    must get past that gate.
     """
     static = tmp_path / "static"
     static.mkdir()
+    (static / "index.html").write_text("<html></html>")
+    (static / "assets").mkdir()
     return static
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3719,3 +3719,38 @@ class TestDissolveEdgeCases:
         )
         assert resp.status_code == 400
         assert "source_file" in resp.json()["detail"]
+
+
+class TestStaticBuildReady:
+    """``static_build_ready`` gates both static mounting and ``haute serve``."""
+
+    def test_missing_dir_is_not_ready(self, tmp_path: Path) -> None:
+        from haute.server import static_build_ready
+
+        assert not static_build_ready(tmp_path / "nonexistent")
+
+    def test_empty_dir_is_not_ready(self, tmp_path: Path) -> None:
+        """A bare directory (fresh worktree, interrupted build) must not count."""
+        from haute.server import static_build_ready
+
+        static = tmp_path / "static"
+        static.mkdir()
+        assert not static_build_ready(static)
+
+    def test_index_without_assets_is_not_ready(self, tmp_path: Path) -> None:
+        """Mounting a missing assets/ raises at import — require it up front."""
+        from haute.server import static_build_ready
+
+        static = tmp_path / "static"
+        static.mkdir()
+        (static / "index.html").write_text("<html></html>")
+        assert not static_build_ready(static)
+
+    def test_complete_build_is_ready(self, tmp_path: Path) -> None:
+        from haute.server import static_build_ready
+
+        static = tmp_path / "static"
+        static.mkdir()
+        (static / "index.html").write_text("<html></html>")
+        (static / "assets").mkdir()
+        assert static_build_ready(static)


### PR DESCRIPTION
## Problem

`haute serve` from a source checkout whose `src/haute/static/` was never built (fresh git worktrees) either printed a terse error or — when `static/` existed but was empty/partial (interrupted build) — passed the bare `STATIC_DIR.exists()` check and crashed with an opaque `RuntimeError` from uvicorn mounting the missing `assets/` subdirectory.

## Changes

- **`server.py`**: new `static_build_ready()` — a static dir only counts as built when it holds `index.html` **and** `assets/` (the two artefacts every Vite build produces). Used by the dev-mode CORS branch, the static mount, and the CLI, so all paths agree on what "built" means.
- **`haute serve` prod mode**: fails fast through the same readiness check with an actionable message: `cd frontend && npm install && npm run build`, or run `scripts/setup-worktree.sh`. The server never runs npm itself (egress principle).
- **Source-checkout detection**: `_source_checkout_root()` keys off `frontend/package.json` two levels above the package — true for editable installs/worktrees, never for wheel installs in site-packages. PyPI installs ship prebuilt assets, so a wheel with broken assets gets a "reinstall haute" hint instead of npm instructions.
- **`scripts/setup-worktree.sh`**: re-authored from `archive/data-model` (8aa3ca94). Idempotent `npm install` + `npm run build`; verified end-to-end (fresh provision + no-op re-run).

## Testing

- New tests: empty-static fail-fast, source-checkout message content, wheel-install message content, checkout-root detection, `static_build_ready` unit tests (server.py is critical-coverage).
- Existing tests faking `static/` as a bare dir upgraded to fake a complete build.
- Full `scripts/preflight.sh` green; fail-fast also verified live in an unbuilt worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)