### PR TITLE
Test write-sandbox pilot: scratch fixture, AST gate, runtime guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
       - run: uv sync --group dev --locked
 
       - name: Cross-platform path and debt smoke
-        run: uv run pytest tests/test_path_resolution.py tests/test_pipeline_runtime_path_validation.py tests/test_test_debt.py tests/test_file_ops.py -q
+        run: uv run pytest tests/test_path_resolution.py tests/test_pipeline_runtime_path_validation.py tests/test_test_debt.py tests/test_file_ops.py tests/test_write_sandbox_guard.py -q
 
   mutation-config-smoke:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ xfail_strict = true
 markers = [
     "slow: marks tests as slow but still part of the default suite",
     "perf: marks benchmark-style tests excluded from default pytest runs",
+    "sandbox_strict: opts a test into the strict write-sandbox (see tests/_write_sandbox.py)",
 ]
 filterwarnings = [
     "error::RuntimeWarning",

--- a/tests/_write_sandbox.py
+++ b/tests/_write_sandbox.py
@@ -16,10 +16,9 @@ Layers 1 and 3 of the test write-sandbox (layer 2, the static AST gate, is
   perf-marked tests, whose wall-clock budgets must not pay for interception.
 
 The sandbox root is exported per test as ``HAUTE_TEST_SANDBOX_ROOT`` and
-readable via :func:`sandbox_root`. That surface is deliberate: the permission
-layer can later scope an exec grant such as "run tests" to "writes under the
-advertised sandbox root" without knowing anything else about pytest
-(the grant-scoping design this pilot feeds).
+readable via :func:`sandbox_root`. That surface is deliberate: a permission
+layer can scope an exec grant such as "run tests" to "writes under the
+advertised sandbox root" without knowing anything else about pytest.
 
 Known gaps, stated: writes made by native code (polars sinks, catboost
 artifact dumps) do not pass through Python ``open`` — in strict mode they are

--- a/tests/_write_sandbox.py
+++ b/tests/_write_sandbox.py
@@ -1,0 +1,236 @@
+"""Per-test write-sandbox: containment env + ``open`` interception.
+
+Layers 1 and 3 of the test write-sandbox (layer 2, the static AST gate, is
+``tests/test_write_sandbox_lint.py``). The autouse fixture in
+``tests/conftest.py`` drives this module for every test:
+
+* **strict** (converted modules, listed in :data:`STRICT_FILES`, or tests
+  marked ``sandbox_strict``): the test runs chdir'd into its ``tmp_path``,
+  with ``TMPDIR``/``TEMP``/``TMP`` and ``HOME``/``USERPROFILE`` pointed at
+  subdirectories of it, and any *write-intent* ``open``/``os.open`` whose
+  resolved path escapes the sandbox raises :class:`OutOfSandboxWriteError`.
+* **observe** (everything else): the same interception, but escapes are
+  recorded and reported in the terminal summary instead of failing — the
+  violation census that drives the conversion ratchet.
+* **off**: escape hatch (``HAUTE_TEST_WRITE_SANDBOX=off``) and the mode for
+  perf-marked tests, whose wall-clock budgets must not pay for interception.
+
+The sandbox root is exported per test as ``HAUTE_TEST_SANDBOX_ROOT`` and
+readable via :func:`sandbox_root`. That surface is deliberate: the permission
+layer can later scope an exec grant such as "run tests" to "writes under the
+advertised sandbox root" without knowing anything else about pytest
+(the grant-scoping design this pilot feeds).
+
+Known gaps, stated: writes made by native code (polars sinks, catboost
+artifact dumps) do not pass through Python ``open`` — in strict mode they are
+still *contained* by the chdir + temp-dir redirect, but not intercepted.
+``os.rename``/``os.mkdir``/fd-inheritance tricks are likewise not
+intercepted, and file descriptors passed as integers cannot be resolved to
+paths. The static gate and the census exist to shrink those corners over
+time; deliberately obfuscated escapes are out of scope (review's job).
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ENV_ROOT = "HAUTE_TEST_SANDBOX_ROOT"
+ENV_MODE = "HAUTE_TEST_WRITE_SANDBOX"  # "off" | "observe" | "strict" (override)
+ENV_CENSUS_DIR = "HAUTE_TEST_WRITE_SANDBOX_CENSUS_DIR"
+
+# Test files that run in strict mode: the converted pilot slice. Grows as the
+# conversion ratchet advances; a file listed here must also be absent from the
+# layer-2 allowlist in tests/test_write_sandbox_lint.py.
+STRICT_FILES = frozenset(
+    {
+        "test_write_sandbox_guard.py",
+        "test_optimiser_apply.py",
+        "test_bugfixes.py",
+        "test_streaming_chunk_size_threading.py",
+        "test_partial_failure.py",
+    }
+)
+
+_WRITE_MODE_CHARS = frozenset("wax+")
+
+# O_EXCL matters only alongside O_CREAT; O_CREAT/O_TRUNC/O_APPEND all imply
+# an intent to change the filesystem even when paired with read-only access.
+_WRITE_FLAGS = os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_TRUNC
+
+
+def sandbox_root() -> Path | None:
+    """The current test's sandbox root, or ``None`` outside a sandboxed test.
+
+    Reads the environment variable the autouse fixture exports, so it works
+    from any process that inherits the test's environment — including a
+    future permission hook inspecting what a test run is allowed to touch.
+    """
+    value = os.environ.get(ENV_ROOT)
+    return Path(value) if value else None
+
+
+def mode_writes(mode: str) -> bool:
+    """True if an ``open`` mode string implies write intent."""
+    return bool(_WRITE_MODE_CHARS & set(mode))
+
+
+def flags_write(flags: int) -> bool:
+    """True if ``os.open`` flags imply write intent."""
+    return bool(flags & _WRITE_FLAGS)
+
+
+def _realpath(target: object) -> str | None:
+    """Resolve *target* to a real absolute path, or ``None`` if unresolvable.
+
+    Relative paths resolve against the current working directory — which in
+    strict mode is the sandbox itself, so relative writes are contained by
+    construction. Integer file descriptors and exotic path types return
+    ``None`` (documented gap: allow rather than crash the interposer).
+    """
+    if isinstance(target, int):
+        return None
+    try:
+        return os.path.realpath(os.fsdecode(os.fspath(target)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_within(child_real: str, root_real: str) -> bool:
+    child = os.path.normcase(child_real)
+    root = os.path.normcase(root_real)
+    return child == root or child.startswith(root.rstrip(os.sep) + os.sep)
+
+
+@dataclass(frozen=True)
+class Violation:
+    nodeid: str
+    api: str  # "open" | "os.open"
+    path: str  # resolved real path
+    detail: str  # mode string or flags repr
+
+
+#: Per-process record of observe-mode escapes (and blocked strict writes).
+VIOLATIONS: list[Violation] = []
+
+
+class OutOfSandboxWriteError(PermissionError):
+    """A strict-mode test attempted a write outside its sandbox."""
+
+
+@dataclass
+class Guard:
+    """Installable interposer over ``builtins.open``/``io.open``/``os.open``.
+
+    ``allowed_roots`` are pre-resolved real paths; a write-intent call whose
+    resolved target is inside none of them is blocked (strict) or recorded
+    (observe). ``os.devnull`` is always allowed.
+    """
+
+    mode: str  # "strict" | "observe"
+    nodeid: str
+    allowed_roots: tuple[str, ...]
+    _installed: bool = False
+    _orig_open: object = field(default=None, repr=False)
+    _orig_os_open: object = field(default=None, repr=False)
+
+    def _check(self, api: str, target: object, detail: str) -> None:
+        real = _realpath(target)
+        if real is None:
+            return
+        if os.path.normcase(real) == os.path.normcase(os.path.realpath(os.devnull)):
+            return
+        if any(_is_within(real, root) for root in self.allowed_roots):
+            return
+        if self.mode == "strict":
+            raise OutOfSandboxWriteError(
+                f"{self.nodeid}: {api}({real!r}, {detail}) writes outside the test "
+                f"write-sandbox (allowed roots: {list(self.allowed_roots)}). Derive "
+                "the path from the haute_scratch fixture; see tests/_write_sandbox.py."
+            )
+        VIOLATIONS.append(Violation(nodeid=self.nodeid, api=api, path=real, detail=detail))
+
+    def install(self) -> None:
+        assert not self._installed
+        orig_open = builtins.open
+        orig_os_open = os.open
+        guard = self
+
+        def guarded_open(file, mode="r", *args, **kwargs):
+            if isinstance(mode, str) and mode_writes(mode):
+                guard._check("open", file, f"mode={mode!r}")
+            return orig_open(file, mode, *args, **kwargs)
+
+        def guarded_os_open(path, flags, *args, **kwargs):
+            if flags_write(flags):
+                guard._check("os.open", path, f"flags={flags:#o}")
+            return orig_os_open(path, flags, *args, **kwargs)
+
+        self._orig_open = orig_open
+        self._orig_os_open = orig_os_open
+        builtins.open = guarded_open
+        io.open = guarded_open
+        os.open = guarded_os_open
+        self._installed = True
+
+    def uninstall(self) -> None:
+        assert self._installed
+        builtins.open = self._orig_open
+        io.open = self._orig_open
+        os.open = self._orig_os_open
+        self._installed = False
+
+
+def resolve_mode(env_mode: str | None, *, is_perf: bool, filename: str, marked_strict: bool) -> str:
+    """Pick the guard mode for one test. Pure — unit-tested directly."""
+    env = (env_mode or "").strip().lower()
+    if env == "off":
+        return "off"
+    if is_perf:
+        return "off"
+    if env == "strict":
+        return "strict"
+    if marked_strict or filename in STRICT_FILES:
+        return "strict"
+    return "observe"
+
+
+def dump_census(census_dir: str, worker_id: str, violations: list[Violation] | None = None) -> None:
+    """Write this process's violations as JSON into *census_dir*.
+
+    Used to aggregate across pytest-xdist workers: each worker dumps at
+    session finish, the controller merges in the terminal summary.
+    """
+    out = Path(census_dir) / f"census-{worker_id}-{os.getpid()}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    rows = VIOLATIONS if violations is None else violations
+    payload = [violation.__dict__ for violation in rows]
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def load_census(census_dir: str) -> list[Violation]:
+    merged: list[Violation] = []
+    directory = Path(census_dir)
+    if not directory.is_dir():
+        return merged
+    for file in sorted(directory.glob("census-*.json")):
+        for row in json.loads(file.read_text(encoding="utf-8")):
+            merged.append(Violation(**row))
+    return merged
+
+
+def summarize(violations: list[Violation]) -> list[str]:
+    """Group violations into human-readable census lines (path → tests)."""
+    by_path: dict[str, set[str]] = {}
+    for violation in violations:
+        by_path.setdefault(violation.path, set()).add(violation.nodeid)
+    lines = []
+    for path in sorted(by_path):
+        tests = sorted(by_path[path])
+        shown = ", ".join(tests[:3]) + (f" (+{len(tests) - 3} more)" if len(tests) > 3 else "")
+        lines.append(f"{path}  <-  {shown}")
+    return lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -13,6 +16,7 @@ from haute._sandbox import _get_project_root, set_project_root
 from haute.executor import _preview_cache
 from haute.graph_utils import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
 from haute.trace import _cache as _trace_cache
+from tests import _write_sandbox as _ws
 
 _TEST_LOCAL_SESSION_TOKEN = "pytest-haute-local-session-token"
 
@@ -428,3 +432,109 @@ def clean_job_store():
     yield _store
     _store.jobs.clear()
     _store.jobs.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Test write-sandbox (layers 1 + 3) — logic in tests/_write_sandbox.py
+# ---------------------------------------------------------------------------
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_WS_REPO_ROOT = _TESTS_DIR.parent
+
+
+@pytest.fixture(autouse=True)
+def _haute_write_sandbox(
+    request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Layer-3 runtime guard: containment env + open() interception.
+
+    Strict for the converted pilot slice (``_write_sandbox.STRICT_FILES`` or
+    the ``sandbox_strict`` marker), observe-and-record for everything else,
+    off for perf-marked tests and under ``HAUTE_TEST_WRITE_SANDBOX=off``.
+    """
+    mode = _ws.resolve_mode(
+        os.environ.get(_ws.ENV_MODE),
+        is_perf=request.node.get_closest_marker("perf") is not None,
+        filename=request.path.name,
+        marked_strict=request.node.get_closest_marker("sandbox_strict") is not None,
+    )
+    if mode == "off":
+        yield
+        return
+    monkeypatch.setenv(_ws.ENV_ROOT, str(tmp_path))
+    if mode == "strict":
+        sandbox_tmp = tmp_path / "_tmp"
+        sandbox_home = tmp_path / "_home"
+        sandbox_tmp.mkdir(exist_ok=True)
+        sandbox_home.mkdir(exist_ok=True)
+        monkeypatch.chdir(tmp_path)
+        for var in ("TMPDIR", "TEMP", "TMP"):
+            monkeypatch.setenv(var, str(sandbox_tmp))
+        monkeypatch.setattr(tempfile, "tempdir", str(sandbox_tmp))
+        monkeypatch.setenv("HOME", str(sandbox_home))
+        monkeypatch.setenv("USERPROFILE", str(sandbox_home))
+        allowed = (os.path.realpath(str(tmp_path)),)
+    else:
+        allowed = (
+            os.path.realpath(str(tmp_path.parent)),  # this run's basetemp
+            os.path.realpath(tempfile.gettempdir()),
+            os.path.realpath(str(_WS_REPO_ROOT / ".hypothesis")),  # example DB, harness infra
+        )
+    guard = _ws.Guard(mode=mode, nodeid=request.node.nodeid, allowed_roots=allowed)
+    guard.install()
+    try:
+        yield
+    finally:
+        guard.uninstall()
+
+
+@pytest.fixture()
+def haute_scratch(tmp_path: Path) -> Path:
+    """Layer-1 convention: the per-test scratch directory all writes derive from.
+
+    Same substrate as ``tmp_path`` (unique per test, platform-appropriate,
+    auto-pruned) plus the sandbox semantics: it is exactly the root the
+    layer-3 guard confines strict tests to and exports as
+    ``HAUTE_TEST_SANDBOX_ROOT``.
+    """
+    return tmp_path
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Aggregate the write-sandbox census across xdist workers: the controller
+    # allocates a shared spool dir before workers spawn; workers inherit it via
+    # the environment and dump their in-process records at session finish. The
+    # controller merges, reports, and removes the spool in the summary hook.
+    if os.environ.get(_ws.ENV_CENSUS_DIR) or hasattr(config, "workerinput"):
+        return
+    spool = tempfile.mkdtemp(prefix="haute-write-sandbox-census-")  # write-sandbox: deliberate
+    os.environ[_ws.ENV_CENSUS_DIR] = spool
+    config._ws_census_spool = spool
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    census_dir = os.environ.get(_ws.ENV_CENSUS_DIR)
+    if census_dir and _ws.VIOLATIONS:
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+        _ws.dump_census(census_dir, worker)
+
+
+def pytest_terminal_summary(terminalreporter) -> None:
+    violations = list(_ws.VIOLATIONS)
+    census_dir = os.environ.get(_ws.ENV_CENSUS_DIR)
+    if census_dir:
+        merged = _ws.load_census(census_dir)
+        if merged:
+            violations = merged
+    spool = getattr(terminalreporter.config, "_ws_census_spool", None)
+    if spool:
+        shutil.rmtree(spool, ignore_errors=True)
+        os.environ.pop(_ws.ENV_CENSUS_DIR, None)
+    if violations:
+        terminalreporter.section("write-sandbox census (observe mode)")
+        for line in _ws.summarize(violations):
+            terminalreporter.line(line)
+        terminalreporter.line(
+            f"{len(violations)} out-of-sandbox write(s) recorded; "
+            "see tests/_write_sandbox.py (conversion ratchet)."
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,7 +528,7 @@ def pytest_terminal_summary(terminalreporter) -> None:
             violations = merged
     spool = getattr(terminalreporter.config, "_ws_census_spool", None)
     if spool:
-        shutil.rmtree(spool, ignore_errors=True)
+        shutil.rmtree(spool, ignore_errors=True)  # write-sandbox: deliberate
         os.environ.pop(_ws.ENV_CENSUS_DIR, None)
     if violations:
         terminalreporter.section("write-sandbox census (observe mode)")

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -11,8 +11,6 @@ Covers:
 
 from __future__ import annotations
 
-import shutil
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -162,7 +160,7 @@ class TestStreamingChunkRestoreExecutor:
 class TestStreamingChunkRestoreOptimiser:
     """Verify the optimiser pipeline execution doesn't crash on chunk restore."""
 
-    def test_execute_pipeline_no_prior_chunk_size(self, tmp_path):
+    def test_execute_pipeline_no_prior_chunk_size(self, haute_scratch):
         """_execute_pipeline should not raise when POLARS_STREAMING_CHUNK_SIZE
         was never set (the exact scenario that caused the production bug).
 
@@ -207,12 +205,10 @@ class TestStreamingChunkRestoreOptimiser:
                 return_value="batch",
             ),
         ):
-            checkpoint_dir = Path(tempfile.mkdtemp(prefix="haute_test_"))
-            try:
-                result = svc._execute_pipeline(body, "test-job", checkpoint_dir)
-                assert "opt" in result
-            finally:
-                shutil.rmtree(checkpoint_dir, ignore_errors=True)
+            checkpoint_dir = haute_scratch / "haute_test_ckpt"
+            checkpoint_dir.mkdir()
+            result = svc._execute_pipeline(body, "test-job", checkpoint_dir)
+            assert "opt" in result
 
         # Verify no ValueError was raised and chunk size is valid
         current = pl.Config.state().get("POLARS_STREAMING_CHUNK_SIZE")

--- a/tests/test_optimiser_apply.py
+++ b/tests/test_optimiser_apply.py
@@ -4,9 +4,8 @@ Covers: type inference, config building, codegen, executor (online + ratebook),
 artifact caching, and deploy bundling/scoring.
 """
 
+import itertools
 import json
-import os
-import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -59,12 +58,16 @@ def _make_ratebook_artifact(version: str = "rb_v1") -> dict:
     }
 
 
-def _write_artifact(artifact: dict) -> str:
-    fd, path = tempfile.mkstemp(suffix=".json")
-    os.close(fd)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(artifact, f)
-    return path
+@pytest.fixture()
+def write_artifact(haute_scratch):
+    counter = itertools.count()
+
+    def _write(artifact: dict) -> str:
+        path = haute_scratch / f"artifact_{next(counter)}.json"
+        path.write_text(json.dumps(artifact), encoding="utf-8")
+        return str(path)
+
+    return _write
 
 
 def _make_node(config: dict, label: str = "apply_opt") -> GraphNode:
@@ -277,27 +280,21 @@ class TestExecutorPassthrough:
         lf = pl.DataFrame({"x": [1]}).lazy()
         assert fn(lf).collect().columns == ["x"]
 
-    def test_file_source_type_with_path(self):
-        path = _write_artifact(_make_online_artifact())
-        try:
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            assert len(result) == 2
-            assert "optimal_scenario_value" in result.columns
-        finally:
-            os.unlink(path)
+    def test_file_source_type_with_path(self, write_artifact):
+        path = write_artifact(_make_online_artifact())
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        assert len(result) == 2
+        assert "optimal_scenario_value" in result.columns
 
-    def test_missing_source_type_with_path_raises(self):
+    def test_missing_source_type_with_path_raises(self, write_artifact):
         from haute.errors import ConfigError
 
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            node = _make_node({"artifact_path": path})
-            with pytest.raises(ConfigError, match="sourceType"):
-                _build_node_fn(node, source_names=["base"])
-        finally:
-            os.unlink(path)
+        path = write_artifact(_make_ratebook_artifact())
+        node = _make_node({"artifact_path": path})
+        with pytest.raises(ConfigError, match="sourceType"):
+            _build_node_fn(node, source_names=["base"])
 
 
 # ---------------------------------------------------------------------------
@@ -306,74 +303,57 @@ class TestExecutorPassthrough:
 
 
 class TestExecutorOnline:
-    def test_online_apply_basic(self):
-        path = _write_artifact(_make_online_artifact())
-        try:
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            assert len(result) == 2  # one row per quote
-            assert "optimal_scenario_value" in result.columns
-            assert "optimal_objective" in result.columns
-            assert "__optimiser_version__" in result.columns
-            assert result["__optimiser_version__"][0] == "test_v1"
-        finally:
-            os.unlink(path)
+    def test_online_apply_basic(self, write_artifact):
+        path = write_artifact(_make_online_artifact())
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        assert len(result) == 2  # one row per quote
+        assert "optimal_scenario_value" in result.columns
+        assert "optimal_objective" in result.columns
+        assert "__optimiser_version__" in result.columns
+        assert result["__optimiser_version__"][0] == "test_v1"
 
-    def test_online_custom_version_column(self):
-        path = _write_artifact(_make_online_artifact())
-        try:
-            node = _make_node(
-                {"sourceType": "file", "artifact_path": path, "version_column": "__v__"}
-            )
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            assert "__v__" in result.columns
-            assert "__optimiser_version__" not in result.columns
-        finally:
-            os.unlink(path)
+    def test_online_custom_version_column(self, write_artifact):
+        path = write_artifact(_make_online_artifact())
+        node = _make_node({"sourceType": "file", "artifact_path": path, "version_column": "__v__"})
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        assert "__v__" in result.columns
+        assert "__optimiser_version__" not in result.columns
 
-    def test_online_custom_optimised_value_column(self):
-        path = _write_artifact(_make_online_artifact())
-        try:
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "optimised_value_column": "selected_price_factor",
-                }
-            )
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            assert "selected_price_factor" in result.columns
-            assert "optimal_scenario_value" not in result.columns
-        finally:
-            os.unlink(path)
+    def test_online_custom_optimised_value_column(self, write_artifact):
+        path = write_artifact(_make_online_artifact())
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "optimised_value_column": "selected_price_factor",
+            }
+        )
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        assert "selected_price_factor" in result.columns
+        assert "optimal_scenario_value" not in result.columns
 
