### PR TITLE
refactor(git): remove dead list_branches() and commit_count

### DIFF
--- a/src/haute/_git.py
+++ b/src/haute/_git.py
@@ -550,68 +550,35 @@ def get_status(cwd: Path | None = None) -> GitStatusResponse:
     )
 
 
-def list_branches(cwd: Path | None = None) -> GitBranchListResponse:
-    """List all branches, with the user's branches first.
-
-    Uses ``%(ahead-behind:<default>)`` (git 2.35+) to get commit counts
-    in a single subprocess call instead of one per branch.
-    """
-    return _list_branches_with_tips(cwd=cwd)[0]
-
-
 def _list_branches_with_tips(
-    cwd: Path | None = None, *, with_counts: bool = True
+    cwd: Path | None = None,
 ) -> tuple[GitBranchListResponse, dict[str, str]]:
-    """:func:`list_branches` plus a ``{short ref name: tip SHA}`` map covering
-    EVERY local head (ledgers and archived pairs included), read from the same
-    single ``for-each-ref`` call via ``%(objectname)``.
+    """List all local branches (user's first), plus a ``{short ref name: tip
+    SHA}`` map covering EVERY local head (ledgers and archived pairs included),
+    both read from a single ``for-each-ref`` call via ``%(objectname)``.
 
     The graph and branch-manager paths key their content-addressed caches by
     these tips instead of issuing per-branch ``rev-parse`` subprocesses — refs
     are resolved to SHAs exactly once per request, here.
 
