### PR TITLE
Gate and atomically write the optimiser ratebook /save artifact

### DIFF
--- a/src/haute/routes/optimiser.py
+++ b/src/haute/routes/optimiser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import tempfile
 import time
 from pathlib import Path
@@ -12,6 +13,7 @@ from typing import Any, Protocol, cast
 from fastapi import APIRouter, HTTPException
 
 from haute._execution_context import ExecutionContext, ExecutionProfile
+from haute._file_ops import atomic_write_text
 from haute._logging import get_logger
 from haute._polars_utils import (
     DEFAULT_STREAMING_CHUNK_SIZE,
@@ -1579,6 +1581,69 @@ def _build_artifact_payload(
     return payload
 
 
+def _non_finite_paths(value: Any, path: str = "") -> list[str]:
+    """Return JSON paths of every non-finite float nested inside *value*."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return [path or "<root>"]
+    if isinstance(value, dict):
+        return [
+            found
+            for key, item in value.items()
+            for found in _non_finite_paths(item, f"{path}.{key}" if path else str(key))
+        ]
+    if isinstance(value, (list, tuple)):
+        return [
+            found
+            for index, item in enumerate(value)
+            for found in _non_finite_paths(item, f"{path}[{index}]")
+        ]
+    return []
+
+
+def _validate_artifact_payload(payload: dict[str, Any]) -> None:
+    """Gate the artifact payload before it is written to disk.
+
+    The saved artifact is exactly what OPTIMISER_APPLY reads to price, so a
+    payload with NaN/Infinity values or a missing ratebook factor-table
+    section would mis-price silently downstream. Reject with an actionable
+    4xx instead of persisting a poisoned artifact — and because this runs
+    before the write and before the post-save result slimming, the in-memory
+    solve result survives for the user to inspect.
+    """
+    lambdas = payload.get("lambdas")
+    if not isinstance(lambdas, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="Solve result has no lambda mapping. Re-run the solve before saving.",
+        )
+    if payload.get("total_objective") is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Solve result has no total objective. Re-run the solve before saving.",
+        )
+    if payload.get("mode") == "ratebook" and not isinstance(payload.get("factor_tables"), dict):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Ratebook solve result has no factor tables, so the saved artifact "
+                "could not be applied for pricing. Re-run the solve before saving."
+            ),
+        )
+    bad_paths = _non_finite_paths(payload)
+    if bad_paths:
+        shown = ", ".join(bad_paths[:5])
+        if len(bad_paths) > 5:
+            shown += f", … ({len(bad_paths)} in total)"
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Solve result contains non-finite values ({shown}); the artifact was "
+                "not saved. Check the solve inputs and constraints, then re-run the "
+                "solve — a pricing artifact must not contain NaN or Infinity."
+            ),
+        )
+
+
 @router.post("/save", response_model=OptimiserSaveResponse)
 def save_result(body: OptimiserSaveRequest) -> OptimiserSaveResponse:
     """Save the optimisation result to disk."""
@@ -1625,7 +1690,14 @@ def save_result(body: OptimiserSaveRequest) -> OptimiserSaveResponse:
             version_override=body.version,
             selected_frontier_point=selected_frontier_point,
         )
-        out.write_text(json.dumps(payload, indent=2, default=str))
+        _validate_artifact_payload(payload)
+        # Atomic write (same posture as the schema-mapping save in
+        # `_helpers.save_sidecar`): stage to a sibling temp then rename, so a
+        # crash or disk error mid-write can never tear the previous artifact
+        # — this file is what OPTIMISER_APPLY prices from. `allow_nan=False`
+        # is a backstop behind `_validate_artifact_payload`: nothing
+        # non-finite may ever reach disk.
+        atomic_write_text(out, json.dumps(payload, indent=2, default=str, allow_nan=False))
         logger.info("result_saved", path=str(out), job_id=body.job_id)
 
         response = OptimiserSaveResponse(

--- a/tests/test_error_detail_sanitization.py
+++ b/tests/test_error_detail_sanitization.py
@@ -510,7 +510,7 @@ class TestOptimiserRoutesSafeDetail:
             "created_at": time.time(),
         }
         with patch(
-            "pathlib.Path.write_text",
+            "pathlib.Path.write_bytes",
             side_effect=OSError("Permission denied: '/secure/results/output.json'"),
         ):
             resp = client.post(

--- a/tests/test_optimiser_routes.py
+++ b/tests/test_optimiser_routes.py
@@ -12856,7 +12856,7 @@ class TestSaveExceptionPaths:
         out_path = str(tmp_path / "out.json")
 
         with (
-            patch("pathlib.Path.write_text", side_effect=OSError("disk full")),
+            patch("pathlib.Path.write_bytes", side_effect=OSError("disk full")),
             patch("haute.routes.optimiser.logger.error") as log_error,
         ):
             resp = client.post(
@@ -12898,7 +12898,7 @@ class TestSaveExceptionPaths:
         out_path = str(tmp_path / "out.json")
 
         with (
-            patch("pathlib.Path.write_text", side_effect=RuntimeError("unexpected")),
+            patch("pathlib.Path.write_bytes", side_effect=RuntimeError("unexpected")),
             patch("haute.routes.optimiser.logger.error") as log_error,
         ):
             resp = client.post(
@@ -12911,6 +12911,178 @@ class TestSaveExceptionPaths:
         assert log_error.call_args.kwargs["error"] == "unexpected"
         assert log_error.call_args.kwargs["job_id"] == "save_gen"
         assert log_error.call_args.kwargs["exc_info"] is True
+
+
+class TestSaveArtifactGate:
+    """Pre-write validation and atomic write for the /save pricing artifact.
+
+    The saved JSON is exactly what OPTIMISER_APPLY reads to price, and a
+    successful save clears the in-memory solve result — so a poisoned or
+    torn artifact is unrecoverable without a full re-solve. These tests pin
+    the gate: non-finite values are rejected before any bytes hit disk, a
+    failed write leaves the previous artifact intact, and a failed save
+    leaves the solve result in the job store for retry.
+    """
+
+    @staticmethod
+    def _completed_job(
+        store,
+        job_id: str,
+        *,
+        lambdas: dict | None = None,
+        total_objective: float = 100.0,
+        config: dict | None = None,
+        solve_result_extra: dict | None = None,
+    ) -> None:
+        solve_result = SimpleNamespace(
+            lambdas={"volume": 0.5} if lambdas is None else lambdas,
+            total_objective=total_objective,
+            total_constraints={"volume": 0.92},
+            baseline_constraints={"volume": 0.88},
+            baseline_objective=95.0,
+            converged=True,
+            **(solve_result_extra or {}),
+        )
+        store.jobs[job_id] = {
+            "status": "completed",
+            "solve_result": solve_result,
+            "solver": MagicMock(),
+            "config": config or {"mode": "online"},
+            "node_label": "opt",
+            "created_at": time.time(),
+        }
+
+    @pytest.mark.parametrize(
+        ("job_kwargs", "expected_path"),
+        [
+            ({"lambdas": {"volume": float("nan")}}, "lambdas.volume"),
+            ({"lambdas": {"volume": float("inf")}}, "lambdas.volume"),
+            ({"total_objective": float("nan")}, "total_objective"),
+        ],
+    )
+    def test_save_rejects_non_finite_values_pre_write(
+        self, client, clean_job_store, tmp_path, job_kwargs, expected_path
+    ):
+        """A non-finite solve value is a 400 and the artifact is untouched."""
+        self._completed_job(clean_job_store, "save_nonfinite", **job_kwargs)
+        set_project_root(tmp_path)
+        out_path = tmp_path / "artifact.json"
+        out_path.write_text('{"version": "previous"}')
+
+        resp = client.post(
+            "/api/optimiser/save",
+            json={"job_id": "save_nonfinite", "output_path": str(out_path)},
+        )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "non-finite" in detail
+        assert expected_path in detail
+        assert out_path.read_text() == '{"version": "previous"}'
+        job = clean_job_store.jobs["save_nonfinite"]
+        assert "solve_result" in job
+        assert "solver" in job
+
+    def test_save_rejects_non_finite_ratebook_factor_level(self, client, clean_job_store, tmp_path):
+        """A NaN factor level in a ratebook artifact is rejected pre-write."""
+        self._completed_job(
+            clean_job_store,
+            "save_rb_nan",
+            config={"mode": "ratebook"},
+            solve_result_extra={
+                "factor_tables": {
+                    "region": [
+                        {
+                            "__factor_group__": "North",
+                            "optimal_scenario_value": float("nan"),
+                            "quote_count": 1,
+                        }
+                    ]
+                },
+                "clamp_rate": 0.0,
+            },
+        )
+        set_project_root(tmp_path)
+        out_path = tmp_path / "ratebook.json"
+
+        resp = client.post(
+            "/api/optimiser/save",
+            json={"job_id": "save_rb_nan", "output_path": str(out_path)},
+        )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "non-finite" in detail
+        assert "factor_tables" in detail
+        assert not out_path.exists()
+        assert "solve_result" in clean_job_store.jobs["save_rb_nan"]
+
+    def test_save_rejects_ratebook_artifact_without_factor_tables(
+        self, client, clean_job_store, tmp_path
+    ):
+        """A ratebook artifact with no factor tables cannot price — 400."""
+        self._completed_job(clean_job_store, "save_rb_none", config={"mode": "ratebook"})
+        set_project_root(tmp_path)
+        out_path = tmp_path / "ratebook.json"
+
+        resp = client.post(
+            "/api/optimiser/save",
+            json={"job_id": "save_rb_none", "output_path": str(out_path)},
+        )
+
+        assert resp.status_code == 400
+        assert "factor tables" in resp.json()["detail"]
+        assert not out_path.exists()
+        assert "solve_result" in clean_job_store.jobs["save_rb_none"]
+
+    def test_save_write_failure_preserves_previous_artifact(
+        self, client, clean_job_store, tmp_path
+    ):
+        """A write failure never tears the previous artifact (atomic write)."""
+        self._completed_job(clean_job_store, "save_torn")
+        set_project_root(tmp_path)
+        out_path = tmp_path / "artifact.json"
+        out_path.write_text('{"version": "previous"}')
+
+        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            resp = client.post(
+                "/api/optimiser/save",
+                json={"job_id": "save_torn", "output_path": str(out_path)},
+            )
+
+        assert resp.status_code == 500
+        assert out_path.read_text() == '{"version": "previous"}'
+        assert list(tmp_path.glob("*.tmp")) == []
+        job = clean_job_store.jobs["save_torn"]
+        assert "solve_result" in job
+        assert "solver" in job
+
+    def test_save_failure_then_retry_succeeds_without_resolve(
+        self, client, clean_job_store, tmp_path
+    ):
+        """After a failed save the in-memory result still saves on retry."""
+        import json as json_mod
+
+        self._completed_job(clean_job_store, "save_retry")
+        set_project_root(tmp_path)
+        out_path = tmp_path / "artifact.json"
+
+        with patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            first = client.post(
+                "/api/optimiser/save",
+                json={"job_id": "save_retry", "output_path": str(out_path)},
+            )
+        assert first.status_code == 500
+
+        second = client.post(
+            "/api/optimiser/save",
+            json={"job_id": "save_retry", "output_path": str(out_path)},
+        )
+        assert second.status_code == 200
+        saved = json_mod.loads(out_path.read_text(encoding="utf-8"))
+        assert saved["lambdas"] == {"volume": 0.5}
+        # The successful retry then slims the job as usual.
+        assert "solve_result" not in clean_job_store.jobs["save_retry"]
 
 
 class TestMlflowLogExceptionPath:


### PR DESCRIPTION
## Problem

`/api/optimiser/save` (`routes/optimiser.py` `save_result`) wrote the pricing artifact directly in place with `Path.write_text` and no validation. That file is exactly what `OPTIMISER_APPLY` reads to price, and two failure modes poisoned it:

1. **Torn write** — a crash, kill, or disk error mid-write truncated or corrupted the artifact in place. Because the route clears the in-memory solve result after a successful save (`_clear_result_data_after_user_action`), recovery from a corrupt artifact was a full re-solve, not a retry.
2. **No finiteness gate** — a solve that produced NaN/inf lambdas, factor levels, or totals saved them silently (`json.dumps` emits bare `NaN`/`Infinity`, which isn't even strict JSON) and they applied silently downstream — a fail-loud violation on the pricing artifact.

## Fix

- **Pre-write gate** (`_validate_artifact_payload`): runs before any bytes hit disk. Shape checks (lambda mapping present, total objective present, ratebook artifacts must carry factor tables) plus a recursive finiteness walk (`_non_finite_paths`) that rejects with an actionable **400** naming the offending JSON paths (e.g. `lambdas.volume`, `factor_tables.region[0].optimal_scenario_value`). `json.dumps` also gets `allow_nan=False` as a backstop so nothing non-finite can ever reach disk.
- **Atomic write**: the artifact now goes through the existing `atomic_write_text` primitive (sibling `.tmp` + rename) — same posture the schema-mapping save adopted in `_helpers.save_sidecar`. A failed write always leaves the previous artifact byte-identical.
- **Retry-safety**: both failure paths fire before the post-save result slimming, so a failed save keeps the solve result in the job store and the user retries without re-solving.

## Tests

`TestSaveArtifactGate` (`tests/test_optimiser_routes.py`) was written failing-first against the old code and covers: (a) NaN/inf lambdas and totals rejected pre-write with the previous artifact untouched; (b) a simulated write failure (patched rename) leaving the previous artifact intact and no `.tmp` litter; (c) a failed save then a successful retry from the same in-memory result — no re-solve. Three pre-existing OSError-path tests that patched `Path.write_text` now patch `write_bytes`, matching the staged temp-file write.

## Verification

Forward-merged current `main` (`a0e047bc`) into the branch first; `scripts/preflight.sh --backend-only` green on the combined tree — **12,560 passed, 27 skipped, critical coverage gates green for all 30 files**, ruff + mypy clean. Verification is route-level through the FastAPI TestClient (including the real-library ratebook solve→save tests), not a live `haute serve` walkthrough.

**Scope note:** `/mlflow/log` shares `_build_artifact_payload` but logs to MLflow rather than writing the pricing artifact, so it was intentionally left ungated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)