### PR TITLE
CI: dependency-floors lane + scheduled unlocked-resolve lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,11 @@ jobs:
       - name: Show the floor resolution (direct dependencies)
         run: uv tree --depth 1 --frozen
 
+      # --frozen again: a bare `uv run` re-locks at the default resolution and
+      # would silently swap the floor env back to highest before testing.
       - name: Core subset at floors
         run: >
-          uv run pytest $(grep -v '^#' scripts/core_test_files.txt)
+          uv run --frozen pytest $(grep -v '^#' scripts/core_test_files.txt)
           -q -n 4 --timeout=60 --timeout-method=signal
 
   # Version-independent static gates + package build — run once on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,12 @@ permissions:
 
 jobs:
   # Early-feedback canary: the cheapest checks that historically red CI
-  # (ruff format/lint), then the test files most often touched by fix
-  # commits. Runs standalone — nothing waits on it; it exists to make PR
-  # failures specific and early rather than suite-as-a-whole and late.
-  # Subset provenance (refresh occasionally):
-  #   git log main --diff-filter=M --name-only --format=% -i --grep=fix \
-  #     --grep=bug -- tests/ | grep '^tests/' | sort | uniq -c | sort -rn
-  #   Mined 2026-07-06: git_engine 13, model_scorer 12, optimiser_routes 11,
-  #   codegen 10, then a four-way tie at 9 (mlflow_io, executor,
-  #   codegen_builders, api_contracts). From the tie we keep executor and
-  #   api_contracts (core execution + API-contract signal) and drop mlflow_io
-  #   (extras-adjacent surface) and codegen_builders (overlaps codegen).
-  #   ~2.5 min at -n 4. The known load-sensitive wall-clock benchmark in
-  #   test_column_contracts_adoption is deliberately excluded.
+  # (ruff format/lint), then the core test subset. Runs standalone — nothing
+  # waits on it; it exists to make PR failures specific and early rather than
+  # suite-as-a-whole and late. The subset lives in scripts/core_test_files.txt
+  # (selection rationale + refresh recipe there); it is shared with the
+  # dependency-floors job below and the scheduled unlocked-resolve lane
+  # (dependencies.yml), so a canary refresh re-derives those lanes' subset too.
   canary:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -42,15 +35,9 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check .
 
-      - name: Canary test subset (historically most regression-prone files)
+      - name: Canary test subset (core subset — historically most regression-prone files)
         run: >
-          uv run pytest
-          tests/test_git_engine.py
-          tests/test_model_scorer.py
-          tests/test_optimiser_routes.py
-          tests/test_codegen.py
-          tests/test_executor.py
-          tests/test_api_contracts.py
+          uv run pytest $(grep -v '^#' scripts/core_test_files.txt)
           -q -n 4 --timeout=60 --timeout-method=signal
 
   # Fresh-install smoke: wheel (HAUTE_BUILD_FRONTEND=1, never editable) ->
@@ -78,6 +65,43 @@ jobs:
 
       - name: Fresh-install smoke
         run: uv run --no-project python scripts/init_smoke.py
