### PR TITLE
Invariants battery: sanitizer drift gate, case-ambiguity audit, module-delete casefold guard, NFC/NFD + inode pins

### DIFF
--- a/scripts/regen_sanitize_parity_fixture.py
+++ b/scripts/regen_sanitize_parity_fixture.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Regenerate the sanitizer parity fixture from the backend implementation.
+
+The fixture ``frontend/src/utils/__tests__/sanitizeParity.fixture.json`` pins
+``frontend/src/utils/sanitizeName.ts`` to the backend
+``haute._graph_utils._sanitize_func_name`` (vitest asserts the TS side,
+``tests/test_sanitize_parity_fixture.py`` asserts the Python side — a change
+to either implementation fails its leg until the pair is realigned).
+
+This script re-derives every expected output from the CURRENT backend
+sanitizer, keeping the input set as-is.  Run it after an intentional backend
+sanitizer change, then update ``sanitizeName.ts`` until vitest is green again:
+
+    python3 scripts/regen_sanitize_parity_fixture.py
+
+To extend coverage, append ``["new input", ""]`` pairs to the fixture and
+rerun — the expected side is always recomputed.  The serialization is
+canonical (compact ``json.dumps`` with ``ensure_ascii=False``, no trailing
+newline); ``tests/test_sanitize_parity_fixture.py`` asserts that shape so the
+fixture can only be produced this way.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from haute._graph_utils import _sanitize_func_name  # noqa: E402
+
+FIXTURE = ROOT / "frontend" / "src" / "utils" / "__tests__" / "sanitizeParity.fixture.json"
+
+
+def regenerate() -> int:
+    pairs = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    regenerated = [[inp, _sanitize_func_name(inp)] for inp, _expected in pairs]
+    FIXTURE.write_text(json.dumps(regenerated, ensure_ascii=False), encoding="utf-8")
+    return len(regenerated)
+
+
+if __name__ == "__main__":
+    count = regenerate()
+    print(f"regenerated {count} pairs -> {FIXTURE.relative_to(ROOT)}")

--- a/src/haute/_builders.py
+++ b/src/haute/_builders.py
@@ -358,9 +358,10 @@ def _resolve_runtime_data_path(data_path: str) -> str:
     if not data_path:
         return data_path
 
+    from haute._path_case_audit import warn_if_case_ambiguous
     from haute._path_resolution import resolve_runtime_file_path
 
