### PR TITLE
test(frontend): close 8 latent test-order leaks from shuffle audit

### DIFF
--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -73,6 +73,7 @@ beforeEach(() => {
   mockDeleteJsonCache.mockReset()
   mockCancelJsonCache.mockReset()
   mockInferJsonCacheSchema.mockReset()
+  DEFAULT_PROPS.onUpdate.mockClear()
 })
 
 const DEFAULT_PROPS = {

--- a/frontend/src/__tests__/editors/OutputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/OutputEditor.test.tsx
@@ -43,6 +43,14 @@ const mockPreviewNode = vi.mocked(previewNode)
 
 afterEach(cleanup)
 
+// File-global reset: clear both preview API spies before every test so no
+// test can inherit a stale mockResolvedValue/mockRejectedValue or a leaked
+// call count from an earlier test under any (shuffled) run order.
+beforeEach(() => {
+  mockOutputAssembleDryRun.mockReset()
+  mockPreviewNode.mockReset()
+})
+
 // ─── Graph fixtures ───────────────────────────────────────────────
 
 // A single-port source (null sourceHandle) whose columns come from _columns.
@@ -1093,11 +1101,6 @@ describe("OutputEditor — frames-table input schema", () => {
 // ─── Assembled-output preview ─────────────────────────────────────
 
 describe("OutputEditor — assembled-output preview", () => {
-  beforeEach(() => {
-    mockOutputAssembleDryRun.mockReset()
-    mockPreviewNode.mockReset()
-  })
-
   const SINGLE_PORT_CONFIG = {
     outputMapping: [
       { source_port: "Upstream Node", source_column: "premium", output_path: "$[:].premium", enabled: true },
@@ -1213,11 +1216,6 @@ describe("OutputEditor — assembled-output preview", () => {
 // ─── Per-frame input-data preview ─────────────────────────────────
 
 describe("OutputEditor — per-frame input-data preview", () => {
-  beforeEach(() => {
-    mockOutputAssembleDryRun.mockReset()
-    mockPreviewNode.mockReset()
-  })
-
   it("each frame block has an Input-data preview with Copy + Export", () => {
     render(<OutputEditor {...DEFAULT_PROPS} />, {
       allNodes: SINGLE_PORT_NODES,

--- a/frontend/src/__tests__/editors/ScenarioExpanderEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ScenarioExpanderEditor.test.tsx
@@ -5,7 +5,7 @@
  * default values, editing min, editing steps with clamping, step column,
  * preview line, selecting a column, InputSourcesBar rendering.
  */
-import { describe, it, expect, vi, afterEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup } from "@testing-library/react"
 import { useState } from "react"
 import ScenarioExpanderEditor from "../../panels/editors/ScenarioExpanderEditor"
@@ -42,6 +42,10 @@ const DEFAULT_PROPS = {
   upstreamColumns: [] as { name: string; dtype: string }[],
   accentColor: "#2dd4bf",
 }
+
+beforeEach(() => {
+  DEFAULT_PROPS.onUpdate.mockClear()
+})
 
 function applyConfigUpdate(
   config: Record<string, unknown>,

--- a/frontend/src/__tests__/editors/SinkEditor.test.tsx
+++ b/frontend/src/__tests__/editors/SinkEditor.test.tsx
@@ -28,6 +28,7 @@ afterEach(cleanup)
 
 beforeEach(() => {
   mockExecuteSink.mockReset()
+  DEFAULT_PROPS.onUpdate.mockClear()
 })
 
 const DEFAULT_PROPS = {

--- a/frontend/src/__tests__/editors/v1RemovalContract.test.tsx
+++ b/frontend/src/__tests__/editors/v1RemovalContract.test.tsx
@@ -89,6 +89,7 @@ beforeEach(() => {
       { path: "$[:]", label: "quotes", emit: true, columns: [{ name: "id", path: "$[:].id", type: "str" }] },
     ],
   })
+  DEFAULT_PROPS.onUpdate.mockClear()
 })
 
 const DEFAULT_PROPS = {

--- a/frontend/src/components/__tests__/PolarsIcon.test.tsx
+++ b/frontend/src/components/__tests__/PolarsIcon.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "vitest"
-import { render } from "@testing-library/react"
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
 import PolarsIcon from "../PolarsIcon"
+
+afterEach(cleanup)
 
 describe("PolarsIcon", () => {
   it("renders SVG with default props", () => {

--- a/frontend/src/components/__tests__/shell-merge.test.tsx
+++ b/frontend/src/components/__tests__/shell-merge.test.tsx
@@ -78,6 +78,13 @@ beforeEach(() => {
 
 afterEach(cleanup)
 
+afterEach(() => {
+  // The "Tab from OUTSIDE the modal" test writes a bare #outside button
+  // directly into document.body; RTL's cleanup() only unmounts React trees,
+  // so remove it here to stop it leaking into later tests.
+  document.getElementById("outside")?.remove()
+})
+
 describe("Phase 2D-3 shell merge — panel surface preserved", () => {
   it("panel with a title string renders the title", () => {
     // A panel built by wrapping PanelHeader inside PanelShell (the current

--- a/frontend/src/hooks/__tests__/useWebSocketSync.undoHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocketSync.undoHistory.test.ts
@@ -73,6 +73,9 @@ vi.mock("../../stores/useGraphStore.ts", () => {
 })
 
 import useWebSocketSync from "../../hooks/useWebSocketSync.ts"
+import useToastStore from "../../stores/useToastStore.ts"
+import useUIStore from "../../stores/useUIStore.ts"
+import useGraphStore from "../../stores/useGraphStore.ts"
 
 // ── Mock WebSocket ───────────────────────────────────────────────
 
@@ -118,6 +121,13 @@ describe("useWebSocketSync — WS sync must not corrupt undo history (#8)", () =
     mockWSInstances = []
     originalWebSocket = globalThis.WebSocket
     globalThis.WebSocket = createMockWebSocket() as unknown as typeof WebSocket
+
+    // Clear the mocked-store spies so call counts / args don't leak across
+    // tests (mirrors src/__tests__/hooks/useWebSocketSync.test.ts).
+    vi.mocked(useGraphStore.getState().markSaved).mockClear()
+    vi.mocked(useToastStore.getState().addToast).mockClear()
+    vi.mocked(useToastStore.getState().dismissToast).mockClear()
+    vi.mocked(useUIStore.getState().setSyncBanner).mockClear()
   })
 
   afterEach(() => {

--- a/frontend/src/panels/__tests__/ExplorePreview.test.tsx
+++ b/frontend/src/panels/__tests__/ExplorePreview.test.tsx
@@ -172,7 +172,7 @@ function seedCachedExplore({
 
 function resetStores() {
   resetNodeResultsDerivedCaches()
-  useGraphStore.setState({ structuralVersion: 0 })
+  useGraphStore.setState({ structuralVersion: 0, nodes: [], edges: [] })
   useNodeResultsStore.setState({
     previews: {},
     pinnedPreviewNodeId: null,

--- a/frontend/src/panels/__tests__/ImportsPanel.test.tsx
+++ b/frontend/src/panels/__tests__/ImportsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup } from "@testing-library/react"
 import ImportsPanel from "../ImportsPanel"
 
@@ -20,6 +20,11 @@ describe("ImportsPanel", () => {
     onPreambleChange: vi.fn(),
     onClose: vi.fn(),
   }
+
+  beforeEach(() => {
+    defaultProps.onClose.mockClear()
+    defaultProps.onPreambleChange.mockClear()
+  })
 
   afterEach(cleanup)
 

--- a/frontend/src/panels/__tests__/LazyNodeEditors.accessibility.test.tsx
+++ b/frontend/src/panels/__tests__/LazyNodeEditors.accessibility.test.tsx
@@ -1,9 +1,11 @@
 import { lazy } from "react"
-import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
 import { LazyEditorBoundary } from "../LazyNodeEditors"
 
 const SuspendedEditor = lazy(() => new Promise<{ default: () => null }>(() => {}))
+
+afterEach(cleanup)
 
 describe("LazyEditorBoundary accessibility", () => {
   it("announces lazy editor loading state", () => {


### PR DESCRIPTION
## What

Test-only hardening. The shuffle-order audit (following #70/#74) surfaced 8 **latent** within-file state leaks — states that leak between tests but that no current assertion reads, so they are not live bugs but are traps the moment a future test asserts on the leaked state (exactly how the #70 and #74 bugs would have been born). This closes all 8.

| # | File | Fix |
|---|------|-----|
| 1 | `ImportsPanel.test.tsx` | `beforeEach` clears shared `onClose`/`onPreambleChange` spies |
| 2 | `LazyNodeEditors.accessibility.test.tsx` | add `afterEach(cleanup)` (none existed) |
| 3 | `OutputEditor.test.tsx` | hoist describe-scoped `mockReset`s to one file-global `beforeEach` |
| 4 | `ApiInputEditor` / `ScenarioExpanderEditor` / `SinkEditor` / `v1RemovalContract` | `DEFAULT_PROPS.onUpdate.mockClear()` in `beforeEach` |
| 5 | `PolarsIcon.test.tsx` | add `afterEach(cleanup)` |
| 6 | `shell-merge.test.tsx` | remove the stray `#outside` DOM node after each test |
| 7 | `useWebSocketSync.undoHistory.test.ts` | clear `markSaved` / toast / UI store spies (the latent #70 shape) |
| 8 | `ExplorePreview.test.tsx` | reset graph `nodes`/`edges` in `resetStores()` |

11 files, +48/−17. No product code. No behaviour change — every fix only adds cleanup/reset.

## Verified

- Per-file under `--sequence.shuffle` seeds 1–8 (11 files × 8).
- Full suite default order: 5218 tests / 269 files.
- Full suite under shuffle: seeds 203/205/401 (agent) + 555/777/909 (independent) + 203/611 on the combined tree after forward-merging `main` — all 5218/5218 green.

## Out of scope

- The shuffle-CI-lane decision (whether CI should run `--sequence.shuffle`) — separate, under discussion.
- A pre-existing non-top-level `vi.mock("@xyflow/react")` warning in `src/__tests__/adversarial/resilience.test.ts` (not order-related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)