### PR TITLE
Add per-file critical-coverage gates for the data-io modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,22 @@ min_branch_coverage = 100.0
 rationale = "Path resolution is a security and portability boundary."
 
 [[tool.haute.critical_coverage.files]]
+path = "src/haute/_polars_dtypes.py"
+min_statement_coverage = 84.0
+min_branch_coverage = 77.0
+rationale = "Struct-capable dtype codec decodes user-supplied schema declarations for dataInput/dataOutput configs."
+# Seeded from PR #68 landing measurement (87.2% stmt / 80.3% branch); ratchet as coverage grows.
+
+[[tool.haute.critical_coverage.files]]
+path = "src/haute/_polars_io_registry.py"
+min_statement_coverage = 73.0
+min_branch_coverage = 64.0
+rationale = "Format registry defines the dataInput/dataOutput argument surface and enforces the bounded-memory and path-security posture per format."
+# Seeded from PR #68 landing measurement (75.7% stmt / 67.4% branch); engine-gated
+# formats (Excel/ODS/database/Delta/Iceberg) skip without their optional engines,
+# which caps measurable coverage. Ratchet if engines join CI.
+
+[[tool.haute.critical_coverage.files]]
 path = "src/haute/_ram_estimate.py"
 min_statement_coverage = 98.0
 min_branch_coverage = 94.0


### PR DESCRIPTION
Adds the two per-file critical-coverage entries deferred from PR #68 (data-io PLAN §8a):

- `src/haute/_polars_dtypes.py`: 84% statement / 77% branch (measured at landing: 87.2 / 80.3)
- `src/haute/_polars_io_registry.py`: 73% statement / 64% branch (measured: 75.7 / 67.4)

Thresholds sit a couple of points below measured coverage for headroom. The registry's low ceiling is structural: engine-gated formats (Excel, ODS, database, Delta, Iceberg) skip their execution paths when the optional engine packages aren't installed — noted in a comment on the entry, to be ratcheted if engines ever join CI.

Verified: `check_critical_coverage.py` passes for all 30 backend files against a fresh full-suite coverage run; full `scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)