### PR TITLE
save: align sanitized-name guard scope with codegen (global; per-graph + cross-module)

### DIFF
--- a/src/haute/codegen.py
+++ b/src/haute/codegen.py
@@ -516,6 +516,15 @@ def _error_on_name_collisions(labels: list[str]) -> None:
 
     Pass a flat list of every label that will ultimately become a
     function name in any emitted file (root graph + every submodel).
+    The scope is deliberately GLOBAL, not per-file: a root node and a
+    submodel node emit ``def``s into different Python modules (legal as
+    files), but at run/preview/trace time ``flatten_graph`` dissolves
+    every submodel into ONE graph keyed by ``node.id`` — which
+    round-trips to the sanitised function name — so a cross-module
+    duplicate silently shadows its twin in ``PipelineGraph.node_map``.
+    Do NOT relax this to per-file bucketing without changing how the
+    flattened execution graph is keyed.
+
     The raised :class:`ParseError` enumerates every colliding bucket
     so the user can fix them all in one editing pass.
     """
@@ -545,8 +554,11 @@ def _error_on_name_collisions(labels: list[str]) -> None:
     )
     raise ParseError(
         "Multiple node labels sanitize to the same Python function name. "
-        "Rename the offending nodes so each label produces a unique "
-        "identifier:\n"
+        "Node names must be unique across the whole pipeline, including "
+        "its submodels: submodels run in one flattened namespace with the "
+        "main pipeline, so a duplicate would silently shadow its twin at "
+        "execution time. Rename the offending nodes so each label "
+        "produces a unique identifier:\n"
         f"{bullets}",
         collisions={k: list(v) for k, v in collisions.items()},
     )

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -312,9 +312,7 @@ class SavePipelineService:
                 name: labels for name, labels in sanitized_to_labels.items() if len(labels) > 1
             }
             if collisions:
-                parts = [
-                    f"  {name!r} <- {labels!r}" for name, labels in sorted(collisions.items())
-                ]
+                parts = [f"  {name!r} <- {labels!r}" for name, labels in sorted(collisions.items())]
                 raise HTTPException(
                     status_code=400,
                     detail=(

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -269,25 +269,126 @@ class SavePipelineService:
 
     @staticmethod
     def _validate_unique_sanitized_names(graph: PipelineGraph) -> None:
-        """Reject graphs where distinct node labels sanitize to the same function name."""
-        sanitized_to_labels: dict[str, list[str]] = defaultdict(list)
-        for node in graph.nodes:
-            sanitized = _sanitize_func_name(node.data.label)
-            sanitized_to_labels[sanitized].append(node.data.label)
+        """Reject graphs where node labels sanitize to the same function name.
 
