### PR TITLE
apiInput editor: inherit/cascade keys — frames table, key tracking, origin/confirm model

### DIFF
--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -1349,8 +1349,8 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
-            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
+            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
           ],
         },
       ],
@@ -1388,8 +1388,8 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "premium", path: "", type: "float", status: "Inferred", origin: "inferred", selected: true, levels: null },
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "premium", path: "", type: "float", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
           ],
         },
       ],
@@ -1431,7 +1431,7 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
           ],
         },
         { path: "", label: "orphan", displayPath: null, emit: false, row_id_column: null, columns: [] },
@@ -1476,7 +1476,7 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", key: false, selected: true, levels: null },
           ],
         },
       ],

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -1349,8 +1349,8 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
-            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", selected: true, levels: null },
+            { name: "", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "premium", path: "$[:].premium", type: "float", status: "Inferred", origin: "inferred", selected: true, levels: null },
           ],
         },
       ],
@@ -1388,8 +1388,8 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "premium", path: "", type: "float", status: "Inferred", selected: true, levels: null },
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+            { name: "premium", path: "", type: "float", status: "Inferred", origin: "inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
           ],
         },
       ],
@@ -1431,7 +1431,7 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
           ],
         },
         { path: "", label: "orphan", displayPath: null, emit: false, row_id_column: null, columns: [] },
@@ -1476,7 +1476,7 @@ describe("ApiInputEditor — blank entry is not lost when an unrelated field is 
           emit: false,
           row_id_column: null,
           columns: [
-            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", selected: true, levels: null },
+            { name: "policy_id", path: "$[:].policy_id", type: "int", status: "Inferred", origin: "inferred", selected: true, levels: null },
           ],
         },
       ],

--- a/frontend/src/__tests__/editors/apiInputInherit.test.ts
+++ b/frontend/src/__tests__/editors/apiInputInherit.test.ts
@@ -19,8 +19,10 @@ import {
   dedupName,
   validateColumnPathAgainstFrame,
   isReservedLeafPath,
+  buildInsertedColumns,
   type InventoryKey,
 } from "../../panels/editors/apiInputInherit"
+import { readV2, writeV2 } from "../../panels/editors/apiInputSchema"
 import type { ApiInputColumnV2, ApiInputTableV2, ColumnType } from "../../panels/editors/apiInputSchema"
 
 function col(name: string, path: string, type: ColumnType = "str"): ApiInputColumnV2 {
@@ -221,5 +223,95 @@ describe("isReservedLeafPath", () => {
   it("detects $value leaves and ignores normal ones", () => {
     expect(isReservedLeafPath("$[:].coverages[:].$value")).toBe(true)
     expect(isReservedLeafPath("$[:].customer.id")).toBe(false)
+  })
+})
+
+// ─── the shared insert builder ──────────────────────────────────────
+
+describe("buildInsertedColumns", () => {
+  const inventory = inv(
+    key("$[:].quote_id", "qid"),
+    key("$[:].orders[:].order_date", "order_date", "date"),
+  )
+
+  it("reuses the inventory name (name transport) and carries type/levels", () => {
+    const [c] = buildInsertedColumns(["$[:].quote_id"], inventory, new Set())
+    expect(c.name).toBe("qid")
+    expect(c.path).toBe("$[:].quote_id")
+    expect(c.origin).toBe("inherited")
+    expect(c.status).toBe("Confirmed")
+    expect(c.selected).toBe(true)
+  })
+
+  it("falls back to the salted leaf for an off-inventory path, and honours origin", () => {
+    const [c] = buildInsertedColumns(["$[:].customer.id"], inventory, new Set(), "manual")
+    expect(c.name).toBe("customer_id")
+    expect(c.origin).toBe("manual")
+  })
+
+  it("de-duplicates names against existing and within the batch", () => {
+    const rows = buildInsertedColumns(
+      ["$[:].customer.id", "$[:].order.id"],
+      new Map(),
+      new Set(["customer_id"]),
+    )
+    expect(rows.map((r) => r.name)).toEqual(["customer_id_2", "order_id"])
+  })
+
+  it("orders shallowest level first, then by input order", () => {
+    const rows = buildInsertedColumns(
+      ["$[:].orders[:].order_date", "$[:].quote_id"],
+      inventory,
+      new Set(),
+    )
+    // quote_id is at the root (depth 0) so it sorts ahead of the orders-level key
+    expect(rows.map((r) => r.path)).toEqual(["$[:].quote_id", "$[:].orders[:].order_date"])
+  })
+})
+
+// ─── status-model origin derivation (readV2/writeV2) ────────────────
+
+describe("readV2 / writeV2 origin", () => {
+  it("derives 'inherited' for an ancestor-prefix column and 'inferred' otherwise", () => {
+    const onDisk = {
+      path: "d.json",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:].orders[:]",
+          label: "orders",
+          emit: true,
+          columns: [
+            { name: "total", path: "$[:].orders[:].total", type: "float", status: "Inferred", selected: true },
+            { name: "qid", path: "$[:].quote_id", type: "str", status: "Confirmed", selected: true },
+          ],
+        },
+      ],
+    }
+    const v2 = readV2(onDisk)
+    const cols = v2.tables[0].columns
+    expect(cols.find((c) => c.name === "total")?.origin).toBe("inferred")
+    expect(cols.find((c) => c.name === "qid")?.origin).toBe("inherited") // shallower than the frame
+  })
+
+  it("preserves an explicitly persisted origin and round-trips it", () => {
+    const onDisk = {
+      path: "d.json",
+      contract: "opaque",
+      tables: [
+        {
+          path: "$[:]",
+          label: "root",
+          emit: true,
+          columns: [
+            { name: "k", path: "$[:].k", type: "str", status: "Confirmed", selected: true, origin: "manual" },
+          ],
+        },
+      ],
+    }
+    const v2 = readV2(onDisk)
+    expect(v2.tables[0].columns[0].origin).toBe("manual")
+    const raw = writeV2(v2) as { tables: { columns: { origin: string }[] }[] }
+    expect(raw.tables[0].columns[0].origin).toBe("manual")
   })
 })

