### PR TITLE
Fix flaky ComparisonView fit-race test: await ResizeObserver registration

### DIFF
--- a/frontend/src/components/__tests__/ComparisonView.test.tsx
+++ b/frontend/src/components/__tests__/ComparisonView.test.tsx
@@ -243,10 +243,18 @@ describe("ComparisonView", () => {
     await waitFor(() =>
       expect(screen.getByTestId("comparison-canvas-historical")).toBeInTheDocument(),
     )
+    // The canvases enter the DOM at React's commit, but the panes' observers are
+    // registered by a passive effect that flushes in a LATER scheduler task —
+    // under load, the canvas waitFor above can resolve in between (seen once in
+    // a full-suite preflight run). Await registration explicitly; the panes'
+    // effects don't act-flush on their own here because nothing act-wrapped runs
+    // between the two waits.
+    await waitFor(() => expect(resizeObservers.length).toBeGreaterThan(0)) // both panes observe
     // Ignore any mount-time fits (initial prop / orientation rAF); assert the
-    // ResizeObserver refits once the pane reports a real, non-zero size.
+    // ResizeObserver refits once the pane reports a real, non-zero size. No
+    // await sits between the clear and the assertion, so no stray rAF fit can
+    // leak in and mask a broken ResizeObserver path.
     mockFitView.mockClear()
-    expect(resizeObservers.length).toBeGreaterThan(0) // both panes observe
     triggerResize(800, 600)
     expect(mockFitView).toHaveBeenCalled()
   })
@@ -257,6 +265,10 @@ describe("ComparisonView", () => {
     await waitFor(() =>
       expect(screen.getByTestId("comparison-canvas-historical")).toBeInTheDocument(),
     )
+    // Same effect-flush race as the re-fit test above — and without this wait
+    // the test can pass vacuously (zero observers → nothing fires → trivially
+    // "not called").
+    await waitFor(() => expect(resizeObservers.length).toBeGreaterThan(0))
     mockFitView.mockClear()
     triggerResize(0, 0)
     expect(mockFitView).not.toHaveBeenCalled()


### PR DESCRIPTION
## What

Makes the `ComparisonView` test "re-fits a pane once it gets its real size after mount (vertical-split fit race)" deterministic, and closes a vacuous-pass hazard in its sibling zero-width test. Test-only change: one file, +14/−2. No assertion is weakened — the same conditions are asserted, with the effect-flush ordering made explicit.

## Why

The test failed once in a loaded full-suite `scripts/preflight.sh --frontend-only` run (2026-07-09) with `expected 0 to be greater than 0`, but passes in isolation.

Root cause is a real race in the test, not the component. The pane's ResizeObserver is registered by a passive `useEffect` in `CanvasPane` (ComparisonView.tsx). The canvas elements enter the DOM at React's commit, but that effect flushes in a **later** scheduler task. RTL's `waitFor` resolves via a jsdom MutationObserver microtask fired right after the commit, and its act-environment drain is a bare `setTimeout(0)` — which races React's next scheduler tick (`setImmediate` in Node). Instrumented timelines show the two timers due within ~0.1ms of each other: on an idle machine the effects win; under load (coverage-instrumented suite, worker contention) the drain wins and the test body resumes with `resizeObservers.length === 0`.

## Fix

- Re-fit test: `await waitFor(() => expect(resizeObservers.length).toBeGreaterThan(0))` before clearing the fit spy and firing the simulated resize.
- Zero-width negative test: same awaited registration — previously it could pass vacuously (no observers registered yet → nothing fired → trivially "not called").
- `mockFitView.mockClear()` sits immediately before the synchronous trigger-and-assert in both tests, so a stray mount-time rAF fit cannot leak in and mask a broken ResizeObserver path.

## Verification

- **Deterministic reproduction**: a throwaway harness delayed React's scheduler host callback (`setImmediate` → `setTimeout` 4ms) so the passive-effects task always loses the race — the pre-fix test shape then fails **every** run with the exact preflight failure message, and the fixed shape passes every run under the same simulated load. (Harness kept out of the suite; brute-force stress — ~20 runs incl. 4 concurrent coverage suites — never hit the natural sub-millisecond window.)
- Fixed file run 8× consecutively: 15/15 pass each run.
- Full `npm run test:coverage` in the worktree: 263 files / 5105 tests passed, coverage + critical-coverage gates passed.
- `npm run typecheck` and `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)