### PR TITLE
optimiser: node-unique result save path via the shared sanitizer

### DIFF
--- a/frontend/e2e/core-flows.spec.ts
+++ b/frontend/e2e/core-flows.spec.ts
@@ -11,11 +11,13 @@ const sidecarPath = resolve(ratingDir, "main.haute.json")
 const utilityModulePath = resolve(ratingDir, "utility", "browser_helpers.py")
 const gitMainPath = resolve(ratingDir, "main.py")
 const browserSubmodelPath = resolve(e2eProjectRoot, "rating", "modules", "browser_group.py")
+// Path shape: optimiser_<sanitizeName(label)>_<sanitizeName(nodeId)>.json —
+// for a pipeline-loaded node, label and id are both the function name.
 const optimiserArtifactPath = resolve(
   e2eProjectRoot,
   "rating",
   "output",
-  "optimiser_browser_optimiser.json",
+  "optimiser_browser_optimiser_browser_optimiser.json",
 )
 const selectAll = process.platform === "darwin" ? "Meta+A" : "Control+A"
 
@@ -135,7 +137,9 @@ test.describe("core browser flows", () => {
     await optimiserResultTabs.getByRole("tab", { name: "Export", exact: true }).click()
     await page.getByRole("button", { name: "Save result", exact: true }).click()
 
-    await expect(page.getByText(/optimiser_browser_optimiser\.json/i)).toBeVisible({
+    await expect(
+      page.getByText(/optimiser_browser_optimiser_browser_optimiser\.json/i),
+    ).toBeVisible({
       timeout: 120_000,
     })
     await expect.poll(() => existsSync(optimiserArtifactPath)).toBe(true)
@@ -146,7 +150,7 @@ test.describe("core browser flows", () => {
     await expect(page.locator("input.node-label-input")).toHaveValue("browser_apply")
     await expect(
       page.getByPlaceholder("artifacts/optimiser_v1.json"),
-    ).toHaveValue("rating/output/optimiser_browser_optimiser.json")
+    ).toHaveValue("rating/output/optimiser_browser_optimiser_browser_optimiser.json")
     await expect(page.getByPlaceholder("__optimiser_version__")).toHaveValue(
       "__optimiser_version__",
     )

--- a/frontend/src/panels/OptimiserPreview.tsx
+++ b/frontend/src/panels/OptimiserPreview.tsx
@@ -31,6 +31,7 @@ import SummaryTab from "./optimiser/SummaryTab"
 import DetailCard from "./optimiser/DetailCard"
 import RatebookRatesTab from "./optimiser/RatebookRatesTab"
 import { hasFactorTables } from "./optimiser/ratebookFactorTables"
+import { optimiserResultSavePath } from "./optimiser/optimiserHelpers"
 import { formatOptimiserIterationSummary } from "./optimiser/iterationSummary"
 import PreviewPanelFrame from "./PreviewPanelFrame"
 import PreviewPanelTabs from "./PreviewPanelTabs"
@@ -284,7 +285,10 @@ export default function OptimiserPreview({ data, nodeId, allNodes, edges }: Opti
     setSaving(true)
     setActionMsg(null)
     try {
-      const outputPath = `output/optimiser_${displayData.nodeLabel.toLowerCase().replace(/ /g, "_")}.json`
+      // Node-unique path: label-only names collided across case-variant
+      // labels ("Foo" vs "FOO") and the backend save route has no overwrite
+      // guard — see optimiserResultSavePath.
+      const outputPath = optimiserResultSavePath(displayData.nodeLabel, nodeId)
       const res = await saveOptimiser({
         job_id: jobId,
         output_path: outputPath,
@@ -296,7 +300,7 @@ export default function OptimiserPreview({ data, nodeId, allNodes, edges }: Opti
     } finally {
       setSaving(false)
     }
-  }, [selectedIdx, frontier, jobId, displayData.nodeLabel])
+  }, [selectedIdx, frontier, jobId, displayData.nodeLabel, nodeId])
 
   const handleLogMlflow = useCallback(async () => {
     setLogging(true)

--- a/frontend/src/panels/__tests__/OptimiserPreview.test.tsx
+++ b/frontend/src/panels/__tests__/OptimiserPreview.test.tsx
@@ -123,7 +123,7 @@ describe("OptimiserPreview", () => {
       converged: true,
       error: null,
     })
-    mockSaveOptimiser.mockResolvedValue({ status: "ok", path: "output/optimiser_my_optimiser.json", message: "" })
+    mockSaveOptimiser.mockResolvedValue({ status: "ok", path: "output/optimiser_My_Optimiser_opt_1.json", message: "" })
     mockLogOptimiserToMlflow.mockResolvedValue({ status: "ok", backend: "mlflow", experiment_name: "", run_id: "abc123", run_url: null, tracking_uri: "", error: null })
     mockApplyOptimiser.mockResolvedValue({
       status: "ok",
@@ -743,7 +743,8 @@ describe("OptimiserPreview", () => {
       await waitFor(() => {
         expect(mockSaveOptimiser).toHaveBeenCalledWith({
           job_id: "job_123",
-          output_path: "output/optimiser_my_optimiser.json",
+          // sanitizeName(label) + node id: casing preserved, node-unique.
+          output_path: "output/optimiser_My_Optimiser_opt_1.json",
           point_index: 0,
         })
       })

--- a/frontend/src/panels/optimiser/__tests__/optimiserHelpers.test.ts
+++ b/frontend/src/panels/optimiser/__tests__/optimiserHelpers.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from "vitest"
-import { isConstraintMet } from "../optimiserHelpers"
+import { isConstraintMet, optimiserResultSavePath } from "../optimiserHelpers"
+
+describe("optimiserResultSavePath", () => {
+  it("gives case-variant labels on distinct nodes distinct paths", () => {
+    // "Foo" and "FOO" are legal coexisting node labels; a label-only path
+    // sent both to the same file and the backend save route has no
+    // overwrite guard.
+    const a = optimiserResultSavePath("Foo", "optimiser_1")
+    const b = optimiserResultSavePath("FOO", "optimiser_2")
+    expect(a).toBe("output/optimiser_Foo_optimiser_1.json")
+    expect(b).toBe("output/optimiser_FOO_optimiser_2.json")
+    expect(a).not.toBe(b)
+  })
+
+  it("is stable for the same node, so re-saves overwrite their own file", () => {
+    expect(optimiserResultSavePath("Foo", "optimiser_1")).toBe(
+      optimiserResultSavePath("Foo", "optimiser_1"),
+    )
+  })
+
+  it("routes the label through the shared sanitizeName", () => {
+    // sanitizeName: space → underscore, ASCII punctuation stripped,
+    // casing preserved (NOT the old ad-hoc lowercase rule).
+    expect(optimiserResultSavePath("My Node!", "opt_1")).toBe(
+      "output/optimiser_My_Node_opt_1.json",
+    )
+  })
+
+  it("sanitizes the node id defensively too", () => {
+    // Real ids are filename-safe (<type>_<n> or Python func names); anything
+    // odd is still flattened by sanitizeName rather than reaching the path.
+    expect(optimiserResultSavePath("Foo", "weird id!")).toBe(
+      "output/optimiser_Foo_weird_id.json",
+    )
+  })
+})
 
 describe("isConstraintMet", () => {
   it("evaluates absolute sum constraints with min and max", () => {

--- a/frontend/src/panels/optimiser/optimiserHelpers.ts
+++ b/frontend/src/panels/optimiser/optimiserHelpers.ts
@@ -5,6 +5,29 @@
  * (satisfies `react-refresh/only-export-components`).
  */
 
+import { sanitizeName } from "../../utils/sanitizeName"
+
+/**
+ * Derive the on-disk save path for an optimiser result artifact.
+ *
+ * The path ALWAYS embeds the node id: labels are only case-preservingly
+ * unique (the backend's uniqueness guard allows coexisting nodes "Foo" and
+ * "FOO"), and the backend save route writes the given path verbatim with no
+ * overwrite guard — a label-only filename let one node's save silently
+ * destroy another's.  Including the id makes the path unique per node while
+ * a re-save of the SAME node still overwrites its own file (rerun
+ * semantics).
+ *
+ * The label goes through the shared `sanitizeName` (the backend sanitizer's
+ * case-preserving twin), replacing an ad-hoc lowercase sanitizer that had
+ * diverged from it.  Node ids (`<type>_<n>` for UI-created nodes, Python
+ * function names for pipeline-loaded ones) are already filename-safe, but
+ * are sanitized too as defence in depth.
+ */
+export function optimiserResultSavePath(nodeLabel: string, nodeId: string): string {
+  return `output/optimiser_${sanitizeName(nodeLabel)}_${sanitizeName(nodeId)}.json`
+}
+
 /**
  * Decide whether an absolute constraint is met given its threshold type and
  * observed value.  Used by both `SummaryTab` (to tint

--- a/scripts/run_frontend_e2e_server.py
+++ b/scripts/run_frontend_e2e_server.py
@@ -106,7 +106,7 @@ _BROWSER_OPTIMISER_CONFIG = """{
 """
 _BROWSER_OPTIMISER_APPLY_CONFIG = """{
   "sourceType": "file",
-  "artifact_path": "rating/output/optimiser_browser_optimiser.json",
+  "artifact_path": "rating/output/optimiser_browser_optimiser_browser_optimiser.json",
   "version_column": "__optimiser_version__"
 }
 """


### PR DESCRIPTION
## What

Fixes a silent-overwrite bug (all platforms; mapping-equivalence audit, verified): the optimiser Save button minted `output/optimiser_<label.toLowerCase()>.json` with an ad-hoc rule — a third sanitizer diverging from the shared case-preserving `sanitizeName`. Two legal coexisting optimiser nodes `Foo`/`FOO` both derived `output/optimiser_foo.json`, and the backend save route writes the given path verbatim with no overwrite guard: the second node's save silently destroyed the first node's result.

## The fix (ruled: always include the node id)

`optimiserResultSavePath(label, nodeId)` → `output/optimiser_<sanitizeName(label)>_<sanitizeName(nodeId)>.json`. Distinct nodes never collide (ids differ even for case-variant labels on mac/win); a re-save of the SAME node still overwrites its own file (rerun semantics). Node ids are already filename-safe; sanitized anyway as defence in depth. Also fixes a stale-closure hazard (nodeId added to the save handler's dependency array). Backend unchanged — its path validation has no shape allowlist and accepts the new name.

## Verification

- Characterization: the existing save test failed against the new derivation on exactly the old label-only expectation before expectations were updated.
- Frontend suite 5101 passed; eslint clean; production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)