### PR TITLE
ci: shard backend coverage 2x, gate on one interpreter, add non-blocking 3.14 probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,18 +79,18 @@ jobs:
       - name: Fresh-install smoke
         run: uv run --no-project python scripts/init_smoke.py
 
-  backend:
+  # Version-independent static gates + package build — run once on the
+  # reference interpreter (these were duplicated across the old 3-version
+  # backend matrix). Needs node for the frontend-embedding package build.
+  backend-static:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - uses: actions/setup-node@v4
         with:
@@ -98,8 +98,126 @@ jobs:
 
       - run: uv sync --group dev --locked
 
-      - name: Backend preflight
-        run: bash scripts/preflight.sh --backend-only
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Mypy
+        run: uv run mypy src/haute/
+
+      - name: Package build
+        run: HAUTE_BUILD_FRONTEND=1 uv build
+
+  # Coverage authority: the full suite on the reference interpreter (3.12),
+  # split into 2 balanced shards run in parallel (pytest-split). Each shard
+  # writes its own coverage data file; the gate job below combines them and
+  # enforces the 90% global + per-file critical gates ONCE — coverage is
+  # interpreter-independent, so it no longer recomputes on every matrix leg.
+  backend-coverage-shard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - run: uv sync --group dev --locked
+
+      - name: Pytest shard ${{ matrix.shard }}/2 (coverage)
+        env:
+          COVERAGE_FILE: .coverage.shard${{ matrix.shard }}
+        run: >
+          uv run pytest tests/ -q -n 4 --timeout=60 --timeout-method=signal
+          --splits 2 --group ${{ matrix.shard }}
+          --cov=src/haute --cov-branch --cov-report= --cov-fail-under=0
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-${{ matrix.shard }}
+          path: .coverage.shard${{ matrix.shard }}
+          include-hidden-files: true
+          retention-days: 1
+
+  backend-coverage-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: backend-coverage-shard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - run: uv sync --group dev --locked
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: backend-coverage-*
+          merge-multiple: true
+
+      - name: Combine coverage + enforce global 90% + per-file critical gates
+        run: |
+          mkdir -p .cache/coverage
+          uv run coverage combine .coverage.shard1 .coverage.shard2
+          uv run coverage report --fail-under=90 --show-missing
+          uv run coverage json -o .cache/coverage/backend.json
+          uv run python scripts/check_critical_coverage.py --coverage-json .cache/coverage/backend.json
+
+  # Compatibility: the full suite (no coverage) on the supported version edges.
+  backend-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - run: uv sync --group dev --locked
+
+      - name: Pytest (compat, no coverage)
+        run: uv run pytest tests/ -q -n 4 --timeout=60 --timeout-method=signal
+
+  # Forward-looking, NON-BLOCKING probe: does haute install + its suite pass on
+  # Python 3.14? `continue-on-error` keeps it off the required set; it fails
+  # fast at dependency sync (catboost is the likely cp314-wheel blocker) and the
+  # diagnostic step names that failure mode so a red probe is self-explaining.
+  backend-314-probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.14"
+
+      - name: Dependency sync (fails fast if a dep lacks cp314 wheels)
+        id: sync
+        run: uv sync --group dev --locked
+
+      - name: Diagnose a sync failure
+        if: failure() && steps.sync.outcome == 'failure'
+        run: echo "::warning title=py3.14 probe::uv sync failed on Python 3.14 — a dependency lacks cp314 wheels (most likely catboost). Expected until native wheels catch up; this probe is non-blocking."
+
+      - name: Pytest (3.14, no coverage)
+        if: steps.sync.outcome == 'success'
+        run: uv run pytest tests/ -q -n 4 --timeout=60 --timeout-method=signal
 
   perf:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ dev = [
     "pytest-github-actions-annotate-failures==0.4.2",
     "pytest-timeout==2.4.0",
     "pytest-xdist==3.8.0",
+    # Split the suite into balanced groups for the sharded backend-coverage CI
+    # lane (pytest --splits N --group G); combined via `coverage combine`.
+    "pytest-split==0.11.0",
     "httpx==0.28.1",
     "ruff==0.15.0",
     "mypy==1.19.1",
@@ -187,6 +190,11 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["src/haute"]
 branch = true
+# Store relative file paths in coverage data so the sharded backend-coverage CI
+# lane can `coverage combine` data files produced on separate runner VMs (whose
+# absolute checkout paths differ). Without this, combine sees disjoint absolute
+# paths and the merged report is wrong. Local monolithic runs are unaffected.
+relative_files = true
 
 [tool.coverage.report]
 fail_under = 90

--- a/uv.lock
+++ b/uv.lock
@@ -1226,6 +1226,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-github-actions-annotate-failures" },
+    { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -1269,6 +1270,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = "==0.4.2" },
+    { name = "pytest-split", specifier = "==0.11.0" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.15.0" },
@@ -3127,6 +3129,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/00/a0/bdb91581b03c41016c78e16b8ec36c34d8508206fcb30f1951c9cdff2e97/pytest_github_actions_annotate_failures-0.4.2.tar.gz", hash = "sha256:5dd18304512361788bc7b5c5c805db853f03f4950c6be09b088de6bab8e2e6c9", size = 12158, upload-time = "2026-06-19T15:59:17.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/09/c44e658f3a27c588c2017d858c8b0fa962612af9b74326beabbf010c839c/pytest_github_actions_annotate_failures-0.4.2-py3-none-any.whl", hash = "sha256:02911cd3b55f235328a334f8ca6037a89944398b8e8b028c82de97111eff4071", size = 6151, upload-time = "2026-06-19T15:59:16.486Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Replaces the 3x full `backend` matrix (each running the entire preflight backend gate) with a leaner topology that computes coverage once and shards the gated run.

## New backend jobs
- **`backend-static`** (3.12, once) — ruff + format check + mypy + package build. Version-independent gates, previously recomputed on all 3 legs.
- **`backend-coverage-shard`** (3.12, `shard: [1,2]`) → **`backend-coverage-gate`** — the full suite split 2x with `pytest-split`; each shard uploads its `.coverage` data; the gate `coverage combine`s them and enforces the **90% global + per-file critical** gates once. Coverage is interpreter-independent, so it no longer recomputes per version.
- **`backend-compat`** (3.11, 3.13) — full suite, no coverage (version compatibility).
- **`backend-314-probe`** (3.14, `continue-on-error: true`) — non-blocking forward probe. Fails fast at `uv sync` (catboost the likely cp314-wheel blocker); a diagnostic step names that failure mode so a red probe is self-explaining.

## pyproject
- `pytest-split==0.11.0` (dev) for the balanced split.
- `relative_files = true` under `[tool.coverage.run]` — **essential** so shard data files produced on separate runner VMs combine correctly (absolute checkout paths would otherwise be disjoint). Local monolithic runs unaffected.
- Shards run `--cov-fail-under=0` so the 90% gate applies only to the combined data.

## ⚠️ Action required at merge (branch protection)
The backend job **names changed**, so the current required checks (`backend (3.11/3.12/3.13)`) no longer exist — this PR will read as blocked until the repo required-check list is updated to **`backend-static`, `backend-coverage-gate`, `backend-compat`** (leave `backend-314-probe` non-required). Admin setting; I cannot change it.

## Verification
Local mechanism verified end-to-end on a subset: `pytest --splits 2 --group N` → `coverage combine` → `coverage json` → `check_critical_coverage.py` all wire through. Real coverage numbers (≥90 combined, per-file critical) are verified by this PR CI.

## Follow-up (optional)
Splits are count-based (no `.test_durations`); a committed durations file would time-balance shards. Deferred to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)