### PR TITLE
caches/watcher: canonicalise name- and path-derived keys (casefold family)

### DIFF
--- a/src/haute/_databricks_io.py
+++ b/src/haute/_databricks_io.py
@@ -145,10 +145,26 @@ def _get_credentials(http_path: str | None = None) -> tuple[str, str, str]:
 # ---------------------------------------------------------------------------
 
 
+def _canonical_table(table: str) -> str:
+    """Return the canonical spelling of a fully-qualified table reference.
+
+    Databricks resolves unquoted identifiers case-insensitively, and backtick
+    quoting is spelling rather than identity: ``MyCat.Sch.Tbl``,
+    ``mycat.sch.tbl`` and the backtick-quoted form of either all name ONE
+    table.  Strip backticks and casefold so every spelling derives the same
+    cache identity — otherwise one table double-caches on a case-sensitive
+    deploy filesystem and a clear-cache issued under another spelling misses
+    the live file.
+    """
+    return table.replace("`", "").casefold()
+
+
 def _cache_path_for(table: str, project_root: Path | None = None) -> Path:
     """Return the parquet cache path for a fully-qualified table name.
 
-    All path separators and dots are replaced with underscores, leaving a
+    The table reference is canonicalised first (see :func:`_canonical_table`)
+    so every spelling of one table maps to one cache file.  All path
+    separators and dots are then replaced with underscores, leaving a
     single path component, and the result is verified to sit directly
     inside the cache directory to prevent path-traversal attacks.
 
@@ -160,7 +176,8 @@ def _cache_path_for(table: str, project_root: Path | None = None) -> Path:
     a spurious "Invalid table name" race under concurrent fetches.
     """
     root = project_root or Path.cwd()
-    safe_name = table.replace(".", "_").replace("/", "_").replace("\\", "_")
+    canonical = _canonical_table(table)
+    safe_name = canonical.replace(".", "_").replace("/", "_").replace("\\", "_")
     cache_dir = (root / CACHE_DIR).resolve()
     result = cache_dir / f"{safe_name}.parquet"
     if not safe_name or result.parent != cache_dir:

--- a/src/haute/_stat_gated_cache.py
+++ b/src/haute/_stat_gated_cache.py
@@ -27,6 +27,7 @@ threads and must be treated as immutable by callers.
 
 from __future__ import annotations
 
+import os
 import threading
 from collections.abc import Callable, Hashable
 from pathlib import Path
@@ -34,6 +35,21 @@ from typing import Generic, TypeVar
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
+
+
+def artifact_cache_key(path: str | Path) -> str:
+    """Canonical cache-key string for a filesystem artifact path.
+
+    Mirrors :func:`haute._json_flatten._path_hash`'s canonicalisation:
+    ``expanduser`` + ``resolve`` collapse ``./``, ``..`` and symlinks, and
+    ``os.path.normcase`` folds case where the OS convention is
+    case-insensitive (Windows).  Residual: ``normcase`` is a no-op on POSIX,
+    so on macOS (case-insensitive filesystem, case-preserving API) two case
+    spellings of one file can still occupy two slots — the same accepted
+    posture as the JSON cache; the cost is memory residue only, and Windows
+    (where ``normcase`` folds) is fully covered.
+    """
+    return os.path.normcase(str(Path(path).expanduser().resolve()))
 
 
 class StatGatedCache(Generic[K, V]):

--- a/src/haute/_stat_gated_cache.py
+++ b/src/haute/_stat_gated_cache.py
@@ -37,19 +37,32 @@ K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
 
+def resolve_artifact_path(path: str | Path) -> str:
+    """Canonical ON-DISK spelling of an artifact path — for stat and I/O.
+
+    ``expanduser`` + ``resolve`` collapse ``./``, ``..`` and symlinks but
+    preserve case: this is the string to hand to ``stat``/``open``.  Use
+    :func:`artifact_cache_key` — NOT this — as the cache slot key.
+    """
+    return str(Path(path).expanduser().resolve())
+
+
 def artifact_cache_key(path: str | Path) -> str:
-    """Canonical cache-key string for a filesystem artifact path.
+    """Canonical cache-KEY string for a filesystem artifact path.
 
     Mirrors :func:`haute._json_flatten._path_hash`'s canonicalisation:
-    ``expanduser`` + ``resolve`` collapse ``./``, ``..`` and symlinks, and
-    ``os.path.normcase`` folds case where the OS convention is
-    case-insensitive (Windows).  Residual: ``normcase`` is a no-op on POSIX,
-    so on macOS (case-insensitive filesystem, case-preserving API) two case
-    spellings of one file can still occupy two slots — the same accepted
-    posture as the JSON cache; the cost is memory residue only, and Windows
-    (where ``normcase`` folds) is fully covered.
+    :func:`resolve_artifact_path` plus ``os.path.normcase``, which folds
+    case where the OS convention is case-insensitive (Windows).  The folded
+    string is a KEY ONLY — it must never be used for stat or I/O, where the
+    case-preserved :func:`resolve_artifact_path` spelling belongs (a folded
+    spelling need not exist on a case-sensitive filesystem).  Residual:
+    ``normcase`` is a no-op on POSIX, so on macOS (case-insensitive
+    filesystem, case-preserving API) two case spellings of one file can
+    still occupy two slots — the same accepted posture as the JSON cache;
+    the cost is memory residue only, and Windows (where ``normcase`` folds)
+    is fully covered.
     """
-    return os.path.normcase(str(Path(path).expanduser().resolve()))
+    return os.path.normcase(resolve_artifact_path(path))
 
 
 class StatGatedCache(Generic[K, V]):

--- a/src/haute/deploy/_scorer.py
+++ b/src/haute/deploy/_scorer.py
@@ -30,7 +30,7 @@ from haute._io import load_external_object, read_data_source
 from haute._logging import get_logger
 from haute._node_builder import NodeBuildHooks, NodeFnResult, node_fn_name, wrap_builder
 from haute._polars_utils import streaming_collect
-from haute._stat_gated_cache import StatGatedCache, artifact_cache_key
+from haute._stat_gated_cache import StatGatedCache, artifact_cache_key, resolve_artifact_path
 from haute._types import (
     GraphNode,
     NodeType,
@@ -87,17 +87,19 @@ _local_model_cache: StatGatedCache[tuple[str, str], ScoringModel] = StatGatedCac
 
 def _load_local_model_cached(path: str, task: str) -> ScoringModel:
     """Stat-gated process cache over :func:`haute._mlflow_io.load_local_model`."""
-    # Key = normcase(expanduser(resolve())) — normcase is a no-op on POSIX,
-    # so a macOS case-variant spelling still gets its own slot (the same
-    # accepted posture as haute._json_flatten._path_hash).
-    resolved = artifact_cache_key(path)
+    # The SLOT key is case-folded (normcase; a no-op on POSIX, so a macOS
+    # case-variant spelling still gets its own slot — accepted, as in
+    # haute._json_flatten._path_hash). The stat/open path keeps the on-disk
+    # case: a folded spelling need not exist on a case-sensitive filesystem.
+    io_path = resolve_artifact_path(path)
+    key = artifact_cache_key(io_path)
 
     def _load() -> ScoringModel:
         from haute._mlflow_io import load_local_model
 
-        return load_local_model(path, task)
+        return load_local_model(io_path, task)
 
-    return _local_model_cache.get_or_load((resolved, task), resolved, _load)
+    return _local_model_cache.get_or_load((key, task), io_path, _load)
 
 
 def _load_feature_contract_cached(path: str) -> FeatureContract:

--- a/src/haute/deploy/_scorer.py
+++ b/src/haute/deploy/_scorer.py
@@ -30,7 +30,7 @@ from haute._io import load_external_object, read_data_source
 from haute._logging import get_logger
 from haute._node_builder import NodeBuildHooks, NodeFnResult, node_fn_name, wrap_builder
 from haute._polars_utils import streaming_collect
-from haute._stat_gated_cache import StatGatedCache
+from haute._stat_gated_cache import StatGatedCache, artifact_cache_key
 from haute._types import (
     GraphNode,
     NodeType,
@@ -87,7 +87,10 @@ _local_model_cache: StatGatedCache[tuple[str, str], ScoringModel] = StatGatedCac
 
 def _load_local_model_cached(path: str, task: str) -> ScoringModel:
     """Stat-gated process cache over :func:`haute._mlflow_io.load_local_model`."""
-    resolved = str(Path(path).resolve())
+    # Key = normcase(expanduser(resolve())) — normcase is a no-op on POSIX,
+    # so a macOS case-variant spelling still gets its own slot (the same
+    # accepted posture as haute._json_flatten._path_hash).
+    resolved = artifact_cache_key(path)
 
     def _load() -> ScoringModel:
         from haute._mlflow_io import load_local_model

--- a/src/haute/modelling/_feature_contract.py
+++ b/src/haute/modelling/_feature_contract.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
-from haute._stat_gated_cache import StatGatedCache, artifact_cache_key
+from haute._stat_gated_cache import StatGatedCache, artifact_cache_key, resolve_artifact_path
 from haute.errors import FeatureMismatchError
 
 Task = Literal["classification", "regression"]
@@ -276,14 +276,15 @@ def load_contract_cached(path: Path | str) -> FeatureContract:
     loads are never cached.  The returned :class:`FeatureContract` is
     shared across callers and threads — treat it as immutable.
     """