--- a/frontend/src/__tests__/editors/apiInputInherit.test.ts
+++ b/frontend/src/__tests__/editors/apiInputInherit.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the inherit / cascade logic (`apiInputInherit.ts`) and the
+ * structural path helpers it leans on (`jsonpath.ts` additions). These pin the
+ * path-inventory model, the salted naming, the prefix-based pull/push candidacy,
+ * and the `$value` exclusion against the engine's accept/reject shape.
+ */
+import { describe, it, expect } from "vitest"
+import {
+  arrayDepth,
+  frameSegments,
+  parseColumnPathFull,
+  segmentPrefix,
+} from "../../panels/editors/jsonpath"
+import {
+  buildPathInventory,
+  buildInheritGroups,
+  getCascadeDestinations,
+  inheritedColumnName,
+  dedupName,
+  validateColumnPathAgainstFrame,
+  isReservedLeafPath,
+  type InventoryKey,
+} from "../../panels/editors/apiInputInherit"
+import type { ApiInputColumnV2, ApiInputTableV2, ColumnType } from "../../panels/editors/apiInputSchema"
+
+function col(name: string, path: string, type: ColumnType = "str"): ApiInputColumnV2 {
+  return { name, path, type, status: "Inferred", selected: true, levels: null }
+}
+function tbl(path: string, columns: ApiInputColumnV2[]): ApiInputTableV2 {
+  return { path, label: path, displayPath: null, emit: true, row_id_column: null, columns }
+}
+function inv(...keys: InventoryKey[]): Map<string, InventoryKey> {
+  return new Map(keys.map((k) => [k.path, k]))
+}
+function key(path: string, name: string, type: ColumnType = "str"): InventoryKey {
+  return { path, name, type, levels: null }
+}
+
+// ─── jsonpath structural helpers ────────────────────────────────────
+
+describe("arrayDepth", () => {
+  it.each([
+    ["$[:]", 0],
+    ["$[:].customer.id", 0],
+    ["$[:].orders[:].amount", 1],
+    ["$[:].orders[:].items[:].sku", 2],
+    ["$[:].proposer.claims[:].amount", 1],
+  ])("%s → %i", (p, n) => expect(arrayDepth(p)).toBe(n))
+})
+
+describe("parseColumnPathFull — splits at the deepest array hop", () => {
+  it("root object leaf has empty locating", () => {
+    expect(parseColumnPathFull("$[:].customer.id")).toEqual({ locating: [], leaf: "customer.id" })
+  })
+  it("array level + dotted leaf", () => {
+    const { locating, leaf } = parseColumnPathFull("$[:].drivers[:].profile.age")
+    expect(locating).toEqual([{ name: "drivers", isArray: true }])
+    expect(leaf).toBe("profile.age")
+  })
+  it("object-located array + leaf", () => {
+    const { locating, leaf } = parseColumnPathFull("$[:].proposer.claims[:].amount")
+    expect(locating).toEqual([
+      { name: "proposer", isArray: false },
+      { name: "claims", isArray: true },
+    ])
+    expect(leaf).toBe("amount")
+  })
+  it("$value surfaces as the leaf string", () => {
+    expect(parseColumnPathFull("$[:].coverages[:].$value").leaf).toBe("$value")
+  })
+  it("rejects a path naming no leaf", () => {
+    expect(() => parseColumnPathFull("$[:].orders[:]")).toThrow()
+  })
+})
+
+describe("segmentPrefix — structural, step-by-step", () => {
+  const root = frameSegments("$[:]")
+  const orders = frameSegments("$[:].orders[:]")
+  const items = frameSegments("$[:].orders[:].items[:]")
+  const vehicles = frameSegments("$[:].vehicles[:]")
+
+  it("root is a proper prefix of any deeper frame", () => {
+    expect(segmentPrefix(root, orders, { proper: true })).toBe(true)
+    expect(segmentPrefix(root, items, { proper: true })).toBe(true)
+  })
+  it("orders is a proper prefix of items but not of itself", () => {
+    expect(segmentPrefix(orders, items, { proper: true })).toBe(true)
+    expect(segmentPrefix(orders, orders, { proper: true })).toBe(false)
+  })
+  it("same level is a non-proper prefix (prefix-or-equal)", () => {
+    expect(segmentPrefix(orders, orders)).toBe(true)
+  })
+  it("siblings are never a prefix even at equal depth", () => {
+    expect(segmentPrefix(orders, vehicles, { proper: true })).toBe(false)
+    expect(segmentPrefix(orders, vehicles)).toBe(false)
+  })
+  it("deeper is never a prefix of shallower", () => {
+    expect(segmentPrefix(items, orders)).toBe(false)
+  })
+})
+
+// ─── path inventory ─────────────────────────────────────────────────
+
+describe("buildPathInventory", () => {
+  it("unions current frames and the last-infer snapshot, frames winning on name", () => {
+    const frames = [tbl("$[:].orders[:]", [col("order_total", "$[:].orders[:].total", "float")])]
+    const lastInfer = [
+      tbl("$[:]", [col("qid", "$[:].quote_id")]),
+      tbl("$[:].orders[:]", [col("total", "$[:].orders[:].total", "float")]),
+    ]
+    const inventory = buildPathInventory(frames, lastInfer)
+    // pruned-frame key survives via the snapshot
+    expect(inventory.get("$[:].quote_id")?.name).toBe("qid")
+    // shared path: the current frame's name wins
+    expect(inventory.get("$[:].orders[:].total")?.name).toBe("order_total")
+  })
+  it("excludes $value keys", () => {
+    const lastInfer = [tbl("$[:].coverages[:]", [col("value", "$[:].coverages[:].$value")])]
+    expect(buildPathInventory([], lastInfer).has("$[:].coverages[:].$value")).toBe(false)
+  })
+  it("schema-only when nothing inferred", () => {
+    const frames = [tbl("$[:]", [col("qid", "$[:].quote_id")])]
+    expect([...buildPathInventory(frames, null).keys()]).toEqual(["$[:].quote_id"])
+  })
+})
+
+// ─── inherit candidacy (pull) ───────────────────────────────────────
+
+describe("buildInheritGroups", () => {
+  const inventory = inv(
+    key("$[:].quote_id", "quote_id"),
+    key("$[:].customer.id", "customer_id"),
+    key("$[:].orders[:].order_date", "order_date"),
+    key("$[:].vehicles[:].vid", "vid"),
+    key("$[:].orders[:].items[:].sku", "sku"),
+  )
+
+  it("offers ancestor levels only, grouped and lexically sorted", () => {
+    const groups = buildInheritGroups("$[:].orders[:].items[:]", inventory)
+    expect(groups.map((g) => g.ancestorPath)).toEqual(["$[:]", "$[:].orders[:]"])
+    expect(groups[0].ancestorLabel).toBe("root")
+    expect(groups[1].ancestorLabel).toBe("orders")
+    // root group carries both root-level keys, in inventory order
+    expect(groups[0].candidates.map((c) => c.path)).toEqual(["$[:].quote_id", "$[:].customer.id"])
+    expect(groups[1].candidates.map((c) => c.path)).toEqual(["$[:].orders[:].order_date"])
+  })
+  it("excludes siblings, same-level, and deeper keys", () => {
+    const groups = buildInheritGroups("$[:].orders[:].items[:]", inventory)
+    const offered = groups.flatMap((g) => g.candidates.map((c) => c.path))
+    expect(offered).not.toContain("$[:].vehicles[:].vid") // sibling branch
+    expect(offered).not.toContain("$[:].orders[:].items[:].sku") // same level
+  })
+  it("a root frame has no ancestor groups", () => {
+    expect(buildInheritGroups("$[:]", inventory)).toEqual([])
+  })
+})
+
+// ─── cascade destinations (push) ────────────────────────────────────
+
+describe("getCascadeDestinations", () => {
+  const tables = [
+    tbl("$[:]", []),
+    tbl("$[:].orders[:]", []),
+    tbl("$[:].orders[:].items[:]", []),
+    tbl("$[:].vehicles[:]", []),
+  ]
+  it("a root key cascades into every deeper frame", () => {
+    expect(getCascadeDestinations("$[:].quote_id", tables)).toEqual([1, 2, 3])
+  })
+  it("an orders-level key cascades only into its descendants", () => {
+    expect(getCascadeDestinations("$[:].orders[:].order_date", tables)).toEqual([2])
+  })
+})
+
+// ─── naming + dedup ─────────────────────────────────────────────────
+
+describe("inheritedColumnName — salts the full leaf", () => {
+  it.each([
+    ["$[:].customer.id", "customer_id"],
+    ["$[:].a.b.c", "a_b_c"],
+    ["$[:].quote_id", "quote_id"],
+    ["$[:].orders[:].order_date", "order_date"],
+  ])("%s → %s", (p, name) => expect(inheritedColumnName(p)).toBe(name))
+})
+
+describe("dedupName", () => {
+  it("leaves a free name untouched", () => {
+    expect(dedupName("customer_id", new Set())).toBe("customer_id")
+  })
+  it("suffixes _2 then _3 on collision", () => {
+    expect(dedupName("id", new Set(["id"]))).toBe("id_2")
+    expect(dedupName("id", new Set(["id", "id_2"]))).toBe("id_3")
+  })
+})
+
+// ─── hand-entry validation ──────────────────────────────────────────
+
+describe("validateColumnPathAgainstFrame", () => {
+  const frame = "$[:].orders[:]"
+  it("accepts a same-level column", () => {
+    expect(validateColumnPathAgainstFrame("$[:].orders[:].total", frame)).toBeNull()
+  })
+  it("accepts an ancestor (broadcast) column", () => {
+    expect(validateColumnPathAgainstFrame("$[:].customer.id", frame)).toBeNull()
+  })
+  it("rejects a deeper column", () => {
+    expect(validateColumnPathAgainstFrame("$[:].orders[:].items[:].sku", frame)).not.toBeNull()
+  })
+  it("rejects a sideways (sibling) column", () => {
+    expect(validateColumnPathAgainstFrame("$[:].vehicles[:].vid", frame)).not.toBeNull()
+  })
+  it("rejects a $value key in an object frame", () => {
+    expect(validateColumnPathAgainstFrame("$[:].coverages[:].$value", frame)).not.toBeNull()
+  })
+  it("accepts a $value key on its own scalar-array frame", () => {
+    expect(validateColumnPathAgainstFrame("$[:].coverages[:].$value", "$[:].coverages[:]")).toBeNull()
+  })
+})
+
+describe("isReservedLeafPath", () => {
+  it("detects $value leaves and ignores normal ones", () => {
+    expect(isReservedLeafPath("$[:].coverages[:].$value")).toBe(true)
+    expect(isReservedLeafPath("$[:].customer.id")).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
@@ -1,0 +1,507 @@
+/**
+ * Interaction tests for the inherit / cascade integration half of the API
+ * Input editor: the frames table, the three picker entry points, the shared
+ * insert step (insert-at-top, origin, confirmed), confirm / confirm-all,
+ * edit-confirms, the re-infer reconciliation through the confirm gate, the
+ * pendingInferred guard, and the invalid-frame render-gate treatment.
+ *
+ * Persistence assertions follow the AGENTS contract (§UI Test Assertions):
+ * gestures drive a NON-mocked stateful harness and assert on the persisted
+ * object handed to onUpdate.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
+import { useState } from "react"
+import ApiInputEditor from "../../panels/editors/ApiInputEditor"
+
+afterEach(cleanup)
+
+vi.mock("../../panels/editors/_shared", async () => {
+  const actual = await vi.importActual("../../panels/editors/_shared")
+  return {
+    ...actual,
+    FileBrowser: () => <div data-testid="file-browser" />,
+    SchemaPreview: () => <div data-testid="schema-preview" />,
+  }
+})
+
+const mockInferJsonCacheSchema = vi.fn()
+
+vi.mock("../../api/client", () => ({
+  fetchDatabricksSchema: vi.fn(),
+  buildJsonCache: vi.fn(),
+  getJsonCacheProgress: vi.fn().mockResolvedValue({ active: false }),
+  getJsonCacheStatus: vi.fn().mockResolvedValue({ cached: false }),
+  getJsonCacheStatusForSchema: vi.fn().mockResolvedValue({ cached: false }),
+  deleteJsonCache: vi.fn(),
+  cancelJsonCache: vi.fn(),
+  inferJsonCacheSchema: (...args: unknown[]) => mockInferJsonCacheSchema(...args),
+  ApiError: class ApiError extends Error {},
+}))
+
+vi.mock("../../hooks/useSchemaFetch", () => ({
+  useSchemaFetch: () => ({
+    schema: null,
+    setSchema: vi.fn(),
+    loading: false,
+    fetchForPath: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  mockInferJsonCacheSchema.mockReset()
+})
+
+function StatefulHarness({
+  initialConfig,
+  onUpdateSpy = () => {},
+}: {
+  initialConfig: Record<string, unknown>
+  onUpdateSpy?: (keyOrUpdates: string | Record<string, unknown>, value?: unknown) => void
+}) {
+  const [config, setConfig] = useState(initialConfig)
+  return (
+    <ApiInputEditor
+      config={config}
+      onUpdate={(keyOrUpdates: string | Record<string, unknown>, value?: unknown) => {
+        onUpdateSpy(keyOrUpdates, value)
+        setConfig((prev) =>
+          typeof keyOrUpdates === "string"
+            ? { ...prev, [keyOrUpdates]: value }
+            : { ...prev, ...keyOrUpdates },
+        )
+      }}
+      accentColor="#10b981"
+    />
+  )
+}
+
+type RawColumn = {
+  name: string
+  path: string
+  type?: string
+  status?: string
+  selected?: boolean
+  origin?: string
+}
+
+function col(overrides: RawColumn): Record<string, unknown> {
+  return { type: "str", status: "Inferred", selected: true, ...overrides }
+}
+
+/** Root frame with an id key, plus a nested orders frame — the canonical
+ * inherit/cascade shape ($[:].policy_id can go down into orders). */
+const NESTED = {
+  tables: [
+    {
+      path: "$[:]",
+      label: "policies",
+      emit: true,
+      columns: [
+        col({ name: "policy_id", path: "$[:].policy_id", type: "int" }),
+        col({ name: "premium", path: "$[:].premium", type: "float" }),
+      ],
+    },
+    {
+      path: "$[:].orders[:]",
+      label: "orders",
+      emit: true,
+      columns: [col({ name: "sku", path: "$[:].orders[:].sku" })],
+    },
+  ],
+}
+
+const persistedTables = (spy: ReturnType<typeof vi.fn>) =>
+  (spy.mock.calls.at(-1)![0] as { tables: Array<Record<string, unknown>> }).tables
+
+describe("frames table", () => {
+  it("renders one row per frame with label, path, and column counts; hidden with no frames", () => {
+    render(<StatefulHarness initialConfig={NESTED} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    expect(screen.getByTestId("api-input-frames-row-0")).toHaveTextContent("policies")
+    expect(screen.getByTestId("api-input-frames-row-0-count")).toHaveTextContent("2 cols")
+    expect(screen.getByTestId("api-input-frames-row-1")).toHaveTextContent("orders")
+    expect(screen.getByTestId("api-input-frames-row-1-count")).toHaveTextContent("1 col")
+
+    cleanup()
+    render(<StatefulHarness initialConfig={{ tables: [] }} />)
+    expect(screen.queryByTestId("api-input-frames-table")).toBeNull()
+  })
+
+  it("counts invalid columns and names an invalid frame path without suppressing the row (render-gate)", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            col({ name: "", path: "$[:].policy_id" }), // blank name → invalid
+            col({ name: "premium", path: "$[:].premium" }),
+          ],
+        },
+        // Persisted blank-path frame: must surface, greyed, with the failure
+        // named and its entry points disabled.
+        { path: "", label: "orphan", emit: false, columns: [] },
+      ],
+    }
+    render(<StatefulHarness initialConfig={config} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    expect(screen.getByTestId("api-input-frames-row-0-count")).toHaveTextContent(
+      "2 cols, 1 invalid",
+    )
+    expect(screen.getByTestId("api-input-frames-row-1-path-error")).toHaveTextContent(
+      /path is required/i,
+    )
+    expect(screen.getByTestId("api-input-frames-row-1-add-keys")).toBeDisabled()
+  })
+
+  it("a top-level frame shows no inherit affordance; a deep frame does", () => {
+    render(<StatefulHarness initialConfig={NESTED} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    expect(screen.queryByTestId("api-input-frames-row-0-inherit")).toBeNull()
+    expect(screen.getByTestId("api-input-frames-row-1-inherit")).toBeEnabled()
+  })
+})
+
+describe("inherit (pull one key onto one frame)", () => {
+  it("inserts the key at the top, name transported from the inventory, inherited origin, confirmed", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-inherit"))
+    fireEvent.click(
+      screen
+        .getByTestId("key-picker-candidate-$[:].policy_id")
+        .querySelector("input")!,
+    )
+    fireEvent.click(screen.getByTestId("key-picker-confirm"))
+
+    const tables = persistedTables(onUpdateSpy)
+    const orders = tables[1] as { columns: RawColumn[] }
+    expect(orders.columns[0]).toEqual({
+      name: "policy_id",
+      path: "$[:].policy_id",
+      type: "int",
+      status: "Confirmed",
+      selected: true,
+      levels: null,
+      origin: "inherited",
+    })
+    // Existing column pushed below the inserted one.
+    expect(orders.columns[1].name).toBe("sku")
+    // Chip renders on the new row.
+    expect(screen.getByTestId("api-input-table-1-col-0-origin")).toHaveTextContent(
+      "inherited",
+    )
+  })
+
+  it("a key already on the frame is shown ticked and disabled", () => {
+    const config = structuredClone(NESTED)
+    config.tables[1].columns.unshift(
+      col({ name: "policy_id", path: "$[:].policy_id", type: "int", origin: "inherited" }),
+    )
+    render(<StatefulHarness initialConfig={config} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-inherit"))
+    const box = screen
+      .getByTestId("key-picker-candidate-$[:].policy_id")
+      .querySelector("input")!
+    expect(box).toBeChecked()
+    expect(box).toBeDisabled()
+  })
+})
+
+describe("cascade (push keys into all deeper frames)", () => {
+  it("pushes the selected key into every deeper frame in one confirm, and is idempotent", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-cascade-btn"))
+    fireEvent.click(
+      screen
+        .getByTestId("key-picker-candidate-$[:].policy_id")
+        .querySelector("input")!,
+    )
+    fireEvent.click(screen.getByTestId("key-picker-confirm"))
+
+    let orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns.map((c) => c.name)).toEqual(["policy_id", "sku"])
+    expect(orders.columns[0].origin).toBe("inherited")
+    const callsAfterFirst = onUpdateSpy.mock.calls.length
+
+    // Second cascade of the same key: fully-cascaded keys are disabled, and
+    // no write happens without a selectable candidate.
+    fireEvent.click(screen.getByTestId("api-input-cascade-btn"))
+    const box = screen
+      .getByTestId("key-picker-candidate-$[:].policy_id")
+      .querySelector("input")!
+    expect(box).toBeChecked()
+    expect(box).toBeDisabled()
+    fireEvent.click(screen.getByTestId("key-picker-cancel"))
+    expect(onUpdateSpy.mock.calls.length).toBe(callsAfterFirst)
+    orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns.filter((c) => c.name === "policy_id")).toHaveLength(1)
+  })
+
+  it("a salted-name collision on the destination gets a numeric suffix on the salted form", () => {
+    const config = structuredClone(NESTED)
+    // Destination already has an unrelated column NAMED policy_id.
+    config.tables[1].columns.push(
+      col({ name: "policy_id", path: "$[:].orders[:].policy_id", status: "Confirmed" }),
+    )
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-cascade-btn"))
+    fireEvent.click(
+      screen
+        .getByTestId("key-picker-candidate-$[:].policy_id")
+        .querySelector("input")!,
+    )
+    fireEvent.click(screen.getByTestId("key-picker-confirm"))
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns[0].name).toBe("policy_id_2")
+    expect(orders.columns[0].path).toBe("$[:].policy_id")
+  })
+})
+
+describe("add keys (inherit-attributes) and hand entry", () => {
+  it("a hand-entered field requires BOTH path and type, then arrives manual + confirmed at the top", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+
+    const addBtn = screen.getByTestId("key-picker-manual-add")
+    expect(addBtn).toBeDisabled()
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].orders[:].currency" },
+    })
+    expect(addBtn).toBeDisabled() // path alone is not a complete entry
+    fireEvent.change(screen.getByTestId("key-picker-manual-type"), {
+      target: { value: "str" },
+    })
+    expect(addBtn).toBeEnabled()
+    fireEvent.click(addBtn)
+
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns[0]).toEqual({
+      name: "currency",
+      path: "$[:].orders[:].currency",
+      type: "str",
+      status: "Confirmed",
+      selected: true,
+      levels: null,
+      origin: "manual",
+    })
+  })
+
+  it("rejects a sideways path with a visible error and no write", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].drivers[:].age" },
+    })
+    fireEvent.change(screen.getByTestId("key-picker-manual-type"), {
+      target: { value: "int" },
+    })
+    expect(screen.getByTestId("key-picker-manual-error")).toHaveTextContent(
+      /deeper than, or sideways/i,
+    )
+    expect(screen.getByTestId("key-picker-manual-add")).toBeDisabled()
+    expect(onUpdateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("origin chips, confirm, confirm-all, edit-confirms", () => {
+  it("confirm button confirms one column and disappears; confirm-all sweeps the frame", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    // Per-column confirm.
+    fireEvent.click(screen.getByTestId("api-input-table-0-col-0-confirm"))
+    let tables = persistedTables(onUpdateSpy)
+    expect((tables[0] as { columns: RawColumn[] }).columns[0].status).toBe("Confirmed")
+    expect(screen.queryByTestId("api-input-table-0-col-0-confirm")).toBeNull()
+    // Confirm-all clears the rest and then disappears itself.
+    fireEvent.click(screen.getByTestId("api-input-table-0-confirm-all"))
+    tables = persistedTables(onUpdateSpy)
+    expect(
+      (tables[0] as { columns: RawColumn[] }).columns.every((c) => c.status === "Confirmed"),
+    ).toBe(true)
+    expect(screen.queryByTestId("api-input-table-0-confirm-all")).toBeNull()
+  })
+
+  it("editing a column's name confirms it and follows the row-id nomination", () => {
+    const config = structuredClone(NESTED) as unknown as {
+      tables: Array<Record<string, unknown>>
+    }
+    config.tables[0].row_id_column = "policy_id"
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config as never} onUpdateSpy={onUpdateSpy} />)
+    const nameInput = screen.getByTestId("api-input-table-0-col-0-name")
+    fireEvent.change(nameInput, { target: { value: "policy_ref" } })
+    fireEvent.blur(nameInput)
+    const table = persistedTables(onUpdateSpy)[0] as {
+      row_id_column: string
+      columns: RawColumn[]
+    }
+    expect(table.columns[0].status).toBe("Confirmed")
+    expect(table.row_id_column).toBe("policy_ref")
+  })
+})
+
+describe("re-infer reconciliation through the confirm gate", () => {
+  const configWithPath = (tables: unknown[]) => ({ path: "data.json", tables })
+
+  it("confirmed and blank columns survive; stale non-confirmed go; fresh append de-dup-suffixed; new frame gets cascaded keys prepended", async () => {
+    const initial = configWithPath([
+      {
+        path: "$[:]",
+        label: "policies",
+        emit: true,
+        columns: [
+          // Confirmed, path gone from data: SURVIVES.
+          col({ name: "kept", path: "$[:].kept", status: "Confirmed", origin: "manual" }),
+          // Non-confirmed, path gone: REMOVED.
+          col({ name: "stale", path: "$[:].stale" }),
+          // Structurally blank (mid-typing): SURVIVES (ruled 2026-07-09).
+          col({ name: "", path: "$[:].half_typed" }),
+          // The cascaded key (inherited elsewhere marks it cascade-all).
+          col({ name: "policy_id", path: "$[:].policy_id", type: "int", status: "Confirmed" }),
+        ],
+      },
+      {
+        path: "$[:].orders[:]",
+        label: "orders",
+        emit: true,
+        columns: [
+          col({
+            name: "policy_id",
+            path: "$[:].policy_id",
+            type: "int",
+            status: "Confirmed",
+            origin: "inherited",
+          }),
+        ],
+      },
+    ])
+    mockInferJsonCacheSchema.mockResolvedValue({
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [
+            col({ name: "policy_id", path: "$[:].policy_id", type: "int" }),
+            // Fresh column whose name collides with the user's kept one: the
+            // FRESH side gets the suffix.
+            col({ name: "kept", path: "$[:].other_kept" }),
+          ],
+        },
+        { path: "$[:].orders[:]", label: "orders", emit: true, columns: [] },
+        {
+          // Frame new in this inference — a valid cascade destination for
+          // $[:].policy_id, which arrives prepended.
+          path: "$[:].claims[:]",
+          label: "claims",
+          emit: true,
+          columns: [col({ name: "amount", path: "$[:].claims[:].amount", type: "float" })],
+        },
+      ],
+    })
+
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={initial} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-infer-btn"))
+    await waitFor(() =>
+      expect(screen.getByTestId("api-input-infer-confirm")).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId("api-input-infer-confirm"))
+
+    const tables = persistedTables(onUpdateSpy) as Array<{
+      path: string
+      columns: RawColumn[]
+    }>
+    const policies = tables.find((t) => t.path === "$[:]")!
+    expect(policies.columns.map((c) => c.name)).toEqual([
+      "kept", // confirmed survivor keeps its name
+      "", // blank mid-typing column survives
+      "policy_id", // confirmed, also in fresh
+      "kept_2", // fresh side suffixed, never the user's column
+    ])
+    expect(policies.columns.map((c) => c.path)).toEqual([
+      "$[:].kept",
+      "$[:].half_typed",
+      "$[:].policy_id",
+      "$[:].other_kept",
+    ])
+    const claims = tables.find((t) => t.path === "$[:].claims[:]")!
+    expect(claims.columns.map((c) => c.name)).toEqual(["policy_id", "amount"])
+    expect(claims.columns[0].origin).toBe("inherited")
+    expect(claims.columns[0].status).toBe("Confirmed")
+  })
+
+  it("the cascade / inherit / add-keys entry points are disabled while the replace gate is open", async () => {
+    const initial = configWithPath(structuredClone(NESTED).tables)
+    mockInferJsonCacheSchema.mockResolvedValue({ tables: structuredClone(NESTED).tables })
+    render(<StatefulHarness initialConfig={initial} />)
+    fireEvent.click(screen.getByTestId("api-input-infer-btn"))
+    await waitFor(() =>
+      expect(screen.getByTestId("api-input-infer-confirm")).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId("api-input-cascade-btn")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    expect(screen.getByTestId("api-input-frames-row-1-inherit")).toBeDisabled()
+    expect(screen.getByTestId("api-input-frames-row-1-add-keys")).toBeDisabled()
+    // Cancelling the gate re-enables them.
+    fireEvent.click(screen.getByTestId("api-input-infer-cancel"))
+    expect(screen.getByTestId("api-input-cascade-btn")).toBeEnabled()
+  })
+})
+
+describe("frame-path edit re-checks columns (none left stranded)", () => {
+  it("re-pointing a frame's path flags columns that no longer sit on its branch", () => {
+    const config = structuredClone(NESTED)
+    render(<StatefulHarness initialConfig={config} />)
+    expect(screen.queryByTestId("api-input-table-1-col-0-frame-error")).toBeNull()
+    const pathInput = screen.getByTestId("api-input-table-1-path")
+    fireEvent.change(pathInput, { target: { value: "$[:].drivers[:]" } })
+    fireEvent.blur(pathInput)
+    expect(screen.getByTestId("api-input-table-1-col-0-frame-error")).toHaveTextContent(
+      /deeper than, or sideways/i,
+    )
+  })
+})
+
+describe("salting toggle", () => {
+  it("with salting off a dotted leaf falls back to its bare final segment", () => {
+    const config = {
+      tables: [
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          // Inventory name comes from the column itself, so hand entry (which
+          // derives from the leaf) is the surface that shows the toggle.
+          columns: [col({ name: "premium", path: "$[:].premium" })],
+        },
+        { path: "$[:].orders[:]", label: "orders", emit: true, columns: [] },
+      ],
+    }
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-salt-toggle")) // off
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].orders[:].meta.currency" },
+    })
+    fireEvent.change(screen.getByTestId("key-picker-manual-type"), {
+      target: { value: "str" },
+    })
+    fireEvent.click(screen.getByTestId("key-picker-manual-add"))
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns[0].name).toBe("currency") // bare leaf, not meta_currency
+  })
+})

--- a/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
@@ -474,6 +474,132 @@ describe("frame-path edit re-checks columns (none left stranded)", () => {
   })
 })
 