-    def test_online_no_version_when_empty(self):
+    def test_online_no_version_when_empty(self, write_artifact):
         artifact = _make_online_artifact(version="")
-        path = _write_artifact(artifact)
-        try:
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            # Version column should not be present when version is empty
-            assert "__optimiser_version__" not in result.columns
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        # Version column should not be present when version is empty
+        assert "__optimiser_version__" not in result.columns
 
-    def test_online_zero_lambdas_picks_max_objective(self):
+    def test_online_zero_lambdas_picks_max_objective(self, write_artifact):
         """With zero lambdas, each quote should pick the step maximizing objective."""
         artifact = _make_online_artifact(lambdas={"predicted_volume": 0.0})
-        path = _write_artifact(artifact)
-        try:
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["scored"])
-            result = fn(_scored_df().lazy()).collect()
-            # Step 2 (scenario_value=1.1) has highest income for both quotes
-            assert result["optimal_scenario_value"].to_list() == pytest.approx([1.1, 1.1])
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["scored"])
+        result = fn(_scored_df().lazy()).collect()
+        # Step 2 (scenario_value=1.1) has highest income for both quotes
+        assert result["optimal_scenario_value"].to_list() == pytest.approx([1.1, 1.1])
 
 
 # ---------------------------------------------------------------------------