-        collisions = {
-            name: labels for name, labels in sanitized_to_labels.items() if len(labels) > 1
+        Scope is GLOBAL across the root graph and every embedded submodel
+        graph, matching codegen's ``_error_on_name_collisions``.  The
+        load-bearing reason is runtime flattening: preview/trace/run call
+        ``flatten_graph`` which inlines every submodel child into ONE
+        graph keyed by ``node.id`` — and ``node.id`` round-trips to the
+        sanitised function name for root and submodel nodes alike
+        (``_graph_builders._build_rf_nodes``).  ``PipelineGraph.node_map``
+        is a plain ``{n.id: n}`` dict, so a cross-module duplicate would
+        silently shadow its twin at execution time.
+
+        Two passes:
+
+        * per-graph — any two nodes in the SAME graph (root, or one
+          submodel) whose labels sanitise identically.  This preserves the
+          historical root-graph semantics unchanged (identical labels
+          collide too) and extends them to each submodel graph, closing
+          the gap where in-submodel collisions escaped this guard and
+          surfaced as codegen ``ParseError`` (an unhandled 500).
+        * cross-module — a sanitised name used in more than one module.
+          Structural ``SUBMODEL`` / ``SUBMODEL_PORT`` nodes are excluded
+          from this pass: a submodel placeholder legally shares its label
+          with one of its own children (the placeholder's runtime id is
+          ``submodel__<name>``-prefixed and it never emits a ``def``).
+        """
+        scoped_graphs: list[tuple[str, PipelineGraph]] = [("the pipeline", graph)]
+        scoped_graphs.extend(
+            (f"submodel {name!r}", nested)
+            for name, nested in SavePipelineService._iter_named_embedded_submodel_graphs(graph)
+        )
+
+        # Pass 1 — collisions within a single graph (root or one submodel).
+        for scope, scoped_graph in scoped_graphs:
+            sanitized_to_labels: dict[str, list[str]] = defaultdict(list)
+            for node in scoped_graph.nodes:
+                sanitized = _sanitize_func_name(node.data.label)
+                sanitized_to_labels[sanitized].append(node.data.label)
+
+            collisions = {
+                name: labels for name, labels in sanitized_to_labels.items() if len(labels) > 1
+            }
+            if collisions:
+                parts = [
+                    f"  {name!r} <- {labels!r}" for name, labels in sorted(collisions.items())
+                ]
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Duplicate sanitized node names detected in {scope}. "
+                        "The following node labels produce the same Python "
+                        "function name:\n" + "\n".join(parts)
+                    ),
+                )
+
+        # Pass 2 — collisions across modules.  Submodels execute in one
+        # flattened namespace with the root graph, so a sanitised name may
+        # only be used in a single module.  Nodes are assigned to modules
+        # the same way codegen assigns them to files
+        # (``graph_to_code_multi``): a node listed in some submodel's
+        # ``childNodeIds`` belongs to that submodel even when a payload
+        # also duplicates it in the parent ``nodes`` list, so such
+        # duplicates must not be double-counted as a root-module use.
+        structural_types = (NodeType.SUBMODEL, NodeType.SUBMODEL_PORT)
+        sanitized_to_scoped: dict[str, dict[str, list[str]]] = defaultdict(dict)
+        for scope, scoped_graph in scoped_graphs:
+            child_ids: set[str] = set()
+            for sm_meta in (scoped_graph.submodels or {}).values():
+                child_ids.update(sm_meta.get("childNodeIds", []))
+            for node in scoped_graph.nodes:
+                if node.data.nodeType in structural_types:
+                    continue
+                if node.id in child_ids:
+                    continue
+                sanitized = _sanitize_func_name(node.data.label)
+                sanitized_to_scoped[sanitized].setdefault(scope, []).append(node.data.label)
+
+        cross_module = {
+            name: scopes for name, scopes in sanitized_to_scoped.items() if len(scopes) > 1
         }
-        if collisions:
-            parts = [f"  {name!r} <- {labels!r}" for name, labels in sorted(collisions.items())]
+        if cross_module:
+            parts = [
+                f"  {name!r} <- "
+                + "; ".join(f"{labels!r} in {scope}" for scope, labels in scopes.items())
+                for name, scopes in sorted(cross_module.items())
+            ]
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "Duplicate sanitized node names detected. "
-                    "The following node labels produce the same Python "
-                    "function name:\n" + "\n".join(parts)
+                    "Duplicate sanitized node names detected across the "
+                    "pipeline and its submodels. Submodels run in one "
+                    "flattened namespace with the main pipeline, so each "
+                    "node name may be used in only one module:\n" + "\n".join(parts)
                 ),
             )
+
+    @staticmethod
+    def _iter_named_embedded_submodel_graphs(
+        graph: PipelineGraph,
+    ) -> Iterator[tuple[str, PipelineGraph]]:
+        """Yield ``(submodel_name, embedded_graph)`` pairs, recursively.
+
+        Nested submodels are unsupported (the parser warns and drops
+        them), but recurse defensively so a crafted payload cannot smuggle
+        a colliding node past the guard inside a nested graph.
+        """
+        for sm_name, sm_meta in (graph.submodels or {}).items():
+            sm_graph_dict: Any = sm_meta.get("graph", {})
+            nested = PipelineGraph.model_validate(
+                {
+                    "nodes": sm_graph_dict.get("nodes", []),
+                    "edges": sm_graph_dict.get("edges", []),
+                    "submodels": sm_graph_dict.get("submodels"),
+                }
+            )
+            yield sm_name, nested
+            for deep_name, deep_graph in SavePipelineService._iter_named_embedded_submodel_graphs(
+                nested
+            ):
+                yield f"{sm_name}/{deep_name}", deep_graph
 
     @staticmethod
     def _validate_no_load_errors(graph: PipelineGraph) -> None:

--- a/tests/test_route_save_pipeline.py
+++ b/tests/test_route_save_pipeline.py
@@ -209,6 +209,159 @@ class TestValidateUniqueSanitizedNames:
 
 
 # ---------------------------------------------------------------------------
+# _validate_unique_sanitized_names — recursive (submodel-aware) scope
+# ---------------------------------------------------------------------------
+
+
+def _make_submodel_graph(
+    *nodes: GraphNode,
+    sm_name: str = "pricing",
+    root_nodes: tuple[GraphNode, ...] = (),
+    include_placeholder: bool = True,
+) -> PipelineGraph:
+    """Build a hierarchical graph with one embedded submodel.
+
+    Mirrors the shape ``merge_submodels`` produces: a ``submodel__<name>``
+    placeholder node in the root ``nodes`` list plus the full child graph
+    stashed under ``submodels[<name>]["graph"]``.
+    """
+    all_root: list[GraphNode] = list(root_nodes)
+    if include_placeholder:
+        all_root.append(
+            _make_node(f"submodel__{sm_name}", sm_name, "submodel", {})
+        )
+    return PipelineGraph(
+        nodes=all_root,
+        edges=[],
+        submodels={
+            sm_name: {
+                "file": f"modules/{sm_name}.py",
+                "childNodeIds": [n.id for n in nodes],
+                "graph": {
+                    "nodes": [n.model_dump() for n in nodes],
+                    "edges": [],
+                },
+            }
+        },
+    )
+
+
+class TestValidateUniqueSanitizedNamesRecursiveScope:
+    """Global (root + submodel) scope for the save-side name guard.
+
+    Runtime is the load-bearing reason: preview/trace/run call
+    ``flatten_graph`` which inlines every submodel child into ONE graph
+    keyed by ``node.id`` — and ``node.id`` round-trips to the sanitised
+    function name for root and submodel nodes alike
+    (``_graph_builders._build_rf_nodes``).  ``PipelineGraph.node_map`` is a
+    plain ``{n.id: n}`` dict, so a cross-module duplicate silently shadows
+    its twin at execution time.  The save guard must therefore agree with
+    codegen's ``_error_on_name_collisions`` global scope, and reject with a
+    clean 400 instead of leaking codegen's ParseError as a 500.
+    """
+
+    def test_cross_module_distinct_labels_raise_400(self) -> None:
+        """Root 'Foo Bar' + submodel child 'Foo-Bar' sanitize identically."""
+        graph = _make_submodel_graph(
+            _make_node("child", "Foo-Bar", "polars", {"code": "df"}),
+            root_nodes=(_make_node("root", "Foo Bar", "polars", {"code": "df"}),),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService._validate_unique_sanitized_names(graph)
+        assert exc_info.value.status_code == 400
+        assert "Foo_Bar" in exc_info.value.detail
+
+    def test_cross_module_identical_labels_raise_400(self) -> None:
+        """Root 'Foo' + submodel child 'Foo': identical ids after round-trip,
+        so the flattened execution graph silently drops one of them."""
+        graph = _make_submodel_graph(
+            _make_node("child", "Foo", "polars", {"code": "df"}),
+            root_nodes=(_make_node("root", "Foo", "polars", {"code": "df"}),),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService._validate_unique_sanitized_names(graph)
+        assert exc_info.value.status_code == 400
+        assert "Foo" in exc_info.value.detail
+
+    def test_collision_inside_one_submodel_raises_400(self) -> None:
+        """Two colliding children INSIDE one submodel must be caught at save
+        time (previously escaped the root-only guard and hit codegen's
+        ParseError as a 500)."""
+        graph = _make_submodel_graph(
+            _make_node("c1", "my-node", "polars", {"code": "df"}),
+            _make_node("c2", "my_node", "polars", {"code": "df"}),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService._validate_unique_sanitized_names(graph)
+        assert exc_info.value.status_code == 400
+        assert "my_node" in exc_info.value.detail
+
+    def test_submodel_placeholder_matching_its_child_passes(self) -> None:
+        """A submodel named after one of its own children is legal: the
+        placeholder's runtime id is ``submodel__<name>`` (never collides)
+        and no ``def`` is emitted for it.  Guard must NOT over-reject."""
+        graph = _make_submodel_graph(
+            _make_node("pricing", "pricing", "polars", {"code": "df"}),
+            sm_name="pricing",
+        )
+        SavePipelineService._validate_unique_sanitized_names(graph)
+
+    def test_root_node_vs_placeholder_same_label_still_raises_400(self) -> None:
+        """Pin current root-graph semantics: a root node whose label matches
+        a submodel placeholder's label collides within the root bucket."""
+        graph = _make_submodel_graph(
+            _make_node("child", "unrelated", "polars", {"code": "df"}),
+            sm_name="pricing",
+            root_nodes=(_make_node("root", "pricing", "polars", {"code": "df"}),),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService._validate_unique_sanitized_names(graph)
+        assert exc_info.value.status_code == 400
+
+    def test_child_duplicated_in_root_nodes_passes(self) -> None:
+        """Some payloads duplicate a submodel child in the parent ``nodes``
+        list (codegen tolerates this via its ``root_nodes`` filter on
+        ``childNodeIds``).  The duplicate is ONE node in one module, not a
+        cross-module collision — guard must not reject it."""
+        child = _make_node("a", "a", "polars", {"code": "df"})
+        graph = _make_submodel_graph(
+            child,
+            sm_name="sm1",
+            root_nodes=(child,),
+            include_placeholder=False,
+        )
+        SavePipelineService._validate_unique_sanitized_names(graph)
+
+    def test_distinct_names_across_modules_pass(self) -> None:
+        """No collision: distinct sanitized names everywhere."""
+        graph = _make_submodel_graph(
+            _make_node("c1", "Base Rate", "polars", {"code": "df"}),
+            _make_node("c2", "Adjust", "polars", {"code": "df"}),
+            root_nodes=(_make_node("root", "Load Data", "polars", {"code": "df"}),),
+        )
+        SavePipelineService._validate_unique_sanitized_names(graph)
+
+    def test_save_rejects_cross_module_collision_with_400(self, tmp_path: Path) -> None:
+        """End-to-end through ``save()``: the guard fires before codegen, so
+        the caller sees a clean 400 (not codegen's ParseError as a 500)."""
+        graph = _make_submodel_graph(
+            _make_node("child", "Foo-Bar", "polars", {"code": "df"}),
+            root_nodes=(_make_node("root", "Foo Bar", "polars", {"code": "df"}),),
+        )
+        svc = SavePipelineService(tmp_path)
+        req = SavePipelineRequest(
+            name="main",
+            description="",
+            graph=graph,
+            source_file="main.py",
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            svc.save(req)
+        assert exc_info.value.status_code == 400
+        assert "Foo_Bar" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
 # _resolve_source_file
 # ---------------------------------------------------------------------------
 

--- a/tests/test_route_save_pipeline.py
+++ b/tests/test_route_save_pipeline.py
@@ -227,9 +227,7 @@ def _make_submodel_graph(
     """
     all_root: list[GraphNode] = list(root_nodes)
     if include_placeholder:
-        all_root.append(
-            _make_node(f"submodel__{sm_name}", sm_name, "submodel", {})
-        )
+        all_root.append(_make_node(f"submodel__{sm_name}", sm_name, "submodel", {}))
     return PipelineGraph(
         nodes=all_root,
         edges=[],


### PR DESCRIPTION
## What

The audit flagged codegen's `_error_on_name_collisions` as over-rejection ("root and submodel defs live in separate Python modules — legal"). Investigation OVERTURNED that: preview/trace/run/explore/output-assemble/optimiser all call `flatten_graph`, which dissolves every submodel into ONE graph keyed by `node.id` — and node ids round-trip to sanitised function names — so a cross-module duplicate silently shadows its twin in `node_map` at execution time. Global uniqueness is load-bearing; the rejection stays, now with a do-not-relax docstring and a user-facing message explaining the flattened namespace.

## The real bug fixed

The save-side `_validate_unique_sanitized_names` checked root nodes only, so a collision INSIDE a submodel escaped save validation and surfaced as codegen's ParseError — an unhandled 500 from `/pipeline/save`. The save guard now matches codegen's scope with two passes: per-graph (root semantics unchanged, extended recursively to each embedded submodel graph) and cross-module (a sanitised name may be used in only one module), with the structural-placeholder exception (a submodel placeholder legally shares its label with one of its own children) and the childNodeIds exclusion (a child duplicated in a parent payload is not double-counted as a root use, matching codegen's file assignment).

## Verification

- Characterization: 4 new tests failed pre-fix as predicted, including the in-submodel collision escaping save as a 500.
- 8 new tests in `TestValidateUniqueSanitizedNamesRecursiveScope` incl. end-to-end save → clean 400, placeholder-matches-own-child passes, child-duplicated-at-root passes.
- Full suite 12335 passed; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)