+describe("confirm-on-use (ruled 2026-07-09): keying a field confirms its carriers, source included", () => {
+  it("cascading a key confirms the SOURCE column on its home frame", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-cascade-btn"))
+    fireEvent.click(
+      screen.getByTestId("key-picker-candidate-$[:].policy_id").querySelector("input")!,
+    )
+    fireEvent.click(screen.getByTestId("key-picker-confirm"))
+    const tables = persistedTables(onUpdateSpy) as Array<{ columns: RawColumn[] }>
+    const source = tables[0].columns.find((c) => c.path === "$[:].policy_id")!
+    expect(source.status).toBe("Confirmed")
+    // ...and its origin pill is untouched (still inferred, now with the check).
+    expect(source.origin).toBe("inferred")
+  })
+
+  it("inheriting a key confirms the ancestor's source column too", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={NESTED} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-inherit"))
+    fireEvent.click(
+      screen.getByTestId("key-picker-candidate-$[:].policy_id").querySelector("input")!,
+    )
+    fireEvent.click(screen.getByTestId("key-picker-confirm"))
+    const tables = persistedTables(onUpdateSpy) as Array<{ columns: RawColumn[] }>
+    expect(tables[0].columns.find((c) => c.path === "$[:].policy_id")!.status).toBe(
+      "Confirmed",
+    )
+  })
+})
+
+describe("no duplicate paths — ever (ruled 2026-07-09)", () => {
+  const DRIVERS = {
+    tables: [
+      {
+        path: "$[:]",
+        label: "policies",
+        emit: true,
+        columns: [col({ name: "policy_id", path: "$[:].policy_id", type: "int" })],
+      },
+      {
+        path: "$[:].drivers[:]",
+        label: "drivers",
+        emit: true,
+        columns: [
+          col({ name: "age", path: "$[:].drivers[:].age", type: "int" }),
+          col({ name: "licence", path: "$[:].drivers[:].licence" }),
+        ],
+      },
+    ],
+  }
+
+  it("hand-entering an EXISTING path greys the type, promotes the column to the top, confirms it, and keeps name/type/origin", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={DRIVERS} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].drivers[:].licence" },
+    })
+    // Existing path: type select greyed with the already-exists treatment, Add
+    // enabled without a type.
+    expect(screen.getByTestId("key-picker-manual-type")).toBeDisabled()
+    expect(screen.getByTestId("key-picker-manual-exists")).toBeInTheDocument()
+    const addBtn = screen.getByTestId("key-picker-manual-add")
+    expect(addBtn).toBeEnabled()
+    fireEvent.click(addBtn)
+
+    const drivers = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(drivers.columns.map((c) => c.path)).toEqual([
+      "$[:].drivers[:].licence", // promoted to the top…
+      "$[:].drivers[:].age",
+    ])
+    expect(drivers.columns.filter((c) => c.path === "$[:].drivers[:].licence")).toHaveLength(1)
+    expect(drivers.columns[0]).toEqual({
+      name: "licence", // …keeping its internal field-name,
+      path: "$[:].drivers[:].licence",
+      type: "str", // …its type,
+      status: "Confirmed", // …confirmed,
+      selected: true,
+      levels: null,
+      origin: "inferred", // …and its inferred pill — NOT manual.
+    })
+  })
+
+  it("after keying a field, a re-infer does not re-add it in duplicate", async () => {
+    const initial = { path: "data.json", tables: structuredClone(DRIVERS).tables }
+    mockInferJsonCacheSchema.mockResolvedValue({
+      tables: structuredClone(DRIVERS).tables,
+    })
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={initial} onUpdateSpy={onUpdateSpy} />)
+    // Key licence via hand entry (promote+confirm), then re-infer + replace.
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].drivers[:].licence" },
+    })
+    fireEvent.click(screen.getByTestId("key-picker-manual-add"))
+    fireEvent.click(screen.getByTestId("key-picker-cancel"))
+    fireEvent.click(screen.getByTestId("api-input-infer-btn"))
+    await waitFor(() =>
+      expect(screen.getByTestId("api-input-infer-confirm")).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId("api-input-infer-confirm"))
+    const drivers = (persistedTables(onUpdateSpy) as Array<{ path: string; columns: RawColumn[] }>).find(
+      (t) => t.path === "$[:].drivers[:]",
+    )!
+    expect(
+      drivers.columns.filter((c) => c.path === "$[:].drivers[:].licence"),
+    ).toHaveLength(1)
+  })
+
+  it("the picker checkbox route cannot duplicate either — an on-frame path is ticked and disabled", () => {
+    render(<StatefulHarness initialConfig={DRIVERS} onUpdateSpy={vi.fn()} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    const box = screen
+      .getByTestId("key-picker-candidate-$[:].drivers[:].licence")
+      .querySelector("input")!
+    expect(box).toBeChecked()
+    expect(box).toBeDisabled()
+  })
+})
+
 describe("salting toggle", () => {
   it("with salting off a dotted leaf falls back to its bare final segment", () => {
     const config = {

--- a/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
@@ -187,6 +187,7 @@ describe("inherit (pull one key onto one frame)", () => {
       selected: true,
       levels: null,
       origin: "inherited",
+      key: true,
     })
     // Existing column pushed below the inserted one.
     expect(orders.columns[1].name).toBe("sku")
@@ -292,6 +293,7 @@ describe("add keys (inherit-attributes) and hand entry", () => {
       selected: true,
       levels: null,
       origin: "manual",
+      key: true,
     })
   })
 
@@ -488,6 +490,11 @@ describe("confirm-on-use (ruled 2026-07-09): keying a field confirms its carrier
     expect(source.status).toBe("Confirmed")
     // ...and its origin pill is untouched (still inferred, now with the check).
     expect(source.origin).toBe("inferred")
+    // The act also marks the source as a key (ruled 2026-07-09), and the key
+    // glyph renders on both the source row and the destination row.
+    expect((source as { key?: boolean }).key).toBe(true)
+    expect(screen.getByTestId("api-input-table-0-col-0-key")).toBeInTheDocument()
+    expect(screen.getByTestId("api-input-table-1-col-0-key")).toBeInTheDocument()
   })
 
   it("inheriting a key confirms the ancestor's source column too", () => {
@@ -557,6 +564,7 @@ describe("no duplicate paths — ever (ruled 2026-07-09)", () => {
       selected: true,
       levels: null,
       origin: "inferred", // …and its inferred pill — NOT manual.
+      key: true, // …now tracked as a key.
     })
   })
 

--- a/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
@@ -426,17 +426,22 @@ describe("re-infer reconciliation through the confirm gate", () => {
       columns: RawColumn[]
     }>
     const policies = tables.find((t) => t.path === "$[:]")!
+    // Non-keys land in data-model (JSON appearance) order per the 2026-07-09
+    // ordering ruling: the fresh inference ranks policy_id and other_kept
+    // first; the kept survivor follows; the blank row (no rankable path)
+    // holds the tail. Survival semantics are unchanged — kept keeps its name,
+    // the fresh side takes the suffix, the blank is spared.
     expect(policies.columns.map((c) => c.name)).toEqual([
-      "kept", // confirmed survivor keeps its name
-      "", // blank mid-typing column survives
       "policy_id", // confirmed, also in fresh
       "kept_2", // fresh side suffixed, never the user's column
+      "kept", // confirmed survivor keeps its name
+      "", // blank mid-typing column survives
     ])
     expect(policies.columns.map((c) => c.path)).toEqual([
-      "$[:].kept",
-      "$[:].half_typed",
       "$[:].policy_id",
       "$[:].other_kept",
+      "$[:].kept",
+      "$[:].half_typed",
     ])
     const claims = tables.find((t) => t.path === "$[:].claims[:]")!
     expect(claims.columns.map((c) => c.name)).toEqual(["policy_id", "amount"])
@@ -605,6 +610,177 @@ describe("no duplicate paths — ever (ruled 2026-07-09)", () => {
       .querySelector("input")!
     expect(box).toBeChecked()
     expect(box).toBeDisabled()
+  })
+})
+
+describe("key toggle + keys-section ordering (ruled 2026-07-09)", () => {
+  const THREE_LEVEL = {
+    tables: [
+      {
+        path: "$[:]",
+        label: "policies",
+        emit: true,
+        columns: [
+          col({ name: "policy_id", path: "$[:].policy_id", type: "int" }),
+          col({ name: "premium", path: "$[:].premium", type: "float" }),
+        ],
+      },
+      {
+        path: "$[:].orders[:]",
+        label: "orders",
+        emit: true,
+        columns: [
+          col({ name: "sku", path: "$[:].orders[:].sku" }),
+          col({ name: "amount", path: "$[:].orders[:].amount", type: "float" }),
+          // Pre-existing keys out of ruled order: a full-depth key ABOVE a
+          // shallower one.
+          col({
+            name: "order_ref",
+            path: "$[:].orders[:].order_ref",
+            status: "Confirmed",
+            origin: "manual",
+            key: true,
+          } as never),
+          col({
+            name: "policy_id",
+            path: "$[:].policy_id",
+            type: "int",
+            status: "Confirmed",
+            origin: "inherited",
+            key: true,
+          } as never),
+        ],
+      },
+    ],
+  }
+
+  it("toggling a row ON confirms it and moves it into the keys section; OFF returns it to data-model order, still confirmed", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={structuredClone(NESTED)} onUpdateSpy={onUpdateSpy} />)
+    // NESTED orders frame: [sku]. Toggle sku ON.
+    fireEvent.click(screen.getByTestId("api-input-table-1-col-0-key"))
+    let orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    const sku = orders.columns.find((c) => c.name === "sku")! as RawColumn & { key?: boolean }
+    expect(sku.key).toBe(true)
+    expect(sku.status).toBe("Confirmed")
+    // Toggle OFF: key cleared, confirmation NOT revoked.
+    fireEvent.click(screen.getByTestId("api-input-table-1-col-0-key"))
+    orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    const sku2 = orders.columns.find((c) => c.name === "sku")! as RawColumn & { key?: boolean }
+    expect(sku2.key).toBe(false)
+    expect(sku2.status).toBe("Confirmed")
+  })
+
+  it("a manually-added field is promotable to a key via the toggle (ruled 2026-07-09)", () => {
+    const config = structuredClone(NESTED)
+    // A hand-entered spelling variant, exactly the tested `license` case:
+    // manual origin, full-depth, not a key.
+    config.tables[1].columns.push(
+      col({
+        name: "license",
+        path: "$[:].orders[:].license",
+        status: "Confirmed",
+        origin: "manual",
+      }),
+    )
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={config} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-table-1-col-1-key"))
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    const lic = orders.columns.find((c) => c.name === "license")! as RawColumn & {
+      key?: boolean
+      origin?: string
+    }
+    expect(lic.key).toBe(true)
+    expect(lic.origin).toBe("manual") // promotion doesn't rewrite its origin
+    // It joined the keys section (top), ahead of the non-key sku.
+    expect(orders.columns.map((c) => c.name)).toEqual(["license", "sku"])
+  })
+
+  it("any key act re-sorts the keys section: shallower keys first, full-depth keys after in add order, non-keys in data-model order", () => {
+    const onUpdateSpy = vi.fn()
+    render(
+      <StatefulHarness initialConfig={structuredClone(THREE_LEVEL)} onUpdateSpy={onUpdateSpy} />,
+    )
+    // Toggle `amount` (full-depth) into the keys — this reorders the frame.
+    fireEvent.click(screen.getByTestId("api-input-table-1-col-1-key"))
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns.map((c) => c.name)).toEqual([
+      "policy_id", // shallower key rises above the full-depth ones
+      "order_ref", // full-depth keys in add order…
+      "amount", // …the newly toggled one last
+      "sku", // non-keys in data-model order
+    ])
+  })
+})
+
+describe("Add Column arrives blank and inherits its name from the committed path (ruled 2026-07-09)", () => {
+  it("creates a blank row (flagged invalid), then derives the name when a valid path commits", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={structuredClone(NESTED)} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-table-1-add-col"))
+    let orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    const blank = orders.columns.find((c) => c.path === "")! as RawColumn & {
+      origin?: string
+      status?: string
+    }
+    expect(blank.name).toBe("")
+    expect(blank.origin).toBe("manual")
+    expect(blank.status).toBe("Inferred") // unconfirmed until completed
+    const blankIdx = orders.columns.findIndex((c) => c.path === "")
+    // Commit a dotted path onto the blank row: name derives from the salted
+    // leaf (meta.currency → meta_currency) and edit-confirms fires.
+    const pathInput = screen.getByTestId(`api-input-table-1-col-${blankIdx}-path`)
+    fireEvent.change(pathInput, { target: { value: "$[:].orders[:].meta.currency" } })
+    fireEvent.blur(pathInput)
+    orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    const filled = orders.columns.find(
+      (c) => c.path === "$[:].orders[:].meta.currency",
+    )! as RawColumn & { status?: string }
+    expect(filled.name).toBe("meta_currency")
+    expect(filled.status).toBe("Confirmed")
+  })
+})
+
+describe("hand-entry extras (ruled 2026-07-09)", () => {
+  it("Add & close adds the field and closes the dialog in one click", () => {
+    const onUpdateSpy = vi.fn()
+    render(<StatefulHarness initialConfig={structuredClone(NESTED)} onUpdateSpy={onUpdateSpy} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].orders[:].currency" },
+    })
+    fireEvent.change(screen.getByTestId("key-picker-manual-type"), {
+      target: { value: "str" },
+    })
+    fireEvent.click(screen.getByTestId("key-picker-manual-add-close"))
+    expect(screen.queryByTestId("key-picker-modal")).toBeNull()
+    const orders = persistedTables(onUpdateSpy)[1] as { columns: RawColumn[] }
+    expect(orders.columns.some((c) => c.path === "$[:].orders[:].currency")).toBe(true)
+  })
+
+  it("the already-exists notice names the key status when the existing field is a key", () => {
+    const config = structuredClone(NESTED)
+    config.tables[1].columns.unshift(
+      col({
+        name: "policy_id",
+        path: "$[:].policy_id",
+        type: "int",
+        status: "Confirmed",
+        origin: "inherited",
+        key: true,
+      } as never),
+    )
+    render(<StatefulHarness initialConfig={config} />)
+    fireEvent.click(screen.getByTestId("api-input-frames-toggle"))
+    fireEvent.click(screen.getByTestId("api-input-frames-row-1-add-keys"))
+    fireEvent.change(screen.getByTestId("key-picker-manual-path"), {
+      target: { value: "$[:].policy_id" },
+    })
+    expect(screen.getByTestId("key-picker-manual-exists")).toHaveTextContent(
+      /already added as a key/i,
+    )
   })
 })
 

