### PR TITLE
save: 400 when a written filename is a Windows reserved device name

### DIFF
--- a/src/haute/_config_io.py
+++ b/src/haute/_config_io.py
@@ -206,6 +206,39 @@ def _remap_config_ids_for_saved_graph(
 # Path helpers
 # ---------------------------------------------------------------------------
 
+# Windows reserves the DOS device names below: a filename whose stem before
+# the FIRST dot matches one of them, case-insensitively and with ANY
+# extension, denotes the device rather than a file (``CON.json`` is the
+# console, ``NUL.py`` is the null device). Creating such a file fails or
+# silently aliases the device on any Windows checkout.
+_WINDOWS_RESERVED_DEVICE_STEMS: frozenset[str] = frozenset(
+    {"con", "prn", "aux", "nul"}
+    | {f"com{i}" for i in range(1, 10)}
+    | {f"lpt{i}" for i in range(1, 10)}
+)
+
+
+def is_windows_reserved_filename(filename: str) -> bool:
+    """Whether *filename* names a reserved DOS device on Windows.
+
+    The stem before the FIRST dot is compared casefolded against the
+    reserved set (CON, PRN, AUX, NUL, COM1-COM9, LPT1-LPT9) — the
+    extension is irrelevant, so ``CON.json`` and ``nul.tar.gz`` are both
+    reserved while ``CONTRACT.json`` and ``COM10.json`` are not.
+
+    Windows additionally strips trailing dots and spaces when resolving
+    names; sanitized node names cannot carry those, but the check strips
+    them anyway so the predicate is robust for any caller.
+
+    Used by the save-time guards (``routes/_save_pipeline.py``,
+    ``routes/submodel.py``) that reject these filenames on EVERY
+    platform, mirroring the portability rationale of the casefold
+    collision guards: rejecting on every platform keeps a pipeline saved
+    on Linux/macOS loadable on a Windows checkout.
+    """
+    stem = filename.rstrip(" .").split(".", 1)[0].rstrip(" .")
+    return stem.casefold() in _WINDOWS_RESERVED_DEVICE_STEMS
+
 
 def has_config_folder(node_type: NodeType) -> bool:
     """Whether this node type stores config in an external JSON file."""

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -380,6 +380,29 @@ class SavePipelineService:
                 detail="Codegen output path contains a traversal segment ('..').",
             )
 
+        # Reserved device names are rejected on EVERY platform, mirroring the
+        # casefold collision guards: a generated ``modules/NUL.py`` (or a main
+        # file named ``CON.py``) names a device, not a file, on Windows — any
+        # extension, any casing. Rejecting on every platform keeps a pipeline
+        # saved on Linux/macOS loadable on a Windows checkout.
+        from haute._config_io import is_windows_reserved_filename
+
+        filename = normalised.rsplit("/", 1)[-1]
+        if is_windows_reserved_filename(filename):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Codegen output filename {filename!r} is a reserved "
+                    "device name on Windows. Windows treats a filename whose "
+                    "stem is CON, PRN, AUX, NUL, COM1-COM9 or LPT1-LPT9 (any "
+                    "casing, any extension) as a device, not a file, so it "
+                    "cannot be written or checked out there. The name is "
+                    "rejected on every platform so a pipeline saved here "
+                    "stays loadable on a Windows checkout. Rename the node "
+                    "or submodel before saving."
+                ),
+            )
+
         allowed_main = (source_file or "").replace("\\", "/")
 
         out_path: Path | None
@@ -779,7 +802,11 @@ class SavePipelineService:
 
     @staticmethod
     def _validate_unique_config_paths_in_graph(graph: PipelineGraph) -> None:
-        from haute._config_io import config_path_for_node, has_config_folder
+        from haute._config_io import (
+            config_path_for_node,
+            has_config_folder,
+            is_windows_reserved_filename,
+        )
 
         # Compare paths casefolded: labels differing only in case (``Foo`` /
         # ``foo``) sanitize to distinct Python identifiers, but their sidecars