@@ -382,165 +362,147 @@ class TestExecutorOnline:
 
 
 class TestExecutorRatebook:
-    def test_ratebook_apply_basic(self):
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2", "q3"],
-                    "region": ["London", "Manchester", "London"],
-                    "price": [100.0, 200.0, 150.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            assert "region_optimised_factor" in result.columns
-            assert "optimised_factor" in result.columns
-            assert "__optimiser_version__" in result.columns
-            # London factor = 1.05
-            london = result.filter(pl.col("region") == "London")
-            assert london["region_optimised_factor"][0] == pytest.approx(1.05)
-            assert london["optimised_factor"][0] == pytest.approx(1.05)
-            # Manchester factor = 0.98
-            manc = result.filter(pl.col("region") == "Manchester")
-            assert manc["region_optimised_factor"][0] == pytest.approx(0.98)
-            assert manc["optimised_factor"][0] == pytest.approx(0.98)
-        finally:
-            os.unlink(path)
+    def test_ratebook_apply_basic(self, write_artifact):
+        path = write_artifact(_make_ratebook_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2", "q3"],
+                "region": ["London", "Manchester", "London"],
+                "price": [100.0, 200.0, 150.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        assert "region_optimised_factor" in result.columns
+        assert "optimised_factor" in result.columns
+        assert "__optimiser_version__" in result.columns
+        # London factor = 1.05
+        london = result.filter(pl.col("region") == "London")
+        assert london["region_optimised_factor"][0] == pytest.approx(1.05)
+        assert london["optimised_factor"][0] == pytest.approx(1.05)
+        # Manchester factor = 0.98
+        manc = result.filter(pl.col("region") == "Manchester")
+        assert manc["region_optimised_factor"][0] == pytest.approx(0.98)
+        assert manc["optimised_factor"][0] == pytest.approx(0.98)
 
-    def test_ratebook_multi_factor_combined(self):
+    def test_ratebook_multi_factor_combined(self, write_artifact):
         """Multiple factor tables should each get a column and be multiplied together."""
         artifact = _make_ratebook_artifact()
         artifact["factor_tables"]["age_band"] = [
             {"__factor_group__": "young", "optimal_scenario_value": 1.10},
             {"__factor_group__": "old", "optimal_scenario_value": 0.95},
         ]
-        path = _write_artifact(artifact)
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["London", "Manchester"],
-                    "age_band": ["young", "old"],
-                    "price": [100.0, 200.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            assert "region_optimised_factor" in result.columns
-            assert "age_band_optimised_factor" in result.columns
-            assert "optimised_factor" in result.columns
-            # q1: London(1.05) * young(1.10) = 1.155
-            assert result["optimised_factor"][0] == pytest.approx(1.05 * 1.10)
-            # q2: Manchester(0.98) * old(0.95) = 0.931
-            assert result["optimised_factor"][1] == pytest.approx(0.98 * 0.95)
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["London", "Manchester"],
+                "age_band": ["young", "old"],
+                "price": [100.0, 200.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        assert "region_optimised_factor" in result.columns
+        assert "age_band_optimised_factor" in result.columns
+        assert "optimised_factor" in result.columns
+        # q1: London(1.05) * young(1.10) = 1.155
+        assert result["optimised_factor"][0] == pytest.approx(1.05 * 1.10)
+        # q2: Manchester(0.98) * old(0.95) = 0.931
+        assert result["optimised_factor"][1] == pytest.approx(0.98 * 0.95)
 
-    def test_ratebook_custom_optimised_value_column(self):
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["London", "Manchester"],
-                    "price": [100.0, 200.0],
-                }
-            )
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "optimised_value_column": "selected_price_factor",
-                }
-            )
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            assert "selected_price_factor" in result.columns
-            assert "optimised_factor" not in result.columns
-            assert result["selected_price_factor"].to_list() == pytest.approx([1.05, 0.98])
-        finally:
-            os.unlink(path)
+    def test_ratebook_custom_optimised_value_column(self, write_artifact):
+        path = write_artifact(_make_ratebook_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["London", "Manchester"],
+                "price": [100.0, 200.0],
+            }
+        )
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "optimised_value_column": "selected_price_factor",
+            }
+        )
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        assert "selected_price_factor" in result.columns
+        assert "optimised_factor" not in result.columns
+        assert result["selected_price_factor"].to_list() == pytest.approx([1.05, 0.98])
 
-    def test_ratebook_unseen_level_rates_neutral_and_warns(self):
+    def test_ratebook_unseen_level_rates_neutral_and_warns(self, write_artifact):
         """3b.5: an unseen factor level still rates 1.0 (neutral relativity)
         but the miss is counted and logged — never silent."""
         import structlog.testing
 
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1"],
-                    "region": ["Edinburgh"],  # not in factor table
-                    "price": [100.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            with structlog.testing.capture_logs() as logs:
-                result = fn(df.lazy()).collect()
-            assert result["region_optimised_factor"][0] == pytest.approx(1.0)
-            assert result["optimised_factor"][0] == pytest.approx(1.0)
-            miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
-            assert len(miss_logs) == 1
-            assert miss_logs[0]["log_level"] == "warning"
-            assert miss_logs[0]["table"] == "region"
-            assert miss_logs[0]["output_column"] == "region_optimised_factor"
-            assert miss_logs[0]["miss_count"] == 1
-            assert miss_logs[0]["missing_keys"] == [{"region": "Edinburgh"}]
-        finally:
-            os.unlink(path)
+        path = write_artifact(_make_ratebook_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1"],
+                "region": ["Edinburgh"],  # not in factor table
+                "price": [100.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        with structlog.testing.capture_logs() as logs:
+            result = fn(df.lazy()).collect()
+        assert result["region_optimised_factor"][0] == pytest.approx(1.0)
+        assert result["optimised_factor"][0] == pytest.approx(1.0)
+        miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
+        assert len(miss_logs) == 1
+        assert miss_logs[0]["log_level"] == "warning"
+        assert miss_logs[0]["table"] == "region"
+        assert miss_logs[0]["output_column"] == "region_optimised_factor"
+        assert miss_logs[0]["miss_count"] == 1
+        assert miss_logs[0]["missing_keys"] == [{"region": "Edinburgh"}]
 
-    def test_ratebook_seen_levels_do_not_warn(self):
+    def test_ratebook_seen_levels_do_not_warn(self, write_artifact):
         import structlog.testing
 
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["London", "Manchester"],
-                    "price": [100.0, 200.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            with structlog.testing.capture_logs() as logs:
-                result = fn(df.lazy()).collect()
-            assert result["region_optimised_factor"].to_list() == pytest.approx([1.05, 0.98])
-            assert [log for log in logs if log["event"] == "rating_table_lookup_misses"] == []
-        finally:
-            os.unlink(path)
+        path = write_artifact(_make_ratebook_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["London", "Manchester"],
+                "price": [100.0, 200.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        with structlog.testing.capture_logs() as logs:
+            result = fn(df.lazy()).collect()
+        assert result["region_optimised_factor"].to_list() == pytest.approx([1.05, 0.98])
+        assert [log for log in logs if log["event"] == "rating_table_lookup_misses"] == []
 
-    def test_ratebook_null_factor_value_rates_neutral_and_warns(self):
+    def test_ratebook_null_factor_value_rates_neutral_and_warns(self, write_artifact):
         """A null factor value can never match the lookup join — it is a
         counted neutral miss, not a silent 1.0 and not a crash."""
         import structlog.testing
 
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["London", None],
-                    "price": [100.0, 200.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            with structlog.testing.capture_logs() as logs:
-                result = fn(df.lazy()).collect()
-            assert result["region_optimised_factor"].to_list() == pytest.approx([1.05, 1.0])
-            miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
-            assert len(miss_logs) == 1
-            assert miss_logs[0]["miss_count"] == 1
-        finally:
-            os.unlink(path)
+        path = write_artifact(_make_ratebook_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["London", None],
+                "price": [100.0, 200.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        with structlog.testing.capture_logs() as logs:
+            result = fn(df.lazy()).collect()
+        assert result["region_optimised_factor"].to_list() == pytest.approx([1.05, 1.0])
+        miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
+        assert len(miss_logs) == 1
+        assert miss_logs[0]["miss_count"] == 1
 
-    def test_ratebook_partial_miss_combines_neutral_with_matched(self):
+    def test_ratebook_partial_miss_combines_neutral_with_matched(self, write_artifact):
         """One table misses, the other matches: per-factor columns are
         [matched, 1.0] and the combined relativity is their product."""
         import structlog.testing
@@ -549,166 +511,145 @@ class TestExecutorRatebook:
         artifact["factor_tables"]["age_band"] = [
             {"__factor_group__": "young", "optimal_scenario_value": 1.10},
         ]
-        path = _write_artifact(artifact)
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1"],
-                    "region": ["London"],
-                    "age_band": ["unseen-band"],
-                    "price": [100.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            with structlog.testing.capture_logs() as logs:
-                result = fn(df.lazy()).collect()
-            assert result["region_optimised_factor"][0] == pytest.approx(1.05)
-            assert result["age_band_optimised_factor"][0] == pytest.approx(1.0)
-            assert result["optimised_factor"][0] == pytest.approx(1.05)
-            miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
-            assert [log["table"] for log in miss_logs] == ["age_band"]
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1"],
+                "region": ["London"],
+                "age_band": ["unseen-band"],
+                "price": [100.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        with structlog.testing.capture_logs() as logs:
+            result = fn(df.lazy()).collect()
+        assert result["region_optimised_factor"][0] == pytest.approx(1.05)
+        assert result["age_band_optimised_factor"][0] == pytest.approx(1.0)
+        assert result["optimised_factor"][0] == pytest.approx(1.05)
+        miss_logs = [log for log in logs if log["event"] == "rating_table_lookup_misses"]
+        assert [log["table"] for log in miss_logs] == ["age_band"]
 
-    def test_ratebook_empty_factor_tables(self):
+    def test_ratebook_empty_factor_tables(self, write_artifact):
         artifact = _make_ratebook_artifact()
         artifact["factor_tables"] = {}
-        path = _write_artifact(artifact)
-        try:
-            df = pl.DataFrame({"x": [1, 2]})
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            # Should pass through with version column added
-            assert len(result) == 2
-            assert "__optimiser_version__" in result.columns
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        df = pl.DataFrame({"x": [1, 2]})
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        # Should pass through with version column added
+        assert len(result) == 2
+        assert "__optimiser_version__" in result.columns
 
-    def test_ratebook_apply_uses_configured_input_dataframe(self):
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            scored_quotes = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["London", "Manchester"],
-                    "price": [100.0, 200.0],
-                }
-            )
-            banded_quotes = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "region": ["Manchester", "London"],
-                    "price": [100.0, 200.0],
-                }
-            )
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "ratebook_input": "banding-node",
-                }
-            )
-            _, fn, _ = _build_node_fn(
-                node,
-                source_names=["scored_quotes", "banded_quotes"],
-                source_ids=["scored-node", "banding-node"],
-            )
-            result = fn(scored_quotes.lazy(), banded_quotes.lazy()).collect()
+    def test_ratebook_apply_uses_configured_input_dataframe(self, write_artifact):
+        path = write_artifact(_make_ratebook_artifact())
+        scored_quotes = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["London", "Manchester"],
+                "price": [100.0, 200.0],
+            }
+        )
+        banded_quotes = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "region": ["Manchester", "London"],
+                "price": [100.0, 200.0],
+            }
+        )
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "ratebook_input": "banding-node",
+            }
+        )
+        _, fn, _ = _build_node_fn(
+            node,
+            source_names=["scored_quotes", "banded_quotes"],
+            source_ids=["scored-node", "banding-node"],
+        )
+        result = fn(scored_quotes.lazy(), banded_quotes.lazy()).collect()
 
