### PR TITLE
Guard the unborn-repo seed against committing secrets (defence-in-depth)

### DIFF
--- a/src/haute/_git.py
+++ b/src/haute/_git.py
@@ -1181,7 +1181,7 @@ def set_working_branch(
                 _get_default_branch_cached.cache_clear()
                 _clear_content_caches()
 
-            # Seed staging is defence-in-depth (ruled 2026-07-15): a file
+            # Seed staging is defence-in-depth: a file
             # enters the root commit only by matching a haute-owned pathspec
             # (_SEED_PATHSPECS, the permit gate) AND surviving the .gitignore
             # guard entries (the deny gate). `haute init` writes the guards,

--- a/src/haute/_git.py
+++ b/src/haute/_git.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 
+from haute._gitignore_guard import ensure_gitignore_guards
 from haute._logging import get_logger
 from haute.errors import HauteError
 from haute.schemas import (
@@ -1154,6 +1155,18 @@ def set_working_branch(
                 _get_default_branch_cached.cache_clear()
                 _clear_content_caches()
 
+            # The add-all below trusts .gitignore to keep secrets and per-clone
+            # state out of the root commit. `haute init` writes the guard
+            # entries, but a foreign `git init` repo carries no such guarantee
+            # — assert them before staging anything, or the seed publishes
+            # .env into history and commits .haute/ (the clone-lockout class).
+            toplevel = Path(_run_git("rev-parse", "--show-toplevel", cwd=cwd).strip())
+            ensure_gitignore_guards(toplevel)
+            # Pre-staged index content bypasses .gitignore and would survive
+            # `add -A`; start from an empty index so the fresh guards alone
+            # decide what enters the root commit. --cached leaves the working
+            # tree untouched; -f covers stage-vs-disk mismatches.
+            _run_git("rm", "-r", "-f", "-q", "--cached", "--ignore-unmatch", "--", ".", cwd=cwd)
             _run_git("add", "-A", cwd=cwd)
             # If nothing was staged (empty working tree) use --allow-empty so we
             # still establish a root commit and the model remains consistent.

--- a/src/haute/_git.py
+++ b/src/haute/_git.py
@@ -1103,6 +1103,32 @@ def working_branch_status(project_root: Path, cwd: Path | None = None) -> GitWor
     return base
 
 
+# What haute owns in a project tree — the permit half of the unborn-repo
+# seed's defence-in-depth (haute._gitignore_guard carries the deny half).
+# Shapes follow the `haute init` scaffold plus the nested-pipeline layout.
+# Default git pathspec globs: '*' also matches '/', so "*.py" covers
+# rating/utility/helpers.py and "*/config/*" covers any pipeline's config
+# dir (a wildcard combined with a bare trailing slash matches nothing —
+# hence the explicit /* suffix there).
+_SEED_PATHSPECS: tuple[str, ...] = (
+    "haute.toml",
+    "pyproject.toml",
+    "uv.lock",
+    ".gitignore",
+    ".env.example",
+    "*.py",
+    "*.haute.json",
+    "config/",
+    "*/config/*",
+    "prompts/",
+    "tests/",
+    ".githooks/",
+    ".github/",
+    ".gitlab-ci.yml",
+    "azure-pipelines.yml",
+)
+
+
 def set_working_branch(
     branch: str,
     project_root: Path,
@@ -1155,19 +1181,37 @@ def set_working_branch(
                 _get_default_branch_cached.cache_clear()
                 _clear_content_caches()
 
-            # The add-all below trusts .gitignore to keep secrets and per-clone
-            # state out of the root commit. `haute init` writes the guard
-            # entries, but a foreign `git init` repo carries no such guarantee
-            # — assert them before staging anything, or the seed publishes
-            # .env into history and commits .haute/ (the clone-lockout class).
+            # Seed staging is defence-in-depth (ruled 2026-07-15): a file
+            # enters the root commit only by matching a haute-owned pathspec
+            # (_SEED_PATHSPECS, the permit gate) AND surviving the .gitignore
+            # guard entries (the deny gate). `haute init` writes the guards,
+            # but a foreign `git init` repo carries no such guarantee — assert
+            # them here, or the seed publishes .env into history and commits
+            # .haute/ (the clone-lockout class).
             toplevel = Path(_run_git("rev-parse", "--show-toplevel", cwd=cwd).strip())
             ensure_gitignore_guards(toplevel)
-            # Pre-staged index content bypasses .gitignore and would survive
-            # `add -A`; start from an empty index so the fresh guards alone
-            # decide what enters the root commit. --cached leaves the working
-            # tree untouched; -f covers stage-vs-disk mismatches.
+            # Pre-staged index content bypasses .gitignore and would ride into
+            # the commit unstaged-checks notwithstanding; start from an empty
+            # index so the two gates alone decide what enters the root commit.
+            # --cached leaves the working tree untouched; -f covers
+            # stage-vs-disk mismatches.
             _run_git("rm", "-r", "-f", "-q", "--cached", "--ignore-unmatch", "--", ".", cwd=cwd)
-            _run_git("add", "-A", cwd=cwd)
+            # ls-files applies both gates: the pathspecs permit, and
+            # --exclude-standard enforces the ignore rules.
+            listed = _run_git(
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "-z",
+                "--",
+                *_SEED_PATHSPECS,
+                cwd=cwd,
+            )
+            seed_files = [f for f in listed.split("\0") if f]
+            if seed_files:
+                # :(literal) so a filename containing glob characters cannot
+                # re-expand into a broader pathspec at add time.
+                _run_git("add", "--", *[f":(literal){f}" for f in seed_files], cwd=cwd)
             # If nothing was staged (empty working tree) use --allow-empty so we
             # still establish a root commit and the model remains consistent.
             ok_diff, _ = _run_git_ok("diff", "--cached", "--quiet", cwd=cwd)

--- a/src/haute/_gitignore_guard.py
+++ b/src/haute/_gitignore_guard.py
@@ -1,0 +1,48 @@
+"""Guard entries haute asserts into a project's ``.gitignore``.
+
+Two sites write these entries and must never drift: ``haute init`` (project
+scaffolding) and the unborn-repo seed in :func:`haute._git.set_working_branch`
+(which stages the whole working tree for the root commit and therefore cannot
+trust an ambient ``.gitignore`` the user may never have written).
+
+NB: ``<pipeline>.haute.json`` is STABLE-LAYER (node positions etc.) and MUST
+stay tracked — it rides the save ledger.  Never add ``*.haute.json`` here.
+The per-clone ``.haute/`` state directory is the untracked part: committing
+one clone's ``state.json`` locks out every other clone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+GITIGNORE_GUARD_ENTRIES: tuple[str, ...] = (
+    ".env",
+    ".haute/",
+    "impact_report.md",
+    ".haute_cache/",
+    "mlruns/",
+    "data/",
+)
+
+
+def ensure_gitignore_guards(project_dir: Path) -> list[str]:
+    """Ensure every guard entry is present in ``project_dir/.gitignore``.
+
+    Appends the missing entries (creating the file when absent) and returns
+    them; an empty list means the file already carried the full set and was
+    left byte-identical.
+    """
+    gitignore_path = project_dir / ".gitignore"
+    if not gitignore_path.exists():
+        gitignore_path.write_text("\n".join(GITIGNORE_GUARD_ENTRIES) + "\n", encoding="utf-8")
+        return list(GITIGNORE_GUARD_ENTRIES)
+
+    # User-authored files may carry non-UTF-8 bytes; replace instead of raising
+    # (same posture as haute._io.read_user_text, inlined to keep this module
+    # free of the polars import chain).
+    existing = set(gitignore_path.read_text(encoding="utf-8", errors="replace").splitlines())
+    missing = [entry for entry in GITIGNORE_GUARD_ENTRIES if entry not in existing]
+    if missing:
+        with open(gitignore_path, "a", encoding="utf-8") as fh:
+            fh.write("\n# Haute\n" + "\n".join(missing) + "\n")
+    return missing

--- a/src/haute/_gitignore_guard.py
+++ b/src/haute/_gitignore_guard.py
@@ -23,7 +23,7 @@ GITIGNORE_GUARD_ENTRIES: tuple[str, ...] = (
     "mlruns/",
     "data/",
     # Without this, .venv/ contents would pass the seed's *.py allowlist
-    # pathspec — the deny gate has to carry it (ruled 2026-07-15).
+    # pathspec — the deny gate has to carry it.
     ".venv/",
 )
 

--- a/src/haute/_gitignore_guard.py
+++ b/src/haute/_gitignore_guard.py
@@ -22,6 +22,9 @@ GITIGNORE_GUARD_ENTRIES: tuple[str, ...] = (
     ".haute_cache/",
     "mlruns/",
     "data/",
+    # Without this, .venv/ contents would pass the seed's *.py allowlist
+    # pathspec — the deny gate has to carry it (ruled 2026-07-15).
+    ".venv/",
 )
 
 

--- a/src/haute/cli/_init_cmd.py
+++ b/src/haute/cli/_init_cmd.py
@@ -19,6 +19,7 @@ import click
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
+from haute._gitignore_guard import ensure_gitignore_guards
 from haute._io import read_user_text
 
 
@@ -645,25 +646,13 @@ def handle_init(config: InitConfig) -> None:
             installed.chmod(0o755)
 
     # -- .gitignore - append if exists, create if not --------------------------
-    # NB: <pipeline>.haute.json is STABLE-LAYER (node positions etc.) and MUST be
-    # tracked — it rides the save ledger. Do NOT gitignore *.haute.json. The
-    # per-clone .haute/ state directory (working-branch association, caches) is
-    # the untracked part.
+    # The guard entries (and the stable-layer *.haute.json caveat) live in
+    # haute._gitignore_guard, shared with the unborn-repo seed in haute._git so
+    # the two sites cannot drift.
     gitignore_path = project_dir / ".gitignore"
-    haute_entries = ".env\n.haute/\nimpact_report.md\n.haute_cache/\nmlruns/\ndata/\n"
-    if gitignore_path.exists():
-        existing_lines = set(read_user_text(gitignore_path).splitlines())
-        missing = [
-            line for line in haute_entries.splitlines() if line and line not in existing_lines
-        ]
-        if missing:
-            with open(gitignore_path, "a", encoding="utf-8") as fh:
-                fh.write("\n# Haute\n" + "\n".join(missing) + "\n")
-    else:
-        gitignore_path.write_text(
-            "__pycache__/\n*.pyc\n.venv/\n.env\n.haute/\n.haute_cache/\nmlruns/\ndata/\n",
-            encoding="utf-8",
-        )
+    if not gitignore_path.exists():
+        gitignore_path.write_text("__pycache__/\n*.pyc\n.venv/\n", encoding="utf-8")
+    ensure_gitignore_guards(project_dir)
 
     # -- Summary ---------------------------------------------------------------
     click.echo(f"Initialised Haute project '{name}' ({target} + {ci})\n")

--- a/tests/test_git_engine.py
+++ b/tests/test_git_engine.py
@@ -833,9 +833,9 @@ class TestSeedGitignoreGuards:
 
         assert (unborn_repo / ".gitignore").read_text() == content
 
-    # --- Allowlist gate (defence-in-depth, ruled 2026-07-15): the seed stages
-    # only haute-owned pathspecs, so an unintended file must fail BOTH the
-    # allowlist and the .gitignore guards to reach history. -------------------
+    # --- Allowlist gate (defence-in-depth): the seed stages only haute-owned
+    # pathspecs, so an unintended file must fail BOTH the allowlist and the
+    # .gitignore guards to reach history. -------------------------------------
 
     def test_unallowed_file_not_committed_even_when_not_ignored(self, unborn_repo: Path) -> None:
         """The allowlist gate alone: files matching no haute-owned pathspec
@@ -870,9 +870,8 @@ class TestSeedGitignoreGuards:
         )
         assert ".venv/" in (unborn_repo / ".gitignore").read_text().splitlines()
 
-    # --- Over-exclusion guard (Nick's note, ruled 2026-07-15): unintended
-    # EXCLUSION is a loud failure mode — pin that legitimate project files ARE
-    # still captured by the seed. ---------------------------------------------
+    # --- Over-exclusion guard: unintended EXCLUSION is a loud failure mode —
+    # pin that legitimate project files ARE still captured by the seed. -------
 
     def test_haute_scaffold_shape_is_fully_committed(self, unborn_repo: Path) -> None:
         """Every file shape `haute init` scaffolds (plus the nested-pipeline

--- a/tests/test_git_engine.py
+++ b/tests/test_git_engine.py
@@ -833,6 +833,76 @@ class TestSeedGitignoreGuards:
 
         assert (unborn_repo / ".gitignore").read_text() == content
 
+    # --- Allowlist gate (defence-in-depth, ruled 2026-07-15): the seed stages
+    # only haute-owned pathspecs, so an unintended file must fail BOTH the
+    # allowlist and the .gitignore guards to reach history. -------------------
+
+    def test_unallowed_file_not_committed_even_when_not_ignored(self, unborn_repo: Path) -> None:
+        """The allowlist gate alone: files matching no haute-owned pathspec
+        stay out of the root commit even though nothing gitignores them."""
+        (unborn_repo / "main.py").write_text("x = 1\n")
+        (unborn_repo / "notes.txt").write_text("meeting notes\n")
+        (unborn_repo / "backup.tar").write_text("tarball bytes")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert "notes.txt" not in committed, f"unallowed file leaked: {committed}"
+        assert "backup.tar" not in committed, f"unallowed file leaked: {committed}"
+        # Not committed but also untouched: still on disk for the user.
+        assert (unborn_repo / "notes.txt").exists()
+
+    def test_venv_fails_both_gates(self, unborn_repo: Path) -> None:
+        """.venv/ contents match the *.py allowlist pathspec, so only the
+        gitignore guard (which must include .venv/) keeps them out."""
+        venv_pkg = unborn_repo / ".venv" / "lib" / "site-packages"
+        venv_pkg.mkdir(parents=True)
+        (venv_pkg / "dep.py").write_text("VERSION = '1.0'\n")
+        (unborn_repo / "main.py").write_text("x = 1\n")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert not any(f.startswith(".venv/") for f in committed), (
+            f".venv/ leaked into history: {committed}"
+        )
+        assert ".venv/" in (unborn_repo / ".gitignore").read_text().splitlines()
+
+    # --- Over-exclusion guard (Nick's note, ruled 2026-07-15): unintended
+    # EXCLUSION is a loud failure mode — pin that legitimate project files ARE
+    # still captured by the seed. ---------------------------------------------
+
+    def test_haute_scaffold_shape_is_fully_committed(self, unborn_repo: Path) -> None:
+        """Every file shape `haute init` scaffolds (plus the nested-pipeline
+        layout) enters the root commit — the allowlist must not over-exclude."""
+        legitimate = [
+            "haute.toml",
+            "pyproject.toml",
+            "uv.lock",
+            ".env.example",
+            "rating/main.py",
+            "rating/main.haute.json",
+            "rating/utility/helpers.py",
+            "rating/config/data_source/quotes.json",
+            "prompts/starter.md",
+            "tests/test_pipeline.py",
+            ".githooks/pre-commit",
+            ".github/workflows/ci.yml",
+        ]
+        for rel in legitimate:
+            target = unborn_repo / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(f"# {rel}\n")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        missing = [rel for rel in legitimate if rel not in committed]
+        assert not missing, f"legitimate scaffold files over-excluded: {missing}"
+        assert ".gitignore" in committed
+
 
 class TestSetWorkingBranchUnbornNonDefault:
     """set_working_branch(create=True) when HEAD is on an unborn NON-default branch.

--- a/tests/test_git_engine.py
+++ b/tests/test_git_engine.py
@@ -750,6 +750,90 @@ class TestSetWorkingBranchUnborn:
             set_working_branch("ghost", repo, create=False, cwd=repo)
 
 
+class TestSeedGitignoreGuards:
+    """The unborn-repo seed must not trust an ambient .gitignore.
+
+    ``haute init`` writes the guard entries (``.env``, ``.haute/``, ``data/``,
+    …), so the haute-scaffolded flow is protected.  But a FOREIGN unborn repo —
+    the user ran bare ``git init`` themselves in a directory holding a ``.env``
+    or datasets — has no such guarantee, and the seed's ``git add -A`` would
+    publish credentials into git history and commit the per-clone ``.haute/``
+    state (the clone-lockout class).  The seed therefore asserts the shared
+    guard entries into ``.gitignore`` before staging anything, and stages from
+    an empty index so pre-staged secrets cannot ride through either.
+    """
+
+    def test_foreign_unborn_repo_secrets_not_committed(self, unborn_repo: Path) -> None:
+        """PRIMARY repro: planted .env / .haute/ / data/ and NO .gitignore —
+        none of them may enter the root commit."""
+        (unborn_repo / "main.py").write_text("x = 1\n")
+        (unborn_repo / ".env").write_text("DATABRICKS_TOKEN=hunter2\n")
+        (unborn_repo / "sub").mkdir()
+        (unborn_repo / "sub" / ".env").write_text("NESTED_SECRET=1\n")
+        (unborn_repo / ".haute").mkdir()
+        (unborn_repo / ".haute" / "state.json").write_text("{}")
+        (unborn_repo / "data").mkdir()
+        (unborn_repo / "data" / "quotes.csv").write_text("a,b\n1,2\n")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert not any(".env" in f for f in committed), f".env leaked into history: {committed}"
+        assert not any(f.startswith(".haute/") for f in committed), (
+            f"per-clone .haute/ state committed: {committed}"
+        )
+        assert not any(f.startswith("data/") for f in committed), (
+            f"data/ leaked into history: {committed}"
+        )
+        # The asserted guards are themselves captured, so clones inherit them.
+        assert ".gitignore" in committed
+
+    def test_seed_appends_guards_to_partial_gitignore(self, unborn_repo: Path) -> None:
+        """An existing .gitignore missing the guard entries gets them appended;
+        the user's own entries keep working."""
+        (unborn_repo / ".gitignore").write_text("*.pyc\n")
+        (unborn_repo / "model.pyc").write_text("bytecode")
+        (unborn_repo / ".env").write_text("SECRET=1\n")
+        (unborn_repo / "main.py").write_text("x = 1\n")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert ".env" not in committed, f".env leaked into history: {committed}"
+        assert not any(f.endswith(".pyc") for f in committed), f".pyc leaked: {committed}"
+        gitignore = (unborn_repo / ".gitignore").read_text()
+        assert "*.pyc" in gitignore
+        assert ".env" in gitignore.splitlines()
+
+    def test_prestaged_secret_not_committed(self, unborn_repo: Path) -> None:
+        """Staged index content ignores .gitignore entirely — a .env the user
+        pre-staged must still be kept out of the root commit (and left on disk)."""
+        (unborn_repo / "main.py").write_text("x = 1\n")
+        (unborn_repo / ".env").write_text("SECRET=1\n")
+        _git(unborn_repo, "add", "main.py", ".env")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        committed = _git(unborn_repo, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert ".env" not in committed, f"pre-staged .env leaked into history: {committed}"
+        assert (unborn_repo / ".env").exists()  # working tree untouched
+
+    def test_seed_leaves_complete_gitignore_untouched(self, unborn_repo: Path) -> None:
+        """A .gitignore already carrying the full guard set is not rewritten."""
+        from haute._gitignore_guard import GITIGNORE_GUARD_ENTRIES
+
+        content = "\n".join(GITIGNORE_GUARD_ENTRIES) + "\n"
+        (unborn_repo / ".gitignore").write_text(content)
+        (unborn_repo / "main.py").write_text("x = 1\n")
+
+        set_working_branch("initial-model", unborn_repo, create=True, cwd=unborn_repo)
+
+        assert (unborn_repo / ".gitignore").read_text() == content
+
+
 class TestSetWorkingBranchUnbornNonDefault:
     """set_working_branch(create=True) when HEAD is on an unborn NON-default branch.
 

--- a/tests/test_git_routes.py
+++ b/tests/test_git_routes.py
@@ -833,6 +833,33 @@ class TestWorkingBranchRoutes:
         assert res.status_code == 400
 
 
+class TestWorkingBranchSeedGuards:
+    def test_create_on_foreign_unborn_repo_keeps_env_out_of_history(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Through the real route: a bare `git init` repo (no haute scaffold,
+        no .gitignore) with a planted .env — the seeded root commit must not
+        publish the secret into git history."""
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        _git(foreign, "init", "-b", "main")
+        _git(foreign, "config", "user.name", "Test User")
+        _git(foreign, "config", "user.email", "test@example.com")
+        (foreign / ".env").write_text("TOKEN=hunter2\n")
+        (foreign / "main.py").write_text("x = 1\n")
+        monkeypatch.chdir(foreign)
+
+        res = client.post("/api/git/working-branch", json={"branch": "fresh", "create": True})
+        assert res.status_code == 200
+        assert res.json()["state"] == "ready"
+
+        committed = _git(foreign, "show", "--name-only", "--format=", "main").splitlines()
+        assert "main.py" in committed
+        assert ".env" not in committed, f".env leaked into history: {committed}"
+        # The asserted guards were captured, so clones inherit them.
+        assert ".gitignore" in committed
+
+
 class TestIdentityRoute:
     def test_set_identity_local(self, client: TestClient, tmp_path: Path) -> None:
         res = client.post(

--- a/tests/test_gitignore_guard.py
+++ b/tests/test_gitignore_guard.py
@@ -19,7 +19,7 @@ class TestGuardEntryList:
         assert "data/" in GITIGNORE_GUARD_ENTRIES
         assert "mlruns/" in GITIGNORE_GUARD_ENTRIES
         assert "impact_report.md" in GITIGNORE_GUARD_ENTRIES
-        assert ".venv/" in GITIGNORE_GUARD_ENTRIES  # matches *.py otherwise (ruled 2026-07-15)
+        assert ".venv/" in GITIGNORE_GUARD_ENTRIES  # matches the *.py seed pathspec otherwise
 
     def test_stable_layer_json_is_not_ignored(self) -> None:
         """<pipeline>.haute.json is stable-layer (tracked) — must NOT be ignored."""

--- a/tests/test_gitignore_guard.py
+++ b/tests/test_gitignore_guard.py
@@ -1,0 +1,67 @@
+"""Tests for haute._gitignore_guard — the shared .gitignore guard-entry list.
+
+One list, two writers: ``haute init`` and the unborn-repo seed in
+``haute._git.set_working_branch``.  These tests pin the helper's contract so
+the two sites cannot drift.
+"""
+
+from pathlib import Path
+
+from haute._gitignore_guard import GITIGNORE_GUARD_ENTRIES, ensure_gitignore_guards
+
+
+class TestGuardEntryList:
+    def test_covers_the_secret_and_per_clone_paths(self) -> None:
+        """The entries haute must never let into git history."""
+        assert ".env" in GITIGNORE_GUARD_ENTRIES
+        assert ".haute/" in GITIGNORE_GUARD_ENTRIES  # per-clone state — lockout class
+        assert ".haute_cache/" in GITIGNORE_GUARD_ENTRIES
+        assert "data/" in GITIGNORE_GUARD_ENTRIES
+        assert "mlruns/" in GITIGNORE_GUARD_ENTRIES
+        assert "impact_report.md" in GITIGNORE_GUARD_ENTRIES
+
+    def test_stable_layer_json_is_not_ignored(self) -> None:
+        """<pipeline>.haute.json is stable-layer (tracked) — must NOT be ignored."""
+        assert not any("haute.json" in entry for entry in GITIGNORE_GUARD_ENTRIES)
+
+
+class TestEnsureGitignoreGuards:
+    def test_creates_file_when_absent(self, tmp_path: Path) -> None:
+        added = ensure_gitignore_guards(tmp_path)
+
+        assert added == list(GITIGNORE_GUARD_ENTRIES)
+        content = (tmp_path / ".gitignore").read_text()
+        for entry in GITIGNORE_GUARD_ENTRIES:
+            assert entry in content.splitlines()
+
+    def test_appends_only_missing_entries(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("__pycache__/\n.env\n")
+
+        added = ensure_gitignore_guards(tmp_path)
+
+        assert ".env" not in added
+        assert ".haute/" in added
+        lines = (tmp_path / ".gitignore").read_text().splitlines()
+        assert lines.count(".env") == 1  # no duplicate
+        assert "__pycache__/" in lines  # user content preserved
+        for entry in GITIGNORE_GUARD_ENTRIES:
+            assert entry in lines
+
+    def test_noop_when_all_entries_present(self, tmp_path: Path) -> None:
+        content = "\n".join(GITIGNORE_GUARD_ENTRIES) + "\n"
+        (tmp_path / ".gitignore").write_text(content)
+
+        added = ensure_gitignore_guards(tmp_path)
+
+        assert added == []
+        assert (tmp_path / ".gitignore").read_text() == content
+
+    def test_tolerates_non_utf8_bytes(self, tmp_path: Path) -> None:
+        """User-authored files may carry Windows-1252 bytes; must not raise."""
+        (tmp_path / ".gitignore").write_bytes(b"caf\xe9/\n.env\n")
+
+        added = ensure_gitignore_guards(tmp_path)
+
+        assert ".env" not in added
+        lines = (tmp_path / ".gitignore").read_text(errors="replace").splitlines()
+        assert lines.count(".env") == 1

--- a/tests/test_gitignore_guard.py
+++ b/tests/test_gitignore_guard.py
@@ -19,6 +19,7 @@ class TestGuardEntryList:
         assert "data/" in GITIGNORE_GUARD_ENTRIES
         assert "mlruns/" in GITIGNORE_GUARD_ENTRIES
         assert "impact_report.md" in GITIGNORE_GUARD_ENTRIES
+        assert ".venv/" in GITIGNORE_GUARD_ENTRIES  # matches *.py otherwise (ruled 2026-07-15)
 
     def test_stable_layer_json_is_not_ignored(self) -> None:
         """<pipeline>.haute.json is stable-layer (tracked) — must NOT be ignored."""


### PR DESCRIPTION
## Problem

`set_working_branch(create=True)` on a repo whose HEAD is unborn (fresh `git init`, zero commits) seeded the root commit with an unscoped `git add -A`, trusting whatever `.gitignore` happened to exist. `haute init` writes the guard entries, so the scaffolded flow was protected — but a **foreign** unborn repo (the user ran bare `git init` themselves in a directory already holding a `.env` or datasets, then pointed haute at it) had no such guarantee. Confirming a new working branch in the startup modal then committed **everything** into history: credential publish (`.env`, including nested ones), the per-clone `.haute/` state directory (one clone's `state.json` committed locks out every other clone), and `data/`. Pre-staged index content was worse still — staged files bypass `.gitignore` entirely.

## Fix — two independent gates

A file now enters the root commit only by passing **both**:

1. **Deny gate** (`7df15ce1`): the `.gitignore` guard-entry list moves out of `_init_cmd.py` into a shared module `haute._gitignore_guard` (`GITIGNORE_GUARD_ENTRIES` + `ensure_gitignore_guards()`), consumed by both `haute init` and the seed so the two sites cannot drift. The seed asserts the entries into the repo-toplevel `.gitignore` (append-if-missing, create-if-absent; user entries preserved), then empties the index (`git rm -r --cached`, working tree untouched) so pre-staged secrets cannot ride through. Also fixes an existing drift: init's created-from-scratch `.gitignore` omitted `impact_report.md`, and neither init path wrote `.venv/` on append — `.venv/` now joins the shared list (its contents would otherwise pass the `*.py` allowlist below).
2. **Permit gate** (`aa883a9a`): the bare `git add -A` is gone. The seed stages via `git ls-files --others --exclude-standard -- <pathspecs>` over an allowlist of what haute owns (`haute.toml`, `pyproject.toml`, `uv.lock`, `.env.example`, `*.py`, `*.haute.json`, `config/` at any depth, `prompts/`, `tests/`, `.githooks/`, CI files), with matched paths added under `:(literal)` so glob-looking filenames cannot re-expand. `--exclude-standard` applies both gates in one listing.

`commit_save` was already pathspec-scoped; a sweep found no other unscoped add sites.

## Tests (TDD — negatives written first, failing on the leak)

- Engine level (`TestSeedGitignoreGuards`): planted `.env` (root + nested `sub/.env`), `.haute/`, `data/` with no `.gitignore`; partial `.gitignore` append; **pre-staged** `.env`; unallowed-but-not-ignored file (permit gate alone); `.venv/**/*.py` (must fail both gates); idempotence on a complete `.gitignore`. All read the commit graph directly.
- Over-exclusion positive: every scaffold-shaped legitimate file must still be committed. This test caught a real bug during development — a wildcard pathspec with a bare trailing slash (`*/config/`) matches nothing in git; fixed as `*/config/*`.
- Route level: the same repro driven through the real `POST /api/git/working-branch`.
- `tests/test_gitignore_guard.py` pins the shared helper's contract.

## Verification

`scripts/preflight.sh --backend-only` green on the final tree: 12,552 passed, global coverage 92.67%, all 30 per-file critical-coverage gates (`_git.py` 93.75%/83.27% vs its 89%/76% gate). One earlier gate run flaked on 3 unrelated load-sensitive tests that pass in isolation; the clean rerun confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)