@@ -788,8 +815,15 @@ class SavePipelineService:
         # second write silently overwrites the first. Rejecting the collision
         # on every platform keeps a pipeline saved on Linux loadable on a
         # macOS/Windows checkout.
+        #
+        # Reserved device names get the same all-platform treatment: a label
+        # like ``CON`` sanitizes to a valid identifier, but its sidecar
+        # ``CON.json`` names the console device, not a file, on Windows —
+        # regardless of extension. Rejecting on every platform keeps a
+        # pipeline saved on Linux/macOS loadable on a Windows checkout.
         seen: dict[str, str] = {}
         duplicates: set[str] = set()
+        reserved: set[str] = set()
         for node in graph.nodes:
             nt = node.data.nodeType
             if not has_config_folder(nt):
@@ -798,11 +832,14 @@ class SavePipelineService:
                 continue
             func_name = _sanitize_func_name(node.data.label)
             rel_path = config_path_for_node(nt, func_name).as_posix()
+            if is_windows_reserved_filename(f"{func_name}.json"):
+                reserved.add(rel_path)
             folded = rel_path.casefold()
             if folded in seen:
                 duplicates.update((seen[folded], rel_path))
             else:
                 seen[folded] = rel_path
+        SavePipelineService._raise_reserved_device_filenames(reserved)
         SavePipelineService._raise_config_path_conflicts(duplicates)
 
     @staticmethod
@@ -821,6 +858,24 @@ class SavePipelineService:
             target[rel_path] = content
             folded_target[folded] = rel_path
         SavePipelineService._raise_config_path_conflicts(duplicates)
+
+    @staticmethod
+    def _raise_reserved_device_filenames(paths: set[str]) -> None:
+        if not paths:
+            return
+        formatted = ", ".join(repr(path) for path in sorted(paths))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Filename is a reserved device name on Windows: {formatted}. "
+                "Windows treats a filename whose stem is CON, PRN, AUX, NUL, "
+                "COM1-COM9 or LPT1-LPT9 (any casing, any extension) as a "
+                "device, not a file, so it cannot be written or checked out "
+                "there. The name is rejected on every platform so a pipeline "
+                "saved here stays loadable on a Windows checkout. Rename the "
+                "node before saving."
+            ),
+        )
 
     @staticmethod
     def _raise_config_path_conflicts(paths: set[str]) -> None:

--- a/src/haute/routes/submodel.py
+++ b/src/haute/routes/submodel.py
@@ -48,6 +48,30 @@ async def create_submodel(body: CreateSubmodelRequest) -> CreateSubmodelResponse
     def _run() -> CreateSubmodelResponse:
         SavePipelineService._validate_unique_sanitized_names(body.graph)
 
+        # Reject reserved device names at creation, before the graph is
+        # transformed: a submodel named ``NUL`` would mint ``modules/NUL.py``,
+        # which names a device, not a file, on Windows (any casing, any
+        # extension). Enforced on every platform — mirroring the save
+        # pipeline's casefold and reserved-name guards — so a pipeline saved
+        # on Linux/macOS stays loadable on a Windows checkout. The save-time
+        # allowlist (``_validate_output_rel_path``) backstops this check.
+        from haute._config_io import is_windows_reserved_filename
+        from haute.graph_utils import _sanitize_func_name
+
+        sm_filename = f"{_sanitize_func_name(body.name)}.py"
+        if is_windows_reserved_filename(sm_filename):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Submodel name {body.name!r} would create module file "
+                    f"'modules/{sm_filename}', whose name is a reserved "
+                    "device name on Windows (CON, PRN, AUX, NUL, COM1-COM9, "
+                    "LPT1-LPT9 — any casing, any extension). Windows treats "
+                    "it as a device, not a file, so it cannot be written or "
+                    "checked out there. Choose a different submodel name."
+                ),
+            )
+
         try:
             result = create_submodel_graph(body.graph, body.node_ids, body.name)
         except ValueError:

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -17,6 +17,7 @@ from haute._config_io import (
     config_path_for_node,
     find_config_by_func_name,
     has_config_folder,
+    is_windows_reserved_filename,
     load_node_config,
     remove_config_file,
 )