-    # Key = normcase(expanduser(resolve())) — normcase is a no-op on POSIX,
-    # so a macOS case-variant spelling still gets its own slot (the same
-    # accepted posture as haute._json_flatten._path_hash).
-    resolved = artifact_cache_key(path)
+    # The SLOT key is case-folded (normcase; a no-op on POSIX, so a macOS
+    # case-variant spelling still gets its own slot — accepted, as in
+    # haute._json_flatten._path_hash). The stat/open path keeps the on-disk
+    # case: a folded spelling need not exist on a case-sensitive filesystem.
+    io_path = resolve_artifact_path(path)
     return _contract_cache.get_or_load(
-        resolved,
-        resolved,
-        lambda: load_contract(path),
+        artifact_cache_key(io_path),
+        io_path,
+        lambda: load_contract(io_path),
     )
 
 

--- a/src/haute/modelling/_feature_contract.py
+++ b/src/haute/modelling/_feature_contract.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
-from haute._stat_gated_cache import StatGatedCache
+from haute._stat_gated_cache import StatGatedCache, artifact_cache_key
 from haute.errors import FeatureMismatchError
 
 Task = Literal["classification", "regression"]
@@ -276,7 +276,10 @@ def load_contract_cached(path: Path | str) -> FeatureContract:
     loads are never cached.  The returned :class:`FeatureContract` is
     shared across callers and threads — treat it as immutable.
     """
-    resolved = str(Path(path).resolve())
+    # Key = normcase(expanduser(resolve())) — normcase is a no-op on POSIX,
+    # so a macOS case-variant spelling still gets its own slot (the same
+    # accepted posture as haute._json_flatten._path_hash).
+    resolved = artifact_cache_key(path)
     return _contract_cache.get_or_load(
         resolved,
         resolved,

--- a/src/haute/routes/_helpers.py
+++ b/src/haute/routes/_helpers.py
@@ -654,6 +654,19 @@ def discover_pipelines() -> list[Path]:
 _module_deps: dict[str, set[Path]] | None = None
 
 
+def _module_dep_key(module_stem: str) -> str:
+    """Canonical module-dep map key for a module file stem.
+
+    The build side derives stems from ``pipeline.submodel("modules/<name>.py")``
+    source literals; the file-watcher derives them from on-disk filenames.  On
+    a case-insensitive filesystem (macOS/Windows) a literal ``modules/foo.py``
+    resolves against an on-disk ``modules/Foo.py`` — the two spellings name
+    ONE module, so both sides must casefold through this single helper or the
+    map key and the watcher's query silently drift and live-sync goes stale.
+    """
+    return module_stem.casefold()
+
+
 def _ensure_module_deps() -> dict[str, set[Path]]:
     """Build or return the cached module → pipeline dependency map.
 
@@ -679,16 +692,21 @@ def _ensure_module_deps() -> dict[str, set[Path]]:
 
         for rel_path in extract_submodel_calls(tree):
             module_stem = Path(rel_path).stem
-            deps.setdefault(module_stem, set()).add(f)
+            deps.setdefault(_module_dep_key(module_stem), set()).add(f)
 
     _module_deps = deps
     return _module_deps
 
 
 def pipelines_importing_module(module_stem: str) -> list[Path]:
-    """Return the pipeline files that import a given module (by stem name)."""
+    """Return the pipeline files that import a given module (by stem name).
+
+    The stem is matched case-insensitively (see :func:`_module_dep_key`): the
+    watcher passes the on-disk filename's stem, which may differ in case from
+    the ``pipeline.submodel("...")`` source literal the map was built from.
+    """
     deps = _ensure_module_deps()
-    return list(deps.get(module_stem, []))
+    return list(deps.get(_module_dep_key(module_stem), []))
 
 
 def lookup_pipeline_by_name(name: str) -> Path | None:

--- a/tests/test_databricks_io.py
+++ b/tests/test_databricks_io.py
@@ -629,6 +629,42 @@ class TestCachePathTraversal:
 
 
 # ---------------------------------------------------------------------------
+# Cache identity canonicalisation (_cache_path_for)
+# ---------------------------------------------------------------------------
+
+
+class TestCachePathCanonicalisation:
+    """One Databricks table → one cache file, whatever the spelling.
+
+    Databricks resolves unquoted identifiers case-insensitively, and backtick
+    quoting is spelling rather than identity — so case/backtick variants of a
+    single table must derive a single cache path, or the table double-caches
+    on a case-sensitive deploy filesystem and clear-cache under one spelling
+    misses the file written under another.
+    """
+
+    def test_case_variant_spellings_share_one_path(self, tmp_path: Path) -> None:
+        from haute._databricks_io import _cache_path_for
+
+        base = _cache_path_for("mycat.sch.tbl", project_root=tmp_path)
+        assert _cache_path_for("MyCat.Sch.Tbl", project_root=tmp_path) == base
+        assert _cache_path_for("MYCAT.SCH.TBL", project_root=tmp_path) == base
+
+    def test_backtick_quoted_spelling_shares_the_path(self, tmp_path: Path) -> None:
+        from haute._databricks_io import _cache_path_for
+
+        base = _cache_path_for("mycat.sch.tbl", project_root=tmp_path)
+        assert _cache_path_for("`MyCat`.`Sch`.`Tbl`", project_root=tmp_path) == base
+
+    def test_distinct_tables_keep_distinct_paths(self, tmp_path: Path) -> None:
+        from haute._databricks_io import _cache_path_for
+
+        a = _cache_path_for("cat.sch.alpha", project_root=tmp_path)
+        b = _cache_path_for("cat.sch.beta", project_root=tmp_path)
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
 # Gap: EXECUTE IMMEDIATE bypass — only EXEC is blocked, not EXECUTE
 # Production failure: attacker runs arbitrary SQL via EXECUTE IMMEDIATE
 # ---------------------------------------------------------------------------

--- a/tests/test_deploy_scorer_artifact_cache.py
+++ b/tests/test_deploy_scorer_artifact_cache.py
@@ -585,6 +585,80 @@ class TestArtifactCacheUnit:
 
 
 # ---------------------------------------------------------------------------