-            assert result["region"].to_list() == ["Manchester", "London"]
-            assert result["region_optimised_factor"].to_list() == pytest.approx([0.98, 1.05])
-        finally:
-            os.unlink(path)
+        assert result["region"].to_list() == ["Manchester", "London"]
+        assert result["region_optimised_factor"].to_list() == pytest.approx([0.98, 1.05])
 
-    def test_ratebook_apply_rejects_stale_configured_input(self):
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "ratebook_input": "deleted-banding-node",
-                }
-            )
-            _, fn, _ = _build_node_fn(
-                node,
-                source_names=["scored_quotes", "banded_quotes"],
-                source_ids=["scored-node", "banding-node"],
-            )
+    def test_ratebook_apply_rejects_stale_configured_input(self, write_artifact):
+        path = write_artifact(_make_ratebook_artifact())
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "ratebook_input": "deleted-banding-node",
+            }
+        )
+        _, fn, _ = _build_node_fn(
+            node,
+            source_names=["scored_quotes", "banded_quotes"],
+            source_ids=["scored-node", "banding-node"],
+        )
 
-            with pytest.raises(ValueError, match="deleted-banding-node"):
-                fn(
-                    pl.DataFrame({"region": ["London"]}).lazy(),
-                    pl.DataFrame({"region": ["Manchester"]}).lazy(),
-                ).collect()
-        finally:
-            os.unlink(path)
+        with pytest.raises(ValueError, match="deleted-banding-node"):
+            fn(
+                pl.DataFrame({"region": ["London"]}).lazy(),
+                pl.DataFrame({"region": ["Manchester"]}).lazy(),
+            ).collect()
 
-    def test_ratebook_apply_requires_source_ids_for_configured_input(self):
-        path = _write_artifact(_make_ratebook_artifact())
-        try:
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "ratebook_input": "banded_quotes",
-                }
-            )
-            _, fn, _ = _build_node_fn(
-                node,
-                source_names=["scored_quotes", "banded_quotes"],
-            )
+    def test_ratebook_apply_requires_source_ids_for_configured_input(self, write_artifact):
+        path = write_artifact(_make_ratebook_artifact())
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "ratebook_input": "banded_quotes",
+            }
+        )
+        _, fn, _ = _build_node_fn(
+            node,
+            source_names=["scored_quotes", "banded_quotes"],
+        )
 
-            with pytest.raises(ValueError, match="source_ids"):
-                fn(
-                    pl.DataFrame({"region": ["London"]}).lazy(),
-                    pl.DataFrame({"region": ["Manchester"]}).lazy(),
-                ).collect()
-        finally:
-            os.unlink(path)
+        with pytest.raises(ValueError, match="source_ids"):
+            fn(
+                pl.DataFrame({"region": ["London"]}).lazy(),
+                pl.DataFrame({"region": ["Manchester"]}).lazy(),
+            ).collect()
 
-    def test_online_apply_ignores_ratebook_input_and_uses_first_dataframe(self):
-        path = _write_artifact(_make_online_artifact(lambdas={"predicted_volume": 0.0}))
-        try:
-            unusable_ratebook_input = pl.DataFrame({"region": ["London"]})
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "ratebook_input": "unusable-ratebook-node",
-                }
-            )
-            _, fn, _ = _build_node_fn(
-                node,
-                source_names=["scored_quotes", "unusable_ratebook_input"],
-                source_ids=["scored-node", "unusable-ratebook-node"],
-            )
-            result = fn(_scored_df().lazy(), unusable_ratebook_input.lazy()).collect()
+    def test_online_apply_ignores_ratebook_input_and_uses_first_dataframe(self, write_artifact):
+        path = write_artifact(_make_online_artifact(lambdas={"predicted_volume": 0.0}))
+        unusable_ratebook_input = pl.DataFrame({"region": ["London"]})
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "ratebook_input": "unusable-ratebook-node",
+            }
+        )
+        _, fn, _ = _build_node_fn(
+            node,
+            source_names=["scored_quotes", "unusable_ratebook_input"],
+            source_ids=["scored-node", "unusable-ratebook-node"],
+        )
+        result = fn(_scored_df().lazy(), unusable_ratebook_input.lazy()).collect()
 
-            assert len(result) == 2
-            assert "optimal_scenario_value" in result.columns
-        finally:
-            os.unlink(path)
+        assert len(result) == 2
+        assert "optimal_scenario_value" in result.columns
 
-    def test_online_apply_uses_configured_optimised_value_column(self):
-        path = _write_artifact(_make_online_artifact(lambdas={"predicted_volume": 0.0}))
-        try:
-            node = _make_node(
-                {
-                    "sourceType": "file",
-                    "artifact_path": path,
-                    "optimised_value_column": "selected_price_factor",
-                }
-            )
-            _, fn, _ = _build_node_fn(node, source_names=["scored_quotes"])
-            result = fn(_scored_df().lazy()).collect()
+    def test_online_apply_uses_configured_optimised_value_column(self, write_artifact):
+        path = write_artifact(_make_online_artifact(lambdas={"predicted_volume": 0.0}))
+        node = _make_node(
+            {
+                "sourceType": "file",
+                "artifact_path": path,
+                "optimised_value_column": "selected_price_factor",
+            }
+        )
+        _, fn, _ = _build_node_fn(node, source_names=["scored_quotes"])
+        result = fn(_scored_df().lazy()).collect()
 
-            assert "selected_price_factor" in result.columns
-            assert "optimal_scenario_value" not in result.columns
-        finally:
-            os.unlink(path)
+        assert "selected_price_factor" in result.columns
+        assert "optimal_scenario_value" not in result.columns
 
 
 # ---------------------------------------------------------------------------
@@ -748,31 +689,28 @@ def _make_composite_artifact(version: str = "rb_comp_v1") -> dict:
 
 
 class TestExecutorRatebookComposite:
-    def test_composite_group_joins_on_component_columns(self):
+    def test_composite_group_joins_on_component_columns(self, write_artifact):
         """3b.2 repro: a composite artifact must join channel+age_band, not a
         literal "channel:age_band" column (ColumnNotFoundError at HEAD)."""
-        path = _write_artifact(_make_composite_artifact())
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2", "q3"],
-                    "channel": ["online", "phone", "online"],
-                    "age_band": ["18-25", "18-25", "26-40"],
-                    "price": [100.0, 200.0, 300.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            assert result["channel:age_band_optimised_factor"].to_list() == pytest.approx(
-                [1.05, 0.98, 1.10]
-            )
-            assert result["optimised_factor"].to_list() == pytest.approx([1.05, 0.98, 1.10])
-            # Join columns keep their values and dtypes.
-            assert result["channel"].to_list() == ["online", "phone", "online"]
-            assert result["age_band"].to_list() == ["18-25", "18-25", "26-40"]
-        finally:
-            os.unlink(path)
+        path = write_artifact(_make_composite_artifact())
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2", "q3"],
+                "channel": ["online", "phone", "online"],
+                "age_band": ["18-25", "18-25", "26-40"],
+                "price": [100.0, 200.0, 300.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        assert result["channel:age_band_optimised_factor"].to_list() == pytest.approx(
+            [1.05, 0.98, 1.10]
+        )
+        assert result["optimised_factor"].to_list() == pytest.approx([1.05, 0.98, 1.10])
+        # Join columns keep their values and dtypes.
+        assert result["channel"].to_list() == ["online", "phone", "online"]
+        assert result["age_band"].to_list() == ["18-25", "18-25", "26-40"]
 
     def test_composite_survives_json_round_trip(self):
         """The unit separator must survive json.dumps/load (\\u001f escape)."""
@@ -798,30 +736,27 @@ class TestExecutorRatebookComposite:
         result = _apply_ratebook(df.lazy(), artifact, "v1", "__ver__").collect()
         assert result["a:b:c_optimised_factor"].to_list() == pytest.approx([1.25])
 
-    def test_composite_mixed_with_single_column_table(self):
+    def test_composite_mixed_with_single_column_table(self, write_artifact):
         artifact = _make_composite_artifact()
         artifact["factor_tables"]["region"] = [
             {"__factor_group__": "London", "optimal_scenario_value": 1.20},
         ]
-        path = _write_artifact(artifact)
-        try:
-            df = pl.DataFrame(
-                {
-                    "quote_id": ["q1"],
-                    "channel": ["online"],
-                    "age_band": ["18-25"],
-                    "region": ["London"],
-                    "price": [100.0],
-                }
-            )
-            node = _make_node({"sourceType": "file", "artifact_path": path})
-            _, fn, _ = _build_node_fn(node, source_names=["base"])
-            result = fn(df.lazy()).collect()
-            assert result["channel:age_band_optimised_factor"][0] == pytest.approx(1.05)
-            assert result["region_optimised_factor"][0] == pytest.approx(1.20)
-            assert result["optimised_factor"][0] == pytest.approx(1.05 * 1.20)
-        finally:
-            os.unlink(path)
+        path = write_artifact(artifact)
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1"],
+                "channel": ["online"],
+                "age_band": ["18-25"],
+                "region": ["London"],
+                "price": [100.0],
+            }
+        )
+        node = _make_node({"sourceType": "file", "artifact_path": path})
+        _, fn, _ = _build_node_fn(node, source_names=["base"])
+        result = fn(df.lazy()).collect()
+        assert result["channel:age_band_optimised_factor"][0] == pytest.approx(1.05)
+        assert result["region_optimised_factor"][0] == pytest.approx(1.20)
+        assert result["optimised_factor"][0] == pytest.approx(1.05 * 1.20)
 
     def test_composite_unseen_combination_rates_neutral_and_warns(self):
         """A channel/age_band pair the solver never saw is a counted neutral
@@ -1140,33 +1075,30 @@ class TestApplyRatebookHelper:
 
 
 class TestBundler:
-    def test_collect_optimiser_apply_artifact(self):
+    def test_collect_optimiser_apply_artifact(self, write_artifact):
         from haute._types import PipelineGraph
         from haute.deploy._bundler import collect_artifacts
 
         artifact = _make_online_artifact()
-        path = _write_artifact(artifact)
-        try:
-            graph = PipelineGraph(
-                nodes=[
-                    GraphNode(
-                        id="apply_1",
-                        data=NodeData(
-                            label="Apply Opt",
-                            nodeType=NodeType.OPTIMISER_APPLY,
-                            config={"sourceType": "file", "artifact_path": path},
-                        ),
+        path = write_artifact(artifact)
+        graph = PipelineGraph(
+            nodes=[
+                GraphNode(
+                    id="apply_1",
+                    data=NodeData(
+                        label="Apply Opt",
+                        nodeType=NodeType.OPTIMISER_APPLY,
+                        config={"sourceType": "file", "artifact_path": path},
                     ),
-                ],
-                edges=[],
-            )
-            artifacts = collect_artifacts(graph, [], pipeline_dir=Path(path).parent)
-            assert len(artifacts) == 1
-            key = list(artifacts.keys())[0]
-            assert key.startswith("apply_1__")
-            assert artifacts[key].name.endswith(".json")
-        finally:
-            os.unlink(path)
+                ),
+            ],
+            edges=[],
+        )
+        artifacts = collect_artifacts(graph, [], pipeline_dir=Path(path).parent)
+        assert len(artifacts) == 1
+        key = list(artifacts.keys())[0]
+        assert key.startswith("apply_1__")
+        assert artifacts[key].name.endswith(".json")
 
     def test_bundler_skips_empty_path(self):
         from haute._types import PipelineGraph

--- a/tests/test_partial_failure.py
+++ b/tests/test_partial_failure.py
@@ -313,7 +313,9 @@ class TestPermissionDenied:
 class TestTempFileCleanupOnCrash:
     """Verify temp parquet files are cleaned up even when the thread crashes."""
 
-    def test_temp_parquet_cleaned_on_execute_exception(self, tmp_path: Path) -> None:
+    def test_temp_parquet_cleaned_on_execute_exception(
+        self, tmp_path: Path, haute_scratch: Path
+    ) -> None:
         """The try/finally pattern in _execute_and_sink cleans up temp files.
 
         Catches: temp file leak when _execute_lazy raises — disk fills up