@@ -811,14 +812,69 @@ class TestConfigPathForNodeEdgeCases:
         p = config_path_for_node(NodeType.BANDING, ".")
         assert p == Path("config/banding/..json")
 
-    @pytest.mark.skipif(
-        __import__("sys").platform != "win32",
-        reason="Windows-specific reserved name test",
-    )
-    def test_windows_reserved_names_produce_paths(self):
+    def test_windows_reserved_names_produce_paths_here_but_flag_as_reserved(self):
+        """Path construction stays permissive; the predicate is the guard.
+
+        ``config_path_for_node`` is not the reserved-name choke point — the
+        save pipeline rejects reserved device stems on EVERY platform via
+        ``is_windows_reserved_filename`` (see
+        ``routes/_save_pipeline.py``), so this runs everywhere, not just
+        on win32.
+        """
         for name in ("CON", "PRN", "AUX"):
             p = config_path_for_node(NodeType.BANDING, name)
             assert p == Path(f"config/banding/{name}.json")
+            assert is_windows_reserved_filename(p.name)
+
+
+class TestIsWindowsReservedFilename:
+    """All-platform truth table for the reserved device-name predicate.
+
+    The stem before the FIRST dot is what Windows compares, case-
+    insensitively and regardless of extension.
+    """
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "CON",
+            "CON.json",
+            "con.json",
+            "Con.py",
+            "PRN.json",
+            "AUX.json",
+            "NUL.py",
+            "nul.tar.gz",  # stem before the FIRST dot
+            "Com1.json",
+            "COM9.py",
+            "lpt1.json",
+            "LPT9.py",
+            "CON.",  # trailing dot stripped by Windows name resolution
+            "CON .json",  # trailing space in stem stripped likewise
+        ],
+    )
+    def test_reserved(self, filename):
+        assert is_windows_reserved_filename(filename)
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "CONTRACT.json",
+            "CONS.json",
+            "COM.json",  # bare COM is not reserved, only COM1-COM9
+            "COM10.json",  # two-digit units are ordinary names
+            "COM0.json",
+            "LPT.json",
+            "LPT0.json",
+            "LPT10.json",
+            "NULL.json",
+            "banding.json",
+            ".json",  # empty stem
+            "",
+        ],
+    )
+    def test_not_reserved(self, filename):
+        assert not is_windows_reserved_filename(filename)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_path_resolution_properties.py
+++ b/tests/test_path_resolution_properties.py
@@ -8,6 +8,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+from haute._config_io import is_windows_reserved_filename
 from haute._path_resolution import resolve_runtime_file_path
 
 _WINDOWS_RESERVED_NAMES = {
@@ -19,12 +20,42 @@ _WINDOWS_RESERVED_NAMES = {
     *(f"LPT{i}" for i in range(1, 10)),
 }
 
+# The safe strategies below deliberately filter reserved names OUT, because
+# these properties assume the generated paths are writable on every platform.
+# ``TestWindowsReservedNameProperties`` inverts that: it deliberately
+# generates reserved-stem filenames and asserts the save-time predicate
+# flags every one.
 _SAFE_PATH_PART = st.text(
     alphabet=string.ascii_letters + string.digits + "_-",
     min_size=1,
     max_size=12,
 ).filter(lambda value: value.upper() not in _WINDOWS_RESERVED_NAMES)
 _SAFE_RELATIVE_PATH = st.lists(_SAFE_PATH_PART, min_size=1, max_size=4)
+
+
+def _mix_case(stem: str, flags: list[bool]) -> str:
+    return "".join(
+        ch.upper() if flag else ch.lower()
+        for ch, flag in zip(stem, flags + [False] * (len(stem) - len(flags)))
+    )
+
+
+_EXTENSION_PART = st.text(
+    alphabet=string.ascii_letters + string.digits,
+    min_size=1,
+    max_size=8,
+)
+
+# A reserved stem in arbitrary casing, with zero or more dot-joined
+# extensions (``NUL``, ``con.json``, ``Com1.tar.gz``, ...). Windows
+# compares the stem before the FIRST dot, case-insensitively, with any
+# extension.
+_RESERVED_STEM_FILENAME = st.builds(
+    lambda stem, flags, exts: ".".join([_mix_case(stem, flags), *exts]),
+    st.sampled_from(sorted(_WINDOWS_RESERVED_NAMES)),
+    st.lists(st.booleans(), min_size=1, max_size=4),
+    st.lists(_EXTENSION_PART, min_size=0, max_size=2),
+)
 
 
 class TestPathResolutionProperties:
@@ -184,3 +215,20 @@ class TestPathResolutionProperties:
         )
 
         assert resolved_from_source == resolved_from_pipeline_dir
