### PR TITLE
apiInput: compare table-label sanitised stems casefolded (B2)

### DIFF
--- a/frontend/src/utils/__tests__/apiInputPorts.test.ts
+++ b/frontend/src/utils/__tests__/apiInputPorts.test.ts
@@ -194,8 +194,19 @@ describe("apiInputLabelIssue", () => {
     })
   })
 
-  it("is case-sensitive (backend labels are exact strings)", () => {
-    expect(apiInputLabelIssue("Drivers", ["drivers"])).toBeNull()
+  it("rejects labels differing only in case (one parquet file on macOS/Windows)", () => {
+    // "Drivers.parquet" and "drivers.parquet" are the SAME file on the
+    // case-insensitive filesystems macOS and Windows default to — the
+    // shred write would silently clobber one table's data. Mirrors the
+    // backend B2 casefolded comparison; exact duplicates still report
+    // as "duplicate", so this pair reports the sanitised collision.
+    expect(apiInputLabelIssue("Drivers", ["drivers"])).toEqual({
+      kind: "sanitised-collision",
+      other: "drivers",
+      sanitised: "Drivers",
+    })
+    // Genuinely distinct labels still pass.
+    expect(apiInputLabelIssue("Drivers", ["policies"])).toBeNull()
   })
 
   it("produces a user-facing message per issue kind, and null for none", () => {

--- a/frontend/src/utils/apiInputPorts.ts
+++ b/frontend/src/utils/apiInputPorts.ts
@@ -156,9 +156,14 @@ export function apiInputLabelIssue(
   for (const other of otherLabels) {
     if (other === candidate) return { kind: "duplicate", other }
   }
+  // Compared case-insensitively, mirroring the backend's B2: sanitised
+  // stems are pure ASCII, and `Foo.parquet` / `foo.parquet` are the SAME
+  // file on the case-insensitive filesystems macOS and Windows default
+  // to — case-variant labels would silently clobber one parquet.
   const sanitised = sanitiseLabelForFilesystem(candidate)
+  const folded = sanitised.toLowerCase()
   for (const other of otherLabels) {
-    if (sanitiseLabelForFilesystem(other) === sanitised) {
+    if (sanitiseLabelForFilesystem(other).toLowerCase() === folded) {
       return { kind: "sanitised-collision", other, sanitised }
     }
   }
@@ -174,7 +179,7 @@ export function apiInputLabelIssueMessage(issue: ApiInputLabelIssue | null): str
     case "duplicate":
       return `Duplicate label: "${issue.other}" is already used by another table.`
     case "sanitised-collision":
-      return `Label collides with "${issue.other}": both become "${issue.sanitised}" on disk.`
+      return `Label collides with "${issue.other}": both become "${issue.sanitised}" on disk (case-insensitive — macOS/Windows treat case-variant filenames as one file).`
   }
 }
 

--- a/src/haute/_api_input_schema.py
+++ b/src/haute/_api_input_schema.py
@@ -444,19 +444,32 @@ def validate_v2_schema(config: dict[str, Any]) -> None:
             )
         seen_labels.add(label)
 
-        # B2 — sanitised-label collision check.
+        # B2 — sanitised-label collision check, compared CASEFOLDED:
+        # ``Foo.parquet`` and ``foo.parquet`` are the SAME file on the
+        # case-insensitive filesystems macOS and Windows default to, so
+        # stems differing only in case would silently clobber one
+        # parquet at the shred-write step. Sanitised stems are pure
+        # ASCII (``[a-zA-Z0-9_-]``), so ``casefold()`` here is exactly
+        # ASCII case folding — and matches the frontend twin's
+        # ``toLowerCase()`` (``apiInputPorts.ts``). Rejecting on every
+        # platform keeps a schema saved on Linux buildable on a
+        # macOS/Windows checkout.
         sanitised = sanitise_label_for_filesystem(label)
-        prior = sanitised_to_label.get(sanitised)
+        folded = sanitised.casefold()
+        prior = sanitised_to_label.get(folded)
         if prior is not None:
             raise ApiInputSchemaError(
                 "v2 table labels collide under filesystem-safe sanitisation "
-                "(both produce the same parquet filename) — pick distinct "
-                "labels that differ in their letters/digits/underscores/hyphens",
+                "(both produce the same parquet filename — filenames are "
+                "compared case-insensitively, because case-insensitive "
+                "filesystems treat names differing only in case as the same "
+                "file) — pick labels that differ in their "
+                "letters/digits/underscores/hyphens, not only in case",
                 label_a=prior,
                 label_b=label,
                 sanitised=sanitised,
             )
-        sanitised_to_label[sanitised] = label
+        sanitised_to_label[folded] = label
 
         columns = table.get("columns", [])
         if not isinstance(columns, list):

--- a/tests/test_v1_removal_contract.py
+++ b/tests/test_v1_removal_contract.py
@@ -492,6 +492,54 @@ def test_t14_validate_v2_schema_rejects_sanitised_label_collision() -> None:
         validate_v2_schema(cfg_collision)
 
 
+def _two_table_cfg(label_a: str, label_b: str) -> dict:
+    return {
+        "tables": [
+            {
+                "path": "$[:]",
+                "label": label_a,
+                "emit": True,
+                "columns": [{"name": "x", "path": "$[:].x", "type": "str"}],
+            },
+            {
+                "path": "$[:].drivers[:]",
+                "label": label_b,
+                "emit": True,
+                "columns": [{"name": "y", "path": "$[:].drivers[:].y", "type": "str"}],
+            },
+        ]
+    }
+
+
+def test_t14b_validate_v2_schema_rejects_case_only_label_collision() -> None:
+    """Labels differing only in case must be rejected (B2, casefolded).
+
+    ``Foo.parquet`` and ``foo.parquet`` are the SAME file on the
+    case-insensitive filesystems macOS and Windows default to: the
+    shred write would silently clobber one table's parquet, and at
+    runtime both frame labels would read the one survivor — wrong data
+    flowing into rating. Rejected on every platform so a schema saved
+    on Linux stays buildable on a macOS/Windows checkout.
+    """
+    from haute._api_input_schema import ApiInputSchemaError, validate_v2_schema
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(_two_table_cfg("Foo", "foo"))
+    assert "case" in str(exc_info.value)
+
+    # Case difference composed with a sanitised collision: 'My$Table' and
+    # 'my%table' both sanitise (case aside) to my_table.
+    with pytest.raises(ApiInputSchemaError):
+        validate_v2_schema(_two_table_cfg("My$Table", "my%table"))
+
+
+def test_t14c_validate_v2_schema_accepts_genuinely_distinct_labels() -> None:
+    """The casefold guard must not over-trigger on distinct names."""
+    from haute._api_input_schema import validate_v2_schema
+
+    validate_v2_schema(_two_table_cfg("Foo", "Bar"))
+
+
 # ─── T15 — validator + path parsers raise ApiInputSchemaError ────────
 
 


### PR DESCRIPTION
## What

Fixes a macOS/Windows data-loss bug (mapping-equivalence audit, verified): two emit tables in one apiInput node labelled `Foo`/`foo` passed both the editor label check and the backend guardrail B2 because `sanitise_label_for_filesystem` preserves case and both sides compared stems with raw string equality. Cache-as-Parquet then wrote `Foo.parquet` and `foo.parquet` into one directory — the SAME file on case-insensitive filesystems — silently clobbering one table's parquet while `meta.json` still listed both: at runtime both frame labels read the one survivor, feeding wrong data into rating.

## The fix

Both validator twins compare stems casefolded: backend `validate_v2_schema` B2 (`casefold()`) and the editor's `apiInputLabelIssue` (`toLowerCase()`) — stems are pure ASCII by construction (`[a-zA-Z0-9_-]`), so the two folds are identical ASCII case folding and cannot drift. Rejection is on every platform, matching the config-sidecar casefold guards' portability rationale. `validate_v2_schema` also runs inside the shred build itself, so already-saved configs carrying a colliding pair now fail the cache build with the structured error instead of clobbering.

## Verification

- Characterization first: the new case-only rejection test fails against the unfixed validator; the no-over-trigger negative passes both pre- and post-fix.
- The old frontend test `is case-sensitive (backend labels are exact strings)` pinned the buggy behaviour — flipped to the new contract.
- Full backend suite 12329 passed; frontend 5097 passed; ruff/mypy/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)