-    return str(
+    resolved = str(
         resolve_runtime_file_path(
             data_path,
             pipeline_dir=_configured_pipeline_dir(),
@@ -386,6 +387,13 @@ def _resolve_runtime_data_path(data_path: str) -> str:
             # unchanged by this anchoring.)
         )
     )
+    # Advisory only: no normalization is applied (pinned contract), but a
+    # path whose spelling is case-ambiguous against the on-disk entries
+    # will break when this checkout moves between case-sensitive and
+    # case-insensitive filesystems — warn at the one seam every standard
+    # input funnels through.
+    warn_if_case_ambiguous(resolved, stop=Path.cwd())
+    return resolved
 
 
 def _config_with_resolved_data_path(config: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/src/haute/_path_case_audit.py
+++ b/src/haute/_path_case_audit.py
@@ -1,0 +1,149 @@
+"""Case-ambiguity audit for user-facing runtime input paths.
+
+Haute pins **no Unicode/case normalization** on user-supplied data paths
+(dataSource / apiInput / externalFile ``path`` config): the string in the
+config is the string handed to the filesystem.  That makes the checkout
+portable only as long as the spelling in the config and the spelling on
+disk agree *under every platform's identity relation*.  Two ways they can
+silently disagree:
+
+- On a case-SENSITIVE filesystem (Linux) two entries differing only in
+  case (``Foo.csv`` / ``foo.csv``) can coexist; picked up on macOS or
+  Windows the pair collapses to one file and the config's reference is
+  ambiguous.
+- On a case-INSENSITIVE filesystem a config path spelled differently from
+  the on-disk entry (``foo.csv`` vs on-disk ``Foo.csv``) opens fine — and
+  breaks the moment the checkout lands on Linux.
+
+Neither is haute's to *fix* (no-normalization is the pinned contract, see
+``notes-haute/common/INVARIANTS.md`` §Invariant 1), but both are worth a
+loud warning at access time.  This module provides that audit as a
+standalone check, plus a generic function wrapper so any path-consuming
+callable can opt in.  The runtime chokepoint every standard input funnels
+through (:func:`haute._builders._resolve_runtime_data_path`) calls
+:func:`warn_if_case_ambiguous` on each resolved path.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from functools import wraps
+from pathlib import Path
+from typing import Any, TypeVar
+
+from haute._logging import get_logger
+
+logger = get_logger(component="path_case_audit")
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+# Paths already warned about in this process.  The audit runs on every node
+# execution, so an interactive preview loop would otherwise repeat the same
+# warning ad infinitum.  Only positive findings are cached: a clean path is
+# re-scanned each time so a twin introduced later is still caught.
+_warned: set[str] = set()
+
+
+def case_equivalent_siblings(
+    path: str | Path,
+    *,
+    stop: str | Path | None = None,
+) -> dict[str, list[str]]:
+    """Map path segments of *path* to their case-equivalent siblings on disk.
+
+    For the file itself and each ancestral directory, list the parent and
+    collect entries whose ``casefold()`` matches the segment while the
+    spelling differs.  Both hazard directions surface this way: coexisting
+    case-twins on a case-sensitive filesystem, and a requested spelling that
+    differs from the single on-disk entry on a case-insensitive one.
+
+    When *stop* is given and *path* sits under it, ancestors are walked up
+    to (and excluding) *stop* — the portability concern is spellings inside
+    the project checkout, and listing directories above it (home, ``/``)
+    would be wasted work.  Otherwise only the final segment is checked.
+
+    Returns ``{ambiguous_path: [equivalent sibling spellings]}``; empty when
+    unambiguous.  Unreadable directories are skipped, never raised.
+    """
+    resolved = Path(os.path.abspath(str(path)))
+    stop_resolved = Path(os.path.abspath(str(stop))) if stop is not None else None
+
+    segments: list[tuple[Path, str]] = []
+    if stop_resolved is not None and resolved.is_relative_to(stop_resolved):
+        node = resolved
+        while node != stop_resolved:
+            segments.append((node.parent, node.name))
+            node = node.parent
+    else:
+        segments.append((resolved.parent, resolved.name))
+
+    ambiguous: dict[str, list[str]] = {}
+    for parent, name in segments:
+        try:
+            entries = os.listdir(parent)
+        except OSError:
+            continue
+        folded = name.casefold()
+        twins = sorted(e for e in entries if e.casefold() == folded and e != name)
+        if twins:
+            ambiguous[str(parent / name)] = twins
+    return ambiguous
+
+
+def warn_if_case_ambiguous(
+    path: str | Path,
+    *,
+    stop: str | Path | None = None,
+) -> dict[str, list[str]]:
+    """Run the case audit on *path* and log a warning on any finding.
+
+    Returns the (possibly empty) finding map so callers can act on it too.
+    Findings are logged once per path per process.
+    """
+    key = str(path)
+    if key in _warned:
+        return {}
+    found = case_equivalent_siblings(path, stop=stop)
+    if found:
+        _warned.add(key)
+        logger.warning(
+            "input_path_case_ambiguous",
+            path=key,
+            equivalents=found,
+            detail=(
+                "This path has case-equivalent sibling spellings on disk. "
+                "It resolves here, but on a filesystem with the other case "
+                "sensitivity (macOS/Windows vs Linux) the same checkout will "
+                "read a different file or fail to resolve. Align the config "
+                "spelling with the on-disk entry, or rename the twins apart."
+            ),
+        )
+    return found
+
+
+def wrap_path_case_audit(
+    func: _F,
+    index: int | str,
+    *,
+    stop: str | Path | None = None,
+) -> _F:
+    """Wrap *func* so the argument at *index* is case-audited on every call.
+
+    *index* selects the path argument: an ``int`` for a positional, a
+    ``str`` for a keyword.  The audit is advisory — a missing argument or a
+    finding never changes the call, it only warns.
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        target: Any = None
+        if isinstance(index, str):
+            target = kwargs.get(index)
+        elif 0 <= index < len(args):
+            target = args[index]
+        if target is not None:
+            warn_if_case_ambiguous(target, stop=stop)
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -145,7 +145,20 @@ class SavePipelineService:
             warnings.extend(
                 self._write_sidecar(py_path, graph, body.sources, body.active_source, touched)
             )
+            # Skip delete targets that casefold-match a file this save just
+            # wrote, mirroring the stale-diff guard in
+            # `_remove_stale_config_files`: after a case-only submodel rename
+            # (``modules/foo.py`` → ``modules/Foo.py``) the client requests
+            # deletion of the old casing, but on the case-insensitive
+            # filesystems macOS and Windows default to that names the SAME
+            # on-disk file as the freshly written module — unlinking it would
+            # destroy the survivor. On case-SENSITIVE Linux the skip leaves
+            # the old-cased file behind as harmless residue; data safety on
+            # macOS/Windows wins over Linux tidiness.
+            written_folded = {str(item.target.resolve()).casefold() for item in touched}
             for target in delete_targets:
+                if str(target.resolve()).casefold() in written_folded:
+                    continue
                 self._stage_delete(target, touched)
         except BaseException:
             self._rollback(touched)

--- a/tests/test_path_case_audit.py
+++ b/tests/test_path_case_audit.py
@@ -1,0 +1,154 @@
+"""Tests for the runtime input-path case-ambiguity audit.
+
+Companion to the no-normalization pin in
+``tests/test_pipeline_runtime_path_validation.py``: haute never rewrites a
+user-supplied data path, so the audit's job is to WARN when the spelling in
+play is case-ambiguous against the on-disk entries — coexisting case-twins
+on a case-sensitive filesystem (Linux), or a requested spelling differing
+from the single on-disk entry on a case-insensitive one (macOS/Windows).
+Real-twin scenarios only materialise on case-sensitive filesystems, so those
+tests probe the filesystem and adapt; the wrapper/dedupe/seam mechanics are
+platform-independent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import haute._path_case_audit as audit_mod
+from haute._path_case_audit import (
+    case_equivalent_siblings,
+    warn_if_case_ambiguous,
+    wrap_path_case_audit,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warned_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(audit_mod, "_warned", set())
+
+
+def _fs_case_insensitive(tmp_path: Path) -> bool:
+    probe = tmp_path / "CaseProbe"
+    probe.write_text("x", encoding="utf-8")
+    try:
+        return (tmp_path / "caseprobe").exists()
+    finally:
+        probe.unlink()
+
+
+def test_unambiguous_path_yields_no_findings(tmp_path: Path) -> None:
+    target = tmp_path / "data" / "rates.csv"
+    target.parent.mkdir()
+    target.write_text("x", encoding="utf-8")
+
+    assert case_equivalent_siblings(target, stop=tmp_path) == {}
+    assert warn_if_case_ambiguous(target, stop=tmp_path) == {}
+
+
+def test_spelling_differs_from_on_disk_entry_is_flagged(tmp_path: Path) -> None:
+    """Requesting ``foo.csv`` when disk holds ``Foo.csv`` is ambiguous.
+
+    On a case-insensitive filesystem this open *works* — and breaks the
+    moment the checkout lands on Linux. On a case-sensitive one the open
+    fails while a confusable sibling exists. Both directions must warn.
+    """
+    (tmp_path / "Foo.csv").write_text("x", encoding="utf-8")
+
+    found = case_equivalent_siblings(tmp_path / "foo.csv", stop=tmp_path)
+
+    assert found == {str(tmp_path / "foo.csv"): ["Foo.csv"]}
+
+
+def test_coexisting_case_twins_are_flagged(tmp_path: Path) -> None:
+    """Real twins (Linux): referencing either spelling reports the other."""
+    if _fs_case_insensitive(tmp_path):
+        pytest.skip("case-insensitive filesystem cannot host coexisting twins")
+    (tmp_path / "Foo.csv").write_text("upper", encoding="utf-8")
+    (tmp_path / "foo.csv").write_text("lower", encoding="utf-8")
+
+    found = case_equivalent_siblings(tmp_path / "foo.csv", stop=tmp_path)
+
+    assert found == {str(tmp_path / "foo.csv"): ["Foo.csv"]}
+
+
+def test_ancestor_directories_are_audited_up_to_stop(tmp_path: Path) -> None:
+    """An ambiguous DIRECTORY segment is a finding, not just the file."""
+    (tmp_path / "Data").mkdir()
+    target = tmp_path / "data" / "rates.csv"
+
+    found = case_equivalent_siblings(target, stop=tmp_path)
+
+    assert str(tmp_path / "data") in found
+    assert found[str(tmp_path / "data")] == ["Data"]
+
+
+def test_path_outside_stop_checks_only_final_segment(tmp_path: Path) -> None:
+    """Outside the project root only the file's own parent is listed."""
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "Foo.csv").write_text("x", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir()
+
+    found = case_equivalent_siblings(outside / "foo.csv", stop=project)
+
+    assert found == {str(outside / "foo.csv"): ["Foo.csv"]}
+
+
+def test_warn_logs_once_per_path(tmp_path: Path) -> None:
+    (tmp_path / "Foo.csv").write_text("x", encoding="utf-8")
+    target = tmp_path / "foo.csv"
+
+    first = warn_if_case_ambiguous(target, stop=tmp_path)
+    second = warn_if_case_ambiguous(target, stop=tmp_path)
+
+    assert first != {}
+    assert second == {}  # cached — no repeat warning for the same path
+
+
+def test_wrap_path_case_audit_positional_and_keyword(tmp_path: Path) -> None:
+    (tmp_path / "Foo.csv").write_text("x", encoding="utf-8")
+    seen: list[str] = []
+
+    def loader(kind: str, path: str) -> str:
+        seen.append(path)
+        return kind
+
+    wrapped_pos = wrap_path_case_audit(loader, 1, stop=tmp_path)
+    assert wrapped_pos("csv", str(tmp_path / "foo.csv")) == "csv"
+    assert audit_mod._warned == {str(tmp_path / "foo.csv")}
+
+    wrapped_kw = wrap_path_case_audit(loader, "path", stop=tmp_path)
+    assert wrapped_kw("csv", path=str(tmp_path / "Foo.csv")) == "csv"
+    assert seen == [str(tmp_path / "foo.csv"), str(tmp_path / "Foo.csv")]
+
+
+def test_wrap_path_case_audit_missing_argument_is_harmless() -> None:
+    wrapped = wrap_path_case_audit(lambda: "ok", 0)
+    assert wrapped() == "ok"
+
+
+def test_resolver_seam_runs_the_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_resolve_runtime_data_path` must audit every resolved input path."""
+    from haute import _builders
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "Foo.csv").write_text("x", encoding="utf-8")
+
+    audited: list[str] = []
+    monkeypatch.setattr(
+        audit_mod,
+        "warn_if_case_ambiguous",
+        lambda path, *, stop=None: audited.append(str(path)) or {},
+    )
+
+    resolved = _builders._resolve_runtime_data_path("foo.csv")
+
+    assert audited == [resolved]
+    assert resolved.endswith("foo.csv")  # spelling preserved, never rewritten

--- a/tests/test_pipeline_runtime_path_validation.py
+++ b/tests/test_pipeline_runtime_path_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,7 @@ from fastapi import HTTPException
 from haute._types import GraphNode, NodeData, NodeType, PipelineGraph
 from haute.routes._save_pipeline import SavePipelineService
 from haute.routes.pipeline import _validate_runtime_input_paths
+from haute.schemas import SavePipelineRequest
 
 
 @pytest.fixture(autouse=True)
@@ -395,3 +398,167 @@ def test_validate_runtime_input_paths_checks_optimiser_apply_file_mode_only() ->
     assert exc_info.value.status_code == 403
 
     _validate_runtime_input_paths(job_graph)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end write+cleanup ordering on a REAL filesystem.
+#
+# The guard tests above exercise set logic that is right on every OS; these
+# two prove the physical outcome — which bytes the surviving inode holds and
+# whether the explicit module-delete path can destroy a freshly written
+# module — on the case-insensitive filesystems the macOS/Windows
+# platform-smoke CI legs provide. On case-sensitive Linux the same tests pin
+# the accepted residue trade-off instead.
+# ---------------------------------------------------------------------------
+
+
+def test_case_only_rename_single_surviving_inode_holds_new_bytes(
+    tmp_path: Path,
+) -> None:
+    """After Foo→FOO, the one physical file must hold the NEW config bytes.
+
+    `test_case_only_rename_survives_stale_cleanup` asserts the guard's set
+    logic; this asserts the disk: on a case-insensitive filesystem both
+    spellings must reach ONE directory entry whose content is the fresh
+    save, proving write-then-cleanup ordering end to end. On a
+    case-sensitive filesystem the excluded prev casing stays behind with
+    its OLD bytes — the documented Linux residue trade-off.
+    """
+    svc = SavePipelineService(tmp_path)
+    sidecar_dir = tmp_path / "config" / "data_source"
+    sidecar_dir.mkdir(parents=True)
+    old = sidecar_dir / "Foo.json"
+    old.write_text('{"path": "old.csv"}', encoding="utf-8")
+    svc._prev_config_files = {"config/data_source/Foo.json": '{"path": "old.csv"}'}
+    graph = PipelineGraph(nodes=[_config_node("a", "FOO")], edges=[])
+
+    svc._write_config_files(graph)
+    removed = svc._remove_stale_config_files(graph)
+
+    assert removed == []
+    new = sidecar_dir / "FOO.json"
+    assert new.is_file()
+    assert "a.csv" in new.read_text(encoding="utf-8")
+    if old.exists() and os.path.samefile(old, new):
+        # Case-insensitive filesystem: one inode, one directory entry (the
+        # filesystem is case-PRESERVING, so the entry keeps whichever
+        # spelling created it — here prev's ``Foo.json``), and the prev
+        # spelling reads the NEW bytes.
+        entries = [p.name for p in sidecar_dir.iterdir()]
+        assert len(entries) == 1
+        assert entries[0].casefold() == "foo.json"
+        assert "a.csv" in old.read_text(encoding="utf-8")
+    else:
+        # Case-sensitive filesystem: prev casing left behind, old bytes.
+        assert old.read_text(encoding="utf-8") == '{"path": "old.csv"}'
+
+
+def _submodel_save_request(graph: PipelineGraph) -> SavePipelineRequest:
+    return SavePipelineRequest(
+        name="main",
+        description="",
+        graph=graph,
+        source_file="main.py",
+    )
+
+
+def _run_submodel_save(
+    tmp_path: Path,
+    delete_module_files: list[str],
+) -> None:
+    """Drive a full ``save()`` whose codegen emits ``modules/Foo.py``."""
+    from unittest.mock import patch
+
+    svc = SavePipelineService(tmp_path)
+    graph = PipelineGraph(nodes=[_config_node("a", "Src")], edges=[])
+    graph.submodels = {"Foo": {"file": "modules/Foo.py", "graph": {"nodes": [], "edges": []}}}
+    files = {
+        "main.py": 'import haute\npipeline = haute.Pipeline("main")\n',
+        "modules/Foo.py": "# new module\n",
+    }
+    with patch("haute.codegen.graph_to_code_multi", return_value=files):
+        svc.save(_submodel_save_request(graph), delete_module_files=delete_module_files)
+
+
+def test_case_only_module_rename_survives_explicit_delete(tmp_path: Path) -> None:
+    """A case-only submodel rename must not delete the freshly written module.
+
+    Renaming submodel ``foo`` → ``Foo`` makes the client request deletion of
+    ``modules/foo.py`` in the same save that writes ``modules/Foo.py`` — the
+    SAME on-disk file on the case-insensitive filesystems macOS and Windows
+    default to. Unguarded, the staged delete unlinks the module the save
+    just wrote (the explicit-delete twin of the stale-diff bug fixed in
+    PR #43).
+    """
+    (tmp_path / "main.py").write_text(
+        'import haute\npipeline = haute.Pipeline("main")\n', encoding="utf-8"
+    )
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    old = modules_dir / "foo.py"
+    old.write_text("# old module\n", encoding="utf-8")
+
+    _run_submodel_save(tmp_path, delete_module_files=["modules/foo.py"])
+
+    new = modules_dir / "Foo.py"
+    assert new.is_file()
+    assert new.read_text(encoding="utf-8") == "# new module\n"
+    if old.exists() and not os.path.samefile(old, new):
+        # Case-sensitive filesystem: the skip leaves the old casing behind
+        # as residue with its old bytes — same trade-off as the stale diff.
+        assert old.read_text(encoding="utf-8") == "# old module\n"
+
+
+def test_genuine_module_delete_still_removes_the_file(tmp_path: Path) -> None:
+    """The casefold skip must not stop real module deletions."""
+    (tmp_path / "main.py").write_text(
+        'import haute\npipeline = haute.Pipeline("main")\n', encoding="utf-8"
+    )
+    modules_dir = tmp_path / "modules"
+    modules_dir.mkdir()
+    gone = modules_dir / "gone.py"
+    gone.write_text("# retired module\n", encoding="utf-8")
+
+    _run_submodel_save(tmp_path, delete_module_files=["modules/gone.py"])
+
+    assert not gone.exists()
+    assert (modules_dir / "Foo.py").is_file()
+
+
+# ---------------------------------------------------------------------------
+# NFC/NFD: no normalization, pinned.
+#
+# Non-sanitized user paths (dataSource/apiInput/externalFile ``path`` config)
+# are handed to the filesystem exactly as spelled — haute applies NO Unicode
+# normalization (ruled 2026-07-09; the case-ambiguity audit in
+# haute._path_case_audit is the advisory companion). On the normalizing
+# filesystem the macOS leg provides (APFS), an NFD spelling reaching an
+# NFC-named file is the FILESYSTEM's doing; on Linux the same spelling
+# misses and haute must not rescue it. This test pins that contract on both
+# legs.
+# ---------------------------------------------------------------------------
+
+
+def test_nfc_nfd_input_path_spelling_is_never_normalized(tmp_path: Path) -> None:
+    from haute._path_resolution import resolve_runtime_file_path
+
+    nfc = "café.csv"  # é precomposed (U+00E9)
+    nfd = unicodedata.normalize("NFD", nfc)  # e + combining acute (U+0301)
+    assert nfc != nfd
+    (tmp_path / nfc).write_text("nfc-bytes", encoding="utf-8")
+
+    resolved = resolve_runtime_file_path(nfd, pipeline_dir=tmp_path, project_root=tmp_path)
+
+    # The pin: haute preserves the given spelling byte-for-byte — the
+    # resolved path is still NFD, never rewritten to the on-disk NFC form.
+    assert resolved.name == nfd
+    assert resolved.name != nfc
+    if (tmp_path / nfd).exists():
+        # Normalization-insensitive filesystem (APFS on the macOS leg):
+        # both spellings reach the one file — the filesystem's equivalence,
+        # not a haute rewrite.
+        assert (tmp_path / nfd).read_text(encoding="utf-8") == "nfc-bytes"
+    else:
+        # Normalization-sensitive filesystem (ext4/NTFS): the NFD spelling
+        # misses, and haute must NOT quietly resolve it to the NFC file.
+        assert not resolved.exists()

--- a/tests/test_sanitize_parity_fixture.py
+++ b/tests/test_sanitize_parity_fixture.py
@@ -1,0 +1,66 @@
+"""Python-side drift gate for the backend↔frontend sanitizer parity fixture.
+
+The fixture ``frontend/src/utils/__tests__/sanitizeParity.fixture.json`` was
+generated FROM the backend ``_sanitize_func_name`` and is asserted against the
+frontend ``sanitizeName.ts`` by vitest (``sanitizeParity.diff.test.ts``).
+Before this gate existed, a backend sanitizer change kept BOTH suites green
+while the implementations diverged — vitest checks TS against the (stale)
+fixture, and nothing checked the fixture against Python.  This test closes
+that: any backend change that alters an expected output fails here until
+``scripts/regen_sanitize_parity_fixture.py`` is rerun (which in turn breaks
+vitest until the TS side is realigned).  Drift can no longer stay green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from haute._graph_utils import _sanitize_func_name
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURE = _REPO_ROOT / "frontend" / "src" / "utils" / "__tests__" / "sanitizeParity.fixture.json"
+
+
+def _load_pairs() -> list[list[str]]:
+    if not (_REPO_ROOT / "frontend").is_dir():
+        # Running outside the repo checkout (e.g. against an installed
+        # package) — the frontend tree, and therefore the parity contract,
+        # does not exist there. In-repo CI always has it.
+        pytest.skip("frontend tree not present; parity fixture out of scope")
+    # If frontend/ exists the fixture MUST: a missing fixture is drift, not
+    # an excuse to skip.
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_expected_outputs_match_backend_sanitizer() -> None:
+    pairs = _load_pairs()
+    assert len(pairs) >= 400, "parity fixture unexpectedly shrank"
+    mismatches = [
+        (inp, expected, _sanitize_func_name(inp))
+        for inp, expected in pairs
+        if _sanitize_func_name(inp) != expected
+    ]
+    assert mismatches == [], (
+        "Backend _sanitize_func_name diverged from the parity fixture "
+        "(input, fixture, backend): "
+        f"{mismatches[:10]!r} — if the backend change is intentional, run "
+        "scripts/regen_sanitize_parity_fixture.py and realign sanitizeName.ts"
+    )
+
+
+def test_fixture_serialization_is_regenerator_canonical() -> None:
+    """The on-disk bytes must be exactly what the regenerator would emit.
+
+    Guards the regeneration loop itself: a hand-edited or re-serialized
+    fixture (indented, ascii-escaped, trailing newline) would make
+    ``regen_sanitize_parity_fixture.py`` produce spurious diffs.
+    """
+    pairs = _load_pairs()
+    canonical = json.dumps(
+        [[inp, _sanitize_func_name(inp)] for inp, _expected in pairs],
+        ensure_ascii=False,
+    )
+    assert _FIXTURE.read_text(encoding="utf-8") == canonical

--- a/tests/test_test_debt.py
+++ b/tests/test_test_debt.py
@@ -37,6 +37,18 @@ _DEBT_REVIEW_BY = date(2026, 10, 25)
 # path, enclosing scope, debt kind, reason text, and normalized AST source. A new
 # skip/xfail/importorskip, or a changed reason, must be accepted deliberately.
 _EXPECTED_DEBT_IDS = {
+    # Invariants battery — the sanitizer parity drift gate asserts a fixture
+    # that lives in frontend/; outside a repo checkout (installed-package test
+    # runs) the frontend tree, and therefore the parity contract, does not
+    # exist. In-repo CI always runs it. See
+    # tests/test_sanitize_parity_fixture.py::_load_pairs.
+    "06b5fc5b5b500179",
+    # Invariants battery — coexisting case-twin files (Foo.csv + foo.csv) can
+    # only be created on a case-sensitive filesystem, so the real-twin test
+    # skips on macOS/Windows by physical necessity; the Linux CI legs run it,
+    # and the spelling-mismatch test covers the case-insensitive direction.
+    # See tests/test_path_case_audit.py::test_coexisting_case_twins_are_flagged.
+    "b0ad28e0a98cbfa9",
     # W2.9 — the trace-cache budget wiring assertion cannot hold when an
     # operator deliberately overrides HAUTE_TRACE_CACHE_MAX_BYTES; the skip
     # documents that the pin targets default wiring only. See


### PR DESCRIPTION
Seventh (and final planned) branch of the mapping-equivalence workstream: closes the remaining coverage gaps from `notes-haute` INVARIANTS.md §Invariant 1 and lands the ruled case-ambiguity access warning. Follows PRs #42/#43 and the #52–#57 fix batch.

## Coverage gaps closed

- **Gap 1 — sanitizer parity drift gate.** `tests/test_sanitize_parity_fixture.py` recomputes every pair of `frontend/src/utils/__tests__/sanitizeParity.fixture.json` from the backend `_sanitize_func_name`. Previously a backend sanitizer change kept both suites green while the implementations diverged (vitest checks TS against the stale fixture; nothing checked the fixture against Python). A second test pins the fixture's on-disk bytes to the canonical serialization. `scripts/regen_sanitize_parity_fixture.py` is the checked-in regenerator — round-trips today's 458-pair fixture with zero diff.
- **Gap 3 — NFC/NFD pinned to no-normalization.** Platform-smoke test: an NFD-spelled input path is never rewritten to the on-disk NFC form; on APFS both spellings reaching one file is the *filesystem's* equivalence, on ext4 the NFD spelling misses and haute must not rescue it.
- **Gap 4 — module-file case-only rename: bug found and fixed.** A case-only submodel rename (`foo` → `Foo`) makes the client request deletion of `modules/foo.py` in the same save that writes `modules/Foo.py` — the SAME on-disk file on macOS/Windows, so the staged delete unlinked the freshly written module. This is the explicit-delete twin of the PR #43 stale-diff bug; reproduced empirically with the guard reverted. `save()` now skips delete targets that casefold-match a file written this save (same accepted Linux-residue trade-off), with a genuine-delete control test.
- **Gap 5 — real-inode overwrite proof.** After a `Foo` → `FOO` rename, the platform-smoke leg asserts the single surviving directory entry holds the NEW bytes (and documents that case-preserving filesystems keep prev's entry spelling); on Linux the test pins the residue trade-off instead.

## Case-ambiguity access warning (ruled 2026-07-09)

New `haute._path_case_audit`: for the file and each ancestral directory (bounded by the project root), warns — once per path per process, via the structured logger — when a runtime input path has case-equivalent sibling spellings on disk. Catches both hazard directions: coexisting case-twins on Linux (ambiguous when the checkout lands on macOS/Windows), and a config spelling that mismatches the on-disk entry on macOS/Windows (breaks on Linux). Wired into `_resolve_runtime_data_path`, the one seam every dataSource/apiInput/externalFile load shares; also exposes the generic `wrap_path_case_audit(f, index)` opt-in wrapper as ruled. Advisory only — no normalization, no behaviour change.

## Housekeeping

Two new `pytest.skip` sites added to the reviewed test-debt budget (frontend tree absent outside repo checkouts; case-twins physically impossible on case-insensitive filesystems).

Local gate: full pytest suite green (11k+ passed), `ruff check`, `ruff format --check`, `mypy` clean; regenerator smoke-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)