@@ -324,7 +326,9 @@ class TestTempFileCleanupOnCrash:
         """
         import shutil
 
-        tmp_fd, tmp_parquet = tempfile.mkstemp(suffix=".parquet", prefix="haute_train_")
+        tmp_fd, tmp_parquet = tempfile.mkstemp(
+            suffix=".parquet", prefix="haute_train_", dir=haute_scratch
+        )
         os.close(tmp_fd)
         checkpoint_dir = tmp_path / "haute_train_ckpt_test"
         checkpoint_dir.mkdir()

--- a/tests/test_streaming_chunk_size_threading.py
+++ b/tests/test_streaming_chunk_size_threading.py
@@ -215,15 +215,12 @@ class TestSinkRouteThreading:
 class TestOptimiserExecutePipelineChunkSize:
     """The optimiser's ``_execute_pipeline`` honours ``body.streaming_chunk_size``."""
 
-    def _run(self, tmp_path, *, streaming_chunk_size: int | None) -> list[int | None]:
-        import shutil
-        import tempfile
-
+    def _run(self, haute_scratch, *, streaming_chunk_size: int | None) -> list[int | None]:
         from haute.routes._job_store import JobStore
         from haute.routes._optimiser_service import OptimiserSolveService
         from haute.schemas import OptimiserSolveRequest
 
-        data_path = tmp_path / "data.parquet"
+        data_path = haute_scratch / "data.parquet"
         pl.DataFrame(
             {
                 "quote_id": ["q1"],
@@ -270,19 +267,17 @@ class TestOptimiserExecutePipelineChunkSize:
                 side_effect=fake_ctx,
             ),
         ):
-            tmp = Path(tempfile.mkdtemp(prefix="haute_test_chunk_"))
-            try:
-                svc._execute_pipeline(body, "job-id", tmp)
-            finally:
-                shutil.rmtree(tmp, ignore_errors=True)
+            tmp = haute_scratch / "haute_test_chunk"
+            tmp.mkdir()
+            svc._execute_pipeline(body, "job-id", tmp)
         return captured
 
-    def test_uses_request_value(self, tmp_path):
-        captured = self._run(tmp_path, streaming_chunk_size=12345)
+    def test_uses_request_value(self, haute_scratch):
+        captured = self._run(haute_scratch, streaming_chunk_size=12345)
         assert captured == [12345]
 
-    def test_default_when_missing(self, tmp_path):
-        captured = self._run(tmp_path, streaming_chunk_size=None)
+    def test_default_when_missing(self, haute_scratch):
+        captured = self._run(haute_scratch, streaming_chunk_size=None)
         assert captured == [DEFAULT_STREAMING_CHUNK_SIZE]
 
 
@@ -993,7 +988,7 @@ class TestScenarioFrontierRangeAccumulatorFinishChunkSize:
     """``_ScenarioFrontierRangeAccumulator.finish`` wraps the bucket
     ``streaming_collect`` calls in ``temporary_streaming_chunk_size``."""
 
-    def _run(self, *, streaming_chunk_size: int | None) -> list[int | None]:
+    def _run(self, haute_scratch, *, streaming_chunk_size: int | None) -> list[int | None]:
         from contextlib import contextmanager
 
         from haute.routes._optimiser_service import (
@@ -1011,36 +1006,34 @@ class TestScenarioFrontierRangeAccumulatorFinishChunkSize:
 
             return _cm()
 
-        import tempfile
-        from pathlib import Path as _Path
-
-        with tempfile.TemporaryDirectory(prefix="haute_test_acc_") as parts_dir:
-            acc = _ScenarioFrontierRangeAccumulator(
-                quote_id_col="quote_id",
-                constraint_cols=["volume"],
-                partition_count=2,
-                parts_root=_Path(parts_dir),
-            )
-            batch = pl.DataFrame(
-                {
-                    "quote_id": ["q1", "q2"],
-                    "volume": [1.0, 2.0],
-                }
-            )
-            acc.add_batch(batch, batch_index=0)
-            with patch(
-                "haute.routes._optimiser_service.temporary_streaming_chunk_size",
-                side_effect=fake_ctx,
-            ):
-                acc.finish(streaming_chunk_size=streaming_chunk_size)
+        parts_dir = haute_scratch / "acc_parts"
+        parts_dir.mkdir()
+        acc = _ScenarioFrontierRangeAccumulator(
+            quote_id_col="quote_id",
+            constraint_cols=["volume"],
+            partition_count=2,
+            parts_root=parts_dir,
+        )
+        batch = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q2"],
+                "volume": [1.0, 2.0],
+            }
+        )
+        acc.add_batch(batch, batch_index=0)
+        with patch(
+            "haute.routes._optimiser_service.temporary_streaming_chunk_size",
+            side_effect=fake_ctx,
+        ):
+            acc.finish(streaming_chunk_size=streaming_chunk_size)
         return captured
 
-    def test_uses_request_value(self):
-        captured = self._run(streaming_chunk_size=12345)
+    def test_uses_request_value(self, haute_scratch):
+        captured = self._run(haute_scratch, streaming_chunk_size=12345)
         assert 12345 in captured
 
-    def test_default_when_missing(self):
-        captured = self._run(streaming_chunk_size=None)
+    def test_default_when_missing(self, haute_scratch):
+        captured = self._run(haute_scratch, streaming_chunk_size=None)
         assert DEFAULT_STREAMING_CHUNK_SIZE in captured
 
 