+
+
+class TestWindowsReservedNameProperties:
+    """Property coverage for the save-time reserved device-name predicate."""
+
+    @given(filename=_RESERVED_STEM_FILENAME)
+    @settings(max_examples=200)
+    def test_predicate_flags_every_reserved_stem(self, filename: str) -> None:
+        """Every reserved stem is flagged — any casing, any extension chain."""
+        assert is_windows_reserved_filename(filename)
+
+    @given(part=_SAFE_PATH_PART, extension=_EXTENSION_PART)
+    @settings(max_examples=200)
+    def test_predicate_never_flags_safe_names(self, part: str, extension: str) -> None:
+        """Names the safe strategies deem writable are never flagged."""
+        assert not is_windows_reserved_filename(part)
+        assert not is_windows_reserved_filename(f"{part}.{extension}")

--- a/tests/test_pipeline_runtime_path_validation.py
+++ b/tests/test_pipeline_runtime_path_validation.py
@@ -268,6 +268,100 @@ def test_codegen_distinct_module_paths_still_write(tmp_path: Path) -> None:
     assert (tmp_path / "modules" / "claims.py").is_file()
 
 
+# ---------------------------------------------------------------------------
+# Windows-reserved device names in save-time filenames.
+#
+# A node label like ``CON`` sanitizes to a valid Python identifier, but its
+# sidecar ``config/<type>/CON.json`` (and a submodel's ``modules/NUL.py``)
+# names a DOS device, not a file, on Windows — case-insensitively and with
+# ANY extension. The save-time guards therefore reject reserved stems (CON,
+# PRN, AUX, NUL, COM1-COM9, LPT1-LPT9) on every platform, mirroring the
+# casefold collision guards above. Like those guards, these tests live in
+# this file because it runs on the macOS/Windows platform-smoke CI legs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", ["CON", "con", "Com1", "LPT9"])
+def test_reserved_device_label_rejected_before_any_config_write(
+    tmp_path: Path,
+    label: str,
+) -> None:
+    """A config-bearing node whose sidecar stem is a reserved device must not save."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(nodes=[_config_node("a", label)], edges=[])
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_config_files(graph)
+
+    assert exc_info.value.status_code == 400
+    assert "reserved device name on Windows" in exc_info.value.detail
+    assert f"config/data_source/{label}.json" in exc_info.value.detail
+    # Rejected before any write: nothing reached the disk.
+    assert not (tmp_path / "config").exists()
+
+
+def test_reserved_device_label_in_submodel_graph_rejected(tmp_path: Path) -> None:
+    """A reserved-stem sidecar inside an embedded submodel graph must not save."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(nodes=[_config_node("parent", "Safe")], edges=[])
+    child = _config_node("child", "NUL")
+    graph.submodels = {
+        "pricing": {
+            "file": "modules/pricing.py",
+            "graph": {"nodes": [child.model_dump(mode="json")], "edges": []},
+        }
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_config_files(graph)
+
+    assert exc_info.value.status_code == 400
+    assert "reserved device name on Windows" in exc_info.value.detail
+    assert not (tmp_path / "config").exists()
+
+
+@pytest.mark.parametrize("label", ["CONTRACT", "CONS", "COM", "COM10"])
+def test_near_reserved_labels_still_save(tmp_path: Path, label: str) -> None:
+    """The reserved-name guard must not over-trigger on near-miss names."""
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(nodes=[_config_node("a", label)], edges=[])
+
+    svc._write_config_files(graph)
+
+    assert (tmp_path / "config" / "data_source" / f"{label}.json").is_file()
+
+
+def test_codegen_reserved_module_filename_rejected_before_any_write(
+    tmp_path: Path,
+) -> None:
+    """A submodel named ``NUL`` mints ``modules/NUL.py`` — rejected at codegen."""
+    svc = SavePipelineService(tmp_path)
+    files = {"main.py": "# main", "modules/NUL.py": "# device, not a file"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_generated_code_files(files, "main.py", [])
+
+    assert exc_info.value.status_code == 400
+    assert "reserved device name on Windows" in exc_info.value.detail
+    assert "'NUL.py'" in exc_info.value.detail
+    # Rejected before any write: neither file reached the disk.
+    assert not (tmp_path / "modules").exists()
+    assert not (tmp_path / "main.py").exists()
+
+
+def test_codegen_reserved_main_filename_rejected(tmp_path: Path) -> None:
+    """The main pipeline file gets the same reserved-stem treatment."""
+    svc = SavePipelineService(tmp_path)
+    files = {"CON.py": "# console, not a file"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        svc._write_generated_code_files(files, "CON.py", [])
+
+    assert exc_info.value.status_code == 400
+    assert "reserved device name on Windows" in exc_info.value.detail
+    assert not (tmp_path / "CON.py").exists()
+
+
 def test_validate_runtime_input_paths_checks_optimiser_apply_file_mode_only() -> None:
     file_graph = PipelineGraph(
         nodes=[

--- a/tests/test_test_debt.py
+++ b/tests/test_test_debt.py
@@ -66,7 +66,8 @@ _EXPECTED_DEBT_IDS = {
     "923dd77d913747c1",
     "ecfff38c87946544",
     "24665ee51c5161bd",
-    "0a01b882fcbd3dde",
+    # (test_windows_reserved_names_produce_paths's win32 skipif retired: the
+    # test is now an all-platform predicate check, so its debt entry is gone.)
     "6d705bbf63d485c1",
     "27f1c7562a3e3d53",
     "578c7caa35870e0c",


### PR DESCRIPTION
## What

Closes the "beyond case" gap from PR #43 (mapping-equivalence audit, verified twice): Windows treats a filename whose stem before the first dot is CON, PRN, AUX, NUL, COM1-9 or LPT1-9 — any casing, ANY extension — as the device, not a file. Labels like `CON`/`nul` sanitize unchanged, so saves wrote `config/banding/CON.json` or `modules/NUL.py`: unwritable or silently aliased on every Windows checkout. No existing guard recognised reserved stems.

## The fix (ruled: 400 keyed on the written FILENAME, all platforms)

One canonical predicate `is_windows_reserved_filename` (`_config_io.py`; trailing dot/space-robust, stem before first dot, casefolded), enforced at three seams: the config-sidecar path collection, the codegen output allowlist (`modules/<sm>.py` + main file), and submodel creation (rejected before the graph transform; save-time guard as backstop). Enforced on every platform, matching the casefold guards' portability rationale — a pipeline saved on Linux/macOS must stay loadable on a Windows checkout. Sanitizers untouched (parity fixture pins their output).

## Verification

- Characterization: predicate temporarily neutered → 23 new tests fail; restored → pass.
- New reserved-stem block in the platform-smoke test file (runs on real macOS/Windows CI filesystems): CON/con/Com1/LPT9 rejected pre-write; negatives CONTRACT/CONS/COM/COM10 still save; submodel NUL rejected; codegen paths covered.
- The old `skipif win32` test — which executed on NO CI leg — replaced by an all-platform predicate truth table (its reviewed test-debt entry retired). The Hypothesis property suite now deliberately GENERATES reserved stems and asserts the predicate, instead of filtering them out.
- Full suite 12367 passed; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)