+
+  # Dependency floors: prove the published floor specifiers in [project]
+  # dependencies (and the optional extras, pulled in via the dev group's
+  # haute[databricks]) are honest — a lowest-direct resolve must install and
+  # pass the core subset. End users resolve fresh against these floors with no
+  # lockfile of ours, and nothing else verifies that corner. Runs on 3.11 (the
+  # requires-python floor): oldest-python × oldest-deps is where floors
+  # actually bind. The dev group is exact-pinned, so lowest-direct moves only
+  # the [project] floors; the re-resolved uv.lock is ephemeral CI state and is
+  # never committed. A red run means a dishonest floor — raising a floor to
+  # green this lane is a maintainer decision, not something a PR does
+  # unilaterally.
+  dependency-floors:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Re-resolve at published floors (lowest-direct)
+        run: uv lock --resolution lowest-direct
+
+      # --frozen (not --locked): sync must take the floor lockfile as-is —
+      # freshness checks re-run the default `highest` resolution and would
+      # declare the lowest-direct lock stale.
+      - run: uv sync --frozen --group dev
+
+      - name: Show the floor resolution (direct dependencies)
+        run: uv tree --depth 1 --frozen
+
+      - name: Core subset at floors
+        run: >
+          uv run pytest $(grep -v '^#' scripts/core_test_files.txt)
+          -q -n 4 --timeout=60 --timeout-method=signal
 
   # Version-independent static gates + package build — run once on the
   # reference interpreter (these were duplicated across the old 3-version

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,103 @@
+name: Dependencies
+
+# Scheduled unlocked-resolve lane: does a FRESH install of the built wheel —
+# resolving latest-within-caps from the index, no lockfile involved — still
+# init, serve, and pass the core test subset? This catches a new dependency
+# release inside our caps breaking us before a user's fresh install does.
+#
+# Deliberately never triggered by push/PR: it tests the index's state, not the
+# diff's, so a red run must not block unrelated landings. Non-blocking but
+# loud: a failure finds-or-creates a `dependency-watch` issue with the run URL.
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_fail:
+        description: "Fail deliberately to prove the alarm path rings"
+        type: boolean
+        default: false
+  schedule:
+    # Monday 04:41 UTC — offset from performance.yml's Monday 03:17 cron.
+    - cron: "41 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  unlocked-resolve:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Forced failure (alarm-path test)
+        if: inputs.force_fail
+        run: |
+          echo "force_fail input set — failing deliberately to exercise the alarm step"
+          exit 1
+
+      - name: Build wheel (frontend embedded, never editable)
+        run: HAUTE_BUILD_FRONTEND=1 uv build --wheel --out-dir dist-unlocked
+
+      # Reuses the init-smoke machinery end to end: fresh venv, fresh
+      # latest-within-caps dependency resolution of the wheel, `haute init` in
+      # an empty dir, headless serve on packaged static assets, authed
+      # /api/files, clean shutdown.
+      - name: Init-smoke on the wheel (fresh unlocked resolve)
+        run: uv run --no-project python scripts/init_smoke.py --wheel dist-unlocked/haute-*.whl
+
+      # Second fresh venv, this time with the databricks extra so the extras
+      # caps are live-tested too, plus the test tooling at its dev-group pins
+      # (exported from uv.lock — no hand-maintained version list to drift).
+      # Everything else in this venv resolves fresh from the index.
+      - name: Fresh venv with extras (unlocked resolve)
+        run: |
+          uv venv .unlocked --python 3.12
+          uv export --only-group dev --no-hashes --no-emit-project --no-annotate \
+            | grep -E '^(pytest|pytest-asyncio|pytest-timeout|pytest-xdist|httpx)==' \
+            > .unlocked-testdeps.txt
+          WHEEL="$(ls dist-unlocked/haute-*.whl)"
+          uv pip install --python .unlocked/bin/python \
+            "haute[databricks] @ file://${PWD}/${WHEEL}" \
+            -r .unlocked-testdeps.txt
+
+      - name: Show the unlocked resolution
+        run: uv pip list --python .unlocked/bin/python
+
+      # The core subset runs from the checkout but imports the wheel-installed
+      # haute (src layout keeps the checkout's sources off sys.path).
+      - name: Core subset against the unlocked install
+        run: >
+          .unlocked/bin/python -m pytest $(grep -v '^#' scripts/core_test_files.txt)
+          -q -n 4 --timeout=60 --timeout-method=signal
+
+      - name: Raise the alarm (find-or-create dependency-watch issue)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Scheduled unlocked-resolve lane is red"
+          body="A fresh latest-within-caps resolve of the built wheel failed. Run: ${RUN_URL}
+
+          Likely cause: a new release of a dependency inside our caps. Triage: compare the run's 'Show the unlocked resolution' step against uv.lock to spot what moved."
+          gh label create dependency-watch --color D93F0B --force \
+            --description "Automated: scheduled dependency lane failures"
+          existing="$(gh issue list --state open --label dependency-watch \
+            --search "in:title \"${title}\"" --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "Still red: ${RUN_URL}"
+          else
+            gh issue create --title "${title}" --label dependency-watch --body "${body}"
+          fi