+# Cache key canonicalisation: normcase(expanduser(resolve()))
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactCacheKeyCanonicalisation:
+    """Cache keys mirror :func:`haute._json_flatten._path_hash`:
+    ``os.path.normcase(str(Path(p).expanduser().resolve()))``.
+
+    ``normcase`` is a no-op on POSIX, so the case-folding tests pin the
+    convention by patching ``os.path.normcase`` (Windows semantics) rather
+    than relying on the host filesystem — pre-fix the call sites keyed on
+    bare ``resolve()`` and never consulted ``normcase`` at all.
+    """
+
+    def test_model_cache_key_folds_case_via_normcase(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from haute.deploy import _scorer
+
+        model_dir = tmp_path / "Models"
+        model_dir.mkdir()
+        cbm_path, _ = _write_bundle(model_dir)
+        monkeypatch.setattr(os.path, "normcase", lambda s: str(s).lower())
+        spy = _LoadSpy()
+
+        with patch("haute._mlflow_io.load_local_model", side_effect=spy):
+            _scorer._load_local_model_cached(str(cbm_path), "regression")
+
+        expected_key = str(cbm_path.resolve()).lower()
+        assert list(_scorer._local_model_cache._entries) == [(expected_key, "regression")]
+
+    def test_contract_cache_key_folds_case_via_normcase(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from haute.modelling import _feature_contract
+
+        bundle_dir = tmp_path / "Bundle"
+        bundle_dir.mkdir()
+        _, contract_path = _write_bundle(bundle_dir)
+        monkeypatch.setattr(os.path, "normcase", lambda s: str(s).lower())
+
+        _feature_contract.load_contract_cached(str(contract_path))
+
+        expected_key = str(contract_path.resolve()).lower()
+        assert list(_feature_contract._contract_cache._entries) == [expected_key]
+
+    def test_relative_and_absolute_spellings_share_one_model_slot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from haute.deploy._scorer import _load_local_model_cached
+
+        cbm_path, _ = _write_bundle(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        spy = _LoadSpy()
+
+        with patch("haute._mlflow_io.load_local_model", side_effect=spy):
+            first = _load_local_model_cached("./model.cbm", "regression")
+            assert _load_local_model_cached(str(cbm_path), "regression") is first
+
+        assert spy.count == 1
+
+    def test_relative_and_absolute_spellings_share_one_contract_slot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from haute.deploy._scorer import _load_feature_contract_cached
+
+        _, contract_path = _write_bundle(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        first = _load_feature_contract_cached("./" + CONTRACT_FILENAME)
+        assert _load_feature_contract_cached(str(contract_path)) is first
+
+
+# ---------------------------------------------------------------------------
 # Behaviour identical apart from caching
 # ---------------------------------------------------------------------------
 

--- a/tests/test_route_helpers_contracts.py
+++ b/tests/test_route_helpers_contracts.py
@@ -56,6 +56,28 @@ def test_pipelines_importing_module_skips_broken_pipeline_source(tmp_path: Path)
         assert helpers.pipelines_importing_module("shared") == []
 
 
+def test_pipelines_importing_module_matches_stem_case_insensitively(tmp_path: Path) -> None:
+    """Build-side stems come from ``pipeline.submodel("...")`` source literals;
+    the watcher passes the ON-DISK filename's stem.  On a case-insensitive
+    filesystem (macOS/Windows) ``modules/rates.py`` in source resolves against
+    an on-disk ``modules/Rates.py`` — one module, two spellings — so the map
+    must be hit regardless of stem case or live-sync silently goes stale."""
+    pricing = tmp_path / "pricing.py"
+    shared = tmp_path / "shared.py"
+    _write_pipeline(pricing, "modules/rates.py")  # lowercase source literal
+    _write_pipeline(shared, "modules/BaseRates.py")  # mixed-case source literal
+
+    helpers.invalidate_pipeline_index()
+    with patch("haute.routes._helpers.discover_pipelines", return_value=[pricing, shared]):
+        # Watcher queries with a differently-cased on-disk stem.
+        assert helpers.pipelines_importing_module("Rates") == [pricing]
+        assert helpers.pipelines_importing_module("RATES") == [pricing]
+        assert helpers.pipelines_importing_module("baserates") == [shared]
+        # Same-case queries still hit, and distinct stems stay distinct.
+        assert helpers.pipelines_importing_module("rates") == [pricing]
+        assert helpers.pipelines_importing_module("other") == []
+
+
 def test_parse_pipeline_to_graph_normalizes_sidecar_sources(tmp_path: Path) -> None:
     py_path = tmp_path / "pipeline.py"
     _write_pipeline(py_path)


### PR DESCRIPTION
## What

Three same-family fixes (mapping-equivalence audit, all verified): comparisons keyed by raw strings where the underlying artefact's identity is coarser.

1. **Module-dep map vs file-watcher stem-case drift** (macOS/Windows, silent). The module→pipelines map keyed by the `pipeline.submodel("modules/<name>.py")` source-literal stem; the watcher queried with the on-disk filename's stem. A case-mismatched pair works everywhere else (resolution is case-insensitive), so the drift never self-corrects — module edits stopped live-syncing the dependent pipeline's canvas. Both sides now derive keys through one shared `_module_dep_key` (casefold), so they cannot drift.
2. **Databricks table cache split** (Linux deploys). Databricks resolves unquoted identifiers case-insensitively and backticks are spelling, not identity — but `_cache_path_for` preserved both, so one table double-cached (repeat multi-GB fetches) and clear-cache under another spelling missed the live file. New `_canonical_table` (strip backticks + casefold) feeds the filename; all routes funnel through it. Existing mixed-case on-disk caches become invisible — a one-off re-fetch, accepted.
3. **Stat-gated artifact caches** (macOS/Windows, memory residue). `load_contract_cached` / `_load_local_model_cached` keyed on `resolve()` without case normalization — two spellings of one model file held two deserialized copies in RAM. New `artifact_cache_key` mirrors the `_json_flatten._path_hash` house pattern (normcase+expanduser+resolve); the POSIX no-op residual is documented as the same accepted posture as the JSON cache.

## Verification

- All three characterized failing pre-fix (tests written first; fix lines temporarily reverted for 1–2). Windows normcase simulated by monkeypatching; a Cyrillic-homoglyph table name stays distinct under casefold.
- Full suite 12335 passed; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)