--- a/frontend/src/components/FramesTable.tsx
+++ b/frontend/src/components/FramesTable.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+
+/**
+ * The frames table at the top of the API Input editor: one row per frame
+ * (label, path, emit, column count), the surface the cascade and
+ * inherit/inherit-attributes operations work from. Modelled on the OUTPUT
+ * editor's collapsible "Frames (N)" table; starts collapsed, and the parent
+ * hides it entirely while there are no frames yet.
+ *
+ * Presentational: the editor supplies one {@link FramesTableRow} of facts per
+ * frame and owns what the three entry points do. A frame whose path is invalid
+ * (blank or failing the grammar) still gets its row — a persisted entry must
+ * surface (render-gate) — shown greyed with the failure named, and its
+ * inherit/cascade entry points disabled, since a frame with no position in the
+ * JSON tree can take part in neither direction.
+ */
+export interface FramesTableRow {
+  label: string
+  path: string
+  emit: boolean
+  columnCount: number
+  /** Columns on this frame that are structurally incomplete or fail path
+   * validation — surfaced in the count so the row never disagrees with what
+   * opening the frame shows. */
+  invalidColumnCount: number
+  /** The failure keeping this frame out of inherit/cascade (blank or
+   * ungrammatical path), or null when the frame is sound. */
+  pathError: string | null
+  /** Whether any inventory key sits at a shallower level on this frame's
+   * branch — a top-level frame simply shows no inherit affordance. */
+  canInherit: boolean
+}
+
+export default function FramesTable({
+  rows,
+  accentColor,
+  disabled = false,
+  disabledReason,
+  onCascade,
+  onInherit,
+  onAddKeys,
+}: {
+  rows: FramesTableRow[]
+  accentColor: string
+  /** True while the replace-tables confirmation gate is open — all three
+   * entry points are disabled rather than mutating tables mid-decision. */
+  disabled?: boolean
+  disabledReason?: string
+  onCascade: () => void
+  onInherit: (frameIdx: number) => void
+  onAddKeys: (frameIdx: number) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div
+      data-testid="api-input-frames-table"
+      className="rounded-md"
+      style={{ border: "1px solid var(--border)", background: "var(--bg-elevated)" }}
+    >
+      <div className="flex items-center justify-between gap-2 px-2 py-2">
+        <button
+          type="button"
+          data-testid="api-input-frames-toggle"
+          onClick={() => setExpanded((open) => !open)}
+          className="flex items-center gap-1 flex-1 min-w-0 text-left"
+          title={expanded ? "Collapse frames" : "Show frames"}
+        >
+          {expanded ? (
+            <ChevronDown size={14} style={{ color: "var(--text-muted)" }} className="shrink-0" />
+          ) : (
+            <ChevronRight size={14} style={{ color: "var(--text-muted)" }} className="shrink-0" />
+          )}
+          <span className="text-[11px] font-semibold" style={{ color: "var(--text-muted)" }}>
+            Frames ({rows.length})
+          </span>
+        </button>
+        <button
+          type="button"
+          data-testid="api-input-cascade-btn"
+          onClick={onCascade}
+          disabled={disabled}
+          title={disabled ? disabledReason : "Push keys into every deeper frame on their branch"}
+          className="text-[11px] font-semibold px-2 py-0.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ color: accentColor, border: `1px solid ${accentColor}` }}
+        >
+          Cascade keys
+        </button>
+      </div>
+
+      {expanded && (
+        <div
+          data-testid="api-input-frames-rows"
+          className="px-2 pb-2 pt-1.5 space-y-1"
+          style={{ borderTop: "1px solid var(--border)" }}
+        >
+          {rows.map((row, fi) => (
+            <div
+              key={fi}
+              data-testid={`api-input-frames-row-${fi}`}
+              className="rounded p-1.5 space-y-0.5"
+              style={{
+                border: "1px solid var(--border)",
+                background: "var(--bg-input)",
+                opacity: row.pathError !== null ? 0.6 : 1,
+              }}
+            >
+              <div className="flex items-center gap-2 text-[11px]">
+                <span
+                  className="font-mono font-semibold truncate"
+                  style={{ color: "var(--text-primary)" }}
+                >
+                  {row.label || "(unnamed)"}
+                </span>
+                <span
+                  className="font-mono flex-1 min-w-0 truncate"
+                  style={{
+                    color: row.pathError !== null ? "var(--danger-text)" : "var(--text-muted)",
+                  }}
+                >
+                  {row.path || "(no path)"}
+                </span>
+                <span className="shrink-0" style={{ color: "var(--text-muted)" }}>
+                  {row.emit ? "emit" : "—"}
+                </span>
+                <span
+                  className="shrink-0"
+                  data-testid={`api-input-frames-row-${fi}-count`}
+                  style={{
+                    color:
+                      row.invalidColumnCount > 0 ? "var(--danger-text)" : "var(--text-muted)",
+                  }}
+                >
+                  {row.columnCount} col{row.columnCount === 1 ? "" : "s"}
+                  {row.invalidColumnCount > 0 ? `, ${row.invalidColumnCount} invalid` : ""}
+                </span>
+                <span className="shrink-0 flex items-center gap-1">
+                  {row.canInherit && (
+                    <button
+                      type="button"
+                      data-testid={`api-input-frames-row-${fi}-inherit`}
+                      onClick={() => onInherit(fi)}
+                      disabled={disabled || row.pathError !== null}
+                      title={
+                        disabled
+                          ? disabledReason
+                          : "Pull a key from a shallower level onto this frame"
+                      }
+                      className="text-[10px] font-semibold px-1.5 py-0.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                      style={{ color: accentColor, border: `1px solid ${accentColor}` }}
+                    >
+                      Inherit
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    data-testid={`api-input-frames-row-${fi}-add-keys`}
+                    onClick={() => onAddKeys(fi)}
+                    disabled={disabled || row.pathError !== null}
+                    title={
+                      disabled
+                        ? disabledReason
+                        : row.pathError !== null
+                          ? `This frame's path is invalid, so keys cannot be placed on it: ${row.pathError}`
+                          : "Add keys from the inventory, or enter a field by hand"
+                    }
+                    className="text-[10px] font-semibold px-1.5 py-0.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                    style={{ color: "var(--text-secondary)", border: "1px solid var(--border)" }}
+                  >
+                    Add keys
+                  </button>
+                </span>
+              </div>
+              {row.pathError !== null && (
+                <div
+                  data-testid={`api-input-frames-row-${fi}-path-error`}
+                  className="px-1.5 py-0.5 rounded text-[10px] leading-snug"
+                  style={{ background: "var(--danger-soft)", color: "var(--danger-text)" }}
+                >
+                  {row.pathError}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/KeyPickerModal.tsx
+++ b/frontend/src/components/KeyPickerModal.tsx
@@ -3,6 +3,9 @@ import { ChevronDown, ChevronRight } from "lucide-react"
 import ModalShell from "./ModalShell"
 import { withAlpha } from "../utils/color"
 import type { InheritGroup } from "../panels/editors/apiInputInherit"
+import type { ColumnType } from "../panels/editors/apiInputSchema"
+
+const MANUAL_TYPES: ColumnType[] = ["int", "float", "str", "bool", "date"]
 
 /**
  * The one shared dialog behind inherit, inherit-attributes, and the key-pick step
@@ -29,6 +32,15 @@ export interface KeyPickerModalProps {
   confirmLabel?: (count: number) => string
   onConfirm: (paths: string[]) => void
   onClose: () => void
+  /** When set (inherit-attributes mode), renders the enter-a-field-by-hand
+   * section: a path plus a REQUIRED type — the entry is not complete without
+   * both. The path is validated against the target frame; an invalid one shows
+   * its error and cannot be added. Adding is immediate (independent of the
+   * checkbox selection); the caller marks the column manual + confirmed. */
+  manualEntry?: {
+    validatePath: (path: string) => string | null
+    onAdd: (path: string, type: ColumnType) => void
+  }
 }
 
 export default function KeyPickerModal({
@@ -40,10 +52,14 @@ export default function KeyPickerModal({
   confirmLabel = (n) => `Add ${n}`,
   onConfirm,
   onClose,
+  manualEntry,
 }: KeyPickerModalProps) {
   // Default expanded — collapse is opt-in to tame deep cases.
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [manualPath, setManualPath] = useState("")
+  // No default type — the entry is incomplete until BOTH path and type are set.
+  const [manualType, setManualType] = useState<ColumnType | "">("")
 
   const toggleCollapse = (ancestorPath: string) =>
     setCollapsed((prev) => {
@@ -142,6 +158,82 @@ export default function KeyPickerModal({
           )
         })}
       </div>
+
+      {/* Enter a field by hand (inherit-attributes mode only) */}
+      {manualEntry && (() => {
+        const trimmed = manualPath.trim()
+        const pathError = trimmed ? manualEntry.validatePath(trimmed) : null
+        const addable = trimmed !== "" && pathError === null && manualType !== ""
+        return (
+          <div
+            className="px-4 py-2.5 space-y-1"
+            style={{ borderTop: "1px solid var(--border)" }}
+            data-testid="key-picker-manual"
+          >
+            <div className="text-[11px] font-semibold" style={{ color: "var(--text-secondary)" }}>
+              Enter a field by hand
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                data-testid="key-picker-manual-path"
+                type="text"
+                placeholder="$[:].orders[:].currency"
+                value={manualPath}
+                onChange={(e) => setManualPath(e.target.value)}
+                aria-invalid={pathError !== null ? true : undefined}
+                className="flex-1 min-w-0 text-[11px] font-mono px-1.5 py-1 rounded"
+                style={{
+                  background: "var(--bg-input)",
+                  border: `1px solid ${pathError !== null ? "var(--danger-border-strong)" : "var(--border)"}`,
+                  color: "var(--text-primary)",
+                }}
+              />
+              <select
+                data-testid="key-picker-manual-type"
+                value={manualType}
+                onChange={(e) => setManualType(e.target.value as ColumnType | "")}
+                className="text-[11px] px-1 py-1 rounded"
+                style={{
+                  background: "var(--bg-input)",
+                  border: "1px solid var(--border)",
+                  // A missing type is the incomplete half of the entry — read as such.
+                  color: manualType === "" ? "var(--text-muted)" : "var(--text-primary)",
+                }}
+              >
+                <option value="">type…</option>
+                {MANUAL_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                data-testid="key-picker-manual-add"
+                disabled={!addable}
+                onClick={() => {
+                  manualEntry.onAdd(trimmed, manualType as ColumnType)
+                  setManualPath("")
+                  setManualType("")
+                }}
+                className="text-[11px] font-semibold px-2 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ background: accentColor, color: "var(--text-on-accent)" }}
+              >
+                Add
+              </button>
+            </div>
+            {pathError !== null && (
+              <div
+                data-testid="key-picker-manual-error"
+                className="px-1.5 py-0.5 rounded text-[10px] leading-snug"
+                style={{ background: "var(--danger-soft)", color: "var(--danger-text)" }}
+              >
+                {pathError}
+              </div>
+            )}
+          </div>
+        )
+      })()}
 
       {/* Footer */}
       <div

--- a/frontend/src/components/KeyPickerModal.tsx
+++ b/frontend/src/components/KeyPickerModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { createPortal } from "react-dom"
 import { ChevronDown, ChevronRight } from "lucide-react"
 import ModalShell from "./ModalShell"
 import { withAlpha } from "../utils/color"
@@ -28,6 +29,9 @@ export interface KeyPickerModalProps {
   groups: InheritGroup[]
   /** Paths already on the target — rendered checked + disabled. */
   existingPaths: ReadonlySet<string>
+  /** The subset of `existingPaths` already marked as keys — the hand-entry
+   * already-exists notice names the key status when it applies. */
+  existingKeyPaths?: ReadonlySet<string>
   /** Builds the primary-button label from the live selection count. */
   confirmLabel?: (count: number) => string
   onConfirm: (paths: string[]) => void
@@ -52,6 +56,7 @@ export default function KeyPickerModal({
   accentColor,
   groups,
   existingPaths,
+  existingKeyPaths,
   confirmLabel = (n) => `Add ${n}`,
   onConfirm,
   onClose,
@@ -83,7 +88,12 @@ export default function KeyPickerModal({
   const count = selected.size
   const hasCandidates = groups.some((g) => g.candidates.length > 0)
 
-  return (
+  // Portal to document.body: this dialog mounts INSIDE the node side pane, and
+  // ModalShell's fixed inset-0 overlay is contained by any transformed ancestor
+  // — rendering the backdrop over just the pane with the dialog box clipped
+  // (the observed sidebar grey-out freeze). At body level, fixed means the
+  // viewport again for every mount point.
+  return createPortal(
     <ModalShell ariaLabel={title} onClose={onClose} width="w-[480px]" testId="key-picker-modal">
       {/* Header */}
       <div className="px-4 py-3" style={{ borderBottom: "1px solid var(--border)" }}>
@@ -230,6 +240,20 @@ export default function KeyPickerModal({
               >
                 Add
               </button>
+              <button
+                type="button"
+                data-testid="key-picker-manual-add-close"
+                disabled={!addable}
+                onClick={() => {
+                  manualEntry.onAdd(trimmed, exists ? null : (manualType as ColumnType))
+                  onClose()
+                }}
+                title="Add this field and close the dialog"
+                className="text-[11px] font-semibold px-2 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{ color: accentColor, border: `1px solid ${accentColor}` }}
+              >
+                Add & close
+              </button>
             </div>
             {pathError !== null && (
               <div
@@ -246,8 +270,9 @@ export default function KeyPickerModal({
                 className="px-1.5 py-0.5 rounded text-[10px] leading-snug"
                 style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
               >
-                Field already exists on this frame — Add moves it to the top and confirms
-                it, keeping its name and type.
+                {existingKeyPaths?.has(trimmed)
+                  ? "This field is already added as a key on this frame — Add re-confirms it and keeps its name and type."
+                  : "Field already exists on this frame — Add makes it a key (moved into the keys at the top), keeping its name and type."}
               </div>
             )}
           </div>
@@ -279,6 +304,7 @@ export default function KeyPickerModal({
           {confirmLabel(count)}
         </button>
       </div>
-    </ModalShell>
+    </ModalShell>,
+    document.body,
   )
 }

--- a/frontend/src/components/KeyPickerModal.tsx
+++ b/frontend/src/components/KeyPickerModal.tsx
@@ -33,13 +33,16 @@ export interface KeyPickerModalProps {
   onConfirm: (paths: string[]) => void
   onClose: () => void
   /** When set (inherit-attributes mode), renders the enter-a-field-by-hand
-   * section: a path plus a REQUIRED type — the entry is not complete without
+   * section: a path plus a REQUIRED type — a new entry is not complete without
    * both. The path is validated against the target frame; an invalid one shows
-   * its error and cannot be added. Adding is immediate (independent of the
-   * checkbox selection); the caller marks the column manual + confirmed. */
+   * its error and cannot be added. A path already on the frame (per
+   * `existingPaths`) greys the type out — the existing column keeps its name
+   * and type — and Add promotes + confirms it instead of duplicating; `type`
+   * is passed as null in that case. Adding is immediate (independent of the
+   * checkbox selection). */
   manualEntry?: {
     validatePath: (path: string) => string | null
-    onAdd: (path: string, type: ColumnType) => void
+    onAdd: (path: string, type: ColumnType | null) => void
   }
 }
 
@@ -162,8 +165,12 @@ export default function KeyPickerModal({
       {/* Enter a field by hand (inherit-attributes mode only) */}
       {manualEntry && (() => {
         const trimmed = manualPath.trim()
-        const pathError = trimmed ? manualEntry.validatePath(trimmed) : null
-        const addable = trimmed !== "" && pathError === null && manualType !== ""
+        const exists = trimmed !== "" && existingPaths.has(trimmed)
+        const pathError = trimmed && !exists ? manualEntry.validatePath(trimmed) : null
+        // An existing path is addable without a type — its column keeps the
+        // name and type it already has; Add promotes + confirms it.
+        const addable =
+          trimmed !== "" && pathError === null && (exists || manualType !== "")
         return (
           <div
             className="px-4 py-2.5 space-y-1"
@@ -192,7 +199,9 @@ export default function KeyPickerModal({
                 data-testid="key-picker-manual-type"
                 value={manualType}
                 onChange={(e) => setManualType(e.target.value as ColumnType | "")}
-                className="text-[11px] px-1 py-1 rounded"
+                disabled={exists}
+                title={exists ? "Field already exists — its name and type are kept" : undefined}
+                className="text-[11px] px-1 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed"
                 style={{
                   background: "var(--bg-input)",
                   border: "1px solid var(--border)",
@@ -212,7 +221,7 @@ export default function KeyPickerModal({
                 data-testid="key-picker-manual-add"
                 disabled={!addable}
                 onClick={() => {
-                  manualEntry.onAdd(trimmed, manualType as ColumnType)
+                  manualEntry.onAdd(trimmed, exists ? null : (manualType as ColumnType))
                   setManualPath("")
                   setManualType("")
                 }}
@@ -229,6 +238,16 @@ export default function KeyPickerModal({
                 style={{ background: "var(--danger-soft)", color: "var(--danger-text)" }}
               >
                 {pathError}
+              </div>
+            )}
+            {exists && (
+              <div
+                data-testid="key-picker-manual-exists"
+                className="px-1.5 py-0.5 rounded text-[10px] leading-snug"
+                style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
+              >
+                Field already exists on this frame — Add moves it to the top and confirms
+                it, keeping its name and type.
               </div>
             )}
           </div>

--- a/frontend/src/components/KeyPickerModal.tsx
+++ b/frontend/src/components/KeyPickerModal.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import ModalShell from "./ModalShell"
+import { withAlpha } from "../utils/color"
+import type { InheritGroup } from "../panels/editors/apiInputInherit"
+
+/**
+ * The one shared dialog behind inherit, inherit-attributes, and the key-pick step
+ * of cascade. It shows candidate keys grouped into collapsible per-level sections
+ * — each candidate a checkbox with its name, source path, and type — and returns
+ * the selected paths on confirm. Keys already present on the target (by path) are
+ * shown ticked and disabled. The dialog is presentational: the caller supplies
+ * the groups and decides what "confirm" does (add to a frame, cascade, …).
+ *
+ * `ModalShell` already provides the backdrop, focus trap, and close-on-Escape /
+ * close-on-click-outside, so this component only owns the collapse and selection
+ * state.
+ */
+export interface KeyPickerModalProps {
+  /** Dialog title, e.g. "Inherit keys" / "Cascade keys". */
+  title: string
+  /** The frame the keys are being added to / from, named in the subtitle. */
+  targetLabel: string
+  accentColor: string
+  groups: InheritGroup[]
+  /** Paths already on the target — rendered checked + disabled. */
+  existingPaths: ReadonlySet<string>
+  /** Builds the primary-button label from the live selection count. */
+  confirmLabel?: (count: number) => string
+  onConfirm: (paths: string[]) => void
+  onClose: () => void
+}
+
+export default function KeyPickerModal({
+  title,
+  targetLabel,
+  accentColor,
+  groups,
+  existingPaths,
+  confirmLabel = (n) => `Add ${n}`,
+  onConfirm,
+  onClose,
+}: KeyPickerModalProps) {
+  // Default expanded — collapse is opt-in to tame deep cases.
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const toggleCollapse = (ancestorPath: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(ancestorPath)) next.delete(ancestorPath)
+      else next.add(ancestorPath)
+      return next
+    })
+
+  const toggleSelect = (path: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+
+  const count = selected.size
+  const hasCandidates = groups.some((g) => g.candidates.length > 0)
+
+  return (
+    <ModalShell ariaLabel={title} onClose={onClose} width="w-[480px]" testId="key-picker-modal">
+      {/* Header */}
+      <div className="px-4 py-3" style={{ borderBottom: "1px solid var(--border)" }}>
+        <h2 className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+          {title}
+        </h2>
+        <p className="text-[11px] mt-0.5 font-mono" style={{ color: "var(--text-muted)" }}>
+          {targetLabel}
+        </p>
+      </div>
+
+      {/* Body — collapsible groups of candidate keys */}
+      <div className="max-h-[400px] overflow-y-auto px-2 py-2 space-y-1">
+        {!hasCandidates && (
+          <div className="text-xs italic px-2 py-3" style={{ color: "var(--text-muted)" }}>
+            No keys available to add here.
+          </div>
+        )}
+        {groups.map((group) => {
+          const isCollapsed = collapsed.has(group.ancestorPath)
+          return (
+            <div key={group.ancestorPath} data-testid={`key-picker-group-${group.ancestorPath}`}>
+              <button
+                type="button"
+                onClick={() => toggleCollapse(group.ancestorPath)}
+                className="w-full flex items-center gap-1 px-1.5 py-1 rounded text-[11px] font-semibold"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {isCollapsed ? (
+                  <ChevronRight size={12} style={{ color: "var(--text-muted)" }} />
+                ) : (
+                  <ChevronDown size={12} style={{ color: "var(--text-muted)" }} />
+                )}
+                <span>{group.ancestorLabel}</span>
+                <span className="font-mono font-normal" style={{ color: "var(--text-muted)" }}>
+                  {group.ancestorPath}
+                </span>
+              </button>
+              {!isCollapsed && (
+                <div className="pl-4 space-y-0.5">
+                  {group.candidates.map((cand) => {
+                    const present = existingPaths.has(cand.path)
+                    const checked = present || selected.has(cand.path)
+                    return (
+                      <label
+                        key={cand.path}
+                        data-testid={`key-picker-candidate-${cand.path}`}
+                        className="flex items-center gap-2 px-1.5 py-1 rounded text-[11px] cursor-pointer"
+                        style={present ? { opacity: 0.5 } : { background: withAlpha(accentColor, 0.04) }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          disabled={present}
+                          onChange={() => toggleSelect(cand.path)}
+                        />
+                        <span className="font-mono" style={{ color: "var(--text-primary)" }}>
+                          {cand.name}
+                        </span>
+                        <span
+                          className="font-mono flex-1 min-w-0 truncate"
+                          style={{ color: "var(--text-muted)" }}
+                        >
+                          {cand.path}
+                        </span>
+                        <span className="shrink-0" style={{ color: "var(--text-muted)" }}>
+                          {cand.type}
+                        </span>
+                      </label>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Footer */}
+      <div
+        className="px-4 py-3 flex gap-2 justify-end"
+        style={{ borderTop: "1px solid var(--border)" }}
+      >
+        <button
+          type="button"
+          data-testid="key-picker-cancel"
+          onClick={onClose}
+          className="text-xs font-semibold px-3 py-1.5 rounded"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          data-testid="key-picker-confirm"
+          disabled={count === 0}
+          onClick={() => onConfirm([...selected])}
+          className="text-xs font-semibold px-3 py-1.5 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ background: accentColor, color: "var(--text-on-accent)" }}
+        >
+          {confirmLabel(count)}
+        </button>
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/components/__tests__/KeyPickerModal.test.tsx
+++ b/frontend/src/components/__tests__/KeyPickerModal.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * UI tests for the shared KeyPickerModal: collapsible grouped candidate list,
+ * already-present (by path) candidates disabled, and confirm returning the
+ * selected paths.
+ */
+import type { ComponentProps } from "react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+import KeyPickerModal from "../KeyPickerModal"
+import type { InheritGroup } from "../../panels/editors/apiInputInherit"
+
+afterEach(cleanup)
+
+const groups: InheritGroup[] = [
+  {
+    ancestorPath: "$[:]",
+    ancestorLabel: "root",
+    candidates: [
+      { path: "$[:].quote_id", name: "quote_id", type: "str", levels: null },
+      { path: "$[:].customer.id", name: "customer_id", type: "str", levels: null },
+    ],
+  },
+  {
+    ancestorPath: "$[:].orders[:]",
+    ancestorLabel: "orders",
+    candidates: [{ path: "$[:].orders[:].order_date", name: "order_date", type: "date", levels: null }],
+  },
+]
+
+function renderModal(over: Partial<ComponentProps<typeof KeyPickerModal>> = {}) {
+  const onConfirm = vi.fn()
+  const onClose = vi.fn()
+  render(
+    <KeyPickerModal
+      title="Inherit keys"
+      targetLabel="$[:].orders[:].items[:]"
+      accentColor="#3b82f6"
+      groups={groups}
+      existingPaths={new Set()}
+      onConfirm={onConfirm}
+      onClose={onClose}
+      {...over}
+    />,
+  )
+  return { onConfirm, onClose }
+}
+
+describe("KeyPickerModal", () => {
+  it("renders one collapsible group per ancestor level with its candidates", () => {
+    renderModal()
+    expect(screen.getByTestId("key-picker-group-$[:]")).toBeTruthy()
+    expect(screen.getByTestId("key-picker-group-$[:].orders[:]")).toBeTruthy()
+    expect(screen.getByTestId("key-picker-candidate-$[:].quote_id")).toBeTruthy()
+    expect(screen.getByTestId("key-picker-candidate-$[:].orders[:].order_date")).toBeTruthy()
+  })
+
+  it("collapsing a group hides its candidates", () => {
+    renderModal()
+    expect(screen.queryByTestId("key-picker-candidate-$[:].quote_id")).toBeTruthy()
+    fireEvent.click(screen.getByTestId("key-picker-group-$[:]").querySelector("button")!)
+    expect(screen.queryByTestId("key-picker-candidate-$[:].quote_id")).toBeNull()
+  })
+
+  it("renders an already-present candidate checked and disabled", () => {
+    renderModal({ existingPaths: new Set(["$[:].quote_id"]) })
+    const cb = screen
+      .getByTestId("key-picker-candidate-$[:].quote_id")
+      .querySelector("input") as HTMLInputElement
+    expect(cb.checked).toBe(true)
+    expect(cb.disabled).toBe(true)
+  })
+
+  it("confirm returns the selected paths; the button counts and disables at zero", () => {
+    const { onConfirm } = renderModal()
+    const confirm = screen.getByTestId("key-picker-confirm") as HTMLButtonElement
+    expect(confirm.disabled).toBe(true)
+    fireEvent.click(
+      screen.getByTestId("key-picker-candidate-$[:].quote_id").querySelector("input")!,
+    )
+    fireEvent.click(
+      screen
+        .getByTestId("key-picker-candidate-$[:].orders[:].order_date")
+        .querySelector("input")!,
+    )
+    expect(confirm.textContent).toContain("2")
+    fireEvent.click(confirm)
+    expect(onConfirm).toHaveBeenCalledWith(["$[:].quote_id", "$[:].orders[:].order_date"])
+  })
+
+  it("cancel closes without confirming", () => {
+    const { onConfirm, onClose } = renderModal()
+    fireEvent.click(screen.getByTestId("key-picker-cancel"))
+    expect(onClose).toHaveBeenCalled()
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type CSSProperties } from "react"
-import { Radio, Check, HelpCircle, Plus, X } from "lucide-react"
+import { Radio, Check, HelpCircle, KeyRound, Plus, X } from "lucide-react"
 import { FileBrowser, SchemaPreview } from "./_shared"
 import type { OnUpdateConfig } from "./_shared"
 import { useSchemaFetch } from "../../hooks/useSchemaFetch"
@@ -410,7 +410,9 @@ export default function ApiInputEditor({
   // frame — the source field of a cascade/inherit included (ruled 2026-07-09):
   // deliberately keying on a field witnesses its correctness just as receiving
   // it does, and an unconfirmed source would be eaten by the next re-infer
-  // while its descendants persist deeper in the data model.
+  // while its descendants persist deeper in the data model. The same act also
+  // MARKS the carriers as keys (`key: true`, ruled 2026-07-09) so the schema
+  // tracks which fields have been used as keys.
   const confirmColumnsByPath = (
     tables: ApiInputTableV2[],
     usedPaths: ReadonlySet<string>,
@@ -418,8 +420,8 @@ export default function ApiInputEditor({
     tables.map((t) => ({
       ...t,
       columns: t.columns.map((c) =>
-        c.status !== "Confirmed" && usedPaths.has(c.path)
-          ? { ...c, status: "Confirmed" as const }
+        usedPaths.has(c.path) && (c.status !== "Confirmed" || c.key !== true)
+          ? { ...c, status: "Confirmed" as const, key: true }
           : c,
       ),
     }))
@@ -442,7 +444,7 @@ export default function ApiInputEditor({
     // a deliberate use of those keys — confirm the carriers; skip the write
     // only when there is truly nothing to insert AND nothing to confirm.
     const anyToConfirm = v2.tables.some((t) =>
-      t.columns.some((c) => c.status !== "Confirmed" && pathSet.has(c.path)),
+      t.columns.some((c) => pathSet.has(c.path) && (c.status !== "Confirmed" || c.key !== true)),
     )
     if (fresh.length === 0 && !anyToConfirm) return
     const withInserts =
@@ -484,7 +486,7 @@ export default function ApiInputEditor({
     }
     const pathSet = new Set(paths)
     const anyToConfirm = v2.tables.some((t) =>
-      t.columns.some((c) => c.status !== "Confirmed" && pathSet.has(c.path)),
+      t.columns.some((c) => pathSet.has(c.path) && (c.status !== "Confirmed" || c.key !== true)),
     )
     if (additions.size === 0 && !anyToConfirm) return
     const withInserts = v2.tables.map((t, ti) => {
@@ -517,11 +519,7 @@ export default function ApiInputEditor({
     if (existingIdx >= 0) {
       const cols = [...table.columns]
       const [existing] = cols.splice(existingIdx, 1)
-      cols.unshift(
-        existing.status === "Confirmed"
-          ? existing
-          : { ...existing, status: "Confirmed" as const },
-      )
+      cols.unshift({ ...existing, status: "Confirmed" as const, key: true })
       writeBack({
         ...v2,
         tables: v2.tables.map((t, ti) => (ti === tableIdx ? { ...t, columns: cols } : t)),
@@ -541,6 +539,7 @@ export default function ApiInputEditor({
       selected: true,
       levels: null,
       origin: "manual",
+      key: true,
     }
     writeBack({
       ...v2,
@@ -1213,6 +1212,16 @@ function ColumnRow({
           </option>
         ))}
       </select>
+      {col.key === true && (
+        <Tooltip label="Used as a key (cascade / inherit / add-keys)">
+          <KeyRound
+            size={10}
+            data-testid={`${testIdPrefix}-key`}
+            style={{ color: "var(--accent)" }}
+            className="shrink-0 mt-0.5"
+          />
+        </Tooltip>
+      )}
       <OriginChip
         origin={col.origin ?? "inferred"}
         confirmed={col.status === "Confirmed"}

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -28,36 +28,32 @@ import {
   type ApiInputConfigV2,
   type ApiInputColumnV2,
   type ApiInputTableV2,
+  type ColumnOrigin,
   type ColumnType,
 } from "./apiInputSchema"
 import { validateInputColumnPath, validateInputTablePath } from "./jsonpath"
 import { nonCanonicalHint, nonCanonicalNote } from "./pathCanonicalWarning"
+import {
+  buildAllKeyGroups,
+  buildInheritGroups,
+  buildInsertedColumns,
+  buildPathInventory,
+  dedupName,
+  getCascadeDestinations,
+  inheritedColumnName,
+  reconcileInferredTables,
+  validateColumnPathAgainstFrame,
+  type InheritGroup,
+  type InventoryKey,
+} from "./apiInputInherit"
+import FramesTable, { type FramesTableRow } from "../../components/FramesTable"
+import KeyPickerModal from "../../components/KeyPickerModal"
 
-// Defect 2 — merge inferred tables into the user's existing tables by
-// `path`. For a table whose path the user already has, we keep their
-// curated emit/label/displayPath/row_id_column choices and only adopt
-// the freshly inferred `columns` (the part that actually reflects a
-// changed source JSON). Tables the user has that the inference no
-// longer sees are dropped (the source no longer produces them); tables
-// the inference adds that the user lacks are appended. This preserves
-// deliberate user edits instead of clobbering the whole array.
-function mergeInferredTables(
-  existing: ApiInputTableV2[],
-  inferred: ApiInputTableV2[],
-): ApiInputTableV2[] {
-  const byPath = new Map(existing.map((t) => [t.path, t]))
-  return inferred.map((inf) => {
-    const prev = byPath.get(inf.path)
-    if (!prev) return inf
-    return {
-      ...inf,
-      label: prev.label,
-      emit: prev.emit,
-      displayPath: prev.displayPath,
-      row_id_column: prev.row_id_column,
-    }
-  })
-}
+// The re-infer merge is `reconcileInferredTables` (apiInputInherit.ts): the
+// column-level reconciliation that supersedes the old whole-column-array
+// adoption — confirmed and structurally-incomplete columns survive, stale
+// non-confirmed ones go, fresh ones append (fresh side de-dup-suffixed), new
+// frames arrive with the user's cascaded keys prepended.
 
 // ─── JsonCacheButton ──────────────────────────────────────────────
 //
@@ -165,6 +161,20 @@ export default function ApiInputEditor({
   // render a confirm/cancel gate instead of clobbering immediately.
   // First run (empty tables) skips the gate and applies in one click.
   const [pendingInferred, setPendingInferred] = useState<ApiInputTableV2[] | null>(null)
+  // The most-recent-inference snapshot: a single snapshot overwritten on every
+  // infer (never accumulated), so a key deleted from a frame — or whose whole
+  // frame was deleted — can still be offered by the inventory.
+  const [lastInfer, setLastInfer] = useState<ApiInputTableV2[] | null>(null)
+  // Salted naming (full dotted leaf → `customer_id`) vs bare leaf (`id`) for
+  // keys arriving without an inventory name. Salted is the default.
+  const [saltNames, setSaltNames] = useState(true)
+  // Which key picker is open: cascade works over the whole inventory from the
+  // frames table; inherit / add-keys (inherit-attributes) target one frame.
+  const [picker, setPicker] = useState<
+    | { mode: "cascade" }
+    | { mode: "inherit" | "attributes"; tableIdx: number }
+    | null
+  >(null)
 
   // Classify the config. v2 → render the schema editor with its
   // tables. empty (including any pre-v2 config with stray legacy keys)
@@ -174,6 +184,13 @@ export default function ApiInputEditor({
   const shape = useMemo(() => classifyConfig(config), [config])
   const v2: ApiInputConfigV2 =
     shape.kind === "v2" ? shape.v2 : emptyV2(currentPath)
+
+  // The path inventory: every key across the current frames plus the
+  // most-recent inference snapshot (current frames win on name/type).
+  const inventory = useMemo(
+    () => buildPathInventory(v2.tables, lastInfer),
+    [v2.tables, lastInfer],
+  )
 
   // Helpers to push state changes back through onUpdate. Each write
   // recomposes the full v2 record-shaped object so we never have to fan
@@ -209,14 +226,27 @@ export default function ApiInputEditor({
     colIdx: number,
     patch: Partial<ApiInputColumnV2>,
   ) => {
+    // Editing a column's name, path, or type IS confirming it — the user has
+    // looked at the row and made it theirs.
+    const confirming =
+      "name" in patch || "path" in patch || "type" in patch
+        ? { status: "Confirmed" as const }
+        : null
+    // The row-id nomination references a column BY NAME; a rename must carry
+    // the nomination along or it points at a name that no longer exists.
+    const oldName = v2.tables[tableIdx]?.columns[colIdx]?.name
     const next = {
       ...v2,
       tables: v2.tables.map((t, ti) =>
         ti === tableIdx
           ? {
               ...t,
+              row_id_column:
+                patch.name !== undefined && t.row_id_column === oldName
+                  ? patch.name
+                  : t.row_id_column,
               columns: t.columns.map((c, ci) =>
-                ci === colIdx ? { ...c, ...patch } : c,
+                ci === colIdx ? { ...c, ...patch, ...confirming } : c,
               ),
             }
           : t,
@@ -227,13 +257,16 @@ export default function ApiInputEditor({
   const addColumn = (tableIdx: number) => {
     const table = v2.tables[tableIdx]
     const newColPath = `${table.path}.column_${table.columns.length + 1}`
+    // A hand-added column is a deliberate user act: manual origin, arrives
+    // confirmed (so a re-infer never removes it).
     const newCol: ApiInputColumnV2 = {
       name: `column_${table.columns.length + 1}`,
       path: newColPath,
       type: "str",
-      status: "Inferred",
+      status: "Confirmed",
       selected: true,
       levels: null,
+      origin: "manual",
     }
     const next: ApiInputConfigV2 = {
       ...v2,
@@ -288,7 +321,17 @@ export default function ApiInputEditor({
       const selectedCell = (cells[3] ?? "").trim().toLowerCase()
       const selected =
         selectedCell === "" ? true : selectedCell !== "false" && selectedCell !== "0" && selectedCell !== "no"
-      columns.push({ name, path, type, status: "Confirmed", selected, levels: null })
+      // Pasted columns were deliberately supplied by the user — manual origin
+      // (ruled 2026-07-09), arriving confirmed like a hand-entered field.
+      columns.push({
+        name,
+        path,
+        type,
+        status: "Confirmed",
+        selected,
+        levels: null,
+        origin: "manual",
+      })
     }
     const next = {
       ...v2,
@@ -335,6 +378,9 @@ export default function ApiInputEditor({
         { tables: result.tables as unknown[] },
         { dropIncomplete: true },
       ).tables
+      // Refresh the single most-recent-inference snapshot on EVERY infer,
+      // whether or not the replace gate is later confirmed.
+      setLastInfer(inferred)
       if (v2.tables.length === 0) {
         // First run — nothing to clobber, apply in one click.
         writeBack({ ...v2, tables: inferred })
@@ -351,12 +397,150 @@ export default function ApiInputEditor({
   }
   const confirmInferred = () => {
     if (!pendingInferred) return
-    // Merge-by-path: preserve the user's curated emit/label choices for
-    // tables whose path is unchanged; adopt freshly inferred columns.
-    writeBack({ ...v2, tables: mergeInferredTables(v2.tables, pendingInferred) })
+    writeBack({
+      ...v2,
+      tables: reconcileInferredTables(v2.tables, pendingInferred, inventory, saltNames),
+    })
     setPendingInferred(null)
   }
   const cancelInferred = () => setPendingInferred(null)
+
+  // One shared write step every add/cascade/inherit goes through: unique
+  // salted name (inventory name transported first), path verbatim, type from
+  // the inventory, right origin, arrives Confirmed, inserted at the TOP of the
+  // frame's column list (shallowest level first, then add order).
+  const addKeyColumnsToFrame = (
+    tableIdx: number,
+    paths: readonly string[],
+    origin: ColumnOrigin = "inherited",
+  ) => {
+    const table = v2.tables[tableIdx]
+    if (!table) return
+    const present = new Set(table.columns.map((c) => c.path))
+    const fresh = paths.filter((p) => !present.has(p))
+    if (fresh.length === 0) return
+    const inserted = buildInsertedColumns(
+      fresh,
+      inventory,
+      new Set(table.columns.map((c) => c.name)),
+      origin,
+      saltNames,
+    )
+    writeBack({
+      ...v2,
+      tables: v2.tables.map((t, ti) =>
+        ti === tableIdx ? { ...t, columns: [...inserted, ...t.columns] } : t,
+      ),
+    })
+  }
+
+  // Cascade: push each selected key into every deeper frame on its branch.
+  // Adding is idempotent for a given key set — already-present paths are
+  // skipped per destination — and one writeBack covers all frames.
+  const applyCascade = (paths: readonly string[]) => {
+    const additions = new Map<number, string[]>()
+    for (const p of paths) {
+      for (const di of getCascadeDestinations(p, v2.tables)) {
+        const table = v2.tables[di]
+        if (table.columns.some((c) => c.path === p)) continue
+        const list = additions.get(di)
+        if (list) list.push(p)
+        else additions.set(di, [p])
+      }
+    }
+    if (additions.size === 0) return
+    writeBack({
+      ...v2,
+      tables: v2.tables.map((t, ti) => {
+        const list = additions.get(ti)
+        if (!list) return t
+        const inserted = buildInsertedColumns(
+          list,
+          inventory,
+          new Set(t.columns.map((c) => c.name)),
+          "inherited",
+          saltNames,
+        )
+        return { ...t, columns: [...inserted, ...t.columns] }
+      }),
+    })
+  }
+
+  // Hand-entered field (inherit-attributes): name from the salted leaf,
+  // supplied type, manual origin, arrives confirmed.
+  const addManualColumn = (tableIdx: number, path: string, type: ColumnType) => {
+    const table = v2.tables[tableIdx]
+    if (!table || table.columns.some((c) => c.path === path)) return
+    const name = dedupName(
+      inheritedColumnName(path, saltNames),
+      new Set(table.columns.map((c) => c.name)),
+    )
+    const newCol: ApiInputColumnV2 = {
+      name,
+      path,
+      type,
+      status: "Confirmed",
+      selected: true,
+      levels: null,
+      origin: "manual",
+    }
+    writeBack({
+      ...v2,
+      tables: v2.tables.map((t, ti) =>
+        ti === tableIdx ? { ...t, columns: [newCol, ...t.columns] } : t,
+      ),
+    })
+  }
+
+  const confirmAllColumns = (tableIdx: number) => {
+    writeBack({
+      ...v2,
+      tables: v2.tables.map((t, ti) =>
+        ti === tableIdx
+          ? {
+              ...t,
+              columns: t.columns.map((c) =>
+                c.status === "Confirmed" ? c : { ...c, status: "Confirmed" as const },
+              ),
+            }
+          : t,
+      ),
+    })
+  }
+
+  // One fact row per frame for the frames table. An invalid-path frame keeps
+  // its row (render-gate: a persisted entry must surface) with the failure
+  // named; invalid columns are counted so the row never disagrees with what
+  // opening the frame shows.
+  const frameRows: FramesTableRow[] = v2.tables.map((t) => {
+    const pathError = validateTablePath(t.path)
+    return {
+      label: t.label,
+      path: t.path,
+      emit: t.emit,
+      columnCount: t.columns.length,
+      invalidColumnCount: t.columns.filter((c) => columnInvalidInFrame(c, t.path)).length,
+      pathError,
+      canInherit: pathError === null && buildInheritGroups(t.path, inventory).length > 0,
+    }
+  })
+
+  // Keys the cascade picker shows checked+disabled: nowhere left to push —
+  // either no deeper frame exists on the key's branch, or every one already
+  // carries the key (adding is idempotent, so re-selecting would be a no-op).
+  const fullyCascaded = (): Set<string> => {
+    const done = new Set<string>()
+    for (const key of inventory.keys()) {
+      const dests = getCascadeDestinations(key, v2.tables)
+      if (
+        dests.length === 0 ||
+        dests.every((di) => v2.tables[di].columns.some((c) => c.path === key))
+      ) {
+        done.add(key)
+      }
+    }
+    return done
+  }
 
   return (
     <>
@@ -458,6 +642,21 @@ export default function ApiInputEditor({
           )
         })()}
 
+        {/* Frames table — the surface cascade and inherit-attributes operate
+            from. Hidden while there are no frames yet; entry points disabled
+            while the replace-tables confirmation gate is open. */}
+        {v2.tables.length > 0 && (
+          <FramesTable
+            rows={frameRows}
+            accentColor={accentColor}
+            disabled={pendingInferred !== null}
+            disabledReason="Resolve the replace-tables confirmation first"
+            onCascade={() => setPicker({ mode: "cascade" })}
+            onInherit={(i) => setPicker({ mode: "inherit", tableIdx: i })}
+            onAddKeys={(i) => setPicker({ mode: "attributes", tableIdx: i })}
+          />
+        )}
+
         {/* Tables editor (v2 surface — the only surface) */}
         <div data-testid="api-input-tables">
             <div className="flex items-center justify-between mb-1.5">
@@ -468,6 +667,19 @@ export default function ApiInputEditor({
                 Tables
               </label>
               <div className="flex items-center gap-2">
+                <label
+                  className="flex items-center gap-1 text-[10px]"
+                  title="Name new keys by their salted full path (customer_id) rather than the bare leaf (id)"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  <input
+                    data-testid="api-input-salt-toggle"
+                    type="checkbox"
+                    checked={saltNames}
+                    onChange={(e) => setSaltNames(e.target.checked)}
+                  />
+                  salt names
+                </label>
                 {currentPath && (
                   <button
                     data-testid="api-input-infer-btn"
@@ -562,6 +774,7 @@ export default function ApiInputEditor({
                   onUpdateColumn={(ci, patch) => updateColumn(ti, ci, patch)}
                   onRemoveColumn={(ci) => removeColumn(ti, ci)}
                   onPasteColumns={(grid) => pasteColumns(ti, grid)}
+                  onConfirmAll={() => confirmAllColumns(ti)}
                 />
               ))}
             </div>
@@ -592,6 +805,59 @@ export default function ApiInputEditor({
           <SchemaPreview schema={schema} />
         </>
       )}
+
+      {/* The one picker dialog in its three modes. Cascade offers the whole
+          inventory grouped by level; inherit offers a frame's shallower-level
+          keys; add-keys (inherit-attributes) offers the shallower keys first
+          (the cascade-compatible ones) then the frame's own level, plus the
+          enter-a-field-by-hand section. */}
+      {picker?.mode === "cascade" && (
+        <KeyPickerModal
+          title="Cascade keys"
+          targetLabel="each key is pushed into every deeper frame on its branch"
+          accentColor={accentColor}
+          groups={buildAllKeyGroups(inventory)}
+          existingPaths={fullyCascaded()}
+          confirmLabel={(n) => `Cascade ${n}`}
+          onConfirm={(paths) => {
+            applyCascade(paths)
+            setPicker(null)
+          }}
+          onClose={() => setPicker(null)}
+        />
+      )}
+      {picker !== null && picker.mode !== "cascade" && (() => {
+        const t = v2.tables[picker.tableIdx]
+        if (!t) return null
+        const isAttributes = picker.mode === "attributes"
+        return (
+          <KeyPickerModal
+            title={isAttributes ? "Add keys" : "Inherit keys"}
+            targetLabel={`${t.label || "(unnamed)"} — ${t.path}`}
+            accentColor={accentColor}
+            groups={
+              isAttributes
+                ? attributesGroups(t, inventory)
+                : buildInheritGroups(t.path, inventory)
+            }
+            existingPaths={new Set(t.columns.map((c) => c.path))}
+            onConfirm={(paths) => {
+              addKeyColumnsToFrame(picker.tableIdx, paths, "inherited")
+              setPicker(null)
+            }}
+            onClose={() => setPicker(null)}
+            manualEntry={
+              isAttributes
+                ? {
+                    validatePath: (p) =>
+                      validateColumnPath(p) ?? validateColumnPathAgainstFrame(p, t.path),
+                    onAdd: (path, type) => addManualColumn(picker.tableIdx, path, type),
+                  }
+                : undefined
+            }
+          />
+        )
+      })()}
     </>
   )
 }
@@ -608,6 +874,7 @@ function TableBlock({
   onUpdateColumn,
   onRemoveColumn,
   onPasteColumns,
+  onConfirmAll,
 }: {
   table: ApiInputTableV2
   testIdPrefix: string
@@ -619,6 +886,8 @@ function TableBlock({
   onRemoveColumn: (colIdx: number) => void
   /** Replace this table's columns from a pasted tab-separated grid. */
   onPasteColumns: (grid: string[][]) => void
+  /** Confirm every not-yet-confirmed column on this frame. */
+  onConfirmAll: () => void
 }) {
   return (
     <div
@@ -629,7 +898,22 @@ function TableBlock({
       {/* Shared table-actions strip (pushed onto API inputs too): Copy the
           columns as TSV, Share/Save the table's schema as JSON, Save as
           CSV/TSV, and Paste columns in. */}
-      <div className="flex justify-end">
+      <div className="flex items-center justify-end gap-2">
+        {/* Confirm-all appears only while the frame has not-yet-confirmed
+            columns, and disappears with the last of them. */}
+        {table.columns.some((c) => c.status !== "Confirmed") && (
+          <button
+            type="button"
+            data-testid={`${testIdPrefix}-confirm-all`}
+            onClick={onConfirmAll}
+            title="Confirm every not-yet-confirmed column (confirmed columns survive a re-infer)"
+            className="text-[10px] font-semibold px-1.5 py-0.5 rounded flex items-center gap-1"
+            style={{ color: "var(--success)", border: "1px solid var(--success-border)" }}
+          >
+            <Check size={9} />
+            Confirm all
+          </button>
+        )}
         <FrameTableActions
           testIdPrefix={`${testIdPrefix}-table`}
           filename={`api-input-${table.label || "table"}`}
@@ -718,6 +1002,7 @@ function TableBlock({
           <ColumnRow
             key={ci}
             col={col}
+            framePath={table.path}
             testIdPrefix={`${testIdPrefix}-col-${ci}`}
             validateName={(candidate) =>
               columnNameError(
@@ -764,21 +1049,64 @@ function columnNameError(candidate: string, otherNames: readonly string[]): stri
   return null
 }
 
+/** The per-column origin chip: which of inferred / inherited / manual the
+ * column is, with a check glyph once confirmed — a confirmed column still
+ * reads as what it originally was. */
+function OriginChip({
+  origin,
+  confirmed,
+  testId,
+}: {
+  origin: ColumnOrigin
+  confirmed: boolean
+  testId: string
+}) {
+  const palette: Record<ColumnOrigin, { color: string; background: string }> = {
+    inferred: { color: "var(--text-muted)", background: "var(--bg-input)" },
+    inherited: { color: "var(--accent)", background: "var(--accent-soft)" },
+    manual: { color: "var(--success)", background: "var(--success-soft)" },
+  }
+  return (
+    <span
+      data-testid={testId}
+      title={`${origin}${confirmed ? ", confirmed" : ""}`}
+      className="shrink-0 inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide"
+      style={palette[origin]}
+    >
+      {confirmed && <Check size={8} />}
+      {origin}
+    </span>
+  )
+}
+
 function ColumnRow({
   col,
+  framePath,
   testIdPrefix,
   validateName,
   onUpdate,
   onRemove,
 }: {
   col: ApiInputColumnV2
+  framePath: string
   testIdPrefix: string
   validateName: (candidate: string) => string | null
   onUpdate: (patch: Partial<ApiInputColumnV2>) => void
   onRemove: () => void
 }) {
+  // Against-frame check, recomputed on every render: editing the FRAME's path
+  // re-checks its columns against the new path so none are left stranded.
+  // Only meaningful when both paths individually pass the grammar (each has
+  // its own inline error otherwise).
+  const frameError =
+    col.path.trim() &&
+    validateColumnPath(col.path) === null &&
+    validateTablePath(framePath) === null
+      ? validateColumnPathAgainstFrame(col.path, framePath)
+      : null
   return (
-    <div data-testid={testIdPrefix} className="flex items-start gap-2 text-[11px]">
+    <div data-testid={testIdPrefix} className="space-y-0.5">
+    <div className="flex items-start gap-2 text-[11px]">
       <input
         data-testid={`${testIdPrefix}-selected`}
         type="checkbox"
@@ -821,9 +1149,34 @@ function ColumnRow({
           </option>
         ))}
       </select>
+      <OriginChip
+        origin={col.origin ?? "inferred"}
+        confirmed={col.status === "Confirmed"}
+        testId={`${testIdPrefix}-origin`}
+      />
+      {col.status !== "Confirmed" && (
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-confirm`}
+          onClick={() => onUpdate({ status: "Confirmed" })}
+          title="Confirm this column (a confirmed column survives a re-infer)"
+        >
+          <Check size={10} style={{ color: "var(--success)" }} />
+        </button>
+      )}
       <button data-testid={`${testIdPrefix}-remove`} onClick={onRemove}>
         <X size={10} style={{ color: "var(--text-muted)" }} />
       </button>
+    </div>
+    {frameError !== null && (
+      <div
+        data-testid={`${testIdPrefix}-frame-error`}
+        className="px-1.5 py-0.5 rounded text-[10px] leading-snug"
+        style={{ background: "var(--danger-soft)", color: "var(--danger-text)" }}
+      >
+        {frameError}
+      </div>
+    )}
     </div>
   )
 }
@@ -878,6 +1231,40 @@ function validateColumnPath(candidate: string): string | null {
     return "A path is required — this column is invalid and can't be saved without one."
   }
   return validateInputColumnPath(candidate.trim())
+}
+
+/** A column the frames table should count as invalid: structurally incomplete
+ * (blank name/path), failing the path grammar, or — when the frame's own path
+ * is sound — pointing deeper than or sideways from its frame. */
+function columnInvalidInFrame(col: ApiInputColumnV2, framePath: string): boolean {
+  if (!col.name.trim() || !col.path.trim()) return true
+  if (validateColumnPath(col.path) !== null) return true
+  if (validateTablePath(framePath) !== null) return false
+  return validateColumnPathAgainstFrame(col.path, framePath) !== null
+}
+
+/** Candidate groups for the add-keys (inherit-attributes) mode: the frame's
+ * shallower-level keys first — exactly the cascade-compatible ones, so they
+ * lead the list — then the keys at the frame's own level. */
+function attributesGroups(
+  table: ApiInputTableV2,
+  inventory: ReadonlyMap<string, InventoryKey>,
+): InheritGroup[] {
+  const shallower = buildInheritGroups(table.path, inventory)
+  const grouped = new Set(
+    shallower.flatMap((g) => g.candidates.map((c) => c.path)),
+  )
+  const sameLevel: InventoryKey[] = []
+  for (const key of inventory.values()) {
+    if (grouped.has(key.path)) continue
+    if (validateColumnPathAgainstFrame(key.path, table.path) !== null) continue
+    sameLevel.push(key)
+  }
+  if (sameLevel.length === 0) return shallower
+  return [
+    ...shallower,
+    { ancestorPath: table.path, ancestorLabel: "this level", candidates: sameLevel },
+  ]
 }
 
 function CommittedTextInput({

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type CSSProperties } from "react"
-import { Radio, Check, Plus, X } from "lucide-react"
+import { Radio, Check, HelpCircle, Plus, X } from "lucide-react"
 import { FileBrowser, SchemaPreview } from "./_shared"
 import type { OnUpdateConfig } from "./_shared"
 import { useSchemaFetch } from "../../hooks/useSchemaFetch"
@@ -48,6 +48,7 @@ import {
 } from "./apiInputInherit"
 import FramesTable, { type FramesTableRow } from "../../components/FramesTable"
 import KeyPickerModal from "../../components/KeyPickerModal"
+import Tooltip from "../../components/Tooltip"
 
 // The re-infer merge is `reconcileInferredTables` (apiInputInherit.ts): the
 // column-level reconciliation that supersedes the old whole-column-array
@@ -405,6 +406,24 @@ export default function ApiInputEditor({
   }
   const cancelInferred = () => setPendingInferred(null)
 
+  // Using a path as a key CONFIRMS every column already carrying it, on any
+  // frame — the source field of a cascade/inherit included (ruled 2026-07-09):
+  // deliberately keying on a field witnesses its correctness just as receiving
+  // it does, and an unconfirmed source would be eaten by the next re-infer
+  // while its descendants persist deeper in the data model.
+  const confirmColumnsByPath = (
+    tables: ApiInputTableV2[],
+    usedPaths: ReadonlySet<string>,
+  ): ApiInputTableV2[] =>
+    tables.map((t) => ({
+      ...t,
+      columns: t.columns.map((c) =>
+        c.status !== "Confirmed" && usedPaths.has(c.path)
+          ? { ...c, status: "Confirmed" as const }
+          : c,
+      ),
+    }))
+
   // One shared write step every add/cascade/inherit goes through: unique
   // salted name (inventory name transported first), path verbatim, type from
   // the inventory, right origin, arrives Confirmed, inserted at the TOP of the
@@ -416,22 +435,37 @@ export default function ApiInputEditor({
   ) => {
     const table = v2.tables[tableIdx]
     if (!table) return
+    const pathSet = new Set(paths)
     const present = new Set(table.columns.map((c) => c.path))
     const fresh = paths.filter((p) => !present.has(p))
-    if (fresh.length === 0) return
-    const inserted = buildInsertedColumns(
-      fresh,
-      inventory,
-      new Set(table.columns.map((c) => c.name)),
-      origin,
-      saltNames,
+    // Even when everything selected is already present, the selection is still
+    // a deliberate use of those keys — confirm the carriers; skip the write
+    // only when there is truly nothing to insert AND nothing to confirm.
+    const anyToConfirm = v2.tables.some((t) =>
+      t.columns.some((c) => c.status !== "Confirmed" && pathSet.has(c.path)),
     )
-    writeBack({
-      ...v2,
-      tables: v2.tables.map((t, ti) =>
-        ti === tableIdx ? { ...t, columns: [...inserted, ...t.columns] } : t,
-      ),
-    })
+    if (fresh.length === 0 && !anyToConfirm) return
+    const withInserts =
+      fresh.length === 0
+        ? v2.tables
+        : v2.tables.map((t, ti) =>
+            ti === tableIdx
+              ? {
+                  ...t,
+                  columns: [
+                    ...buildInsertedColumns(
+                      fresh,
+                      inventory,
+                      new Set(t.columns.map((c) => c.name)),
+                      origin,
+                      saltNames,
+                    ),
+                    ...t.columns,
+                  ],
+                }
+              : t,
+          )
+    writeBack({ ...v2, tables: confirmColumnsByPath(withInserts, pathSet) })
   }
 
   // Cascade: push each selected key into every deeper frame on its branch.
@@ -448,29 +482,53 @@ export default function ApiInputEditor({
         else additions.set(di, [p])
       }
     }
-    if (additions.size === 0) return
-    writeBack({
-      ...v2,
-      tables: v2.tables.map((t, ti) => {
-        const list = additions.get(ti)
-        if (!list) return t
-        const inserted = buildInsertedColumns(
-          list,
-          inventory,
-          new Set(t.columns.map((c) => c.name)),
-          "inherited",
-          saltNames,
-        )
-        return { ...t, columns: [...inserted, ...t.columns] }
-      }),
+    const pathSet = new Set(paths)
+    const anyToConfirm = v2.tables.some((t) =>
+      t.columns.some((c) => c.status !== "Confirmed" && pathSet.has(c.path)),
+    )
+    if (additions.size === 0 && !anyToConfirm) return
+    const withInserts = v2.tables.map((t, ti) => {
+      const list = additions.get(ti)
+      if (!list) return t
+      const inserted = buildInsertedColumns(
+        list,
+        inventory,
+        new Set(t.columns.map((c) => c.name)),
+        "inherited",
+        saltNames,
+      )
+      return { ...t, columns: [...inserted, ...t.columns] }
     })
+    // Cascading a key confirms its carriers everywhere — the SOURCE field
+    // included, so the next re-infer can't remove the shallow original while
+    // its broadcast copies persist deeper in the data model.
+    writeBack({ ...v2, tables: confirmColumnsByPath(withInserts, pathSet) })
   }
 
   // Hand-entered field (inherit-attributes): name from the salted leaf,
-  // supplied type, manual origin, arrives confirmed.
-  const addManualColumn = (tableIdx: number, path: string, type: ColumnType) => {
+  // supplied type, manual origin, arrives confirmed. A path ALREADY on the
+  // frame is never duplicated (ruled 2026-07-09): the existing column is
+  // promoted to the top of the schema keeping its internal field-name, type,
+  // and origin pill, and is confirmed — same witnessing logic as a cascade.
+  const addManualColumn = (tableIdx: number, path: string, type: ColumnType | null) => {
     const table = v2.tables[tableIdx]
-    if (!table || table.columns.some((c) => c.path === path)) return
+    if (!table) return
+    const existingIdx = table.columns.findIndex((c) => c.path === path)
+    if (existingIdx >= 0) {
+      const cols = [...table.columns]
+      const [existing] = cols.splice(existingIdx, 1)
+      cols.unshift(
+        existing.status === "Confirmed"
+          ? existing
+          : { ...existing, status: "Confirmed" as const },
+      )
+      writeBack({
+        ...v2,
+        tables: v2.tables.map((t, ti) => (ti === tableIdx ? { ...t, columns: cols } : t)),
+      })
+      return
+    }
+    if (type === null) return // a NEW entry is not complete without a type
     const name = dedupName(
       inheritedColumnName(path, saltNames),
       new Set(table.columns.map((c) => c.name)),
@@ -669,7 +727,6 @@ export default function ApiInputEditor({
               <div className="flex items-center gap-2">
                 <label
                   className="flex items-center gap-1 text-[10px]"
-                  title="Name new keys by their salted full path (customer_id) rather than the bare leaf (id)"
                   style={{ color: "var(--text-muted)" }}
                 >
                   <input
@@ -679,6 +736,13 @@ export default function ApiInputEditor({
                     onChange={(e) => setSaltNames(e.target.checked)}
                   />
                   salt names
+                  <Tooltip label="New keys are named from their full dotted path — customer.id becomes customer_id — so the same field reads identically on every frame and never collides with a sibling leaf. Untick to use the bare leaf name (id) instead; collisions then get a numeric suffix.">
+                    <HelpCircle
+                      size={11}
+                      data-testid="api-input-salt-help"
+                      style={{ color: "var(--text-muted)" }}
+                    />
+                  </Tooltip>
                 </label>
                 {currentPath && (
                   <button

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -41,6 +41,7 @@ import {
   dedupName,
   getCascadeDestinations,
   inheritedColumnName,
+  orderFrameColumns,
   reconcileInferredTables,
   validateColumnPathAgainstFrame,
   type InheritGroup,
@@ -192,6 +193,14 @@ export default function ApiInputEditor({
     () => buildPathInventory(v2.tables, lastInfer),
     [v2.tables, lastInfer],
   )
+  // JSON-appearance ranks for the keys-section ordering (ruled 2026-07-09):
+  // the inventory's insertion order is the working proxy for data-model order.
+  const jsonOrder = useMemo(() => {
+    const m = new Map<string, number>()
+    let i = 0
+    for (const path of inventory.keys()) m.set(path, i++)
+    return m
+  }, [inventory])
 
   // Helpers to push state changes back through onUpdate. Each write
   // recomposes the full v2 record-shaped object so we never have to fan
@@ -233,9 +242,32 @@ export default function ApiInputEditor({
       "name" in patch || "path" in patch || "type" in patch
         ? { status: "Confirmed" as const }
         : null
+    // Committing a path onto a still-blank name fills the name in from the
+    // inventory's used name for that path, falling back to the (salted) leaf —
+    // so a blank hand-added row inherits its name instead of needing a second
+    // edit (ruled 2026-07-09).
+    const current = v2.tables[tableIdx]?.columns[colIdx]
+    if (
+      patch.path !== undefined &&
+      patch.name === undefined &&
+      current !== undefined &&
+      current.name === ""
+    ) {
+      try {
+        const derived = dedupName(
+          inventory.get(patch.path)?.name ?? inheritedColumnName(patch.path, saltNames),
+          new Set(
+            v2.tables[tableIdx].columns.filter((_, i) => i !== colIdx).map((c) => c.name),
+          ),
+        )
+        patch = { ...patch, name: derived }
+      } catch {
+        /* unparseable path: leave the name blank; the validator flags it */
+      }
+    }
     // The row-id nomination references a column BY NAME; a rename must carry
     // the nomination along or it points at a name that no longer exists.
-    const oldName = v2.tables[tableIdx]?.columns[colIdx]?.name
+    const oldName = current?.name
     const next = {
       ...v2,
       tables: v2.tables.map((t, ti) =>
@@ -256,15 +288,15 @@ export default function ApiInputEditor({
     writeBack(next)
   }
   const addColumn = (tableIdx: number) => {
-    const table = v2.tables[tableIdx]
-    const newColPath = `${table.path}.column_${table.columns.length + 1}`
-    // A hand-added column is a deliberate user act: manual origin, arrives
-    // confirmed (so a re-infer never removes it).
+    // A hand-added column arrives BLANK (ruled 2026-07-09): no placeholder
+    // column_N name or synthetic path. The render-gate flags the incomplete row
+    // (and reconcile's blank carve-out protects it); committing a valid path
+    // auto-derives a still-blank name, and edit-confirms makes it Confirmed.
     const newCol: ApiInputColumnV2 = {
-      name: `column_${table.columns.length + 1}`,
-      path: newColPath,
+      name: "",
+      path: "",
       type: "str",
-      status: "Confirmed",
+      status: "Inferred",
       selected: true,
       levels: null,
       origin: "manual",
@@ -455,6 +487,7 @@ export default function ApiInputEditor({
               ? {
                   ...t,
                   columns: [
+                    ...t.columns,
                     ...buildInsertedColumns(
                       fresh,
                       inventory,
@@ -462,12 +495,11 @@ export default function ApiInputEditor({
                       origin,
                       saltNames,
                     ),
-                    ...t.columns,
                   ],
                 }
               : t,
           )
-    writeBack({ ...v2, tables: confirmColumnsByPath(withInserts, pathSet) })
+    writeBack({ ...v2, tables: orderAllFrames(confirmColumnsByPath(withInserts, pathSet)) })
   }
 
   // Cascade: push each selected key into every deeper frame on its branch.
@@ -499,12 +531,44 @@ export default function ApiInputEditor({
         "inherited",
         saltNames,
       )
-      return { ...t, columns: [...inserted, ...t.columns] }
+      return { ...t, columns: [...t.columns, ...inserted] }
     })
     // Cascading a key confirms its carriers everywhere — the SOURCE field
     // included, so the next re-infer can't remove the shallow original while
     // its broadcast copies persist deeper in the data model.
-    writeBack({ ...v2, tables: confirmColumnsByPath(withInserts, pathSet) })
+    writeBack({ ...v2, tables: orderAllFrames(confirmColumnsByPath(withInserts, pathSet)) })
+  }
+
+  // Re-apply the keys-section ordering on every frame — key acts can mark
+  // carriers on frames other than the one being edited.
+  const orderAllFrames = (tables: ApiInputTableV2[]): ApiInputTableV2[] =>
+    tables.map((t) => ({ ...t, columns: orderFrameColumns(t.columns, t.path, jsonOrder) }))
+
+  // Toggle a row's key membership (ruled 2026-07-09): ON marks it a key,
+  // confirms it, and moves it into the keys section at the top; OFF returns it
+  // to the non-keys in data-model order (confirmation is not revoked — the
+  // field was still witnessed).
+  const toggleKeyColumn = (tableIdx: number, colIdx: number) => {
+    const table = v2.tables[tableIdx]
+    const col = table?.columns[colIdx]
+    if (!col) return
+    let columns: ApiInputColumnV2[]
+    if (col.key === true) {
+      columns = table.columns.map((c, ci) => (ci === colIdx ? { ...c, key: false } : c))
+    } else {
+      // Append the newly keyed row so full-depth keys read in toggle (add)
+      // order after the stable sort — its old position was non-key order.
+      columns = table.columns.filter((_, ci) => ci !== colIdx)
+      columns.push({ ...col, key: true, status: "Confirmed" as const })
+    }
+    writeBack({
+      ...v2,
+      tables: v2.tables.map((t, ti) =>
+        ti === tableIdx
+          ? { ...t, columns: orderFrameColumns(columns, t.path, jsonOrder) }
+          : t,
+      ),
+    })
   }
 
   // Hand-entered field (inherit-attributes): name from the salted leaf,
@@ -519,10 +583,16 @@ export default function ApiInputEditor({
     if (existingIdx >= 0) {
       const cols = [...table.columns]
       const [existing] = cols.splice(existingIdx, 1)
-      cols.unshift({ ...existing, status: "Confirmed" as const, key: true })
+      // Append: a promoted field is the newest key, so it lands last among the
+      // full-depth keys (add order); the section sort does the rest.
+      cols.push({ ...existing, status: "Confirmed" as const, key: true })
       writeBack({
         ...v2,
-        tables: v2.tables.map((t, ti) => (ti === tableIdx ? { ...t, columns: cols } : t)),
+        tables: v2.tables.map((t, ti) =>
+          ti === tableIdx
+            ? { ...t, columns: orderFrameColumns(cols, t.path, jsonOrder) }
+            : t,
+        ),
       })
       return
     }
@@ -544,7 +614,9 @@ export default function ApiInputEditor({
     writeBack({
       ...v2,
       tables: v2.tables.map((t, ti) =>
-        ti === tableIdx ? { ...t, columns: [newCol, ...t.columns] } : t,
+        ti === tableIdx
+          ? { ...t, columns: orderFrameColumns([...t.columns, newCol], t.path, jsonOrder) }
+          : t,
       ),
     })
   }
@@ -735,7 +807,7 @@ export default function ApiInputEditor({
                     onChange={(e) => setSaltNames(e.target.checked)}
                   />
                   salt names
-                  <Tooltip label="New keys are named from their full dotted path — customer.id becomes customer_id — so the same field reads identically on every frame and never collides with a sibling leaf. Untick to use the bare leaf name (id) instead; collisions then get a numeric suffix.">
+                  <Tooltip label="Key naming: the dotted part of the path inside its record collapses to underscores — $[:].customer.id becomes customer_id — so sibling leaves like customer.id and order.id stay distinct. Any remaining name collision gets a numeric suffix (_2). Untick to name by the bare leaf (id) instead, relying on the suffix alone.">
                     <HelpCircle
                       size={11}
                       data-testid="api-input-salt-help"
@@ -838,6 +910,7 @@ export default function ApiInputEditor({
                   onRemoveColumn={(ci) => removeColumn(ti, ci)}
                   onPasteColumns={(grid) => pasteColumns(ti, grid)}
                   onConfirmAll={() => confirmAllColumns(ti)}
+                  onToggleKeyColumn={(ci) => toggleKeyColumn(ti, ci)}
                 />
               ))}
             </div>
@@ -904,6 +977,9 @@ export default function ApiInputEditor({
                 : buildInheritGroups(t.path, inventory)
             }
             existingPaths={new Set(t.columns.map((c) => c.path))}
+            existingKeyPaths={
+              new Set(t.columns.filter((c) => c.key === true).map((c) => c.path))
+            }
             onConfirm={(paths) => {
               addKeyColumnsToFrame(picker.tableIdx, paths, "inherited")
               setPicker(null)
@@ -938,6 +1014,7 @@ function TableBlock({
   onRemoveColumn,
   onPasteColumns,
   onConfirmAll,
+  onToggleKeyColumn,
 }: {
   table: ApiInputTableV2
   testIdPrefix: string
@@ -951,6 +1028,8 @@ function TableBlock({
   onPasteColumns: (grid: string[][]) => void
   /** Confirm every not-yet-confirmed column on this frame. */
   onConfirmAll: () => void
+  /** Toggle a column's key membership (moves it in/out of the keys section). */
+  onToggleKeyColumn: (colIdx: number) => void
 }) {
   return (
     <div
@@ -1075,6 +1154,7 @@ function TableBlock({
             }
             onUpdate={(patch) => onUpdateColumn(ci, patch)}
             onRemove={() => onRemoveColumn(ci)}
+            onToggleKey={() => onToggleKeyColumn(ci)}
           />
         ))}
         <button
@@ -1149,6 +1229,7 @@ function ColumnRow({
   validateName,
   onUpdate,
   onRemove,
+  onToggleKey,
 }: {
   col: ApiInputColumnV2
   framePath: string
@@ -1156,6 +1237,7 @@ function ColumnRow({
   validateName: (candidate: string) => string | null
   onUpdate: (patch: Partial<ApiInputColumnV2>) => void
   onRemove: () => void
+  onToggleKey: () => void
 }) {
   // Against-frame check, recomputed on every render: editing the FRAME's path
   // re-checks its columns against the new path so none are left stranded.
@@ -1212,16 +1294,29 @@ function ColumnRow({
           </option>
         ))}
       </select>
-      {col.key === true && (
-        <Tooltip label="Used as a key (cascade / inherit / add-keys)">
+      <Tooltip
+        label={
+          col.key === true
+            ? "A key — click to remove it from the keys section (stays confirmed)"
+            : "Make this field a key: confirms it and moves it into the keys at the top"
+        }
+      >
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-key`}
+          aria-pressed={col.key === true}
+          onClick={onToggleKey}
+          className="shrink-0 mt-0.5"
+        >
           <KeyRound
             size={10}
-            data-testid={`${testIdPrefix}-key`}
-            style={{ color: "var(--accent)" }}
-            className="shrink-0 mt-0.5"
+            style={{
+              color: col.key === true ? "var(--accent)" : "var(--text-muted)",
+              opacity: col.key === true ? 1 : 0.45,
+            }}
           />
-        </Tooltip>
-      )}
+        </button>
+      </Tooltip>
       <OriginChip
         origin={col.origin ?? "inferred"}
         confirmed={col.status === "Confirmed"}

--- a/frontend/src/panels/editors/apiInputInherit.ts
+++ b/frontend/src/panels/editors/apiInputInherit.ts
@@ -302,6 +302,9 @@ export function buildInsertedColumns(
       selected: true,
       levels: entry?.levels ?? null,
       origin,
+      // Anything arriving through the key machinery is tracked as a key
+      // (ruled 2026-07-09).
+      key: true,
     })
   }
   return out

--- a/frontend/src/panels/editors/apiInputInherit.ts
+++ b/frontend/src/panels/editors/apiInputInherit.ts
@@ -1,0 +1,224 @@
+/**
+ * Pure logic for the inherit / cascade key system on the API Input editor.
+ *
+ * The whole feature rests on a **path inventory**: a flat list of every key the
+ * editor knows about (the union of every column across the current frames and
+ * the columns of the most-recent inference snapshot), keyed by path and carrying
+ * the name it should reuse across frames plus its type. From the inventory,
+ * the two directions fall out of one structural prefix comparison:
+ *
+ *   - **inherit (pull)** — keys at a strictly shallower level on a frame's branch
+ *     can be pulled onto that frame;
+ *   - **cascade (push)** — a key can be pushed into the frames at strictly deeper
+ *     levels on its branch.
+ *
+ * No UI here. The prefix/leaf primitives all live in `jsonpath.ts` (the one
+ * grammar core); this module composes them. `$value` scalar-array keys are not
+ * valid inherit/cascade material and are excluded / rejected.
+ */
+import type { ApiInputColumnV2, ApiInputTableV2, ColumnType } from "./apiInputSchema"
+import {
+  type Seg,
+  RESERVED_LEAF,
+  frameSegments,
+  makeOutputPath,
+  parseColumnPathFull,
+  segmentPrefix,
+} from "./jsonpath"
+
+/** One key in the path inventory: its source path, the name it should carry
+ * (reused across frames so the same field reads identically everywhere), its
+ * type, and its category levels (carried verbatim). */
+export interface InventoryKey {
+  path: string
+  name: string
+  type: ColumnType
+  levels: (string | null)[] | null
+}
+
+/** The dotted leaf of a path, or null if the path doesn't parse / names no leaf.
+ * Defensive wrapper so a malformed path in the inventory is skipped, not thrown. */
+function leafOf(path: string): string | null {
+  try {
+    return parseColumnPathFull(path).leaf
+  } catch {
+    return null
+  }
+}
+
+/** True iff `path`'s leaf is the reserved `$value` scalar-array marker. Such keys
+ * are a whole-frame scalar mode, not material to inherit a value out of. */
+export function isReservedLeafPath(path: string): boolean {
+  return leafOf(path) === RESERVED_LEAF
+}
+
+/**
+ * Build the path inventory: the union of every column across `tables` and the
+ * columns of the most-recent inference snapshot `lastInfer` (a single snapshot,
+ * or null when nothing has been inferred). Keyed by path; a key present on a
+ * current frame wins over the inference snapshot (the user may have edited its
+ * name or type). `$value` keys are excluded.
+ *
+ * Iteration order is preserved as insertion order (inference snapshot first,
+ * then current frames) so consumers see keys roughly in file-encounter order.
+ */
+export function buildPathInventory(
+  tables: readonly ApiInputTableV2[],
+  lastInfer: readonly ApiInputTableV2[] | null,
+): Map<string, InventoryKey> {
+  const inv = new Map<string, InventoryKey>()
+  const ingest = (cols: readonly ApiInputColumnV2[]): void => {
+    for (const c of cols) {
+      if (!c.path || isReservedLeafPath(c.path)) continue
+      // A Map.set on an existing key updates the value but keeps the original
+      // insertion position — so frames override the snapshot's name/type without
+      // reordering the inventory.
+      inv.set(c.path, { path: c.path, name: c.name, type: c.type, levels: c.levels ?? null })
+    }
+  }
+  if (lastInfer) for (const t of lastInfer) ingest(t.columns)
+  for (const t of tables) ingest(t.columns)
+  return inv
+}
+
+/** One ancestor level's worth of inherit candidates for a frame. */
+export interface InheritGroup {
+  /** Canonical path of the ancestor level (`$[:]`, `$[:].orders[:]`, …) — the
+   * group's stable identity and its lexical sort key. */
+  ancestorPath: string
+  /** The array key at that level (`orders`), or `"root"` for the document root. */
+  ancestorLabel: string
+  candidates: InventoryKey[]
+}
+
+/** The array key naming a level: the deepest step's name, or "root" for `$[:]`. */
+function levelLabel(locating: readonly Seg[]): string {
+  return locating.length === 0 ? "root" : locating[locating.length - 1].name
+}
+
+/**
+ * The keys that can be **inherited** into `framePath` (pull), grouped by ancestor
+ * level. A key qualifies when its locating steps are a strictly-shallower
+ * segment-prefix of the frame. Groups are sorted lexically by their level path
+ * (which clusters structurally-similar levels and puts the root first);
+ * candidates within a group keep inventory order.
+ */
+export function buildInheritGroups(
+  framePath: string,
+  inventory: ReadonlyMap<string, InventoryKey>,
+): InheritGroup[] {
+  let target: Seg[]
+  try {
+    target = frameSegments(framePath)
+  } catch {
+    return []
+  }
+  const groups = new Map<string, InheritGroup>()
+  for (const key of inventory.values()) {
+    let locating: Seg[]
+    try {
+      locating = parseColumnPathFull(key.path).locating
+    } catch {
+      continue
+    }
+    if (!segmentPrefix(locating, target, { proper: true })) continue
+    const ancestorPath = makeOutputPath(locating)
+    let group = groups.get(ancestorPath)
+    if (!group) {
+      group = { ancestorPath, ancestorLabel: levelLabel(locating), candidates: [] }
+      groups.set(ancestorPath, group)
+    }
+    group.candidates.push(key)
+  }
+  return [...groups.values()].sort((a, b) =>
+    a.ancestorPath < b.ancestorPath ? -1 : a.ancestorPath > b.ancestorPath ? 1 : 0,
+  )
+}
+
+/**
+ * The indices of frames in `tables` into which `keyPath` can **cascade** (push):
+ * frames whose path has the key's own locating level as a strictly-deeper
+ * segment-prefix (descendants on the same branch). Siblings are never returned —
+ * the engine would reject them.
+ */
+export function getCascadeDestinations(
+  keyPath: string,
+  tables: readonly ApiInputTableV2[],
+): number[] {
+  let locating: Seg[]
+  try {
+    locating = parseColumnPathFull(keyPath).locating
+  } catch {
+    return []
+  }
+  const out: number[] = []
+  for (let i = 0; i < tables.length; i++) {
+    let frame: Seg[]
+    try {
+      frame = frameSegments(tables[i].path)
+    } catch {
+      continue
+    }
+    if (segmentPrefix(locating, frame, { proper: true })) out.push(i)
+  }
+  return out
+}
+
+/**
+ * Derive a column name from a key path by salting its full leaf: every run of
+ * characters that are not a letter, digit, or underscore collapses to a single
+ * underscore. `$[:].customer.id` → `customer_id` (so it never clashes with a
+ * sibling `order.id`, and arbitrary-unicode JSON keys still yield a valid name).
+ */
+export function inheritedColumnName(path: string): string {
+  return parseColumnPathFull(path).leaf.replace(/[^A-Za-z0-9_]+/g, "_")
+}
+
+/**
+ * Make `name` unique against the `taken` names by appending `_2`, `_3`, … Only
+ * the name is ever changed — never the path — so the engine's per-frame
+ * unique-name rule holds while the path stays the one it accepts.
+ */
+export function dedupName(name: string, taken: ReadonlySet<string>): string {
+  if (!taken.has(name)) return name
+  let i = 2
+  while (taken.has(`${name}_${i}`)) i += 1
+  return `${name}_${i}`
+}
+
+/**
+ * Validate a column path against the frame it would live on (the hand-entry
+ * guard). The column's locating must be a **prefix-or-equal** of the frame's
+ * segments — the frame's own level (a normal column) or an ancestor of it (a
+ * broadcast column) — never deeper and never sideways. A `$value` leaf is
+ * rejected unless the frame is itself that scalar-array frame, because mixing a
+ * `$value` column into an object frame silently empties it at flatten time.
+ * Returns an error string, or null when the path is acceptable.
+ */
+export function validateColumnPathAgainstFrame(
+  columnPath: string,
+  framePath: string,
+): string | null {
+  let parsed: { locating: Seg[]; leaf: string }
+  try {
+    parsed = parseColumnPathFull(columnPath)
+  } catch (e) {
+    return e instanceof Error ? e.message : "invalid column path"
+  }
+  let frame: Seg[]
+  try {
+    frame = frameSegments(framePath)
+  } catch (e) {
+    return e instanceof Error ? e.message : "invalid frame path"
+  }
+  const prefixOrEqual = segmentPrefix(parsed.locating, frame)
+  if (parsed.leaf === RESERVED_LEAF) {
+    const sameLevel = prefixOrEqual && parsed.locating.length === frame.length
+    return sameLevel
+      ? null
+      : "a $value scalar-array key cannot be added to this frame (it would empty the frame)"
+  }
+  return prefixOrEqual
+    ? null
+    : "this path points deeper than, or sideways from, this frame — only this frame's level or an ancestor of it can be added here"
+}

--- a/frontend/src/panels/editors/apiInputInherit.ts
+++ b/frontend/src/panels/editors/apiInputInherit.ts
@@ -321,6 +321,50 @@ function isBlankColumn(c: ApiInputColumnV2): boolean {
   return !c.name || !c.path
 }
 
+/** A column's array depth (its locating steps' `[:]` count), or MAX for a
+ * malformed/blank path so such rows sort after well-formed ones. */
+function columnDepth(c: ApiInputColumnV2): number {
+  try {
+    return arrayDepthOf(parseColumnPathFull(c.path).locating)
+  } catch {
+    return Number.MAX_SAFE_INTEGER
+  }
+}
+
+/**
+ * The frame column ordering (ruled 2026-07-09): keys form a section at the top
+ * — shallower (less-deep) keys first, keys at the same depth in JSON order,
+ * full-depth keys (which are always deliberate adds) in the order they became
+ * keys — and non-keys follow in data-model (JSON appearance) order. The only
+ * violations of JSON order are therefore the depth grouping of keys and the
+ * add-ordering of full-depth keys.
+ *
+ * `jsonOrder` maps path → JSON-appearance index (the inventory's insertion
+ * order is the working proxy); paths it doesn't know keep their relative
+ * order after known ones. Sorts are stable, so equal ranks preserve the
+ * existing arrangement — for full-depth keys that IS the add order.
+ */
+export function orderFrameColumns(
+  columns: readonly ApiInputColumnV2[],
+  framePath: string,
+  jsonOrder: ReadonlyMap<string, number>,
+): ApiInputColumnV2[] {
+  let frameDepth: number
+  try {
+    frameDepth = arrayDepthOf(frameSegments(framePath))
+  } catch {
+    return [...columns] // an invalid frame has no depth to order against
+  }
+  const rank = (c: ApiInputColumnV2) => jsonOrder.get(c.path) ?? Number.MAX_SAFE_INTEGER
+  const keys = columns.filter((c) => c.key === true)
+  const nonKeys = columns.filter((c) => c.key !== true)
+  const shallow = keys.filter((c) => columnDepth(c) < frameDepth)
+  const fullDepth = keys.filter((c) => columnDepth(c) >= frameDepth) // add order (stable)
+  shallow.sort((a, b) => columnDepth(a) - columnDepth(b) || rank(a) - rank(b))
+  nonKeys.sort((a, b) => rank(a) - rank(b))
+  return [...shallow, ...fullDepth, ...nonKeys]
+}
+
 /**
  * The re-infer reconciliation (replaces the whole-column-array adoption of the
  * old merge): applied when the user confirms "Replace tables" after a re-infer.
@@ -362,6 +406,12 @@ export function reconcileInferredTables(
     }
   }
 
+  // JSON-appearance ranks for the section ordering, from the inventory's
+  // insertion order (the working proxy for data-model order).
+  const jsonOrder = new Map<string, number>()
+  let rank = 0
+  for (const path of inventory.keys()) jsonOrder.set(path, rank++)
+
   return inferred.map((inf) => {
     const prev = byPath.get(inf.path)
     if (!prev) {
@@ -381,7 +431,10 @@ export function reconcileInferredTables(
         "inherited",
         salt,
       )
-      return { ...inf, columns: [...prepended, ...inf.columns] }
+      return {
+        ...inf,
+        columns: orderFrameColumns([...prepended, ...inf.columns], inf.path, jsonOrder),
+      }
     }
 
     const freshPaths = new Set(inf.columns.map((c) => c.path))
@@ -397,7 +450,7 @@ export function reconcileInferredTables(
       taken.add(name)
       appended.push({ ...c, name })
     }
-    const columns = [...kept, ...appended]
+    const columns = orderFrameColumns([...kept, ...appended], inf.path, jsonOrder)
     const row_id_column =
       prev.row_id_column && columns.some((c) => c.name === prev.row_id_column)
         ? prev.row_id_column

--- a/frontend/src/panels/editors/apiInputInherit.ts
+++ b/frontend/src/panels/editors/apiInputInherit.ts
@@ -165,13 +165,47 @@ export function getCascadeDestinations(
 }
 
 /**
- * Derive a column name from a key path by salting its full leaf: every run of
- * characters that are not a letter, digit, or underscore collapses to a single
- * underscore. `$[:].customer.id` → `customer_id` (so it never clashes with a
- * sibling `order.id`, and arbitrary-unicode JSON keys still yield a valid name).
+ * Derive a column name from a key path. With `salt` (the default) the full
+ * dotted leaf is salted: every run of characters that are not a letter, digit,
+ * or underscore collapses to a single underscore — `$[:].customer.id` →
+ * `customer_id` (so it never clashes with a sibling `order.id`, and
+ * arbitrary-unicode JSON keys still yield a valid name). With `salt` off only
+ * the final segment is used (`id`), relying on numeric de-dup for collisions.
  */
-export function inheritedColumnName(path: string): string {
-  return parseColumnPathFull(path).leaf.replace(/[^A-Za-z0-9_]+/g, "_")
+export function inheritedColumnName(path: string, salt = true): string {
+  const leaf = parseColumnPathFull(path).leaf
+  const base = salt ? leaf : leaf.split(".").pop() ?? leaf
+  return base.replace(/[^A-Za-z0-9_]+/g, "_")
+}
+
+/**
+ * Group EVERY inventory key by its locating level — the candidate source for
+ * the cascade picker, which offers the whole inventory rather than one frame's
+ * ancestors. Same group shape and lexical level ordering as
+ * {@link buildInheritGroups} so the two feed the same dialog.
+ */
+export function buildAllKeyGroups(
+  inventory: ReadonlyMap<string, InventoryKey>,
+): InheritGroup[] {
+  const groups = new Map<string, InheritGroup>()
+  for (const key of inventory.values()) {
+    let locating: Seg[]
+    try {
+      locating = parseColumnPathFull(key.path).locating
+    } catch {
+      continue
+    }
+    const ancestorPath = makeOutputPath(locating)
+    let group = groups.get(ancestorPath)
+    if (!group) {
+      group = { ancestorPath, ancestorLabel: levelLabel(locating), candidates: [] }
+      groups.set(ancestorPath, group)
+    }
+    group.candidates.push(key)
+  }
+  return [...groups.values()].sort((a, b) =>
+    a.ancestorPath < b.ancestorPath ? -1 : a.ancestorPath > b.ancestorPath ? 1 : 0,
+  )
 }
 
 /**
@@ -240,6 +274,7 @@ export function buildInsertedColumns(
   inventory: ReadonlyMap<string, InventoryKey>,
   existingNames: ReadonlySet<string>,
   origin: ColumnOrigin = "inherited",
+  salt = true,
 ): ApiInputColumnV2[] {
   const ordered = paths
     .map((path, idx) => {
@@ -257,7 +292,7 @@ export function buildInsertedColumns(
   const out: ApiInputColumnV2[] = []
   for (const { path } of ordered) {
     const entry = inventory.get(path)
-    const name = dedupName(entry?.name ?? inheritedColumnName(path), taken)
+    const name = dedupName(entry?.name ?? inheritedColumnName(path, salt), taken)
     taken.add(name)
     out.push({
       name,
@@ -275,4 +310,110 @@ export function buildInsertedColumns(
 /** Array (`[:]`) count of a parsed segment list — local helper for ordering. */
 function arrayDepthOf(segments: readonly Seg[]): number {
   return segments.reduce((n, s) => n + (s.isArray ? 1 : 0), 0)
+}
+
+/** Structurally incomplete: a blank name or path. Such a column is a persisted
+ * entry mid-repair (or mid-typing) — reconciliation must not eat it. */
+function isBlankColumn(c: ApiInputColumnV2): boolean {
+  return !c.name || !c.path
+}
+
+/**
+ * The re-infer reconciliation (replaces the whole-column-array adoption of the
+ * old merge): applied when the user confirms "Replace tables" after a re-infer.
+ *
+ * Per frame whose path exists on both sides, the user's curated
+ * label/emit/displayPath/row-id survive, and columns reconcile:
+ *   - **confirmed columns survive** (any origin — confirming is the user's act);
+ *   - **structurally-incomplete columns survive** (blank name/path: in-progress
+ *     user work; removing it on re-infer would be silent loss — the render-gate
+ *     keeps it visible as invalid instead);
+ *   - other non-confirmed columns survive only while their path is still in the
+ *     fresh inference; stale ones are removed;
+ *   - freshly-detected columns (paths not already on the frame) are appended,
+ *     de-duplicated against the surviving names — the FRESH side is suffixed,
+ *     never a column the user kept;
+ *   - a row-id nomination naming a column that no longer exists is cleared.
+ *
+ * A frame that is new in this inference arrives whole, with the user's
+ * previously-cascaded keys (inherited-origin columns on the existing frames)
+ * prepended where the new frame is a valid cascade destination. Frames the
+ * inference no longer produces are dropped, as before.
+ */
+export function reconcileInferredTables(
+  existing: readonly ApiInputTableV2[],
+  inferred: readonly ApiInputTableV2[],
+  inventory: ReadonlyMap<string, InventoryKey>,
+  salt = true,
+): ApiInputTableV2[] {
+  const byPath = new Map(existing.map((t) => [t.path, t]))
+  // The cascade-all set: every key the user has inherited/cascaded somewhere.
+  const cascadedPaths: string[] = []
+  const seenCascaded = new Set<string>()
+  for (const t of existing) {
+    for (const c of t.columns) {
+      if (c.origin === "inherited" && c.path && !seenCascaded.has(c.path)) {
+        seenCascaded.add(c.path)
+        cascadedPaths.push(c.path)
+      }
+    }
+  }
+
+  return inferred.map((inf) => {
+    const prev = byPath.get(inf.path)
+    if (!prev) {
+      // New frame: fresh columns, with the relevant cascaded keys prepended.
+      const applicable = cascadedPaths.filter((p) => {
+        if (inf.columns.some((c) => c.path === p)) return false
+        try {
+          return isCascadeDestinationOf(p, inf.path)
+        } catch {
+          return false
+        }
+      })
+      const prepended = buildInsertedColumns(
+        applicable,
+        inventory,
+        new Set(inf.columns.map((c) => c.name)),
+        "inherited",
+        salt,
+      )
+      return { ...inf, columns: [...prepended, ...inf.columns] }
+    }
+
+    const freshPaths = new Set(inf.columns.map((c) => c.path))
+    const kept = prev.columns.filter(
+      (c) => c.status === "Confirmed" || isBlankColumn(c) || freshPaths.has(c.path),
+    )
+    const keptPaths = new Set(kept.map((c) => c.path))
+    const taken = new Set(kept.map((c) => c.name))
+    const appended: ApiInputColumnV2[] = []
+    for (const c of inf.columns) {
+      if (keptPaths.has(c.path)) continue
+      const name = dedupName(c.name, taken)
+      taken.add(name)
+      appended.push({ ...c, name })
+    }
+    const columns = [...kept, ...appended]
+    const row_id_column =
+      prev.row_id_column && columns.some((c) => c.name === prev.row_id_column)
+        ? prev.row_id_column
+        : null
+    return {
+      ...inf,
+      label: prev.label,
+      emit: prev.emit,
+      displayPath: prev.displayPath,
+      row_id_column,
+      columns,
+    }
+  })
+}
+
+/** True iff `keyPath`'s locating level is a strictly-shallower segment-prefix of
+ * the frame at `framePath` — i.e. the frame is a valid cascade destination. */
+function isCascadeDestinationOf(keyPath: string, framePath: string): boolean {
+  return segmentPrefix(parseColumnPathFull(keyPath).locating, frameSegments(framePath), {
+    proper: true,
+  })
 }

--- a/frontend/src/panels/editors/apiInputInherit.ts
+++ b/frontend/src/panels/editors/apiInputInherit.ts
@@ -16,7 +16,7 @@
  * grammar core); this module composes them. `$value` scalar-array keys are not
  * valid inherit/cascade material and are excluded / rejected.
  */
-import type { ApiInputColumnV2, ApiInputTableV2, ColumnType } from "./apiInputSchema"
+import type { ApiInputColumnV2, ApiInputTableV2, ColumnOrigin, ColumnType } from "./apiInputSchema"
 import {
   type Seg,
   RESERVED_LEAF,
@@ -221,4 +221,58 @@ export function validateColumnPathAgainstFrame(
   return prefixOrEqual
     ? null
     : "this path points deeper than, or sideways from, this frame — only this frame's level or an ancestor of it can be added here"
+}
+
+/**
+ * Turn a set of selected key `paths` into the column rows to insert onto a frame
+ * — the pure core shared by inherit, cascade, and inherit-attributes. Each row
+ * reuses the inventory's name for that key (so a field reads the same across
+ * frames — "name transport"), falling back to the salted leaf, then de-duplicated
+ * against `existingNames` (and the rows already built in this batch). The type
+ * and category levels are carried from the inventory. Every row arrives
+ * `Confirmed` (a deliberate user act) with the given `origin` ("inherited" for
+ * inherit/cascade, "manual" for hand entry). Rows are ordered shallowest level
+ * first, then by the order the paths were given — the caller inserts the block
+ * at the top of the frame. A path that does not parse is skipped.
+ */
+export function buildInsertedColumns(
+  paths: readonly string[],
+  inventory: ReadonlyMap<string, InventoryKey>,
+  existingNames: ReadonlySet<string>,
+  origin: ColumnOrigin = "inherited",
+): ApiInputColumnV2[] {
+  const ordered = paths
+    .map((path, idx) => {
+      try {
+        const depth = arrayDepthOf(parseColumnPathFull(path).locating)
+        return { path, idx, depth }
+      } catch {
+        return null
+      }
+    })
+    .filter((r): r is { path: string; idx: number; depth: number } => r !== null)
+    .sort((a, b) => a.depth - b.depth || a.idx - b.idx)
+
+  const taken = new Set(existingNames)
+  const out: ApiInputColumnV2[] = []
+  for (const { path } of ordered) {
+    const entry = inventory.get(path)
+    const name = dedupName(entry?.name ?? inheritedColumnName(path), taken)
+    taken.add(name)
+    out.push({
+      name,
+      path,
+      type: entry?.type ?? "str",
+      status: "Confirmed",
+      selected: true,
+      levels: entry?.levels ?? null,
+      origin,
+    })
+  }
+  return out
+}
+
+/** Array (`[:]`) count of a parsed segment list — local helper for ordering. */
+function arrayDepthOf(segments: readonly Seg[]): number {
+  return segments.reduce((n, s) => n + (s.isArray ? 1 : 0), 0)
 }

--- a/frontend/src/panels/editors/apiInputSchema.ts
+++ b/frontend/src/panels/editors/apiInputSchema.ts
@@ -10,9 +10,19 @@
  * and saves. The v1 keys silently fall off when the strict v2 contract
  * serialises (see backend Pydantic config model).
  */
+import { frameSegments, parseColumnPathFull, segmentPrefix } from "./jsonpath"
 
 export type ColumnType = "int" | "float" | "str" | "bool" | "date"
 export type ColumnStatus = "Confirmed" | "Inferred"
+/**
+ * Where a column came from — the *originating* dimension of its status, kept
+ * separate from whether it has been confirmed (the confirmed dimension is
+ * carried by `status`: `"Confirmed"` vs `"Inferred"`). `"inherited"` covers both
+ * pull-inherited and cascaded keys (a broadcast column sourced at a shallower
+ * level than its frame); `"manual"` is a hand-entered field; `"inferred"` came
+ * from schema inference.
+ */
+export type ColumnOrigin = "inferred" | "inherited" | "manual"
 
 export interface ApiInputColumnV2 {
   name: string
@@ -21,6 +31,9 @@ export interface ApiInputColumnV2 {
   status: ColumnStatus
   selected: boolean
   levels?: (string | null)[] | null
+  /** Originating dimension (see {@link ColumnOrigin}). Optional on disk for
+   * back-compat; `readV2` derives it from the path when absent. */
+  origin?: ColumnOrigin
 }
 
 export interface ApiInputTableV2 {
@@ -58,6 +71,33 @@ const ALLOWED_TYPES: ReadonlySet<ColumnType> = new Set([
   "bool",
   "date",
 ] as const)
+
+const ALLOWED_ORIGINS: ReadonlySet<ColumnOrigin> = new Set([
+  "inferred",
+  "inherited",
+  "manual",
+] as const)
+
+/**
+ * Derive a column's origin from its path relative to its frame, used when the
+ * persisted config carries no `origin` (back-compat, or a save that dropped the
+ * field): a column whose locating is a *proper-ancestor* prefix of the frame is
+ * a broadcast column (`"inherited"`); anything at the frame's own level defaults
+ * to `"inferred"` (a hand-entered `"manual"` column is only known when its
+ * `origin` was persisted). Defensive — a malformed path yields `"inferred"`.
+ */
+function deriveOrigin(columnPath: string, framePath: string): ColumnOrigin {
+  try {
+    if (segmentPrefix(parseColumnPathFull(columnPath).locating, frameSegments(framePath), {
+      proper: true,
+    })) {
+      return "inherited"
+    }
+  } catch {
+    /* fall through to the default */
+  }
+  return "inferred"
+}
 
 /**
  * v2 shape iff `tables` is a non-empty (or at least present) array.
@@ -181,6 +221,10 @@ export function readV2(
           : Array.isArray(cc.levels)
           ? (cc.levels as (string | null)[])
           : null
+      const corigin: ColumnOrigin =
+        typeof cc.origin === "string" && ALLOWED_ORIGINS.has(cc.origin as ColumnOrigin)
+          ? (cc.origin as ColumnOrigin)
+          : deriveOrigin(cpath, path)
       columns.push({
         name: cname,
         path: cpath,
@@ -188,6 +232,7 @@ export function readV2(
         status: cstatus,
         selected: cselected,
         levels: clevels,
+        origin: corigin,
       })
     }
     tables.push({
@@ -231,6 +276,7 @@ export function writeV2(v2: ApiInputConfigV2): Record<string, unknown> {
         status: c.status,
         selected: c.selected,
         levels: c.levels ?? null,
+        origin: c.origin ?? "inferred",
       })),
     })),
   }

--- a/frontend/src/panels/editors/apiInputSchema.ts
+++ b/frontend/src/panels/editors/apiInputSchema.ts
@@ -34,6 +34,10 @@ export interface ApiInputColumnV2 {
   /** Originating dimension (see {@link ColumnOrigin}). Optional on disk for
    * back-compat; `readV2` derives it from the path when absent. */
   origin?: ColumnOrigin
+  /** True once this field has been used as a key — added or sourced through
+   * cascade / inherit / add-keys (ruled 2026-07-09). Editor metadata like
+   * `origin`; persisted, engine ignores it, absent reads as false. */
+  key?: boolean
 }
 
 export interface ApiInputTableV2 {
@@ -233,6 +237,7 @@ export function readV2(
         selected: cselected,
         levels: clevels,
         origin: corigin,
+        key: cc.key === true,
       })
     }
     tables.push({
@@ -277,6 +282,7 @@ export function writeV2(v2: ApiInputConfigV2): Record<string, unknown> {
         selected: c.selected,
         levels: c.levels ?? null,
         origin: c.origin ?? "inferred",
+        key: c.key ?? false,
       })),
     })),
   }

--- a/frontend/src/panels/editors/jsonpath.ts
+++ b/frontend/src/panels/editors/jsonpath.ts
@@ -358,3 +358,61 @@ export function validateInputColumnPath(path: string): string | null {
     }
   })
 }
+
+// ---------------------------------------------------------------------------
+// Structural helpers for the inherit/cascade key system (apiInputInherit.ts).
+// Each is a thin reduction over parseDataPath/Seg[] — NOT a second parser — so
+// the inherit/cascade prefix logic cannot drift from the grammar core. They
+// mirror the backend's `array_depth` / `parse_column_path_full` / the
+// segment-tuple prefix compare in `parse_column_path` (`_api_input_schema.py`).
+// ---------------------------------------------------------------------------
+
+/** A frame's own `(key, isArray)` steps — a table/prefix path parsed for the
+ * inherit/cascade comparisons. The root array `$[:]` yields `[]`. Throws
+ * {@link PathError} on a malformed path. */
+export function frameSegments(framePath: string): Seg[] {
+  return parseDataPath(framePath, { allowRoot: true, reservedLeaf: RESERVED_LEAF }).segments
+}
+
+/** Number of array (`[:]`) hops in a path — its relational depth. `$[:]` is 0
+ * segments (the root array is the document root, not a step); `$[:].orders[:]`
+ * is depth 1. Mirror of backend `array_depth`. Throws on a malformed path. */
+export function arrayDepth(path: string): number {
+  return frameSegments(path).reduce((n, seg) => n + (seg.isArray ? 1 : 0), 0)
+}
+
+/** Split a column path into its **locating** steps (up to and including the
+ * deepest array hop — the frame the column belongs to) and its dotted **leaf**
+ * (the trailing object hops). The `$value` reserved leaf surfaces as the leaf
+ * string `"$value"`. Mirror of backend `parse_column_path_full`. Throws
+ * {@link PathError} on a path that names no leaf. */
+export function parseColumnPathFull(path: string): { locating: Seg[]; leaf: string } {
+  const { segments } = parseDataPath(path, { allowRoot: false, reservedLeaf: RESERVED_LEAF })
+  let lastArray = -1
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].isArray) lastArray = i
+  }
+  const leafSegs = segments.slice(lastArray + 1)
+  if (leafSegs.length === 0) {
+    throw new PathError("column path names no leaf field (it ends at an array iterator)", path)
+  }
+  return { locating: segments.slice(0, lastArray + 1), leaf: leafSegs.map((s) => s.name).join(".") }
+}
+
+/** Whether `prefix` is a structural segment-prefix of `target`: every step
+ * (name AND isArray) equal up to `prefix.length`. With `{proper: true}` it must
+ * also be strictly shorter (a true ancestor/descendant, not the same level).
+ * The step-by-step compare — not depth, not text — is why a sibling branch
+ * (`$[:].drivers[:]` vs `$[:].vehicles[:]`, equal depth) is never a prefix.
+ * Mirror of the backend `tuple(locating) == tuple(table[:len(locating)])` rule. */
+export function segmentPrefix(
+  prefix: readonly Seg[],
+  target: readonly Seg[],
+  opts: { proper?: boolean } = {},
+): boolean {
+  if (opts.proper ? prefix.length >= target.length : prefix.length > target.length) return false
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i].name !== target[i].name || prefix[i].isArray !== target[i].isArray) return false
+  }
+  return true
+}


### PR DESCRIPTION
## What this does

Implements the inherit/cascade keys system for the API Input schema editor (frontend-only; the engine already accepts ancestor-level column paths and broadcasts them at flatten time).

- **Frames table** at the top of the editor: one row per frame (label, path, emit, column count with invalid-count callout). Invalid-path frames keep their row — greyed, failure named, entry points disabled — per the render-gate invariant.
- **Key movement**: cascade (push a key into every deeper frame on its branch, idempotent), inherit (pull from a shallower level onto one frame), add-keys with enter-a-field-by-hand (path + required type), and a per-row key toggle that moves any field — manual-origin included — in and out of the keys section.
- **Column dimensions**: persisted editor-side `origin` (inferred / inherited / manual) and `key` flags, ignored by the engine, derived on read for old configs. Origin chips with a confirmed check, per-column confirm + per-frame confirm-all, edit-confirms on name/path/type. Using a key confirms every column carrying that path — the cascade source included — so a re-infer can't remove the shallow original while its copies persist deeper.
- **Ordered keys section** per frame: shallower keys first (same depth in JSON order), full-depth keys in the order they became keys, non-keys in data-model order. Every key act routes through one ordering function.
- **Re-infer reconciliation**: confirmed and structurally-blank columns survive, stale non-confirmed are removed, fresh columns append (fresh side suffix-deduped), new frames arrive with previously-cascaded keys prepended, row-id nominations follow renames and clear on removal.
- **Naming**: the inventory's used name transports across frames; fallback salts the dotted leaf (`$[:].customer.id` → `customer_id`), switchable to bare-leaf. A hand-entered path already on the frame is never duplicated — the existing column is promoted and keyed, keeping its name/type/origin. Add Column arrives blank and derives its name when a valid path commits.
- **Fix**: the key-picker dialog portals to document.body (its fixed overlay was contained by a transformed side-pane ancestor, greying the pane with the dialog clipped).

## Verification

- 672 frontend tests (26 new interaction tests assert persisted config shapes through a non-mocked stateful harness), full preflight (eslint, tsc clean build, coverage gates, production build, bundle budget, benchmark gate) green.
- Backend untouched; `tests/test_v2_codec_and_shred.py` (53) green as a guard.
- Browser-driven walkthrough of every gesture (dialogs, toggle reordering, blank-column name derivation, save round-trip with on-disk origin/key inspection) plus two live user testing rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)