### PR TITLE
Mem-log path: resolve lazily at write time, default into .haute_cache

### DIFF
--- a/src/haute/modelling/_algorithms.py
+++ b/src/haute/modelling/_algorithms.py
@@ -21,7 +21,25 @@ from haute._ram_estimate import available_ram_bytes
 
 logger = get_logger(component="algorithms")
 
-_MEM_LOG = Path(os.environ.get("HAUTE_MEM_LOG", str(Path.home() / "training_mem.log")))
+# Explicit override for the memory-log destination; tests patch this.  When
+# None, the destination is resolved per write by _mem_log_path() so that
+# HAUTE_MEM_LOG (or a cwd change) takes effect without a re-import.
+_MEM_LOG: Path | None = None
+
+_DEFAULT_MEM_LOG = Path(".haute_cache") / "training_mem.log"
+
+
+def _mem_log_path() -> Path:
+    """Resolve the memory-log destination at write time.
+
+    Precedence: the ``_MEM_LOG`` override if set, else the ``HAUTE_MEM_LOG``
+    environment variable, else ``.haute_cache/training_mem.log`` under the
+    project root (haute's runtime cwd).
+    """
+    if _MEM_LOG is not None:
+        return _MEM_LOG
+    env = os.environ.get("HAUTE_MEM_LOG")
+    return Path(env) if env else _DEFAULT_MEM_LOG
 
 
 def _get_rss_mb() -> float:
@@ -103,7 +121,9 @@ def _mem_checkpoint(label: str) -> None:
 
     ts = time.strftime("%H:%M:%S")
     entry = f"[{ts}] {label:<45} RSS={rss_mb:>9.1f} MB   Avail={avail_mb:>9.1f} MB\n"
-    with open(_MEM_LOG, "a", encoding="utf-8") as f:
+    log_path = _mem_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as f:
         f.write(entry)
         f.flush()
         try:

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -815,9 +815,11 @@ class TrainService:
         Raises ``HTTPException`` on failure (cleans up temp file first).
         """
         from haute.executor import _build_node_fn
-        from haute.modelling._algorithms import _MEM_LOG, _mem_checkpoint
+        from haute.modelling._algorithms import _mem_checkpoint, _mem_log_path
 
-        _MEM_LOG.write_text("")
+        mem_log = _mem_log_path()
+        mem_log.parent.mkdir(parents=True, exist_ok=True)
+        mem_log.write_text("")
         _mem_checkpoint("train_model endpoint START")
 
         # Free the preview cache to reclaim memory

--- a/tests/test_algorithms_coverage.py
+++ b/tests/test_algorithms_coverage.py
@@ -212,13 +212,18 @@ class TestMemCheckpoint:
 
         assert log_path.exists()
 
-    def test_env_var_controls_path(self, tmp_path):
-        """HAUTE_MEM_LOG env var controls the log file path."""
+    def test_env_var_resolved_at_write_time(self, tmp_path, monkeypatch):
+        """HAUTE_MEM_LOG set after module import still redirects the log.
+
+        Regression: the path used to be frozen at import time, so per-test
+        env redirection could not contain the writes.
+        """
         from haute.modelling import _algorithms as alg_mod
 
         log_path = tmp_path / "custom.log"
+        monkeypatch.setenv("HAUTE_MEM_LOG", str(log_path))
+        monkeypatch.setattr(alg_mod, "_MEM_LOG", None)
         with (
-            patch.object(alg_mod, "_MEM_LOG", log_path),
             patch.object(alg_mod, "_get_rss_mb", return_value=1.0),
             patch.object(alg_mod, "_get_available_mb", return_value=2.0),
         ):
@@ -226,6 +231,31 @@ class TestMemCheckpoint:
 
         assert log_path.exists()
         assert "env var test" in log_path.read_text()
+
+    def test_default_path_is_project_cache_dir_not_home(self, tmp_path, monkeypatch):
+        """With no override and no env var, checkpoints land in cwd/.haute_cache.
+
+        Regression: the default used to be ``Path.home() / "training_mem.log"``,
+        so every suite run appended real bytes to the user's home directory.
+        Nothing may be written under ``Path.home()`` by default.
+        """
+        from haute.modelling import _algorithms as alg_mod
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("HAUTE_MEM_LOG", raising=False)
+        monkeypatch.setattr(alg_mod, "_MEM_LOG", None)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        with (
+            patch.object(alg_mod, "_get_rss_mb", return_value=1.0),
+            patch.object(alg_mod, "_get_available_mb", return_value=2.0),
+        ):
+            alg_mod._mem_checkpoint("default path test")
+
+        log_path = tmp_path / ".haute_cache" / "training_mem.log"
+        assert "default path test" in log_path.read_text()
+        assert list(fake_home.iterdir()) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_MEM_LOG` in `src/haute/modelling/_algorithms.py` was resolved once at module import: `Path(os.environ.get("HAUTE_MEM_LOG", str(Path.home() / "training_mem.log")))`. The test write-sandbox census (PR #62) found that 139 backend tests appended real bytes to the user's actual `~/training_mem.log` on every suite run, and because the path was frozen at import, per-test `HOME`/`HAUTE_MEM_LOG` redirection could not contain it.

History: the home default arrived in `8c1af232` (catboost memory-optimisation work) as a convenient crash-forensics dump location, not a considered choice; the env override added in `a369bd74` never worked post-import. Nothing reads the file back and no docs reference it.

## Fix

- New `_mem_log_path()` resolves the destination **per write**: the `_MEM_LOG` override if set (kept as `Path | None` so every existing test patch works unchanged) → `HAUTE_MEM_LOG` read live → `.haute_cache/training_mem.log` under the project root (cwd-relative per the launch-from-project-root contract, gitignored, matches the house cache-dir convention). Crash-forensics behaviour for real training runs is preserved.
- Both write sites (checkpoint append; train-start truncate in `_train_service.py`) resolve at call time and mkdir the parent.
- Rewrote `test_env_var_controls_path` (it claimed to test the env var but patched `_MEM_LOG`) to set `HAUTE_MEM_LOG` after import and prove it takes effect; added a census regression test that the default lands in `cwd/.haute_cache` with nothing written under a faked `Path.home()`.
- Composes with PR #62's sandbox: strict mode's `chdir(tmp_path)` now automatically contains the mem-log.

## Verified

- Full backend gate on the branch: 12,414 passed, 92.80% coverage (≥90%), all 28 per-file critical gates (`_train_service.py` 100%/99.35%), ruff + mypy clean.
- `~/training_mem.log` byte- and mtime-identical before and after the full run.
- Forward-merged onto current `main` tip (post-#62); sandbox-guard + affected suites green on the combined tree (323 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)