### PR TITLE
Git panel: generation-guard the row refresh against stale branch responses

### DIFF
--- a/frontend/src/panels/GitPanel.tsx
+++ b/frontend/src/panels/GitPanel.tsx
@@ -90,9 +90,11 @@ export default function GitPanel({ onClose }: GitPanelProps) {
   // Whole-forest topology for the graph rail (A-5): fetched best-effort
   // alongside refresh(); null (never loaded) means no rail.
   const [graph, setGraph] = useState<GitGraphResponse | null>(null)
-  // Refresh generation for the fire-and-forget graph fetch: a stale response
-  // must never overwrite a fresher one.
-  const graphGeneration = useRef(0)
+  // Refresh generation, shared by the graph fetch AND the milestone/pending/
+  // working-branch rows: bumped once at the start of every refresh(), and any
+  // refresh that is no longer the newest discards its results instead of
+  // applying them — a stale response must never overwrite a fresher one.
+  const refreshGeneration = useRef(0)
   // The branch the loaded milestone/pending rows belong to. During a peek's
   // one-round-trip window the rows still show the PREVIOUS branch — the rail
   // holds off (renders nothing) until this catches up with the view.
@@ -119,10 +121,10 @@ export default function GitPanel({ onClose }: GitPanelProps) {
     // response lands (generation guard), and a transient refetch failure
     // keeps the last good graph — nulling it would flip the whole list's
     // markup between rail and no-rail layouts.
-    const generation = ++graphGeneration.current
+    const generation = ++refreshGeneration.current
     const graphSettled = getGitGraph(50).then(
       (g) => {
-        if (generation === graphGeneration.current) setGraph(g)
+        if (generation === refreshGeneration.current) setGraph(g)
       },
       () => {},
     )
@@ -136,6 +138,10 @@ export default function GitPanel({ onClose }: GitPanelProps) {
       // row commit until the graph settles or 250ms passes, whichever is
       // sooner, so a peek doesn't paint the list and then pop the tree in.
       await Promise.race([graphSettled, new Promise((r) => setTimeout(r, 250))])
+      // A newer refresh started while this one was in flight (e.g. a peek or
+      // switch moved to another branch): these rows describe the OLD view —
+      // drop them rather than landing them over the newer refresh's rows.
+      if (generation !== refreshGeneration.current) return null
       setMilestones(ms.entries)
       setPending(ps.saves)
       setRowsBranch(viewBranch ?? ms.working_branch)
@@ -145,11 +151,15 @@ export default function GitPanel({ onClose }: GitPanelProps) {
       // change (the effect below), where the milestones genuinely differ.
       return { milestones: ms.entries, pending: ps.saves }
     } catch (err) {
+      // A superseded refresh failing is moot — the newest one owns the toast.
+      if (generation !== refreshGeneration.current) return null
       const detail = err instanceof Error ? err.message : "unknown error"
       addToast("error", `Failed to load version history: ${detail}`)
       return null
     } finally {
-      setLoading(false)
+      // Only the newest refresh owns the spinner: a superseded one settling
+      // must not clear it while the newer fetch is still in flight.
+      if (generation === refreshGeneration.current) setLoading(false)
     }
   }, [addToast, viewBranch])
 

--- a/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react"
+import GitPanel from "../GitPanel"
+import useGitStore from "../../stores/useGitStore"
+
+// Regression pin for the refresh() generation guard: a refresh captured for
+// the PREVIOUS branch (its fetches still in flight when a peek retargets the
+// panel) must not land its rows over the newer branch's rows when it finally
+// resolves. Same api-client mocking conventions as GitPanel.test.tsx.
+const mockGetWorkingBranch = vi.fn()
+const mockGetMilestones = vi.fn()
+const mockGetMilestoneSaves = vi.fn()
+const mockGetPendingSaves = vi.fn()
+const mockCreateWorkingBranch = vi.fn()
+const mockGetWorkingBranches = vi.fn()
+const mockGetGitGraph = vi.fn()
+const mockSetWorkingBranch = vi.fn()
+
+vi.mock("../../api/client", () => ({
+  getWorkingBranch: (...a: unknown[]) => mockGetWorkingBranch(...a),
+  getMilestones: (...a: unknown[]) => mockGetMilestones(...a),
+  getMilestoneSaves: (...a: unknown[]) => mockGetMilestoneSaves(...a),
+  getPendingSaves: (...a: unknown[]) => mockGetPendingSaves(...a),
+  getWorkingBranches: (...a: unknown[]) => mockGetWorkingBranches(...a),
+  getGitGraph: (...a: unknown[]) => mockGetGitGraph(...a),
+  setWorkingBranch: (...a: unknown[]) => mockSetWorkingBranch(...a),
+  createWorkingBranch: (...a: unknown[]) => mockCreateWorkingBranch(...a),
+  gitArchiveBranch: vi.fn(),
+  gitDeleteBranch: vi.fn(),
+  restoreBranch: vi.fn(),
+  undeleteBranch: vi.fn(),
+  getGitPrefs: vi.fn(() => Promise.resolve({ skip_switch_confirm: false })),
+  setGitPrefs: vi.fn(),
+  getGitRemotes: vi.fn(() => Promise.resolve({ remotes: [], working_branch: null })),
+  gitPush: vi.fn(),
+}))
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const now = () => new Date().toISOString()
+
+const readyStatus = {
+  working_branch: "pricing-dev",
+  current_branch: "pricing-dev-save",
+  state: "ready",
+  eligible_branches: [],
+  identity_set: true,
+  user_name: "Nick",
+  user_email: "n@example.com",
+  last_save_sha: "abc12345",
+  errors: [],
+}
+
+// The previous (working) branch's history — the STALE payload.
+const devMilestones = {
+  working_branch: "pricing-dev",
+  entries: [
+    { sha: "m1full", short_sha: "m1abc", message: "Dev milestone", timestamp: now(), version_label: "1.0" },
+  ],
+}
+const devPending = {
+  saves: [{ sha: "p1", short_sha: "p1abc", message: "dev pending save", timestamp: now(), files: [] }],
+}
+
+// The peeked branch's history — the payload that must stay on screen.
+const spurMilestones = {
+  working_branch: "pricing-dev",
+  entries: [
+    { sha: "b1full", short_sha: "b1abcd", message: "Spur milestone", timestamp: now(), version_label: null },
+  ],
+}
+
+const emptyGraph = { working_branch: null, order: [], branches: [] }
+
+describe("GitPanel stale refresh (generation guard)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, selectLatestSaveNonce: 0, selectSaveNonce: 0, selectSaveTarget: null, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    mockGetWorkingBranch.mockResolvedValue(readyStatus)
+    mockGetMilestoneSaves.mockResolvedValue({ saves: [] })
+    mockGetWorkingBranches.mockResolvedValue({ current: "pricing-dev", branches: [] })
+    mockGetGitGraph.mockResolvedValue(emptyGraph)
+  })
+
+  afterEach(cleanup)
+
+  it("an earlier slow refresh resolving after a later fast one does not overwrite the later branch's rows", async () => {
+    // The initial refresh (working branch, viewBranch null) hangs; the peeked
+    // branch's refresh resolves immediately.
+    let resolveDevMilestones!: (value: unknown) => void
+    let resolveDevPending!: (value: unknown) => void
+    mockGetMilestones.mockImplementation((_n: number, branch?: string | null) =>
+      branch === "pricing/nick/spur"
+        ? Promise.resolve(spurMilestones)
+        : new Promise((resolve) => { resolveDevMilestones = resolve }),
+    )
+    mockGetPendingSaves.mockImplementation((branch?: string | null) =>
+      branch === "pricing/nick/spur"
+        ? Promise.resolve({ saves: [] })
+        : new Promise((resolve) => { resolveDevPending = resolve }),
+    )
+
+    render(<GitPanel onClose={vi.fn()} />)
+    await waitFor(() => expect(mockGetMilestones).toHaveBeenCalledWith(50, null))
+
+    // Peek the spur while the working branch's refresh is still in flight —
+    // the later (spur) refresh lands first.
+    act(() => useGitStore.getState().setPeekBranch("pricing/nick/spur"))
+    await waitFor(() => expect(mockGetMilestones).toHaveBeenCalledWith(50, "pricing/nick/spur"))
+    await waitFor(() => expect(screen.getByText("Spur milestone")).toBeInTheDocument())
+
+    // NOW the earlier refresh resolves, carrying the previous branch's rows.
+    // Flush its whole application path (Promise.all → graph race → setState).
+    await act(async () => {
+      resolveDevMilestones(devMilestones)
+      resolveDevPending(devPending)
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // The later branch's rows stay on screen; the stale rows never land.
+    expect(screen.getByText("Spur milestone")).toBeInTheDocument()
+    expect(screen.queryByText("Dev milestone")).not.toBeInTheDocument()
+    expect(screen.queryByText("dev pending save")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("git-panel-pending")).not.toBeInTheDocument()
+  })
+
+  it("a superseded refresh settling does not clear the newer refresh's loading state", async () => {
+    // Both refreshes hang; the FIRST (working branch) then resolves while the
+    // second (spur) is still in flight — the spinner must survive it.
+    let resolveDevMilestones!: (value: unknown) => void
+    mockGetMilestones.mockImplementation((_n: number, branch?: string | null) =>
+      branch === "pricing/nick/spur"
+        ? new Promise(() => {})
+        : new Promise((resolve) => { resolveDevMilestones = resolve }),
+    )
+    mockGetPendingSaves.mockResolvedValue({ saves: [] })
+
+    render(<GitPanel onClose={vi.fn()} />)
+    await waitFor(() => expect(mockGetMilestones).toHaveBeenCalledWith(50, null))
+
+    act(() => useGitStore.getState().setPeekBranch("pricing/nick/spur"))
+    await waitFor(() => expect(mockGetMilestones).toHaveBeenCalledWith(50, "pricing/nick/spur"))
+    await waitFor(() => expect(screen.getByTestId("git-panel-loading")).toBeInTheDocument())
+
+    await act(async () => {
+      resolveDevMilestones(devMilestones)
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+
+    // Still loading the spur's history — the stale refresh neither painted its
+    // rows nor killed the spinner.
+    expect(screen.getByTestId("git-panel-loading")).toBeInTheDocument()
+    expect(screen.queryByText("Dev milestone")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

`refresh()` in `frontend/src/panels/GitPanel.tsx` guarded only the fire-and-forget graph fetch with a generation counter. The `Promise.all` of `getMilestones`/`getPendingSaves`/`getWorkingBranches` had no such guard, so a refresh captured before a branch peek/switch could resolve after the new branch's refresh and land the PREVIOUS branch's rows over the fresh ones.

This shares one generation counter across the whole refresh: bumped once at refresh start, and a superseded refresh discards its results instead of applying them —
- no row `setState` (`setMilestones`/`setPending`/`setRowsBranch`/`setForkBranches`),
- no error toast on a stale failure (the newest refresh owns it),
- the loading spinner is only cleared by the refresh that owns it, so a stale settle can't kill the newer fetch's spinner mid-flight.

## Tests

New `GitPanel.staleRefresh.test.tsx` (api-client mocking per the existing GitPanel test conventions):
1. holds the working branch's fetches open, lands a peeked branch's rows first, then resolves the stale fetches — asserts the peeked branch's rows stay on screen and the stale milestones/pending saves never land;
2. asserts a superseded refresh settling does not clear the newer refresh's loading state.

Both tests fail with the guard disabled.

## Verification

- `vitest run src/panels/__tests__`: 29 files, 780 tests passed
- `tsc -b --force`: clean
- `eslint` on the changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)