### PR TITLE
Render struct/list preview cells as JSON instead of [object Object]

### DIFF
--- a/frontend/src/__tests__/utils/formatValue.test.ts
+++ b/frontend/src/__tests__/utils/formatValue.test.ts
@@ -63,8 +63,8 @@ describe("formatValue", () => {
     expect(formatValue(false)).toBe("false")
   })
 
-  it("converts an object to its string representation", () => {
-    expect(formatValue({ a: 1 })).toBe("[object Object]")
+  it("converts a struct (object) value to JSON, not '[object Object]'", () => {
+    expect(formatValue({ a: 1 })).toBe('{"a":1}')
   })
 
   it("formats Haute non-finite JSON sentinels distinctly from null", () => {

--- a/frontend/src/panels/__tests__/DataPreview.test.tsx
+++ b/frontend/src/panels/__tests__/DataPreview.test.tsx
@@ -106,6 +106,25 @@ describe("DataPreview", () => {
     expect(screen.getByTestId("preview-panel-node-icon").querySelector(".lucide-database")).toBeTruthy()
   })
 
+  it("renders struct and list cell values as JSON, not '[object Object]'", () => {
+    render(
+      <DataPreview
+        data={makePreview({
+          column_count: 2,
+          columns: [
+            { name: "meta", dtype: "struct[2]" },
+            { name: "tags", dtype: "list[str]" },
+          ],
+          row_count: 1,
+          preview: [{ meta: { region: "uk", score: 3 }, tags: ["a", "b"] }],
+        })}
+      />,
+    )
+    expect(screen.getByText('{"region":"uk","score":3}')).toBeInTheDocument()
+    expect(screen.getByText('["a","b"]')).toBeInTheDocument()
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument()
+  })
+
   it("renders error message for error status", () => {
     render(<DataPreview data={makePreview({ status: "error", error: "Division by zero" })} />)
     expect(screen.getAllByText("Division by zero").length).toBeGreaterThanOrEqual(1)

--- a/frontend/src/utils/__tests__/formatValue.test.ts
+++ b/frontend/src/utils/__tests__/formatValue.test.ts
@@ -58,12 +58,21 @@ describe("formatValue", () => {
     expect(formatValue(false)).toBe("false")
   })
 
-  it("formats objects via String()", () => {
-    expect(formatValue({})).toBe("[object Object]")
+  it("formats struct (object) values as JSON, not '[object Object]'", () => {
+    expect(formatValue({})).toBe("{}")
+    expect(formatValue({ a: 1, b: "x" })).toBe('{"a":1,"b":"x"}')
+    expect(formatValue({ nested: { list: [1, 2] } })).toBe('{"nested":{"list":[1,2]}}')
   })
 
-  it("formats arrays via String()", () => {
-    expect(formatValue([1, 2, 3])).toBe("1,2,3")
+  it("formats list/array values as JSON", () => {
+    expect(formatValue([1, 2, 3])).toBe("[1,2,3]")
+    expect(formatValue([{ a: 1 }, null])).toBe('[{"a":1},null]')
+  })
+
+  it("renders non-finite-float sentinels nested inside structs as display strings", () => {
+    expect(
+      formatValue({ x: { __haute_type__: "non_finite_float", value: "nan" }, y: 2 }),
+    ).toBe('{"x":"NaN","y":2}')
   })
 
   it("formats Haute non-finite JSON sentinels distinctly from null", () => {

--- a/frontend/src/utils/formatValue.ts
+++ b/frontend/src/utils/formatValue.ts
@@ -27,6 +27,11 @@ export function formatValue(v: unknown, maxFractionDigits = 4): string {
     if (Number.isInteger(v)) return v.toLocaleString()
     return v.toLocaleString(undefined, { maximumFractionDigits: maxFractionDigits })
   }
+  if (typeof v === "object") {
+    // Struct / list / array cells: render as JSON rather than "[object Object]".
+    // Nested non-finite-float sentinels become their display strings.
+    return JSON.stringify(v, (_key, value: unknown) => formatJsonSpecialValue(value) ?? value)
+  }
   return String(v)
 }
 


### PR DESCRIPTION
## Summary
- `formatValue` fell through to `String(v)` for objects, so struct/list/array cells in the shared DataPreview table rendered as `[object Object]` (most visible on the new dataInput node type from #68). Non-scalar values are now JSON-stringified, with nested `__haute_type__: "non_finite_float"` sentinels rendered as their display strings (`NaN`/`Infinity`), matching the top-level handling.
- Added struct/list/nested-sentinel unit tests and a struct-valued-cell rendering test for DataPreview; updated the two pre-existing assertions that pinned the old `[object Object]` behaviour.

## Testing
- Full frontend suite green (5,204 tests / 269 files)
- `tsc -b` typecheck clean
- Backend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)