### PR TITLE
Degrade Duration columns gracefully in the Explore report

### DIFF
--- a/src/haute/routes/_explore_service.py
+++ b/src/haute/routes/_explore_service.py
@@ -12,6 +12,7 @@ import json
 import threading
 import time
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 import polars as pl
@@ -333,6 +334,20 @@ def _lossy_decode_binary(value: bytes | None) -> str | None:
     return value.decode("utf-8", errors="replace")
 
 
+def _format_duration(value: timedelta | None) -> str | None:
+    """Format a Duration value as text, matching ``str(timedelta)``.
+
+    Mirrors the min/max path, which leaves Duration uncast and lets
+    ``_format_display_value`` apply ``str(timedelta)``, so a Duration column's
+    value-count labels read identically to its min/max ("2:00:00",
+    "1 day, 0:00:00").
+    """
+
+    if value is None:
+        return None
+    return str(value)
+
+
 def _categorical_value_label_expr(name: str, dtype: pl.DataType) -> pl.Expr:
     """Return the String-typed expression whose distinct values are counted.
 
@@ -341,12 +356,20 @@ def _categorical_value_label_expr(name: str, dtype: pl.DataType) -> pl.Expr:
     ``ComputeError: invalid utf8`` on the first undecodable row, aborting the
     entire batched ``streaming_collect`` and taking down the whole Explore
     materialisation. Decode Binary leniently instead so undecodable bytes
-    surface as the Unicode replacement character rather than crashing; every
-    other text-like dtype is already valid UTF-8 and casts cheaply.
+    surface as the Unicode replacement character rather than crashing.
+
+    Duration columns are temporal, so they reach this branch too, but Polars
+    cannot ``cast(pl.Duration, pl.String)`` at all — the strict cast raises
+    ``InvalidOperationError`` and aborts the same collect. Format Duration
+    element-wise instead. Every other text-like dtype is already valid UTF-8
+    and casts cheaply.
     """
 
-    if dtype.base_type() == pl.Binary:
+    base = dtype.base_type()
+    if base == pl.Binary:
         return pl.col(name).map_elements(_lossy_decode_binary, return_dtype=pl.String)
+    if base == pl.Duration:
+        return pl.col(name).map_elements(_format_duration, return_dtype=pl.String)
     return pl.col(name).cast(pl.String)
 
 

--- a/tests/test_explore_routes.py
+++ b/tests/test_explore_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -868,6 +868,56 @@ def test_build_frame_stats_survives_non_utf8_binary_column(
     # Valid bytes decode to text; the two invalid bytes each become a
     # replacement character; nulls surface as a null bucket. Never a crash.
     assert values == {"ok": 2, "��": 1, None: 1}
+
+
+def test_build_frame_stats_survives_duration_column(
+    explore_execution_context,
+) -> None:
+    """A Duration column must not abort the whole Explore materialisation.
+
+    Duration is temporal, so it is admitted to the categorical value-count
+    branch — but Polars cannot ``cast(pl.Duration, pl.String)``, so the strict
+    cast aborts the entire batched ``streaming_collect``, taking every other
+    column's stats down with it. Duration values must instead be formatted
+    leniently (like Binary) so the report always completes, with the column
+    represented sensibly.
+    """
+    from haute.routes._explore_service import _build_frame_stats
+
+    lf = pl.DataFrame(
+        {
+            "premium": [10, 20, 30, 40],
+            "wait": pl.Series(
+                "wait",
+                [timedelta(days=1), timedelta(hours=2), timedelta(hours=2), None],
+                dtype=pl.Duration("us"),
+            ),
+        }
+    ).lazy()
+
+    frame_stats = _build_frame_stats(
+        lf,
+        lf.collect_schema(),
+        execution_context=explore_execution_context,
+    )
+
+    # The whole report survives: both columns are present with core stats.
+    assert frame_stats.row_count == 4
+    stats = {column.name: column for column in frame_stats.columns}
+    assert set(stats) == {"premium", "wait"}
+    assert stats["premium"].mean_value == "25"
+    assert stats["wait"].kind == "Temporal"
+    assert stats["wait"].null_count == 1
+    assert stats["wait"].distinct_count == 3
+    # Duration min/max already format via str(timedelta); labels match them.
+    assert stats["wait"].min_value == "2:00:00"
+    assert stats["wait"].max_value == "1 day, 0:00:00"
+    profiles = {
+        profile.field: profile for profile in frame_stats.overview_summary.categorical_summary
+    }
+    assert "wait" in profiles
+    values = {item.value: item.count for item in profiles["wait"].values}
+    assert values == {"2:00:00": 2, "1 day, 0:00:00": 1, None: 1}
 
 
 def test_build_frame_stats_expands_high_cardinality_categorical_columns_with_top_50_values(


### PR DESCRIPTION
## Problem

A `Duration`-dtype column crashed the **entire** Explore report. `Duration` is temporal, so it is admitted to the categorical value-count branch in `_build_frame_stats`, whose label expression did a strict `cast(pl.String)`. Polars cannot cast `Duration → String` at all (`InvalidOperationError: casting from Duration('μs') to String not supported`), and because every per-column stat runs in one batched `streaming_collect`, that single column's failure aborted the whole report materialisation instead of degrading just that column.

## Fix

Mirrors the Binary-column fix from the W5 wave (`bc96b077`, which touched the same file for the same class of bug). In `_categorical_value_label_expr`, a `Duration` column is now formatted element-wise via `str(timedelta)` instead of cast, so an uncastable exotic dtype degrades to a sensible label rather than taking down the report. The labels match the min/max path, which already leaves `Duration` uncast and renders `str(timedelta)` — e.g. `"2:00:00"`, `"1 day, 0:00:00"`.

`Duration` reaches only the `null_count`, `n_unique`, min/max, and categorical value-count aggregations (numeric-only stats are gated on `is_numeric`); all four now handle it without a strict String cast.

## Test (TDD, failing-first)

`test_build_frame_stats_survives_duration_column` in `tests/test_explore_routes.py` — added failing-first (reproduced the exact `InvalidOperationError`), now green. A frame with a `pl.Duration` column must return a full report with that column represented sensibly: min/max, distinct count, null count, and value-count labels as `str(timedelta)`.

## Checks (local backend gate, run on the combined tree)

- Ruff lint / format / mypy — pass (repo-wide)
- Full pytest suite — 12538 passed, 28 skipped, 2 xfailed
- Global coverage 92.63% ≥ 90%; per-file critical-coverage gate — pass
- Frontend/package-build gates not run locally (Python-only change; worktree lacks `node_modules`) — CI runs the full matrix here

🤖 Generated with [Claude Code](https://claude.com/claude-code)