--- a/scripts/core_test_files.txt
+++ b/scripts/core_test_files.txt
@@ -1,0 +1,27 @@
+# Core test subset — the fast, high-signal slice shared by three CI lanes:
+# canary (early feedback on every PR), dependency-floors (suite health at the
+# published lowest-direct resolution), and the scheduled unlocked-resolve lane
+# (suite health at a fresh latest-within-caps resolution of the built wheel).
+# Consumed as:  uv run pytest $(grep -v '^#' scripts/core_test_files.txt) ...
+#
+# Selection: the test files most often touched by fix commits, which also walk
+# the dependency surface (catboost scoring, polars execution, fastapi/pydantic
+# routes and contracts, libcst codegen), plus the optional-extras smoke so the
+# databricks extra's resolution is exercised wherever this subset runs.
+# Refresh occasionally with:
+#   git log main --diff-filter=M --name-only --format=% -i --grep=fix \
+#     --grep=bug -- tests/ | grep '^tests/' | sort | uniq -c | sort -rn
+#   Mined 2026-07-06: git_engine 13, model_scorer 12, optimiser_routes 11,
+#   codegen 10, then a four-way tie at 9 (mlflow_io, executor,
+#   codegen_builders, api_contracts). From the tie we keep executor and
+#   api_contracts (core execution + API-contract signal) and drop mlflow_io
+#   (extras-adjacent surface) and codegen_builders (overlaps codegen).
+#   ~2.5 min at -n 4. The known load-sensitive wall-clock benchmark in
+#   test_column_contracts_adoption is deliberately excluded.
+tests/test_git_engine.py
+tests/test_model_scorer.py
+tests/test_optimiser_routes.py
+tests/test_codegen.py
+tests/test_executor.py
+tests/test_api_contracts.py
+tests/test_optional_dependency_extras.py


### PR DESCRIPTION
CI_CONTRACT §2 planned lanes 3 and 4, built as one landing.

## What this adds

**`dependency-floors` job in ci.yml (blocking, push/PR to main).** Re-locks the project at `--resolution lowest-direct` on Python 3.11 (our oldest supported interpreter — floors are most brittle there), syncs `--frozen`, and runs the core test subset. This makes the floor specifiers in `[project] dependencies` an enforced claim instead of a hope: nothing previously verified that a fresh resolve at the declared floors actually works.

Two uv traps are deliberately pinned around: `uv sync --locked` *rejects* a lowest-direct lock (its freshness check re-locks at `highest`), and a bare `uv run` after the sync would silently re-lock + re-sync back to `highest` right before the tests — the lane would green-tick floors it never tested. Both steps use `--frozen`. `uv.lock` is never committed from this job; the checkout copy is only mutated in the runner.

**`dependencies.yml` (weekly cron Mon 04:41 UTC + `workflow_dispatch`; non-blocking, loudly reported).** Builds the wheel with the embedded frontend (`HAUTE_BUILD_FRONTEND=1`, non-editable), runs the existing `init_smoke.py --wheel` cycle against a fresh latest-within-caps venv (init → headless serve → authed endpoint probe), then runs the core subset in a second fresh venv with the `databricks` extra — no lockfile anywhere in the lane. This catches a new dependency release *inside our caps* breaking us before a user's fresh install does. On failure it finds-or-creates a `dependency-watch` issue carrying the run URL (one issue, appended per failure, closed when resolved). A `force_fail` dispatch input exists to prove the alarm path independently.

**`scripts/core_test_files.txt`** — the "core subset" single-sourced: the canary's six high-signal test files plus the optional-extras import smoke. The canary job, the floors job, and the scheduled lane all read this file, so the three can't drift apart. The canary also gains the extras smoke (cheap, same files).

## Verification

- Floors lane rehearsed end-to-end locally (macOS/arm64, 3.11): lowest-direct resolve succeeds, core subset **1058 passed, 1 skipped, 95s** — the declared floors are honest today; the lane lands green, no bumps needed.
- Unlocked lane rehearsed end-to-end: wheel build → `init_smoke.py --wheel` green → fresh venv at latest-within-caps → core subset **1057 passed, 1 failed** — the failure is real in-cap drift (below), i.e. the lane doing its job.
- Both workflows YAML-parse; full local preflight green (one documented Hypothesis-deadline gate flake, green in isolation and on backend re-run).
- Not verifiable pre-merge: the scheduled workflow can't fire until this file exists on main. One post-merge `workflow_dispatch` is owed to confirm end-to-end on the runner, plus optionally a `force_fail` dispatch to ring-test the alarm.

## Known first-run red (by design)

At latest-within-caps, pydantic 2.13.4 (locked: 2.12.5) splits request/response models into `-Input`/`-Output` schema refs, failing `test_openapi_contract_fingerprint_matches_expected_snapshot`. Deliberately not papered over: the first scheduled/dispatched run will go red and file the `dependency-watch` issue. Triage (cap tighten vs pin+snapshot refresh vs tolerant snapshot) is a maintainer decision.

## Notes

- `dependency-floors` should be added to the required-check set when branch protection is next configured.
- The declared `polars>=1.39.2` floor points at a yanked release (effective installable floor: 1.39.3); cosmetic, maintainer's call whether to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