-    ``with_counts=False`` drops ``%(ahead-behind:)`` from the format — the one
-    per-branch-EXPENSIVE atom in it (git walks each ref's history to count) —
-    for the sidebar read paths (graph, branch manager, working-branch status),
-    none of which consume ``commit_count``; it is reported as 0 there. The
-    current/user-slug reads stay: ``is_yours`` drives the yours-first sort,
+    The format carries only names, tips and commit times: no per-branch
+    ahead-behind walk, because no caller consumes commit counts. The
+    current/user-slug reads stay — ``is_yours`` drives the yours-first sort,
     which IS consumed (the branch-manager render order and the startup modal's
     ``eligible[0]`` preselection follow it)."""
     _assert_git_repo(cwd)
 
     current = _get_current_branch(cwd)
-    default = _get_default_branch(cwd)
     user_slug = _get_user_slug(cwd)
 
-    cheap_format = "%(refname:short)\t%(objectname)\t%(committerdate:iso-strict)"
-    if with_counts:
-        # Try the fast path first: %(ahead-behind:ref) gives "ahead behind"
-        # counts in one subprocess call (git ≥ 2.35).
-        ok, raw = _run_git_ok(
-            "for-each-ref",
-            "--sort=-committerdate",
-            f"--format={cheap_format}\t%(ahead-behind:{default})",
-            "refs/heads/",
-            cwd=cwd,
-        )
-        if not ok or not raw:
-            # Fallback for very old git: no ahead-behind support.
-            ok, raw = _run_git_ok(
-                "for-each-ref",
-                "--sort=-committerdate",
-                f"--format={cheap_format}",
-                "refs/heads/",
-                cwd=cwd,
-            )
-    else:
-        # The 3-field shape is also the very-old-git fallback — one attempt.
-        ok, raw = _run_git_ok(
-            "for-each-ref",
-            "--sort=-committerdate",
-            f"--format={cheap_format}",
-            "refs/heads/",
-            cwd=cwd,
-        )
+    ref_format = "%(refname:short)\t%(objectname)\t%(committerdate:iso-strict)"
+    ok, raw = _run_git_ok(
+        "for-each-ref",
+        "--sort=-committerdate",
+        f"--format={ref_format}",
+        "refs/heads/",
+        cwd=cwd,
+    )
 
     branches: list[GitBranchItem] = []
     tips: dict[str, str] = {}
@@ -626,23 +593,6 @@ def _list_branches_with_tips(
             commit_time = parts[2]
             tips[name] = tip_sha
 
-            # Parse ahead-behind if available (format: "ahead behind")
-            commit_count = 0
-            if len(parts) >= 4:
-                ab = parts[3].split()
-                if len(ab) == 2 and ab[0].isdigit():
-                    commit_count = int(ab[0])
-            elif with_counts:
-                # Slow fallback: one subprocess per branch
-                ok_count, count_str = _run_git_ok(
-                    "rev-list",
-                    "--count",
-                    f"{default}..{name}",
-                    cwd=cwd,
-                )
-                if ok_count and count_str.isdigit():
-                    commit_count = int(count_str)
-
             branches.append(
                 GitBranchItem(
                     name=name,
@@ -650,7 +600,6 @@ def _list_branches_with_tips(
                     is_current=name == current,
                     is_archived=name.startswith(f"{_ARCHIVE_PREFIX}/"),
                     last_commit_time=commit_time,
-                    commit_count=commit_count,
                 )
             )
 
@@ -1077,10 +1026,10 @@ def _eligible_working_branches(cwd: Path | None = None) -> list[str]:
     the repo's default branch (which is deploy-only, like the hardcoded
     protected set — PROTECTED_BRANCHES being configurable is a later item).
 
-    Cheap enumeration (no ahead-behind): only names, archived flags and the
-    yours-first order are consumed — the startup modal preselects the FIRST
-    eligible branch, so the order must match the full listing's."""
-    listing, _ = _list_branches_with_tips(cwd=cwd, with_counts=False)
+    Only names, archived flags and the yours-first order are consumed — the
+    startup modal preselects the FIRST eligible branch, so the order must match
+    the branch listing's."""
+    listing, _ = _list_branches_with_tips(cwd=cwd)
     default = _get_default_branch(cwd)
     return [
         b.name
@@ -2229,9 +2178,9 @@ def graph_topology(
     # implicit, the deploy branch excluded) — but archived pairs stay in.
     # Refs resolve to tip SHAs once, in the for-each-ref itself; each spine is
     # then a content-addressed read below its tip (cached, so an unmoved
-    # branch costs no rev-list on refresh). Cheap enumeration: the graph never
-    # reads commit_count, so the per-branch ahead-behind walk is skipped.
-    listing, tips = _list_branches_with_tips(cwd=cwd, with_counts=False)
+    # branch costs no rev-list on refresh). The enumeration carries only names,
+    # tips and commit times — no per-branch ahead-behind walk.
+    listing, tips = _list_branches_with_tips(cwd=cwd)
     spines: dict[str, list[str]] = {}
     archived: dict[str, bool] = {}
     for b in listing.branches:
@@ -2948,10 +2897,10 @@ def working_branches(project_root: Path, cwd: Path | None = None) -> GitWorkingB
     entries: list[GitManagedBranch] = []
     # Working AND ledger tips come from the single for-each-ref enumeration
     # (ledgers are local heads too) — no per-branch rev-parse pair, and the
-    # unmerged-saves merge-base is SHA-keyed-cached. Cheap enumeration: the
-    # manager view never reads commit_count (it does consume the yours-first
-    # ORDER, which the cheap format preserves).
-    listing, tips = _list_branches_with_tips(cwd=cwd, with_counts=False)
+    # unmerged-saves merge-base is SHA-keyed-cached. The enumeration carries no
+    # ahead-behind counts, but it does preserve the yours-first ORDER the
+    # manager view consumes.
+    listing, tips = _list_branches_with_tips(cwd=cwd)
     for b in listing.branches:
         # Working branches only — ledgers (category "ledger") and protected
         # branches are not version lines; the default branch is deploy-only.

--- a/src/haute/schemas.py
+++ b/src/haute/schemas.py
@@ -1533,7 +1533,6 @@ class GitBranchItem(BaseModel):
     is_current: bool
     is_archived: bool
     last_commit_time: str = ""
-    commit_count: int = 0
 
 
 class GitBranchListResponse(BaseModel):

--- a/tests/test_git_content_caches.py
+++ b/tests/test_git_content_caches.py
@@ -511,59 +511,12 @@ class TestForkCredit:
 
 
 # ---------------------------------------------------------------------------
-# Old-git fallback — no %(ahead-behind) support: the fallback for-each-ref
-# must still thread tips through, and the per-branch rev-list count still fires.
+# Branch enumeration — the single for-each-ref read must thread tips through
+# and skip malformed ref lines.
 # ---------------------------------------------------------------------------
 
 
-class TestListBranchesFallback:
-    def test_fallback_format_still_threads_tips(
-        self, repo: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        _save(repo, WORKING, "m1")
-        m1 = _milestone(repo, "Milestone 1")
-
-        real_ok = git_mod._run_git_ok
-
-        def no_ahead_behind(*args, **kwargs):
-            if args and args[0] == "for-each-ref" and any("ahead-behind" in a for a in args):
-                return (False, "")  # a git too old for %(ahead-behind)
-            return real_ok(*args, **kwargs)
-
-        monkeypatch.setattr(git_mod, "_run_git_ok", no_ahead_behind)
-
-        listing, tips = git_mod._list_branches_with_tips(cwd=repo)
-        assert tips[WORKING] == m1
-        assert tips[LEDGER] == _git(repo, "rev-parse", LEDGER)
-        by_name = {b.name: b for b in listing.branches}
-        # The slow per-branch rev-list fallback still computes ahead counts.
-        assert by_name[WORKING].commit_count == 2  # milestone merge + its save
-        assert by_name["main"].commit_count == 0
-
-        graph = graph_topology(repo, cwd=repo)
-        assert next(b for b in graph.branches if b.name == WORKING).tip_sha == m1
-
-    def test_cheap_variant_matches_full_except_counts(self, repo: Path) -> None:
-        """with_counts=False must be behaviourally identical for everything the
-        sidebar paths consume: same tips map, same names, same yours-first
-        ORDER (the startup modal preselects eligible[0]), same flags — only
-        commit_count is skipped (reported 0)."""
-        _save(repo, WORKING, "m1")
-        _milestone(repo, "Milestone 1")
-        create_working_branch("pricing-other", repo, at=None, cwd=repo)
-
-        full, full_tips = git_mod._list_branches_with_tips(cwd=repo)
-        cheap, cheap_tips = git_mod._list_branches_with_tips(cwd=repo, with_counts=False)
-
-        assert cheap_tips == full_tips
-        assert cheap.current == full.current
-        assert [b.name for b in cheap.branches] == [b.name for b in full.branches]
-        for c, f in zip(cheap.branches, full.branches):
-            assert c.model_dump(exclude={"commit_count"}) == f.model_dump(exclude={"commit_count"})
-            assert c.commit_count == 0
-        # The full format really does carry counts the cheap one skips.
-        assert next(b for b in full.branches if b.name == WORKING).commit_count > 0
-
+class TestListBranchesEnumeration:
     def test_malformed_ref_line_is_skipped(
         self, repo: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_git_routes_pydantic.py
+++ b/tests/test_git_routes_pydantic.py
@@ -76,18 +76,6 @@ class TestGitModuleReturnsPydantic:
         # trivially coerce to it (i.e. the fields line up).
         GitStatusResponse.model_validate(result.model_dump())
 
-    def test_list_branches_returns_pydantic_model(self) -> None:
-        from haute._git import list_branches
-        from haute.schemas import GitBranchListResponse
-
-        result = list_branches()
-
-        assert isinstance(result, BaseModel), (
-            f"#74: _git.list_branches() must return a Pydantic BaseModel; "
-            f"got {type(result).__name__!r}."
-        )
-        GitBranchListResponse.model_validate(result.model_dump())
-
     def test_move_to_commit_returns_pydantic_model(self, tmp_path: Path) -> None:
         from haute._git import move_to_commit
         from haute.schemas import GitMoveResponse


### PR DESCRIPTION
Removes the dead `list_branches()` and the full `for-each-ref` format that populated `GitBranchItem.commit_count`.

The `/api/git/branches` route was removed with the v0 surface, and every live path (graph, working-branches, branch-manager status) already reads the cheap `_list_branches_with_tips()` variant that omits the `%(ahead-behind)` atom — only tests pinned the full format.

## Changes
- Drop `list_branches()`.
- Collapse `_list_branches_with_tips()` to the single cheap format: remove the `with_counts` flag, the per-branch ahead-behind history walk, and the git<2.35 `rev-list --count` fallback (plus the now-unused `default` local).
- Drop the unused `GitBranchItem.commit_count` field.
- Update the tests that pinned the full format (`test_git_routes_pydantic.py`, and the `TestListBranchesFallback` pair in `test_git_content_caches.py`); keep and rename the surviving enumeration test.

No behaviour change: all three live call sites already requested `with_counts=False`.

## Verification
`scripts/preflight.sh --backend-only` green: 12335 passed / 26 skipped / 2 xfailed, total coverage 92.78%, all 28 critical-coverage gates pass (`_git.py` statement 93.72% / branch 83.40%; `schemas.py` 100%), ruff-format + mypy + wheel build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