--- a/tests/test_write_sandbox_guard.py
+++ b/tests/test_write_sandbox_guard.py
@@ -1,0 +1,193 @@
+"""Self-tests for the write-sandbox runtime guard (layer 3).
+
+This module is listed in ``tests/_write_sandbox.STRICT_FILES``, so every test
+here runs under the strict guard — the placement assertions below are live
+proof that strict mode is what the suite actually applies, not a simulation.
+This file is also part of the CI ``platform-smoke`` lane's explicit list:
+path resolution, temp-dir env names, and home-dir semantics all differ on
+Windows, and the guard must hold there too.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tests import _write_sandbox as ws
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _real(path: object) -> str:
+    return os.path.realpath(str(path))
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode placement: cwd, temp, home, env export
+# ---------------------------------------------------------------------------
+
+
+def test_strict_mode_chdirs_into_sandbox(tmp_path: Path) -> None:
+    assert _real(Path.cwd()) == _real(tmp_path)
+
+
+def test_sandbox_root_exported_for_hooks(tmp_path: Path) -> None:
+    root = ws.sandbox_root()
+    assert root is not None
+    assert _real(root) == _real(tmp_path)
+
+
+def test_tempfile_machinery_points_into_sandbox(tmp_path: Path) -> None:
+    assert ws._is_within(_real(tempfile.gettempdir()), _real(tmp_path))
+    with tempfile.NamedTemporaryFile() as handle:
+        assert ws._is_within(_real(handle.name), _real(tmp_path))
+
+
+def test_home_points_into_sandbox(tmp_path: Path) -> None:
+    env_name = "USERPROFILE" if os.name == "nt" else "HOME"
+    assert ws._is_within(_real(os.environ[env_name]), _real(tmp_path))
+    assert ws._is_within(_real(Path.home()), _real(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_writes_inside_sandbox_succeed(haute_scratch: Path) -> None:
+    target = haute_scratch / "inside.txt"
+    target.write_text("ok", encoding="utf-8")
+    assert target.read_text(encoding="utf-8") == "ok"
+
+
+def test_relative_writes_land_in_sandbox(tmp_path: Path) -> None:
+    with open("relative.txt", "w", encoding="utf-8") as handle:  # write-sandbox: deliberate
+        handle.write("contained")
+    assert (tmp_path / "relative.txt").read_text(encoding="utf-8") == "contained"
+
+
+def test_open_write_outside_sandbox_is_blocked() -> None:
+    outside = _REPO_ROOT / "_write_sandbox_probe.txt"
+    try:
+        with pytest.raises(ws.OutOfSandboxWriteError):
+            open(outside, "w", encoding="utf-8")  # write-sandbox: deliberate
+        assert not outside.exists()
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_os_open_write_outside_sandbox_is_blocked() -> None:
+    outside = _REPO_ROOT / "_write_sandbox_probe_os.txt"
+    try:
+        with pytest.raises(ws.OutOfSandboxWriteError):
+            os.open(outside, os.O_WRONLY | os.O_CREAT)
+        assert not outside.exists()
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_reads_outside_sandbox_still_allowed() -> None:
+    text = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert "[project]" in text
+
+
+def test_devnull_always_writable() -> None:
+    with open(os.devnull, "w", encoding="utf-8") as handle:
+        handle.write("discard")
+
+
+# ---------------------------------------------------------------------------
+# Observe mode (the census): recorded, never blocked
+# ---------------------------------------------------------------------------
+
+
+def test_observe_mode_records_instead_of_blocking(haute_scratch: Path) -> None:
+    """A nested observe guard with a narrower root records the escape.
+
+    The stray write stays inside the *real* strict sandbox (so the outer
+    guard permits it) but outside the nested guard's pretend root — exactly
+    an unconverted test writing outside its sandbox, in miniature.
+    """
+    pretend_root = haute_scratch / "pretend_sandbox"
+    pretend_root.mkdir()
+    stray = haute_scratch / "stray.txt"
+    before = len(ws.VIOLATIONS)
+    guard = ws.Guard(mode="observe", nodeid="census-probe", allowed_roots=(_real(pretend_root),))
+    guard.install()
+    try:
+        with open(stray, "w", encoding="utf-8") as handle:
+            handle.write("observed")
+    finally:
+        guard.uninstall()
+        recorded = [v for v in ws.VIOLATIONS[before:] if v.nodeid == "census-probe"]
+        del ws.VIOLATIONS[before:]  # keep the probe out of the real census
+    assert stray.read_text(encoding="utf-8") == "observed"  # observe never blocks
+    assert any(v.api == "open" and v.path == _real(stray) for v in recorded)
+
+
+def test_observe_mode_ignores_reads_and_in_root_writes(haute_scratch: Path) -> None:
+    inside = haute_scratch / "fine.txt"
+    before = len(ws.VIOLATIONS)
+    guard = ws.Guard(mode="observe", nodeid="census-probe-2", allowed_roots=(_real(haute_scratch),))
+    guard.install()
+    try:
+        inside.write_text("fine", encoding="utf-8")
+        inside.read_text(encoding="utf-8")
+    finally:
+        guard.uninstall()
+    assert [v for v in ws.VIOLATIONS[before:] if v.nodeid == "census-probe-2"] == []
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_mode_precedence() -> None:
+    strict_file = "test_write_sandbox_guard.py"
+
+    def mode(env: str | None, *, perf: bool = False, name: str = "other.py", mark: bool = False):
+        return ws.resolve_mode(env, is_perf=perf, filename=name, marked_strict=mark)
+
+    assert mode("off", name=strict_file, mark=True) == "off"
+    assert mode(None, perf=True, name=strict_file) == "off"
+    assert mode(None, name=strict_file) == "strict"
+    assert mode(None, mark=True) == "strict"
+    assert mode(None) == "observe"
+    assert mode("strict") == "strict"
+
+
+def test_write_intent_detection() -> None:
+    for mode in ("w", "wb", "a", "ab", "x", "xb", "r+", "rb+", "w+"):
+        assert ws.mode_writes(mode), mode
+    for mode in ("r", "rb", "rt"):
+        assert not ws.mode_writes(mode), mode
+    assert ws.flags_write(os.O_WRONLY | os.O_CREAT)
+    assert ws.flags_write(os.O_RDWR)
+    assert ws.flags_write(os.O_RDONLY | os.O_CREAT)
+    assert not ws.flags_write(os.O_RDONLY)
+
+
+def test_is_within_boundaries() -> None:
+    root = _real(Path("alpha")) if os.name == "nt" else "/alpha"
+    assert ws._is_within(root, root)
+    assert ws._is_within(root + os.sep + "child.txt", root)
+    assert not ws._is_within(root + "-sibling" + os.sep + "x", root)
+
+
+def test_census_dump_load_summarize_roundtrip(haute_scratch: Path) -> None:
+    rows = [
+        ws.Violation(nodeid="t::one", api="open", path="/x/shared", detail="mode='w'"),
+        ws.Violation(nodeid="t::two", api="os.open", path="/x/shared", detail="flags=0o1101"),
+        ws.Violation(nodeid="t::three", api="open", path="/y/other", detail="mode='a'"),
+    ]
+    census_dir = haute_scratch / "census"
+    ws.dump_census(str(census_dir), "probe", rows)
+    loaded = ws.load_census(str(census_dir))
+    assert loaded == rows
+    lines = ws.summarize(loaded)
+    assert len(lines) == 2
+    assert any("/x/shared" in line and "t::one" in line for line in lines)

--- a/tests/test_write_sandbox_lint.py
+++ b/tests/test_write_sandbox_lint.py
@@ -1,0 +1,793 @@
+"""Layer 2 of the test write-sandbox: a static AST gate over ``tests/``.
+
+Filesystem-write APIs in test code must target paths derived from the
+per-test scratch fixtures (``haute_scratch`` / ``tmp_path`` /
+``tmp_path_factory`` — one sandbox substrate; ``haute_scratch`` is the
+convention name). This scan turns that rule into a CI gate, in the same
+idiom as the subprocess chokepoint scan (``test_repository_hygiene.py``)
+and the skip/xfail debt ratchet (``test_test_debt.py``): explicit
+allowlist, asserted stale in both directions.
+
+What it flags, per lexical scope, unless the target is *taint-derived*
+from a scratch fixture:
+
+* ``tempfile.mkdtemp`` / ``tempfile.mkstemp`` — system-temp, leak-prone
+  (no ``dir=`` derived from the sandbox). The self-cleaning context
+  managers (``TemporaryDirectory`` etc.) stay legal: the runtime guard
+  redirects them into the sandbox.
+* ``open(..., "w"/"a"/"x"/"+")`` and ``Path.open`` in write modes.
+* ``Path.write_text`` / ``Path.write_bytes``.
+* ``os.makedirs``.
+* Destination-writing ``shutil`` calls.
+* Absolute-path and parent-traversal (``..``) string literals inside the
+  *targets of the write APIs above*. Bare ``Path("/abs")`` constructions
+  and read-mode opens are deliberately not flagged: adversarial-input
+  tests (path traversal, security) use absolute/parent literals as data,
+  and the sandbox rule is about writes, not reads.
+
+A line ending in ``# write-sandbox: deliberate`` is exempt — reserved for
+the guard's own self-tests (which must attempt real escapes) and the
+census spool plumbing in ``conftest.py``.
+
+The taint rule is deliberately conservative-static: fixture parameters
+seed it, assignments/`with` targets/f-strings propagate it, *any*
+function parameter counts as derived (call-side responsibility), and
+targets the scan cannot resolve (call results, non-literal modes) pass —
+the runtime guard (layer 3, ``tests/_write_sandbox.py``) owns what
+static analysis cannot see.
+
+The allowlist below carries the not-yet-converted files with their
+current violation counts. Shrinking it is the conversion ratchet; a new
+entry, or a count that grows, is a deliberate review decision made in
+this file, where review sees it.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+from tests._write_sandbox import ENV_ROOT, STRICT_FILES
+
+_TESTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _TESTS_DIR.parent
+_SKIP_DIRS = {"__pycache__", ".pytest_cache", ".ruff_cache", ".mypy_cache"}
+
+_TAINT_SEEDS = frozenset({"haute_scratch", "tmp_path", "tmp_path_factory"})
+
+_TEMPFILE_SELF_CLEANING = frozenset(
+    {"TemporaryDirectory", "NamedTemporaryFile", "TemporaryFile", "SpooledTemporaryFile"}
+)
+_TEMPFILE_BANNED = frozenset({"mkdtemp", "mkstemp"})
+
+_PATH_WRITE_ATTRS = frozenset({"write_text", "write_bytes"})
+
+# shutil callables that write at a destination: name -> (positional index of
+# the destination, keyword name). Read-only shutil (disk_usage, which) is fine.
+_SHUTIL_DEST = {
+    "copy": (1, "dst"),
+    "copy2": (1, "dst"),
+    "copyfile": (1, "dst"),
+    "copymode": (1, "dst"),
+    "copystat": (1, "dst"),
+    "copytree": (1, "dst"),
+    "move": (1, "dst"),
+    "rmtree": (0, "path"),
+    "make_archive": (0, "base_name"),
+    "unpack_archive": (1, "extract_dir"),
+}
+
+_PATH_CONSTRUCTORS = frozenset(
+    {"Path", "PurePath", "PurePosixPath", "PureWindowsPath", "PosixPath", "WindowsPath"}
+)
+
+_ABS_PATH_RE = re.compile(r"^(?:/|[A-Za-z]:[/\\]|\\\\)")
+_PARENT_RE = re.compile(r"(?:^|[/\\])\.\.(?:[/\\]|$)")
+
+_WRITE_MODE_CHARS = frozenset("wax+")
+
+
+@dataclass(frozen=True)
+class LintViolation:
+    file: str  # repo-relative posix path
+    line: int
+    kind: str
+    detail: str
+
+
+def _iter_test_sources() -> list[Path]:
+    return sorted(
+        path
+        for path in _TESTS_DIR.rglob("*.py")
+        if not any(part in _SKIP_DIRS for part in path.parts)
+    )
+
+
+def _module_aliases(tree: ast.Module, module: str) -> tuple[set[str], dict[str, str]]:
+    """Names bound to *module* and to its members, file-wide.
+
+    Returns ``(module_aliases, member_alias_to_member)`` — e.g. for
+    ``import tempfile as _tempfile`` and ``from tempfile import mkdtemp as mk``:
+    ``({"_tempfile"}, {"mk": "mkdtemp"})``.
+    """
+    aliases: set[str] = set()
+    members: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == module:
+                    aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == module:
+            for alias in node.names:
+                members[alias.asname or alias.name] = alias.name
+    return aliases, members
+
+
+_PRAGMA = "# write-sandbox: deliberate"
+
+
+class _FileScanner:
+    """Scans one test file, scope by scope."""
+
+    def __init__(self, rel: str, tree: ast.Module, source_lines: list[str]) -> None:
+        self.rel = rel
+        self.source_lines = source_lines
+        self.violations: list[LintViolation] = []
+        self.tempfile_aliases, self.tempfile_members = _module_aliases(tree, "tempfile")
+        self.shutil_aliases, self.shutil_members = _module_aliases(tree, "shutil")
+        self.os_aliases, self.os_members = _module_aliases(tree, "os")
+        self.io_aliases, _ = _module_aliases(tree, "io")
+
+    # -- taint ------------------------------------------------------------
+
+    def _call_member(
+        self, call: ast.Call, aliases: set[str], members: dict[str, str]
+    ) -> str | None:
+        """The member name a call resolves to within a module, or None."""
+        func = call.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            if func.value.id in aliases:
+                return func.attr
+        elif isinstance(func, ast.Name) and func.id in members:
+            return members[func.id]
+        return None
+
+    def _is_sandbox_env_lookup(self, node: ast.expr) -> bool:
+        """``os.environ[ENV_ROOT]`` / ``os.environ.get(ENV_ROOT)`` / ``os.getenv(ENV_ROOT)``."""
+        if isinstance(node, ast.Subscript):
+            value, key = node.value, node.slice
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.args:
+            if node.func.attr == "get":
+                value, key = node.func.value, node.args[0]
+            elif node.func.attr == "getenv" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id in self.os_aliases:
+                    key = node.args[0]
+                    return isinstance(key, ast.Constant) and key.value == ENV_ROOT
+                return False
+            else:
+                return False
+        else:
+            return False
+        return (
+            isinstance(value, ast.Attribute)
+            and value.attr == "environ"
+            and isinstance(value.value, ast.Name)
+            and value.value.id in self.os_aliases
+            and isinstance(key, ast.Constant)
+            and key.value == ENV_ROOT
+        )
+
+    def _tainted(self, node: ast.expr, tainted: set[str]) -> bool:
+        """True if *node* plausibly derives from a scratch fixture."""
+        if isinstance(node, ast.Name):
+            return node.id in tainted
+        if isinstance(node, ast.Starred):
+            return self._tainted(node.value, tainted)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return self._tainted(node.left, tainted) or self._tainted(node.right, tainted)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            # str concatenation building on a tainted prefix
+            return self._tainted(node.left, tainted) or self._tainted(node.right, tainted)
+        if isinstance(node, ast.Attribute):
+            # os.devnull is a legitimate sink everywhere
+            if (
+                node.attr == "devnull"
+                and isinstance(node.value, ast.Name)
+                and node.value.id in self.os_aliases
+            ):
+                return True
+            return self._tainted(node.value, tainted)
+        if isinstance(node, ast.Subscript):
+            if self._is_sandbox_env_lookup(node):
+                return True
+            return self._tainted(node.value, tainted)
+        if isinstance(node, ast.JoinedStr):
+            return any(
+                self._tainted(part.value, tainted)
+                for part in node.values
+                if isinstance(part, ast.FormattedValue)
+            )
+        if isinstance(node, ast.IfExp):
+            return self._tainted(node.body, tainted) or self._tainted(node.orelse, tainted)
+        if isinstance(node, ast.Call):
+            if self._is_sandbox_env_lookup(node):
+                return True
+            func = node.func
+            if isinstance(func, ast.Name) and (
+                func.id in _PATH_CONSTRUCTORS or func.id in {"str", "repr"}
+            ):
+                return any(self._tainted(arg, tainted) for arg in node.args)
+            if isinstance(func, ast.Attribute):
+                if func.attr == "fspath":
+                    return any(self._tainted(arg, tainted) for arg in node.args)
+                # method call on a tainted object: p.with_suffix(...), p.joinpath(...),
+                # tmp_path_factory.mktemp(...), f"{p}".format? (attr chains handled above)
+                return self._tainted(func.value, tainted)
+        return False
+
+    def _bind_targets(self, target: ast.expr, tainted: set[str]) -> None:
+        if isinstance(target, ast.Name):
+            tainted.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._bind_targets(element, tainted)
+        elif isinstance(target, ast.Starred):
+            self._bind_targets(target.value, tainted)
+
+    def _propagate(self, nodes: list[ast.stmt], tainted: set[str]) -> None:
+        """Grow the taint set from assignment-like statements (to fixpoint)."""
+        while True:
+            before = len(tainted)
+            for stmt in nodes:
+                for node in self._walk_scope(stmt):
+                    if isinstance(node, ast.Assign):
+                        if self._assign_value_tainted(node.value, tainted):
+                            for target in node.targets:
+                                self._bind_targets(target, tainted)
+                    elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                        if self._assign_value_tainted(node.value, tainted):
+                            self._bind_targets(node.target, tainted)
+                    elif isinstance(node, ast.NamedExpr):
+                        if self._assign_value_tainted(node.value, tainted):
+                            self._bind_targets(node.target, tainted)
+                    elif isinstance(node, (ast.With, ast.AsyncWith)):
+                        for item in node.items:
+                            if item.optional_vars is None:
+                                continue
+                            if self._with_context_tainted(item.context_expr, tainted):
+                                self._bind_targets(item.optional_vars, tainted)
+                    elif isinstance(node, (ast.For, ast.AsyncFor)):
+                        if self._tainted(node.iter, tainted):
+                            self._bind_targets(node.target, tainted)
+            if len(tainted) == before:
+                return
+
+    def _assign_value_tainted(self, value: ast.expr, tainted: set[str]) -> bool:
+        if self._tainted(value, tainted):
+            return True
+        # fd, path = tempfile.mkstemp(dir=<tainted>) — sandbox-located result
+        if isinstance(value, ast.Call):
+            member = self._call_member(value, self.tempfile_aliases, self.tempfile_members)
+            if member in _TEMPFILE_BANNED and self._dir_kwarg_tainted(value, tainted):
+                return True
+        return False
+
+    def _with_context_tainted(self, context: ast.expr, tainted: set[str]) -> bool:
+        if self._tainted(context, tainted):
+            return True
+        if isinstance(context, ast.Call):
+            member = self._call_member(context, self.tempfile_aliases, self.tempfile_members)
+            if member in _TEMPFILE_SELF_CLEANING:
+                return True  # self-cleaning; runtime TMPDIR redirect sandboxes it
+        return False
+
+    def _dir_kwarg_tainted(self, call: ast.Call, tainted: set[str]) -> bool:
+        for keyword in call.keywords:
+            if keyword.arg == "dir":
+                return self._tainted(keyword.value, tainted)
+        return False
+
+    # -- scope plumbing ----------------------------------------------------
+
+    def _walk_scope(self, root: ast.AST) -> list[ast.AST]:
+        """All nodes under *root* without descending into nested functions."""
+        collected: list[ast.AST] = []
+        stack: list[ast.AST] = [root]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue  # a nested scope — scanned separately with its own taint
+            collected.append(node)
+            stack.extend(ast.iter_child_nodes(node))
+        return collected
+
+    def scan(self, tree: ast.Module) -> list[LintViolation]:
+        # Module/class-level statements form one scope with no parameter seeds;
+        # every function/method is its own scope, seeded with the fixtures, its
+        # parameters, and — closures — everything tainted in its enclosing scope.
+        module_scope: list[ast.stmt] = []
+        functions: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+
+        def split(body: list[ast.stmt]) -> None:
+            for stmt in body:
+                if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    functions.append(stmt)
+                elif isinstance(stmt, ast.ClassDef):
+                    split(stmt.body)
+                else:
+                    module_scope.append(stmt)
+
+        split(tree.body)
+        module_tainted: set[str] = set()
+        self._propagate(module_scope, module_tainted)
+        self._check_scope(module_scope, module_tainted)
+        for function in functions:
+            self._scan_function(function, module_tainted)
+        return self.violations
+
+    def _scan_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, enclosing: set[str]
+    ) -> None:
+        tainted = set(enclosing) | _TAINT_SEEDS
+        args = node.args
+        for arg in (
+            *args.posonlyargs,
+            *args.args,
+            *args.kwonlyargs,
+            *((args.vararg,) if args.vararg else ()),
+            *((args.kwarg,) if args.kwarg else ()),
+        ):
+            tainted.add(arg.arg)
+        self._propagate(node.body, tainted)
+        self._check_scope(node.body, tainted)
+        for nested in self._nested_functions(node.body):
+            self._scan_function(nested, tainted)
+
+    def _nested_functions(
+        self, body: list[ast.stmt]
+    ) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+        found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+        stack: list[ast.AST] = list(body)
+        while stack:
+            node = stack.pop()
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                found.append(node)
+            elif not isinstance(node, ast.Lambda):
+                stack.extend(ast.iter_child_nodes(node))
+        return found
+
+    # -- checks -------------------------------------------------------------
+
+    def _flag(self, node: ast.AST, kind: str, detail: str) -> None:
+        line = getattr(node, "lineno", 0)
+        if 0 < line <= len(self.source_lines) and self.source_lines[line - 1].rstrip().endswith(
+            _PRAGMA
+        ):
+            return
+        self.violations.append(LintViolation(file=self.rel, line=line, kind=kind, detail=detail))
+
+    def _check_write_target(
+        self, call: ast.Call, target: ast.expr, tainted: set[str], kind: str
+    ) -> None:
+        """One violation max per write call: untainted target, else literal escape."""
+        if not self._tainted(target, tainted):
+            self._flag(call, kind, ast.dump(target)[:60])
+            return
+        for node in ast.walk(target):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                # Interior f-string segments legitimately start with a
+                # separator (f"{root}/name"); only a *leading* segment can
+                # re-root the path, and JoinedStr walks handle that below.
+                if _ABS_PATH_RE.match(node.value) and not self._is_interior_fstring_segment(
+                    target, node
+                ):
+                    self._flag(call, "absolute-path-literal", node.value)
+                    return
+                if node.value == ".." or _PARENT_RE.search(node.value):
+                    self._flag(call, "parent-traversal-literal", node.value)
+                    return
+
+    @staticmethod
+    def _is_interior_fstring_segment(target: ast.expr, constant: ast.Constant) -> bool:
+        for node in ast.walk(target):
+            if isinstance(node, ast.JoinedStr) and constant in node.values[1:]:
+                return True
+        return False
+
+    def _open_mode(self, call: ast.Call, position: int) -> str | None:
+        """The literal mode argument of an open-like call, if statically known."""
+        if len(call.args) > position and isinstance(call.args[position], ast.Constant):
+            value = call.args[position].value
+            return value if isinstance(value, str) else None
+        for keyword in call.keywords:
+            if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+                value = keyword.value.value
+                return value if isinstance(value, str) else None
+        return None
+
+    def _check_scope(self, nodes: list[ast.stmt], tainted: set[str]) -> None:
+        for stmt in nodes:
+            for node in self._walk_scope(stmt):
+                if isinstance(node, ast.Call):
+                    self._check_call(node, tainted)
+
+    def _check_call(self, call: ast.Call, tainted: set[str]) -> None:
+        func = call.func
+
+        # tempfile.mkdtemp / mkstemp
+        member = self._call_member(call, self.tempfile_aliases, self.tempfile_members)
+        if member in _TEMPFILE_BANNED:
+            dir_kwargs = [kw.value for kw in call.keywords if kw.arg == "dir"]
+            if not dir_kwargs:
+                self._flag(call, f"tempfile.{member}", "system-temp target; use haute_scratch")
+            else:
+                self._check_write_target(call, dir_kwargs[0], tainted, f"tempfile.{member}")
+            return
+
+        # builtin open / io.open
+        is_open = (isinstance(func, ast.Name) and func.id == "open") or (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and isinstance(func.value, ast.Name)
+            and func.value.id in self.io_aliases
+        )
+        if is_open and call.args:
+            mode = self._open_mode(call, 1)
+            if mode is not None and _WRITE_MODE_CHARS & set(mode):
+                self._check_write_target(call, call.args[0], tainted, "open-write")
+            return
+
+        # Path-object writes: .write_text/.write_bytes/.open("w")
+        if isinstance(func, ast.Attribute):
+            if func.attr in _PATH_WRITE_ATTRS:
+                self._check_write_target(call, func.value, tainted, f"Path.{func.attr}")
+                return
+            if func.attr == "open":
+                mode = self._open_mode(call, 0)
+                if mode is not None and _WRITE_MODE_CHARS & set(mode):
+                    self._check_write_target(call, func.value, tainted, "Path.open-write")
+                return
+
+        # os.makedirs
+        os_member = self._call_member(call, self.os_aliases, self.os_members)
+        if os_member == "makedirs" and call.args:
+            self._check_write_target(call, call.args[0], tainted, "os.makedirs")
+            return
+
+        # shutil destination writers
+        shutil_member = self._call_member(call, self.shutil_aliases, self.shutil_members)
+        if shutil_member in _SHUTIL_DEST:
+            position, kw_name = _SHUTIL_DEST[shutil_member]
+            dest: ast.expr | None = None
+            if len(call.args) > position:
+                dest = call.args[position]
+            else:
+                for keyword in call.keywords:
+                    if keyword.arg == kw_name:
+                        dest = keyword.value
+            if dest is not None:
+                self._check_write_target(call, dest, tainted, f"shutil.{shutil_member}")
+
+
+def scan_source(rel: str, source: str) -> list[LintViolation]:
+    tree = ast.parse(source)
+    return _FileScanner(rel, tree, source.splitlines()).scan(tree)
+
+
+def scan_tests() -> dict[str, list[LintViolation]]:
+    results: dict[str, list[LintViolation]] = {}
+    for path in _iter_test_sources():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        violations = scan_source(rel, path.read_text(encoding="utf-8"))
+        if violations:
+            results[rel] = violations
+    return results
+
+
+# ---------------------------------------------------------------------------
+# The allowlist: not-yet-converted files -> current violation count.
+# Shrink by converting a file to derive its writes from haute_scratch and
+# deleting its row. Counts are exact on purpose: growth in an allowlisted
+# file fails the gate the same as a new file would.
+# ---------------------------------------------------------------------------
+
+EXPECTED_VIOLATIONS: dict[str, int] = {
+    # Mostly writes through cache-dir/model-dir helper call results the static
+    # taint cannot resolve, plus a handful of genuine system-temp users. The
+    # runtime census (layer 3 observe mode) is the ground truth for which of
+    # these actually escape the sandbox at run time.
+    "tests/test_algorithms_coverage.py": 3,
+    "tests/test_cache_perf_fixes.py": 2,
+    "tests/test_databricks_io.py": 3,
+    "tests/test_dataframe_execution_cache.py": 1,
+    "tests/test_deploy.py": 1,
+    "tests/test_deploy_contract_integrity.py": 1,
+    "tests/test_deploy_scorer_artifact_cache.py": 1,
+    "tests/test_executor.py": 2,
+    "tests/test_file_ops.py": 18,
+    "tests/test_git_graph.py": 5,
+    "tests/test_graph_fingerprint_cached.py": 1,
+    "tests/test_json_cache_coverage_uplift.py": 19,
+    "tests/test_json_cache_integrity.py": 1,
+    "tests/test_json_shred_mut_stragglers.py": 1,
+    "tests/test_mlflow_io.py": 2,
+    "tests/test_mlflow_io_concurrency.py": 12,
+    "tests/test_model_score_executor.py": 1,
+    "tests/test_optimiser_routes.py": 2,
+    "tests/test_optimiser_service_coverage.py": 2,
+    "tests/test_polars_utils.py": 1,
+    "tests/test_runtime_input_cache_invalidation.py": 1,
+    "tests/test_server.py": 1,
+    "tests/test_submodel_routes.py": 3,
+}
+
+
+def test_write_apis_derive_from_scratch_fixture() -> None:
+    observed = {rel: len(violations) for rel, violations in scan_tests().items()}
+    details = {
+        rel: [f"  {v.file}:{v.line} {v.kind} ({v.detail})" for v in violations]
+        for rel, violations in scan_tests().items()
+    }
+
+    unexpected = {
+        rel: count for rel, count in observed.items() if count > EXPECTED_VIOLATIONS.get(rel, 0)
+    }
+    stale = {
+        rel: expected
+        for rel, expected in EXPECTED_VIOLATIONS.items()
+        if observed.get(rel, 0) < expected
+    }
+
+    unexpected_lines = "\n".join(
+        line
+        for rel in sorted(unexpected)
+        for line in [f"{rel}: {observed[rel]} (allowlisted: {EXPECTED_VIOLATIONS.get(rel, 0)})"]
+        + details.get(rel, [])
+    )
+    assert unexpected == {}, (
+        "New test-write violations outside the sandbox convention. Derive the "
+        "write target from the haute_scratch fixture (or tmp_path); tempfile."
+        "mkdtemp/mkstemp, absolute paths, and '..' are banned in tests/. If the "
+        "file genuinely cannot convert yet, add/update its allowlist row here, "
+        f"where review sees it.\n{unexpected_lines}"
+    )
+    stale_report = {rel: (EXPECTED_VIOLATIONS[rel], observed.get(rel, 0)) for rel in sorted(stale)}
+    assert stale == {}, (
+        "Allowlist is stale — these files now have fewer violations than "
+        "recorded. Ratchet down their counts (or delete the rows) so the "
+        f"gate keeps its teeth: {stale_report}"
+    )
+
+
+def test_strict_files_are_lint_clean() -> None:
+    """Layer coupling: a strict (converted) module may not be allowlisted."""
+    overlap = sorted(rel for rel in EXPECTED_VIOLATIONS if Path(rel).name in STRICT_FILES)
+    assert overlap == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the scanner itself (textwrap probes, test_test_debt idiom)
+# ---------------------------------------------------------------------------
+
+
+def _probe(source: str) -> list[str]:
+    violations = scan_source("tests/probe.py", textwrap.dedent(source))
+    return [v.kind for v in violations]
+
+
+def test_scanner_flags_bare_mkstemp_and_mkdtemp() -> None:
+    kinds = _probe(
+        """
+        import tempfile
+
+        def test_x():
+            fd, path = tempfile.mkstemp(suffix=".json")
+            d = tempfile.mkdtemp()
+        """
+    )
+    assert kinds == ["tempfile.mkstemp", "tempfile.mkdtemp"]
+
+
+def test_scanner_allows_mkstemp_into_scratch() -> None:
+    kinds = _probe(
+        """
+        import tempfile
+
+        def test_x(haute_scratch):
+            fd, path = tempfile.mkstemp(dir=haute_scratch)
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("ok")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_flags_untainted_open_write_but_not_read() -> None:
+    kinds = _probe(
+        """
+        def test_x():
+            data = open("config.json", encoding="utf-8").read()
+            with open(computed(), "w", encoding="utf-8") as fh:
+                fh.write("x")
+        """
+    )
+    assert kinds == ["open-write"]
+
+
+def test_scanner_allows_scratch_derived_writes_through_assignments() -> None:
+    kinds = _probe(
+        """
+        import shutil
+
+        def test_x(tmp_path, haute_scratch):
+            sub = tmp_path / "nested" / "dir"
+            target = sub.with_suffix(".json")
+            target.write_text("{}", encoding="utf-8")
+            (haute_scratch / "b.bin").write_bytes(b"x")
+            shutil.copytree("fixtures", haute_scratch / "copy")
+            shutil.rmtree(sub)
+            with open(f"{tmp_path}/f.txt", "w", encoding="utf-8") as fh:
+                fh.write("ok")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_flags_module_level_literal_writes() -> None:
+    kinds = _probe(
+        """
+        from pathlib import Path
+
+        Path("out.json").write_text("{}", encoding="utf-8")
+        """
+    )
+    assert kinds == ["Path.write_text"]
+
+
+def test_scanner_flags_literal_escapes_from_tainted_roots() -> None:
+    kinds = _probe(
+        """
+        def test_x(tmp_path, haute_scratch):
+            (tmp_path / ".." / "escape.txt").write_text("x", encoding="utf-8")
+            with open(f"{haute_scratch}/../gone.txt", "w", encoding="utf-8") as fh:
+                fh.write("x")
+            (tmp_path / "/etc/absolute").write_bytes(b"x")
+        """
+    )
+    assert sorted(kinds) == [
+        "absolute-path-literal",
+        "parent-traversal-literal",
+        "parent-traversal-literal",
+    ]
+
+
+def test_scanner_flags_untainted_write_targets_once_each() -> None:
+    kinds = _probe(
+        """
+        from pathlib import Path
+
+        def test_x():
+            Path("/etc/haute.cfg").write_text("x", encoding="utf-8")
+            with open("/var/log/haute.log", "a", encoding="utf-8") as fh:
+                fh.write("x")
+        """
+    )
+    assert kinds == ["Path.write_text", "open-write"]
+
+
+def test_scanner_spares_adversarial_path_data_and_reads() -> None:
+    kinds = _probe(
+        """
+        from pathlib import Path
+
+        def test_x(client):
+            evil = Path("/etc/evil.py")
+            probe = Path("../../../etc/passwd")
+            body = open("/etc/hosts", encoding="utf-8").read()
+            response = client.post("/api/save", json={"path": str(evil)})
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_honours_deliberate_pragma_and_devnull() -> None:
+    kinds = _probe(
+        """
+        import os
+
+        def test_x():
+            with open("outside.txt", "w", encoding="utf-8") as fh:  # write-sandbox: deliberate
+                fh.write("probe")
+            with open(os.devnull, "w", encoding="utf-8") as sink:
+                sink.write("gone")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_does_not_flag_route_literals_or_data_strings() -> None:
+    kinds = _probe(
+        """
+        def test_x(client):
+            response = client.get("/api/files")
+            assert "../traversal" in response.text
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_treats_env_root_lookup_as_scratch_derived() -> None:
+    kinds = _probe(
+        f"""
+        import os
+        from pathlib import Path
+
+        def helper():
+            root = Path(os.environ["{ENV_ROOT}"])
+            (root / "artifact.json").write_text("{{}}", encoding="utf-8")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_trusts_function_parameters_call_side() -> None:
+    kinds = _probe(
+        """
+        def write_config(directory, payload):
+            (directory / "cfg.json").write_text(payload, encoding="utf-8")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_taints_self_cleaning_tempfile_context_names() -> None:
+    kinds = _probe(
+        """
+        import tempfile
+        from pathlib import Path
+
+        def test_x():
+            with tempfile.TemporaryDirectory() as td:
+                (Path(td) / "f.txt").write_text("ok", encoding="utf-8")
+        """
+    )
+    assert kinds == []
+
+
+def test_scanner_scopes_closures_and_nested_defs() -> None:
+    kinds = _probe(
+        """
+        def test_x(tmp_path):
+            target = tmp_path / "f.py"
+
+            def writer(content):
+                target.write_text(content, encoding="utf-8")
+
+            def helper(path):
+                path.write_text("x", encoding="utf-8")
+
+            def stray():
+                open("outside.txt", "w", encoding="utf-8").write("bad")
+
+            writer("data")
+        """
+    )
+    assert kinds == ["open-write"]
+
+
+def test_scanner_flags_untainted_makedirs_and_shutil_dest() -> None:
+    kinds = _probe(
+        """
+        import os
+        import shutil
+
+        def test_x(tmp_path):
+            os.makedirs(computed_dir())
+            shutil.copy(tmp_path / "src.txt", computed_dir())
+            shutil.move(computed(), tmp_path / "kept.txt")
+        """
+    )
+    assert kinds == ["os.makedirs", "shutil.copy"]


### PR DESCRIPTION
Three-layer write-sandbox for the test suite, piloted on a bounded slice rather than converted wholesale:

**Layer 1 — convention.** A `haute_scratch` fixture (per-test `pathlib.Path`, `tmp_path` substrate, auto-pruned) is the named root all test writes derive from. The sandbox root is exported per test as `HAUTE_TEST_SANDBOX_ROOT` and readable via `tests._write_sandbox.sandbox_root()`, so tooling outside pytest can discover what a test run is allowed to touch.

**Layer 2 — static gate.** `tests/test_write_sandbox_lint.py`: an AST scan over `tests/` (same idiom as the subprocess chokepoint scan and the skip/xfail debt ratchet) banning `tempfile.mkdtemp`/`mkstemp`, write-mode `open`/`Path.open`, `Path.write_text/bytes`, `os.makedirs`, and destination-writing `shutil` calls unless the target derives from the scratch fixtures via a conservative lexical taint (parameters seed it; assignments, `with`-targets, f-strings, and closures propagate it). Absolute/`..` literals are flagged in write targets only — adversarial path *data* in traversal/security tests is deliberately spared. A 23-file allowlist with exact violation counts is asserted stale in both directions: new violations fail, and so does a conversion that forgets to delete its row.

**Layer 3 — runtime guard.** An autouse fixture (`tests/_write_sandbox.py`) intercepts write-intent `open`/`os.open` for every test. The converted pilot slice runs **strict**: chdir'd into its sandbox, `TMPDIR`/`TEMP`/`TMP` + `HOME`/`USERPROFILE` redirected inside, out-of-sandbox writes raise. Everything else runs **observe**: escapes are recorded and reported as a census in the terminal summary (aggregated across xdist workers). Perf-marked tests are exempt, so perf budgets pay nothing. This layer catches the computed paths the static gate cannot see. Known gaps stated in the module docstring: native-code writes are contained (chdir/TMPDIR) but not intercepted; `os.rename`/`os.mkdir`/integer fds are not intercepted.

**Pilot slice (strict, fully converted):** `test_optimiser_apply.py` (mkstemp helper → fixture factory; 23 try/finally-unlink wrappers dropped), `test_bugfixes.py`, `test_streaming_chunk_size_threading.py`, `test_partial_failure.py` (keeps its production-cleanup mkstemp pattern, pinned to `dir=haute_scratch`), plus the guard's own self-tests.

## Violation census (observe mode, full suite: 12,445 passed)

**1,764 out-of-sandbox write events across 19 paths**, all in gitignored or out-of-repo locations — which is why none of this was visible to `git status`:

| Class | Paths | Detail |
|---|---|---|
| Repo pollution via product state roots | 12 | `.haute_cache/` working+committed layers (`test_load_v2_api_source`, `test_json_shred_mut_lifecycle`, `test_deploy`), `mlruns/` (`test_codegen_builders`), `outputs/train.*` (`test_modelling_routes`, `test_train_param_routing`) |
| User-home pollution | 1 (~1,700 events) | `~/training_mem.log`: `_algorithms.py` resolves its mem-log path from `Path.home()` **at import time**, so 139 tests append to the real home file and per-test HOME redirection cannot contain it. Product fix tracked separately — invisible to the static gate (the write is in `src/`), unfixable by converting tests. |
| Hardcoded system temp | 1 | `/private/tmp/test_mono/` (`test_modelling` monotone-constraint test) |
| Interpreter noise | 6 | first-import `.pyc` compilation of lazily-loaded libs; benign, warm-venv-free |

## Ratchet plan

1. Product fix for the home-dir mem-log (separate PR), then re-census — event count should collapse to double digits.
2. Convert the repo-polluting families (point product state roots at `haute_scratch`); each conversion joins `STRICT_FILES` and deletes its allowlist row — the staleness assertions make forgetting impossible.
3. Allowlist (23 files) shrinks with the same conversions; new test files are born gated.
4. End state (strict by default) is a one-line flip once the census classes are empty — deliberately not this PR.

## CI

- `platform-smoke` (windows + macos) now runs the guard self-tests — path resolution, temp/home env names, and case-insensitive prefix semantics differ off-Linux, and the runtime layer must hold there.
- Everything else is covered by existing lanes: the gate and self-tests run in every backend leg; the mutation lane's `tests/**` path filter triggers its bounded PR run as designed.
- No new dependencies; `pyproject.toml` change is the `sandbox_strict` marker registration only.

## Verification

- Full backend suite green with the guard live in observe mode everywhere (12,445 passed / 26 skipped / 2 xfailed); pilot slice green under strict, with `-n 4` and in isolation.
- Guard behaviour proven as executed tests, not claims: blocked out-of-sandbox `open`/`os.open`, contained relative writes, sandboxed `tempfile`/`HOME` placement, observe-mode recording (a real stray write recorded and not blocked), census dump/load/summarize round-trip.
- The layer-2 gate caught a real violation during development (the census spool cleanup added to `conftest.py` after the first run) — gate demonstrated live on its own patch.
- Full `scripts/preflight.sh` green on the exact landed tree (details in checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
