### PR TITLE
Fix flaky RemotePushControl tests: await the remotes load before clicking

### DIFF
--- a/frontend/src/components/__tests__/RemotePushControl.test.tsx
+++ b/frontend/src/components/__tests__/RemotePushControl.test.tsx
@@ -60,7 +60,16 @@ describe("RemotePushControl", () => {
   it("auto-selects the sole remote and pushes it", async () => {
     mockGetGitRemotes.mockResolvedValue({ remotes: [remote()], working_branch: "dev" })
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // `git-push-control` is in the DOM from the FIRST commit, before the
+    // remotes load has resolved — so waiting for it can resume the test while
+    // the push button is still disabled (no selection yet), and under machine
+    // load the click below lands on the disabled button and is silently
+    // swallowed (seen once in a full-suite preflight run, 2026-07-09 — same
+    // commit-vs-later-scheduler-task race class as the ComparisonView
+    // fit-race fix). Wait for the button to be ENABLED instead: that state
+    // only exists once the load has committed the auto-selected remote. Same
+    // pattern in every test below that clicks or asserts right after render.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(mockGitPush).toHaveBeenCalledWith("origin"))
   })
@@ -71,7 +80,10 @@ describe("RemotePushControl", () => {
       working_branch: "dev",
     })
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Wait for the loaded options, not the control: pre-load, the disabled
+    // assertion passes vacuously and the change below has no "backup" option
+    // to select yet.
+    await waitFor(() => expect(screen.getByRole("option", { name: /backup/ })).toBeInTheDocument())
     expect(screen.getByTestId("git-push-button")).toBeDisabled()
     fireEvent.change(screen.getByTestId("git-push-remote"), { target: { value: "backup" } })
     fireEvent.click(screen.getByTestId("git-push-button"))
@@ -81,7 +93,7 @@ describe("RemotePushControl", () => {
   it("warns before pushing out-of-version saves and pushes on confirm (overridable)", async () => {
     mockGetGitRemotes.mockResolvedValue({ remotes: [remote()], working_branch: "dev" })
     render(<RemotePushControl pendingSaveCount={3} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(screen.getByTestId("git-push-confirm")).toBeInTheDocument())
     expect(mockGitPush).not.toHaveBeenCalled() // a warning, not auto-push
@@ -92,7 +104,7 @@ describe("RemotePushControl", () => {
   it("does not push when the integrity prompt is cancelled", async () => {
     mockGetGitRemotes.mockResolvedValue({ remotes: [remote()], working_branch: "dev" })
     render(<RemotePushControl pendingSaveCount={1} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(screen.getByTestId("git-push-confirm")).toBeInTheDocument())
     fireEvent.click(screen.getByText("Cancel"))
@@ -181,7 +193,7 @@ describe("RemotePushControl", () => {
       new ApiError("HTTP 409", 409, JSON.stringify({ detail: rejection }), { detail: rejection }),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(screen.getByTestId("git-push-rejected")).toBeInTheDocument())
     expect(screen.getByTestId("git-push-rejected")).toHaveTextContent("never force-pushes")
@@ -197,7 +209,7 @@ describe("RemotePushControl", () => {
     mockGetGitRemotes.mockResolvedValue({ remotes: [remote()], working_branch: "dev" })
     mockGitPush.mockRejectedValue(new ApiError("HTTP 500", 500, "server boom"))
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(mockGitPush).toHaveBeenCalled())
     expect(screen.queryByTestId("git-push-rejected")).not.toBeInTheDocument()
@@ -234,7 +246,9 @@ describe("RemotePushControl", () => {
       working_branch: "dev",
     })
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Wait for a post-load signal (the ahead/behind badge) — pre-load the
+    // absence assertion passes vacuously, before Catch up could ever render.
+    await waitFor(() => expect(screen.getByTestId("git-push-aheadbehind")).toBeInTheDocument())
     expect(screen.queryByTestId("git-catch-up-button")).not.toBeInTheDocument()
   })
 
@@ -251,7 +265,7 @@ describe("RemotePushControl", () => {
       new ApiError("HTTP 409", 409, JSON.stringify({ detail: rejection }), { detail: rejection }),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(screen.getByTestId("git-push-rejected-catch-up")).toBeInTheDocument())
     fireEvent.click(screen.getByTestId("git-push-rejected-catch-up"))
@@ -271,7 +285,7 @@ describe("RemotePushControl", () => {
       new ApiError("HTTP 409", 409, JSON.stringify({ detail: rejection }), { detail: rejection }),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() => expect(screen.getByTestId("git-push-rejected")).toBeInTheDocument())
     expect(screen.queryByTestId("git-push-rejected-catch-up")).not.toBeInTheDocument()
@@ -293,7 +307,7 @@ describe("RemotePushControl", () => {
       new ApiError("HTTP 409", 409, JSON.stringify({ detail: rejection }), { detail: rejection }),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() =>
       expect(screen.getByTestId("git-push-rejected-heading")).toHaveTextContent("rewritten"),


### PR DESCRIPTION
## Problem

Eight `RemotePushControl` tests clicked (or asserted on) the Push control immediately after render, waiting only for `git-push-control` to appear. But `git-push-control` is in the DOM from the **first** render commit — `loaded=false` renders the control, not the no-remotes hint — so React Testing Library's `waitFor` can resume the test **before** the `getGitRemotes()` load's state (auto-selected remote → enabled button) commits in a later scheduler task.

Under machine load the click then lands on the still-disabled Push button and is silently swallowed: the integrity prompt never opens and the test times out at the `git-push-confirm` `waitFor`. Seen once in a loaded full-suite preflight run on 2026-07-09; passes in isolation. Same commit-vs-later-scheduler-task race class as the ComparisonView fit-race fix (`476e5c69`).

## Fix

Wait for the Push button to be **enabled** before clicking — a state that only exists once the remotes load has committed — in every test that clicks right after render. Two same-class hardenings in the same file remove vacuous pre-load assertions:

- the multiple-remotes test now waits for the loaded `backup` option before asserting disabled and firing the change (pre-load, the disabled assertion passed vacuously and the change had no `backup` option to select);
- the diverged no-catch-up test waits for the ahead/behind badge before asserting Catch up is absent (so the absence assertion cannot pass vacuously pre-load).

No assertion is weakened — the cancel test still ends with `expect(mockGitPush).not.toHaveBeenCalled()`.

## Verification

- Reproduced deterministically by delaying React's scheduler host callback (`setImmediate` → `setTimeout` 4ms) so the load-commit task always loses the race to `waitFor`'s act-drain timer: the old cancel-test shape failed every run and the fixed shape passed every run under the same simulated load (throwaway harness, since deleted).
- Fixed file green in isolation and under the simulated load (18/18); full frontend suite green (5105 tests, 263 files); three shuffled-order full-suite runs; typecheck, ESLint, and the coverage-threshold run all green.
- Test-only change, so no BUGS.md entry (test-only-fix exemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
