### PR TITLE
Fix leaked mockImplementationOnce order-dependence in useWebSocketSync.failLoudly test

### DIFF
--- a/frontend/src/hooks/__tests__/useWebSocketSync.failLoudly.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocketSync.failLoudly.test.ts
@@ -129,7 +129,11 @@ describe("useWebSocketSync — partial failure rolls back consistently (#37)", (
     globalThis.WebSocket = createMockWebSocket() as unknown as typeof WebSocket
 
     // Default: identity layout — individual tests override to throw.
-    vi.mocked(getLayoutedElements).mockImplementation(async (n: unknown) => n as never)
+    // mockReset (not just mockImplementation) because an unconsumed
+    // mockImplementationOnce queued by a previous test survives a plain
+    // mockImplementation call and would be consumed first, making the
+    // armed throw/success behaviour order-dependent under shuffle.
+    vi.mocked(getLayoutedElements).mockReset().mockImplementation(async (n: unknown) => n as never)
     vi.mocked(useToastStore.getState().addToast).mockClear()
     useToastStore.getState().toasts.length = 0
     // markSaved lives in the module-level store mock, so calls persist
@@ -316,9 +320,12 @@ describe("useWebSocketSync — partial failure rolls back consistently (#37)", (
     // Catches: a failed message should not poison the handler for
     // future messages.  The next valid message must process as usual.
     const params = makeHookParams()
+    // Only the first message triggers a layout call (the second carries
+    // explicit positions, so layout is skipped) — arm exactly one throw.
+    // A second queued Once would go unconsumed and leak into whichever
+    // test's layout call comes next under shuffled order.
     vi.mocked(getLayoutedElements)
       .mockImplementationOnce(async () => { throw new Error("layout failed") })
-      .mockImplementationOnce(async (n: unknown) => n as never)
 
     renderHook(() => useWebSocketSync(params))
     act(() => { latestWS().onopen?.(new Event("open")) })


### PR DESCRIPTION
## What

Second order-dependence bug in `frontend/src/hooks/__tests__/useWebSocketSync.failLoudly.test.ts`, found by a shuffle-order audit following #70 — a different leak class this time: an unconsumed `mockImplementationOnce` queue entry, not call history.

**Mechanism.** "subsequent graph_update after a failed one is handled cleanly" armed two `mockImplementationOnce` entries on `getLayoutedElements`, but its second message carries explicit node positions, so the hook never makes a second layout call — the non-throwing `Once` goes unconsumed. `beforeEach`'s plain `mockImplementation(...)` does **not** purge the once-queue, so under `--sequence.shuffle` the leftover is consumed first by whichever test's layout call comes next: "getLayoutedElements throws → error toast is emitted" then takes the success path (info toast) and fails. ≈1/5 of within-file orderings trip it; default order is silently green because the leaking test happens to run after every layout-arming test.

**Fix (+9/−2, test-only).**
- `beforeEach` now does `mockReset().mockImplementation(identity)` — purges any leaked once-queue under every ordering, closing this class for the mock.
- The dead second `Once` is removed.

## Verified

- Deterministic repro: full-suite `--sequence.shuffle` seeds **203** and **205** fail pre-fix, pass post-fix (vitest 4.1.9, `npm ci` install); also reproduced single-file.
- Post-fix on the pre-merge tree: 6 shuffled full-suite runs + default order green (5216/5216 each); 12 single-file seeds green.
- Combined tree (after forward-merge of `main` @ `12371a36`): seeds 203/205/401/402 + default order all green (5218/5218).

## Context

Part of a wider audit: 26 statically-filtered candidate files were adversarially reviewed and dynamically swept (10 shuffle seeds on the candidate set, 6+ on the full suite) — all 26 clean; this file was the only confirmed leak, and notably was *excluded* by the static filter because #70's fix added a `mockClear`. Hardening recommendations for latent (currently-unasserted) leaks are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)