### PR TITLE
instances: reject ambiguous substring input mapping instead of guessing

### DIFF
--- a/frontend/src/panels/NodePanel.tsx
+++ b/frontend/src/panels/NodePanel.tsx
@@ -366,20 +366,43 @@ function InstancePanel({
 
         const currentMapping = (config.inputMapping || {}) as Record<string, string>
 
-        // Auto-initialise mapping if empty or stale.
+        // Auto-initialise mapping if empty or stale. Mirrors the backend's
+        // build_instance_mapping: exact match, then substring ONLY when the
+        // pairing is unambiguous in both directions, then positional for
+        // names with no substring evidence at all. A contested substring
+        // pairing (e.g. originals rate/base_rate against sources
+        // x_base_rate/x_rate) is deliberately left unmapped: the old greedy
+        // pick could bind the frames crosswise, and the backend now refuses
+        // to save/run an ambiguous mapping — the user must choose here.
         const autoMap: Record<string, string> = {}
         const usedInst = new Set<string>()
         for (const orig of origInputs) {
           const exact = instInputs.find((i) => i.varName === orig && !usedInst.has(i.varName))
           if (exact) { autoMap[orig] = exact.varName; usedInst.add(exact.varName) }
         }
-        for (const orig of origInputs) {
-          if (autoMap[orig]) continue
-          const sub = instInputs.find((i) => !usedInst.has(i.varName) && i.varName.includes(orig))
-          if (sub) { autoMap[orig] = sub.varName; usedInst.add(sub.varName) }
+        const subOrigs = origInputs.filter((o) => !autoMap[o])
+        const subInsts = instInputs.filter((i) => !usedInst.has(i.varName))
+        const candByOrig = new Map(
+          subOrigs.map((o) => [o, subInsts.filter((i) => i.varName.includes(o))]),
+        )
+        const candCountByInst = new Map(
+          subInsts.map((i) => [i.varName, subOrigs.filter((o) => i.varName.includes(o)).length]),
+        )
+        const ambiguousOrigs = new Set(
+          subOrigs.filter((o) => {
+            const cands = candByOrig.get(o) ?? []
+            return cands.length > 0 && !(cands.length === 1 && candCountByInst.get(cands[0].varName) === 1)
+          }),
+        )
+        for (const o of subOrigs) {
+          const cands = candByOrig.get(o) ?? []
+          if (cands.length === 1 && candCountByInst.get(cands[0].varName) === 1) {
+            autoMap[o] = cands[0].varName
+            usedInst.add(cands[0].varName)
+          }
         }
         const remaining = instInputs.filter((i) => !usedInst.has(i.varName))
-        const unmapped = origInputs.filter((o) => !autoMap[o])
+        const unmapped = origInputs.filter((o) => !autoMap[o] && !ambiguousOrigs.has(o))
         unmapped.forEach((orig, idx) => {
           if (idx < remaining.length) autoMap[orig] = remaining[idx].varName
         })
@@ -393,6 +416,7 @@ function InstancePanel({
             effectiveMap[orig] = autoMap[orig] || ""
           }
         }
+        const unresolvedAmbiguous = [...ambiguousOrigs].filter((o) => !effectiveMap[o])
 
         const handleMappingChange = (origParam: string, instVar: string) => {
           const newMapping = { ...effectiveMap, [origParam]: instVar }
@@ -407,6 +431,15 @@ function InstancePanel({
             <p className="text-[10px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
               Map each original input to a connected upstream node.
             </p>
+            {unresolvedAmbiguous.length > 0 && (
+              <div className="flex items-start gap-1.5 px-2 py-1.5 rounded-md" style={{ background: 'var(--warning-soft)', border: '1px solid var(--warning-border)' }}>
+                <AlertTriangle size={11} style={{ color: 'var(--warning-strong)' }} className="shrink-0 mt-0.5" />
+                <span className="text-[10px] leading-relaxed" style={{ color: 'var(--warning-strong)' }}>
+                  Name matching is ambiguous for {unresolvedAmbiguous.join(", ")} — several upstream
+                  sources fit. Pick each one explicitly; saving and running are blocked until mapped.
+                </span>
+              </div>
+            )}
             <div className="flex flex-col gap-1.5">
               {origInputs.map((orig) => (
                 <div key={orig} className="flex items-center gap-2 px-2 py-1.5 rounded-md" style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}>

--- a/src/haute/_graph_utils.py
+++ b/src/haute/_graph_utils.py
@@ -132,9 +132,10 @@ def build_instance_mapping(
 ) -> dict[str, str]:
     """Map original input parameter names to instance input names.
 
-    Priority: explicit mapping → exact name match → substring match → positional.
-    Used by the executor (alias injection) and codegen (kwarg generation).
-    The frontend mirrors this algorithm in NodePanel.tsx (InstanceConfig auto-mapping).
+    Priority: explicit mapping → exact name match → unambiguous substring
+    match → positional. Used by the executor (alias injection) and codegen
+    (kwarg generation). The frontend mirrors this algorithm in NodePanel.tsx
+    (InstanceConfig auto-mapping).
 
     Raises
     ------
@@ -143,6 +144,13 @@ def build_instance_mapping(
         *orig_names* or non-empty values that do not appear in *inst_names*.
         Stale entries indicate the UI-stored ``inputMapping`` is out of
         sync with the current graph and would silently corrupt wiring.
+    ConfigError
+        If a substring pairing is ambiguous — an original name matching
+        several instance sources, or one instance source matching several
+        originals. The old greedy first-fit resolved these silently and
+        could bind frames to the WRONG parameters (swapped inputs, clean
+        run, wrong prices); ambiguity now requires an explicit
+        ``inputMapping`` on the instance node.
     """
     from haute.errors import ConfigError
 
@@ -178,16 +186,45 @@ def build_instance_mapping(
                 mapping[orig] = inst
                 used.add(i)
                 break
-    # Pass 2: substring match (e.g. "claims_aggregate" in "claims_aggregate_instance")
-    for orig in orig_names:
-        if orig in mapping:
-            continue
-        for i, inst in enumerate(inst_names):
-            if i not in used and orig in inst:
-                mapping[orig] = inst
-                used.add(i)
-                break
-    # Pass 3: positional fallback for remaining
+    # Pass 2: substring match (e.g. "claims_aggregate" in
+    # "claims_aggregate_instance") — assigned ONLY when the pairing is
+    # unambiguous in both directions. Substring containment is
+    # many-to-one: with originals ``rate``/``base_rate`` and instance
+    # sources ``x_base_rate``/``x_rate``, the old greedy first-fit gave
+    # ``rate`` → ``x_base_rate`` and left ``base_rate`` to pick up
+    # ``x_rate`` positionally — the two frames bound CROSSWISE, the
+    # pipeline ran clean and priced wrong. A contested pairing now
+    # raises so the user sets ``inputMapping`` explicitly instead of
+    # receiving silently-swapped frames.
+    remaining_origs = [o for o in orig_names if o not in mapping]
+    remaining_idx = [i for i in range(len(inst_names)) if i not in used]
+    cand_by_orig = {
+        o: [i for i in remaining_idx if o in inst_names[i]] for o in remaining_origs
+    }
+    cand_by_idx = {
+        i: [o for o in remaining_origs if o in inst_names[i]] for i in remaining_idx
+    }
+    ambiguous = {
+        o: [inst_names[i] for i in cands]
+        for o, cands in cand_by_orig.items()
+        if cands and not (len(cands) == 1 and len(cand_by_idx[cands[0]]) == 1)
+    }
+    if ambiguous:
+        raise ConfigError(
+            "instance input mapping is ambiguous: name matching cannot "
+            "uniquely pair these original inputs with the instance's "
+            "upstream sources — set the input mapping explicitly on the "
+            "instance node.",
+            ambiguous_originals=ambiguous,
+            orig_names=list(orig_names),
+            inst_names=list(inst_names),
+        )
+    for o, cands in cand_by_orig.items():
+        if len(cands) == 1:
+            mapping[o] = inst_names[cands[0]]
+            used.add(cands[0])
+    # Pass 3: positional fallback for remaining (no substring evidence
+    # at all — e.g. fully renamed sources; order follows the wiring)
     unused = [i for i in range(len(inst_names)) if i not in used]
     unmatched = [o for o in orig_names if o not in mapping]
     for orig, i in zip(unmatched, unused):

--- a/src/haute/_graph_utils.py
+++ b/src/haute/_graph_utils.py
@@ -198,12 +198,8 @@ def build_instance_mapping(
     # receiving silently-swapped frames.
     remaining_origs = [o for o in orig_names if o not in mapping]
     remaining_idx = [i for i in range(len(inst_names)) if i not in used]
-    cand_by_orig = {
-        o: [i for i in remaining_idx if o in inst_names[i]] for o in remaining_origs
-    }
-    cand_by_idx = {
-        i: [o for o in remaining_origs if o in inst_names[i]] for i in remaining_idx
-    }
+    cand_by_orig = {o: [i for i in remaining_idx if o in inst_names[i]] for o in remaining_origs}
+    cand_by_idx = {i: [o for o in remaining_origs if o in inst_names[i]] for i in remaining_idx}
     ambiguous = {
         o: [inst_names[i] for i in cands]
         for o, cands in cand_by_orig.items()

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2407,9 +2407,7 @@ class TestInstanceAmbiguousMapping:
         assert "ambiguous" in str(exc_info.value)
 
     def test_explicit_mapping_unblocks_codegen(self):
-        code = graph_to_code(
-            self._ambiguous_graph({"Rate": "X_Rate", "Base_Rate": "X_Base_Rate"})
-        )
+        code = graph_to_code(self._ambiguous_graph({"Rate": "X_Rate", "Base_Rate": "X_Base_Rate"}))
         compile(code, "<test>", "exec")
         assert "Rate=X_Rate" in code
         assert "Base_Rate=X_Base_Rate" in code

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2340,6 +2340,82 @@ class TestInstanceMissingTarget:
 
 
 # ---------------------------------------------------------------------------
+# Instance input mapping: ambiguous substring pairing fails the save loudly
+# ---------------------------------------------------------------------------
+
+
+class TestInstanceAmbiguousMapping:
+    """An instance whose upstream names pair ambiguously with the original's
+    parameters must fail codegen (and therefore save) with ``ConfigError``,
+    not silently bind frames to the wrong parameters. ``Rate`` is a
+    substring of both ``X_Base_Rate`` and ``X_Rate``, so name matching
+    cannot decide which frame feeds which parameter."""
+
+    @staticmethod
+    def _ambiguous_graph(input_mapping: dict[str, str] | None = None):
+        def src(node_id: str, label: str) -> dict:
+            return {
+                "id": node_id,
+                "data": {
+                    "label": label,
+                    "nodeType": "dataSource",
+                    "config": {"path": f"{node_id}.parquet"},
+                },
+            }
+
+        inst_config: dict = {"instanceOf": "orig"}
+        if input_mapping is not None:
+            inst_config["inputMapping"] = input_mapping
+        return _g(
+            {
+                "nodes": [
+                    src("r", "Rate"),
+                    src("br", "Base Rate"),
+                    src("xr", "X Rate"),
+                    src("xbr", "X Base Rate"),
+                    {
+                        "id": "orig",
+                        "data": {
+                            "label": "Blend",
+                            "nodeType": "polars",
+                            "config": {"code": "df = Rate"},
+                        },
+                    },
+                    {
+                        "id": "inst",
+                        "data": {
+                            "label": "Blend Clone",
+                            "nodeType": "polars",
+                            "config": inst_config,
+                        },
+                    },
+                ],
+                "edges": [
+                    {"id": "e1", "source": "r", "target": "orig"},
+                    {"id": "e2", "source": "br", "target": "orig"},
+                    {"id": "e3", "source": "xbr", "target": "inst"},
+                    {"id": "e4", "source": "xr", "target": "inst"},
+                ],
+            }
+        )
+
+    def test_ambiguous_instance_mapping_fails_codegen(self):
+        from haute.errors import ConfigError
+
+        with pytest.raises(ConfigError) as exc_info:
+            graph_to_code(self._ambiguous_graph())
+        assert "ambiguous" in str(exc_info.value)
+
+    def test_explicit_mapping_unblocks_codegen(self):
+        code = graph_to_code(
+            self._ambiguous_graph({"Rate": "X_Rate", "Base_Rate": "X_Base_Rate"})
+        )
+        compile(code, "<test>", "exec")
+        assert "Rate=X_Rate" in code
+        assert "Base_Rate=X_Base_Rate" in code
+
+
+# ---------------------------------------------------------------------------
 # Gap 5: _submodel_node_to_code replaces only first @pipeline. occurrence
 # ---------------------------------------------------------------------------
 

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -427,6 +427,54 @@ class TestBuildInstanceMapping:
         assert result["a"] == "a"
         assert result["b"] == "b"
 
+    def test_ambiguous_substring_raises(self):
+        """A contested substring pairing must raise, not silently bind.
+
+        The old greedy first-fit gave ``a`` → ``xab`` (first inst
+        containing ``a``), leaving ``ab`` to pick up ``xa``
+        positionally — the two frames bound CROSSWISE and the pipeline
+        ran clean with swapped inputs. Same shape with realistic names:
+        ``rate``/``base_rate`` against ``x_base_rate``/``x_rate``.
+        """
+        from haute.errors import ConfigError
+        from haute.graph_utils import build_instance_mapping
+
+        with pytest.raises(ConfigError) as exc_info:
+            build_instance_mapping(["a", "ab"], ["xab", "xa"])
+        assert "ambiguous" in str(exc_info.value)
+
+        with pytest.raises(ConfigError):
+            build_instance_mapping(["rate", "base_rate"], ["x_base_rate", "x_rate"])
+
+    def test_contested_instance_source_raises(self):
+        """One instance source containing several originals is contested."""
+        from haute.errors import ConfigError
+        from haute.graph_utils import build_instance_mapping
+
+        with pytest.raises(ConfigError):
+            build_instance_mapping(["a", "ab"], ["xab", "zzz"])
+
+    def test_multiple_unique_substrings_still_bind(self):
+        """Uniqueness in both directions keeps the substring convenience."""
+        from haute.graph_utils import build_instance_mapping
+
+        result = build_instance_mapping(
+            ["claims", "exposure"],
+            ["my_claims", "my_exposure"],
+        )
+        assert result == {"claims": "my_claims", "exposure": "my_exposure"}
+
+    def test_explicit_mapping_resolves_ambiguity(self):
+        """An explicit entry for the contested original unblocks the rest."""
+        from haute.graph_utils import build_instance_mapping
+
+        result = build_instance_mapping(
+            ["a", "ab"],
+            ["xab", "xa"],
+            explicit={"a": "xa"},
+        )
+        assert result == {"a": "xa", "ab": "xab"}
+
 
 # ---------------------------------------------------------------------------
 # resolve_orig_source_names


### PR DESCRIPTION
## What

Fixes a silent-wrong-output bug (all platforms; mapping-equivalence audit, verified): `build_instance_mapping`'s greedy substring pass could bind an instance node's upstream frames to the WRONG original parameters. Originals `rate`/`base_rate` with instance sources `x_base_rate`/`x_rate` (wiring order first) bound CROSSWISE — the generated .py encoded the same swap and the pipeline ran clean with silently wrong prices.

## The fix (ruled: reject ambiguity loudly)

The substring pass now assigns a pair only when it is unambiguous in BOTH directions (the instance name is the original's sole candidate AND vice versa). Any contested pairing raises `ConfigError` telling the user to set `inputMapping` explicitly; the save route already surfaces that as a 400 (and codegen's ConfigError handler re-raises), so ambiguity fails at the source instead of mispricing. Unique substring matches (`claims_aggregate` → `claims_aggregate_instance`), the positional fallback for names with no substring evidence, and explicit-mapping override keep their existing behaviour. The NodePanel auto-mapping mirror applies the same rule: contested originals stay unmapped with a warning banner naming them.

## Verification

- Characterization: the swap pinned failing against old code at the unit level AND through real `graph_to_code` (the generated file contained the crosswise kwargs).
- No over-rejection in practice: zero existing test pipelines trip the new guard.
- Full backend suite 12342 passed; frontend 5097 passed; ruff/mypy/eslint clean; production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)