### PR TITLE
Resolve HAUTE_* timeout/limit env vars lazily, not at import

### DIFF
--- a/src/haute/_env.py
+++ b/src/haute/_env.py
@@ -1,0 +1,77 @@
+"""Lazy environment-variable accessors for numeric tuning knobs.
+
+Timeout/limit knobs must be read from ``os.environ`` at call time, never
+frozen into module-level constants at import: a constant captured at import
+silently ignores overrides set afterwards (programmatic server start, pytest
+``monkeypatch.setenv``, uvicorn reload). A malformed value degrades to the
+default with a warning instead of failing the request (or, worse, the
+module import).
+"""
+
+from __future__ import annotations
+
+import os
+
+from haute._logging import get_logger
+
+logger = get_logger(component="env")
+
+
+def float_env(name: str, default: float) -> float:
+    """Read ``name`` from the environment as a float, at call time.
+
+    Returns ``default`` when the variable is unset or unparseable.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "invalid_env_value",
+            name=name,
+            value=raw,
+            default=default,
+        )
+        return default
+
+
+def int_env(name: str, default: int) -> int:
+    """Read ``name`` from the environment as an int, at call time.
+
+    Returns ``default`` when the variable is unset or unparseable.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "invalid_env_value",
+            name=name,
+            value=raw,
+            default=default,
+        )
+        return default
+
+
+def optional_int_env(name: str) -> int | None:
+    """Read ``name`` from the environment as an int, at call time.
+
+    Returns ``None`` when the variable is unset, empty, or unparseable.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "invalid_env_value",
+            name=name,
+            value=raw,
+            default=None,
+        )
+        return None

--- a/src/haute/routes/_optimiser_service.py
+++ b/src/haute/routes/_optimiser_service.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 from haute._banding_config import normalise_banding_factors
 from haute._contracts import Contract, get_column_contract
+from haute._env import int_env, optional_int_env
 from haute._execution_admission import (
     ExecutionAdmissionError,
     create_admitted_execution_context,
@@ -119,21 +120,35 @@ from haute.schemas import (
 logger = get_logger(component="server.optimiser.solve")
 
 # ── Default constants ─────────────────────────────────────────────
-_DEFAULT_SOLVER_TIMEOUT_RAW = os.environ.get("HAUTE_SOLVER_TIMEOUT")
-_DEFAULT_TIMEOUT = int(_DEFAULT_SOLVER_TIMEOUT_RAW) if _DEFAULT_SOLVER_TIMEOUT_RAW else None
-_DEFAULT_AUTO_RANGE_TIMEOUT = int(os.environ.get("HAUTE_AUTO_RANGE_TIMEOUT", "1800"))
 _HISTOGRAM_BINS = 20  # bin count for scenario-value distribution histogram
 _DEFAULT_MAX_ITER = 50  # max solver iterations (online & ratebook)
-_DEFAULT_AUTO_RANGE_CHUNK_SIZE = int(os.environ.get("HAUTE_AUTO_RANGE_CHUNK_SIZE", "2000000"))
+
+
+# Env-tunable defaults — resolved per call so overrides set after import
+# take effect.
+def _default_solver_timeout() -> int | None:
+    return optional_int_env("HAUTE_SOLVER_TIMEOUT")
+
+
+def _default_auto_range_timeout() -> int:
+    return int_env("HAUTE_AUTO_RANGE_TIMEOUT", 1800)
+
+
+def _default_auto_range_chunk_size() -> int:
+    return int_env("HAUTE_AUTO_RANGE_CHUNK_SIZE", 2_000_000)
+
+
+def _default_auto_range_partitions() -> int:
+    # disk buckets for chunked auto-range aggregation
+    return int_env("HAUTE_AUTO_RANGE_PARTITIONS", 16)
+
+
 _DEFAULT_AUTO_RANGE_TARGET_CHUNK_MIN_BYTES = 16 * 1024 * 1024
 _DEFAULT_AUTO_RANGE_TARGET_CHUNK_MAX_BYTES = 512 * 1024 * 1024
 _DEFAULT_AUTO_RANGE_TARGET_CHUNK_BUDGET_DIVISOR = 16
 _DEFAULT_OPTIMISER_SETUP_TARGET_CHUNK_MIN_BYTES = 16 * 1024 * 1024
 _DEFAULT_OPTIMISER_SETUP_TARGET_CHUNK_MAX_BYTES = 512 * 1024 * 1024
 _DEFAULT_OPTIMISER_SETUP_TARGET_CHUNK_BUDGET_DIVISOR = 16
-_DEFAULT_AUTO_RANGE_PARTITIONS = int(
-    os.environ.get("HAUTE_AUTO_RANGE_PARTITIONS", "16")
-)  # disk buckets for chunked auto-range aggregation
 _DEFAULT_TOLERANCE = 1e-6  # convergence tolerance for solver
 _DEFAULT_MAX_CD_ITERATIONS = 10  # max coordinate-descent iterations (ratebook)
 _DEFAULT_CD_TOLERANCE = 1e-3  # coordinate-descent convergence tolerance (ratebook)
@@ -424,7 +439,7 @@ def _optional_positive_int(value: object, *, field: str) -> int | None:
 
 def _solve_timeout_from_config(config: Mapping[str, Any]) -> int | None:
     if "timeout" not in config:
-        return _DEFAULT_TIMEOUT
+        return _default_solver_timeout()
     return _optional_positive_int(config.get("timeout"), field="timeout")
 
 
@@ -497,7 +512,7 @@ def _auto_range_chunk_size_from_config(config: dict[str, Any]) -> int:
             field="auto_range_chunk_size",
         )
     return _positive_int(
-        config.get("chunk_size", _DEFAULT_AUTO_RANGE_CHUNK_SIZE),
+        config.get("chunk_size", _default_auto_range_chunk_size()),
         field="chunk_size",
     )
 
@@ -672,14 +687,14 @@ def _auto_range_data_input_has_objective(
 
 def _auto_range_partition_count_from_config(config: dict[str, Any]) -> int:
     return _positive_int(
-        config.get("auto_range_partition_count", _DEFAULT_AUTO_RANGE_PARTITIONS),
+        config.get("auto_range_partition_count", _default_auto_range_partitions()),
         field="auto_range_partition_count",
     )
 
 
 def _auto_range_timeout_from_config(config: dict[str, Any]) -> int:
     return _positive_int(
-        config.get("auto_range_timeout", _DEFAULT_AUTO_RANGE_TIMEOUT),
+        config.get("auto_range_timeout", _default_auto_range_timeout()),
         field="auto_range_timeout",
     )
 
@@ -1576,8 +1591,8 @@ def _add_frontier_range_batch(
 class FrontierAutoRangeContext:
     """Per-job context for frontier auto-range estimation."""
 
-    chunk_size: int = _DEFAULT_AUTO_RANGE_CHUNK_SIZE
-    partition_count: int = _DEFAULT_AUTO_RANGE_PARTITIONS
+    chunk_size: int = dataclasses.field(default_factory=_default_auto_range_chunk_size)
+    partition_count: int = dataclasses.field(default_factory=_default_auto_range_partitions)
     execution_context: ExecutionContext | None = None
     streaming_chunk_size: int | None = None
 
@@ -3055,7 +3070,7 @@ class OptimiserSolveService:
 
         if job.get("status") == "running":
             start = job.get("start_time")
-            timeout = job.get("timeout", _DEFAULT_AUTO_RANGE_TIMEOUT)
+            timeout = job.get("timeout", _default_auto_range_timeout())
             if start and (time.monotonic() - start) > timeout:
                 self._auto_range_jobs.cancel(job_id, reason="timed_out")
                 updated_job = self._lifecycle.transition(

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -74,6 +74,7 @@ def _default_train_timeout() -> int:
 def _max_train_loss_history() -> int:
     return int_env("HAUTE_TRAIN_LOSS_HISTORY_LIMIT", 200)
 
+
 # Deterministic seed for the RAM/row-limit training downsample. A fixed
 # constant (rather than a config knob) keeps training reproducible by default
 # and matches the project-wide split-seed default (``SplitConfig.seed == 42``).
@@ -364,7 +365,7 @@ def _bounded_loss_history(
     rows = list(history)
     if len(rows) <= _max_train_loss_history():
         return rows, False
-    return rows[-_max_train_loss_history():], True
+    return rows[-_max_train_loss_history() :], True
 
 
 def _check_gpu_vram(
@@ -1083,7 +1084,7 @@ class TrainService:
             history.append({"iteration": float(iteration), **metrics})
             truncated = bool(current_job.get("train_loss_history_truncated"))
             if len(history) > _max_train_loss_history():
-                history = history[-_max_train_loss_history():]
+                history = history[-_max_train_loss_history() :]
                 truncated = True
             self._store.atomic_update(
                 job_id,

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -22,6 +22,7 @@ import polars as pl
 from fastapi import HTTPException
 from pydantic import BaseModel
 
+from haute._env import int_env
 from haute._execution_admission import (
     ExecutionAdmissionError,
     create_admitted_execution_context,
@@ -60,10 +61,18 @@ logger = get_logger(component="server.modelling.train")
 # ── Default constants ─────────────────────────────────────────────
 _DEFAULT_BORDER_COUNT = 128  # CatBoost border count for VRAM estimation
 _DEFAULT_DEPTH = 6  # CatBoost tree depth for VRAM estimation
-_DEFAULT_TIMEOUT = int(os.environ.get("HAUTE_TRAIN_TIMEOUT", "3600"))
-_MAX_TRAIN_LOSS_HISTORY = int(os.environ.get("HAUTE_TRAIN_LOSS_HISTORY_LIMIT", "200"))
 _TRAINING_JOB_TYPE = "training"
 _JOB_TYPE_KEY = "job_type"
+
+
+# Env-tunable defaults — resolved per call so overrides set after import
+# take effect.
+def _default_train_timeout() -> int:
+    return int_env("HAUTE_TRAIN_TIMEOUT", 3600)
+
+
+def _max_train_loss_history() -> int:
+    return int_env("HAUTE_TRAIN_LOSS_HISTORY_LIMIT", 200)
 
 # Deterministic seed for the RAM/row-limit training downsample. A fixed
 # constant (rather than a config knob) keeps training reproducible by default
@@ -353,9 +362,9 @@ def _bounded_loss_history(
     history: Iterable[dict[str, float]],
 ) -> tuple[list[dict[str, float]], bool]:
     rows = list(history)
-    if len(rows) <= _MAX_TRAIN_LOSS_HISTORY:
+    if len(rows) <= _max_train_loss_history():
         return rows, False
-    return rows[-_MAX_TRAIN_LOSS_HISTORY:], True
+    return rows[-_max_train_loss_history():], True
 
 
 def _check_gpu_vram(
@@ -1051,7 +1060,7 @@ class TrainService:
             job_id,
             {
                 "start_time": start_time,
-                "timeout": config.get("timeout", _DEFAULT_TIMEOUT),
+                "timeout": config.get("timeout", _default_train_timeout()),
             },
         )
 
@@ -1073,8 +1082,8 @@ class TrainService:
             history = list(current_job.get("train_loss_history") or [])
             history.append({"iteration": float(iteration), **metrics})
             truncated = bool(current_job.get("train_loss_history_truncated"))
-            if len(history) > _MAX_TRAIN_LOSS_HISTORY:
-                history = history[-_MAX_TRAIN_LOSS_HISTORY:]
+            if len(history) > _max_train_loss_history():
+                history = history[-_max_train_loss_history():]
                 truncated = True
             self._store.atomic_update(
                 job_id,

--- a/src/haute/routes/databricks.py
+++ b/src/haute/routes/databricks.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 
 from haute._databricks_io import _TABLE_NAME_RE
+from haute._env import float_env
 from haute._logging import get_logger
 from haute.routes._helpers import _INTERNAL_ERROR_DETAIL
 from haute.routes._timeouts import run_blocking_with_response_timeout
@@ -30,8 +31,10 @@ logger = get_logger(component="server.databricks")
 
 router = APIRouter(prefix="/api/databricks", tags=["databricks"])
 
-# ── Timeout constant (seconds) ───────────────────────────────────
-_FETCH_TIMEOUT = float(os.environ.get("HAUTE_FETCH_TIMEOUT", "600"))
+# ── Timeout (seconds) — resolved per request so env overrides set
+# after import take effect ───────────────────────────────────────
+def _fetch_timeout() -> float:
+    return float_env("HAUTE_FETCH_TIMEOUT", 600.0)
 
 
 def _validate_table_param(table: str) -> None:
@@ -158,14 +161,14 @@ async def fetch_databricks_table(body: FetchTableRequest) -> FetchTableResponse:
             table=body.table,
             http_path=body.http_path,
             query=body.query,
-            timeout=_FETCH_TIMEOUT,
+            timeout=_fetch_timeout(),
             operation="databricks_fetch",
         )
         return FetchTableResponse.model_validate(result)
     except TimeoutError:
         raise HTTPException(
             status_code=504,
-            detail=f"Databricks fetch timed out ({_FETCH_TIMEOUT:.0f}s limit)",
+            detail=f"Databricks fetch timed out ({_fetch_timeout():.0f}s limit)",
         )
     except ImportError:
         raise HTTPException(

--- a/src/haute/routes/databricks.py
+++ b/src/haute/routes/databricks.py
@@ -31,6 +31,7 @@ logger = get_logger(component="server.databricks")
 
 router = APIRouter(prefix="/api/databricks", tags=["databricks"])
 
+
 # ── Timeout (seconds) — resolved per request so env overrides set
 # after import take effect ───────────────────────────────────────
 def _fetch_timeout() -> float:

--- a/src/haute/routes/json_cache.py
+++ b/src/haute/routes/json_cache.py
@@ -23,7 +23,6 @@ discriminates on ``type`` rather than string-matching ``detail``.
 from __future__ import annotations
 
 import json
-import os
 import threading
 import time
 from pathlib import Path
@@ -35,6 +34,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from haute._api_input_schema import ApiInputSchemaError, is_v2_shape
+from haute._env import float_env
 from haute._logging import get_logger
 from haute._path_resolution import resolve_runtime_file_path
 from haute.routes._helpers import _INTERNAL_ERROR_DETAIL, pipeline_dir
@@ -53,8 +53,10 @@ logger = get_logger(component="server.json_cache")
 
 router = APIRouter(prefix="/api/json-cache", tags=["json-cache"])
 
-# ── Timeout constant (seconds) ───────────────────────────────────
-_BUILD_TIMEOUT = float(os.environ.get("HAUTE_BUILD_TIMEOUT", "1800"))
+# ── Timeout (seconds) — resolved per request so env overrides set
+# after import take effect ───────────────────────────────────────
+def _build_timeout() -> float:
+    return float_env("HAUTE_BUILD_TIMEOUT", 1800.0)
 
 _build_progress: dict[str, dict[str, Any]] = {}
 _build_progress_lock = threading.Lock()
@@ -414,13 +416,13 @@ async def build_json_cache(body: JsonCacheBuildRequest) -> Any:
     try:
         summary = await run_blocking_with_response_timeout(
             _build_with_progress,
-            timeout=_BUILD_TIMEOUT,
+            timeout=_build_timeout(),
             operation="json_cache_build_v2",
         )
     except TimeoutError:
         raise HTTPException(
             status_code=504,
-            detail=f"JSON cache build timed out ({_BUILD_TIMEOUT / 60:.0f} min limit)",
+            detail=f"JSON cache build timed out ({_build_timeout() / 60:.0f} min limit)",
         )
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Data file not found") from None

--- a/src/haute/routes/json_cache.py
+++ b/src/haute/routes/json_cache.py
@@ -53,10 +53,12 @@ logger = get_logger(component="server.json_cache")
 
 router = APIRouter(prefix="/api/json-cache", tags=["json-cache"])
 
+
 # ── Timeout (seconds) — resolved per request so env overrides set
 # after import take effect ───────────────────────────────────────
 def _build_timeout() -> float:
     return float_env("HAUTE_BUILD_TIMEOUT", 1800.0)
+
 
 _build_progress: dict[str, dict[str, Any]] = {}
 _build_progress_lock = threading.Lock()

--- a/src/haute/routes/modelling.py
+++ b/src/haute/routes/modelling.py
@@ -14,11 +14,11 @@ from haute.routes._helpers import _INTERNAL_ERROR_DETAIL
 from haute.routes._job_lifecycle import require_job_status
 from haute.routes._job_store import get_job_store
 from haute.routes._train_service import (
-    _DEFAULT_TIMEOUT,
     TrainService,
     _assert_json_finite,
     _check_gpu_vram,
     _clamp_row_limit,
+    _default_train_timeout,
     _find_modelling_node,
     _VramCheck,
 )
@@ -64,7 +64,7 @@ async def train_status(job_id: str) -> TrainStatusResponse:
 
     if job.get("status") == "running":
         start = job.get("start_time")
-        timeout = job.get("timeout", _DEFAULT_TIMEOUT)
+        timeout = job.get("timeout", _default_train_timeout())
         if start and (time.monotonic() - start) > timeout:
             job = _train_service.timeout(job_id, timeout=timeout, start_time=start)
 

--- a/src/haute/routes/output_assemble.py
+++ b/src/haute/routes/output_assemble.py
@@ -16,12 +16,12 @@ up to empty collections.
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from haute._env import float_env
 from haute._execution_admission import (
     ExecutionAdmissionError,
     create_admitted_execution_context,
@@ -44,7 +44,10 @@ logger = get_logger(component="server.output_assemble")
 
 router = APIRouter(prefix="/api/output-assemble", tags=["output-assemble"])
 
-_DRY_RUN_TIMEOUT = float(os.environ.get("HAUTE_OUTPUT_DRY_RUN_TIMEOUT", "120"))
+# Timeout (seconds) — resolved per request so env overrides set after
+# import take effect.
+def _dry_run_timeout() -> float:
+    return float_env("HAUTE_OUTPUT_DRY_RUN_TIMEOUT", 120.0)
 
 
 class OutputAssembleDryRunRequest(BaseModel):
@@ -118,7 +121,7 @@ async def output_assemble_dry_run(
     try:
         results = await run_blocking_with_response_timeout(
             _run,
-            timeout=_DRY_RUN_TIMEOUT,
+            timeout=_dry_run_timeout(),
             operation="output_assemble_dry_run",
         )
     except BlockingWorkTimeoutError as exc:

--- a/src/haute/routes/output_assemble.py
+++ b/src/haute/routes/output_assemble.py
@@ -44,6 +44,7 @@ logger = get_logger(component="server.output_assemble")
 
 router = APIRouter(prefix="/api/output-assemble", tags=["output-assemble"])
 
+
 # Timeout (seconds) — resolved per request so env overrides set after
 # import take effect.
 def _dry_run_timeout() -> float:

--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -91,6 +91,7 @@ logger = get_logger(component="server.pipeline")
 
 router = APIRouter(prefix="/api", tags=["pipeline"])
 
+
 # ── Timeouts (seconds) — resolved per request so env overrides set
 # after import take effect ───────────────────────────────────────
 def _trace_timeout() -> float:
@@ -103,6 +104,7 @@ def _preview_timeout() -> float:
 
 def _sink_timeout() -> float:
     return float_env("HAUTE_SINK_TIMEOUT", 300.0)
+
 
 _preview_supersession = SupersessionCoordinator()
 _trace_supersession = SupersessionCoordinator()

--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -12,6 +12,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from fastapi.concurrency import run_in_threadpool
 
+from haute._env import float_env
 from haute._execution_admission import (
     ExecutionAdmissionError,
     create_admitted_execution_context,
@@ -90,10 +91,18 @@ logger = get_logger(component="server.pipeline")
 
 router = APIRouter(prefix="/api", tags=["pipeline"])
 
-# ── Timeout constants (seconds) ──────────────────────────────────
-_TRACE_TIMEOUT = float(os.environ.get("HAUTE_TRACE_TIMEOUT", "120"))
-_PREVIEW_TIMEOUT = float(os.environ.get("HAUTE_PREVIEW_TIMEOUT", "120"))
-_SINK_TIMEOUT = float(os.environ.get("HAUTE_SINK_TIMEOUT", "300"))
+# ── Timeouts (seconds) — resolved per request so env overrides set
+# after import take effect ───────────────────────────────────────
+def _trace_timeout() -> float:
+    return float_env("HAUTE_TRACE_TIMEOUT", 120.0)
+
+
+def _preview_timeout() -> float:
+    return float_env("HAUTE_PREVIEW_TIMEOUT", 120.0)
+
+
+def _sink_timeout() -> float:
+    return float_env("HAUTE_SINK_TIMEOUT", 300.0)
 
 _preview_supersession = SupersessionCoordinator()
 _trace_supersession = SupersessionCoordinator()
@@ -447,7 +456,7 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
 
             return await run_blocking_with_response_timeout(
                 _execute_trace_with_chunk_size,
-                timeout=_TRACE_TIMEOUT,
+                timeout=_trace_timeout(),
                 operation="pipeline_trace",
             )
 
@@ -474,7 +483,7 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
     except TimeoutError:
         raise HTTPException(
             status_code=504,
-            detail=f"Trace execution timed out ({_TRACE_TIMEOUT:.0f}s limit)",
+            detail=f"Trace execution timed out ({_trace_timeout():.0f}s limit)",
         )
     except HTTPException:
         raise
@@ -553,7 +562,7 @@ async def preview_node(body: PreviewNodeRequest) -> PreviewNodeResponse:
 
             return await run_blocking_with_response_timeout(
                 _execute_graph_with_chunk_size,
-                timeout=_PREVIEW_TIMEOUT,
+                timeout=_preview_timeout(),
                 operation="pipeline_preview",
             )
 
@@ -689,13 +698,13 @@ async def preview_node(body: PreviewNodeRequest) -> PreviewNodeResponse:
             preview_context = None
         raise HTTPException(
             status_code=504,
-            detail=f"Preview execution timed out ({_PREVIEW_TIMEOUT:.0f}s limit)",
+            detail=f"Preview execution timed out ({_preview_timeout():.0f}s limit)",
         )
     except TimeoutError:
         preview_token.cancel()
         raise HTTPException(
             status_code=504,
-            detail=f"Preview execution timed out ({_PREVIEW_TIMEOUT:.0f}s limit)",
+            detail=f"Preview execution timed out ({_preview_timeout():.0f}s limit)",
         )
     except HTTPException:
         raise
@@ -774,7 +783,7 @@ async def execute_sink_node(body: SinkRequest) -> SinkResponse:
             execution_context=sink_context,
             streaming_chunk_size=body.streaming_chunk_size,
             project_root=project_root,
-            timeout=_SINK_TIMEOUT,
+            timeout=_sink_timeout(),
             operation="pipeline_sink",
         )
         if result.execution_metrics is not None:
@@ -808,14 +817,14 @@ async def execute_sink_node(body: SinkRequest) -> SinkResponse:
             sink_context = None
         raise HTTPException(
             status_code=504,
-            detail=f"Sink execution timed out ({_SINK_TIMEOUT:.0f}s limit)",
+            detail=f"Sink execution timed out ({_sink_timeout():.0f}s limit)",
         )
     except TimeoutError:
         if sink_context is not None:
             sink_context.cancel()
         raise HTTPException(
             status_code=504,
-            detail=f"Sink execution timed out ({_SINK_TIMEOUT:.0f}s limit)",
+            detail=f"Sink execution timed out ({_sink_timeout():.0f}s limit)",
         )
     except HTTPException:
         raise

--- a/tests/test_databricks_endpoints.py
+++ b/tests/test_databricks_endpoints.py
@@ -16,6 +16,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -586,10 +587,7 @@ class TestFetchTable:
 
         with (
             patch("haute.routes._timeouts.asyncio.to_thread", _never_finishes),
-            patch(
-                "haute.routes.databricks._FETCH_TIMEOUT",
-                0.001,
-            ),
+            patch.dict(os.environ, {"HAUTE_FETCH_TIMEOUT": "0.001"}),
         ):
             resp = client.post(
                 "/api/databricks/fetch",

--- a/tests/test_env_lazy_accessors.py
+++ b/tests/test_env_lazy_accessors.py
@@ -1,0 +1,188 @@
+"""Regression tests for lazy environment-variable accessors.
+
+Defect class (Maginot: import-time environment capture): timeout/limit knobs
+used to be frozen into module-level constants at import, so an override set
+*after* the module was imported — the common case for a programmatic server
+start or a pytest ``monkeypatch.setenv`` — was silently ignored, and a
+malformed value crashed module import instead of the request.
+
+The fix (mirroring PR #64's ``HAUTE_MEM_LOG`` treatment) resolves each knob per
+call via ``haute._env``. Every test below sets the env var AFTER the module is
+imported and proves the new value takes effect; the malformed-value tests prove
+a bad value degrades to the default instead of raising.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from haute import _env
+
+
+class TestEnvHelpers:
+    """The shared parse-with-fallback helpers in ``haute._env``."""
+
+    def test_float_env_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("HAUTE_TEST_KNOB", raising=False)
+        assert _env.float_env("HAUTE_TEST_KNOB", 12.5) == 12.5
+
+    def test_float_env_reads_value(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "3.5")
+        assert _env.float_env("HAUTE_TEST_KNOB", 12.5) == 3.5
+
+    def test_float_env_malformed_degrades_to_default(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "not-a-float")
+        assert _env.float_env("HAUTE_TEST_KNOB", 12.5) == 12.5
+
+    def test_int_env_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("HAUTE_TEST_KNOB", raising=False)
+        assert _env.int_env("HAUTE_TEST_KNOB", 42) == 42
+
+    def test_int_env_reads_value(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "7")
+        assert _env.int_env("HAUTE_TEST_KNOB", 42) == 7
+
+    def test_int_env_malformed_degrades_to_default(self, monkeypatch):
+        # A float string is not a valid int and must not crash.
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "3.5")
+        assert _env.int_env("HAUTE_TEST_KNOB", 42) == 42
+
+    def test_optional_int_env_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv("HAUTE_TEST_KNOB", raising=False)
+        assert _env.optional_int_env("HAUTE_TEST_KNOB") is None
+
+    def test_optional_int_env_empty_returns_none(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "")
+        assert _env.optional_int_env("HAUTE_TEST_KNOB") is None
+
+    def test_optional_int_env_reads_value(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "99")
+        assert _env.optional_int_env("HAUTE_TEST_KNOB") == 99
+
+    def test_optional_int_env_malformed_degrades_to_none(self, monkeypatch):
+        monkeypatch.setenv("HAUTE_TEST_KNOB", "not-an-int")
+        assert _env.optional_int_env("HAUTE_TEST_KNOB") is None
+
+
+# (accessor, env var, override string, expected parsed value, default) for every
+# knob that used to be captured at import. Setting the env var AFTER import must
+# change the accessor's result — that is exactly the frozen-constant regression.
+_ACCESSOR_CASES = [
+    ("haute.routes.pipeline", "_trace_timeout", "HAUTE_TRACE_TIMEOUT", "5", 5.0, 120.0),
+    ("haute.routes.pipeline", "_preview_timeout", "HAUTE_PREVIEW_TIMEOUT", "5", 5.0, 120.0),
+    ("haute.routes.pipeline", "_sink_timeout", "HAUTE_SINK_TIMEOUT", "5", 5.0, 300.0),
+    ("haute.routes.json_cache", "_build_timeout", "HAUTE_BUILD_TIMEOUT", "5", 5.0, 1800.0),
+    (
+        "haute.routes.output_assemble",
+        "_dry_run_timeout",
+        "HAUTE_OUTPUT_DRY_RUN_TIMEOUT",
+        "5",
+        5.0,
+        120.0,
+    ),
+    ("haute.routes.databricks", "_fetch_timeout", "HAUTE_FETCH_TIMEOUT", "5", 5.0, 600.0),
+    (
+        "haute.routes._optimiser_service",
+        "_default_auto_range_timeout",
+        "HAUTE_AUTO_RANGE_TIMEOUT",
+        "60",
+        60,
+        1800,
+    ),
+    (
+        "haute.routes._optimiser_service",
+        "_default_auto_range_chunk_size",
+        "HAUTE_AUTO_RANGE_CHUNK_SIZE",
+        "111",
+        111,
+        2_000_000,
+    ),
+    (
+        "haute.routes._optimiser_service",
+        "_default_auto_range_partitions",
+        "HAUTE_AUTO_RANGE_PARTITIONS",
+        "8",
+        8,
+        16,
+    ),
+    (
+        "haute.routes._train_service",
+        "_default_train_timeout",
+        "HAUTE_TRAIN_TIMEOUT",
+        "60",
+        60,
+        3600,
+    ),
+    (
+        "haute.routes._train_service",
+        "_max_train_loss_history",
+        "HAUTE_TRAIN_LOSS_HISTORY_LIMIT",
+        "10",
+        10,
+        200,
+    ),
+]
+
+
+def _resolve(module_name: str, accessor: str):
+    import importlib
+
+    module = importlib.import_module(module_name)
+    return getattr(module, accessor)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "accessor", "env_var", "override", "expected", "default"),
+    _ACCESSOR_CASES,
+    ids=[f"{m.rsplit('.', 1)[-1]}.{a}" for m, a, *_ in _ACCESSOR_CASES],
+)
+def test_accessor_override_takes_effect_after_import(
+    module_name, accessor, env_var, override, expected, default, monkeypatch
+):
+    """An env override set after import is honoured (was frozen before)."""
+    fn = _resolve(module_name, accessor)
+    monkeypatch.delenv(env_var, raising=False)
+    assert fn() == default
+    monkeypatch.setenv(env_var, override)
+    assert fn() == expected
+
+
+@pytest.mark.parametrize(
+    ("module_name", "accessor", "env_var", "override", "expected", "default"),
+    _ACCESSOR_CASES,
+    ids=[f"{m.rsplit('.', 1)[-1]}.{a}" for m, a, *_ in _ACCESSOR_CASES],
+)
+def test_accessor_malformed_value_degrades_to_default(
+    module_name, accessor, env_var, override, expected, default, monkeypatch
+):
+    """A malformed env value degrades to the default instead of crashing."""
+    fn = _resolve(module_name, accessor)
+    monkeypatch.setenv(env_var, "not-a-number")
+    assert fn() == default
+
+
+def test_solver_timeout_optional_semantics(monkeypatch):
+    """``HAUTE_SOLVER_TIMEOUT`` is optional: unset means None (no timeout)."""
+    from haute.routes import _optimiser_service as opt
+
+    monkeypatch.delenv("HAUTE_SOLVER_TIMEOUT", raising=False)
+    assert opt._default_solver_timeout() is None
+    monkeypatch.setenv("HAUTE_SOLVER_TIMEOUT", "42")
+    assert opt._default_solver_timeout() == 42
+    # Malformed degrades to None, not a crash.
+    monkeypatch.setenv("HAUTE_SOLVER_TIMEOUT", "not-an-int")
+    assert opt._default_solver_timeout() is None
+
+
+def test_auto_range_context_default_reflects_env(monkeypatch):
+    """The frozen dataclass default is a ``default_factory``, so a per-test
+    env override reaches ``FrontierAutoRangeContext()`` — proving the fix also
+    covers the dataclass-default capture, not just the direct accessor call.
+    """
+    from haute.routes._optimiser_service import FrontierAutoRangeContext
+
+    monkeypatch.setenv("HAUTE_AUTO_RANGE_CHUNK_SIZE", "333")
+    monkeypatch.setenv("HAUTE_AUTO_RANGE_PARTITIONS", "9")
+    ctx = FrontierAutoRangeContext()
+    assert ctx.chunk_size == 333
+    assert ctx.partition_count == 9

--- a/tests/test_execution_context.py
+++ b/tests/test_execution_context.py
@@ -1910,7 +1910,7 @@ async def test_preview_route_cancels_execution_context_on_timeout(monkeypatch) -
 
     monkeypatch.setenv("HAUTE_PREVIEW_MEMORY_LIMIT_MB", "512")
     monkeypatch.setattr("haute._execution_admission.current_rss_bytes", lambda: 1)
-    monkeypatch.setattr(pipeline_route, "_PREVIEW_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_PREVIEW_TIMEOUT", "0.05")
     graph = make_graph(
         {
             "nodes": [
@@ -1965,7 +1965,7 @@ async def test_preview_route_releases_admission_after_timed_out_worker_finishes(
     from haute.routes import pipeline as pipeline_route
     from haute.schemas import NodeResult, PreviewNodeRequest
 
-    monkeypatch.setattr(pipeline_route, "_PREVIEW_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_PREVIEW_TIMEOUT", "0.05")
     graph = make_graph(
         {
             "nodes": [
@@ -2569,7 +2569,7 @@ async def test_sink_route_cancels_execution_context_on_timeout(monkeypatch, tmp_
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("HAUTE_SINK_MEMORY_LIMIT_MB", "512")
     monkeypatch.setattr("haute._execution_admission.current_rss_bytes", lambda: 1)
-    monkeypatch.setattr(pipeline_route, "_SINK_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_SINK_TIMEOUT", "0.05")
     output_path = tmp_path / "sink.parquet"
     graph = make_graph(
         {

--- a/tests/test_json_cache_routes.py
+++ b/tests/test_json_cache_routes.py
@@ -20,6 +20,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 import time
 from pathlib import Path
@@ -109,7 +110,7 @@ class TestBuildJsonCache:
 
         with (
             patch("haute._json_shred.build_per_port_cache", _slow_build),
-            patch("haute.routes.json_cache._BUILD_TIMEOUT", 0.001),
+            patch.dict(os.environ, {"HAUTE_BUILD_TIMEOUT": "0.001"}),
         ):
             resp = client.post(
                 "/api/json-cache/build",
@@ -273,7 +274,7 @@ class TestJsonCacheProgress:
 
         with (
             patch("haute._json_shred.build_per_port_cache", _slow_build),
-            patch("haute.routes.json_cache._BUILD_TIMEOUT", 0.001),
+            patch.dict(os.environ, {"HAUTE_BUILD_TIMEOUT": "0.001"}),
         ):
             with pytest.raises(HTTPException) as exc_info:
                 await build_json_cache(

--- a/tests/test_modelling_routes.py
+++ b/tests/test_modelling_routes.py
@@ -599,15 +599,15 @@ def test_bounded_loss_history_retains_latest_rows() -> None:
 
     history = [
         {"iteration": float(index), "rmse": float(index)}
-        for index in range(_train_service._MAX_TRAIN_LOSS_HISTORY + 5)
+        for index in range(_train_service._max_train_loss_history() + 5)
     ]
 
     bounded, truncated = _train_service._bounded_loss_history(history)
 
     assert truncated is True
-    assert len(bounded) == _train_service._MAX_TRAIN_LOSS_HISTORY
+    assert len(bounded) == _train_service._max_train_loss_history()
     assert bounded[0]["iteration"] == 5.0
-    assert bounded[-1]["iteration"] == float(_train_service._MAX_TRAIN_LOSS_HISTORY + 4)
+    assert bounded[-1]["iteration"] == float(_train_service._max_train_loss_history() + 4)
 
 
 class TestExportEndpoint:

--- a/tests/test_optimiser_routes.py
+++ b/tests/test_optimiser_routes.py
@@ -22,13 +22,13 @@ from haute.routes._optimiser_limits import (
     FRONTIER_POINT_LIMIT,
 )
 from haute.routes._optimiser_service import (
-    _DEFAULT_AUTO_RANGE_CHUNK_SIZE,
-    _DEFAULT_AUTO_RANGE_PARTITIONS,
     FrontierAutoRangeContext,
     SolveContext,
     _auto_range_required_columns_by_node,
     _build_streaming_auto_range_plan,
     _compute_scenario_value_stats,
+    _default_auto_range_chunk_size,
+    _default_auto_range_partitions,
     _estimate_scenario_frontier_ranges,
     _looks_chunk_local_user_code,
     _optimiser_solve_required_columns_by_node,
@@ -3717,8 +3717,8 @@ class TestEstimateRoute:
         body = OptimiserFrontierAutoRangeRequest(graph=graph, node_id="opt")
         prepared = OptimiserSolveService(JobStore())._prepare_frontier_auto_range(body)
 
-        assert prepared["chunk_size"] == _DEFAULT_AUTO_RANGE_CHUNK_SIZE
-        assert prepared["partition_count"] == _DEFAULT_AUTO_RANGE_PARTITIONS
+        assert prepared["chunk_size"] == _default_auto_range_chunk_size()
+        assert prepared["partition_count"] == _default_auto_range_partitions()
 
     def test_frontier_auto_range_prepare_treats_projection_plan_failure_as_ineligible(
         self,

--- a/tests/test_pipeline_route_supersession.py
+++ b/tests/test_pipeline_route_supersession.py
@@ -851,7 +851,7 @@ async def test_timed_out_preview_requests_hold_slot_until_worker_finishes(
 
     limiter = asyncio.Semaphore(1)
     coordinator = SupersessionCoordinator()
-    monkeypatch.setattr(route_mod, "_PREVIEW_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_PREVIEW_TIMEOUT", "0.05")
     monkeypatch.setattr(route_mod, "_preview_work_slots", limiter)
     monkeypatch.setattr(route_mod, "_preview_supersession", coordinator)
 
@@ -956,7 +956,7 @@ async def test_timed_out_same_key_preview_stays_active_until_worker_finishes(
     from haute.server import app
 
     coordinator = SupersessionCoordinator()
-    monkeypatch.setattr(route_mod, "_PREVIEW_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_PREVIEW_TIMEOUT", "0.05")
     monkeypatch.setattr(route_mod, "_preview_work_slots", asyncio.Semaphore(2))
     monkeypatch.setattr(route_mod, "_preview_supersession", coordinator)
 
@@ -1047,7 +1047,7 @@ async def test_superseded_timed_out_preview_holds_slot_until_worker_finishes(
 
     limiter = asyncio.Semaphore(1)
     coordinator = SupersessionCoordinator()
-    monkeypatch.setattr(route_mod, "_PREVIEW_TIMEOUT", 0.05)
+    monkeypatch.setenv("HAUTE_PREVIEW_TIMEOUT", "0.05")
     monkeypatch.setattr(route_mod, "_preview_work_slots", limiter)
     monkeypatch.setattr(route_mod, "_preview_supersession", coordinator)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -1991,17 +1992,13 @@ class TestPipelineTimeouts:
                 "haute.routes._timeouts.asyncio.to_thread",
                 self._never_finishes,
             ),
-            patch(
-                "haute.routes.pipeline._TRACE_TIMEOUT",
-                0.001,
-            ),
-            patch(
-                "haute.routes.pipeline._PREVIEW_TIMEOUT",
-                0.001,
-            ),
-            patch(
-                "haute.routes.pipeline._SINK_TIMEOUT",
-                0.001,
+            patch.dict(
+                os.environ,
+                {
+                    "HAUTE_TRACE_TIMEOUT": "0.001",
+                    "HAUTE_PREVIEW_TIMEOUT": "0.001",
+                    "HAUTE_SINK_TIMEOUT": "0.001",
+                },
             ),
         ):
             resp = client.post(f"/api/pipeline/{endpoint}", json=body)

--- a/tests/test_trace_api.py
+++ b/tests/test_trace_api.py
@@ -527,9 +527,7 @@ class TestErrorHandling:
         """If trace execution exceeds the timeout, return 504."""
         from unittest.mock import patch
 
-        import haute.routes.pipeline as route_mod
-
-        monkeypatch.setattr(route_mod, "_TRACE_TIMEOUT", 0.01)
+        monkeypatch.setenv("HAUTE_TRACE_TIMEOUT", "0.01")
 
         p = _simple_parquet(tmp_path)
         code = "df = df.with_columns(z=pl.col('x') + 1)"

--- a/tests/test_train_service_coverage.py
+++ b/tests/test_train_service_coverage.py
@@ -1247,7 +1247,7 @@ class TestLaunchBackgroundWorker:
         tmp_parquet = str(tmp_path / "train.parquet")
         Path(tmp_parquet).write_text("x", encoding="utf-8")
 
-        cap = _train_service._MAX_TRAIN_LOSS_HISTORY
+        cap = _train_service._max_train_loss_history()
 
         class FakeJob:
             def run(self, progress, on_iteration, *, check_cancelled, execution_context):


### PR DESCRIPTION
## Problem

Eleven module-level constants across six `routes/` modules captured their `HAUTE_*` environment variable once, at import, via `float(os.environ.get(...))` / `int(os.environ.get(...))`:

- `pipeline.py` — `HAUTE_TRACE_TIMEOUT`, `HAUTE_PREVIEW_TIMEOUT`, `HAUTE_SINK_TIMEOUT`
- `json_cache.py` — `HAUTE_BUILD_TIMEOUT`
- `_optimiser_service.py` — `HAUTE_SOLVER_TIMEOUT`, `HAUTE_AUTO_RANGE_TIMEOUT`, `HAUTE_AUTO_RANGE_CHUNK_SIZE`, `HAUTE_AUTO_RANGE_PARTITIONS`
- `output_assemble.py` — `HAUTE_OUTPUT_DRY_RUN_TIMEOUT`
- `databricks.py` — `HAUTE_FETCH_TIMEOUT`
- `_train_service.py` — `HAUTE_TRAIN_TIMEOUT`, `HAUTE_TRAIN_LOSS_HISTORY_LIMIT`

An override set **after** the module is imported — a programmatic server start, a uvicorn reload, a pytest `monkeypatch.setenv` — was silently ignored because the constant had already frozen the value. Two of the optimiser knobs additionally did `int(...)` at import, so a malformed value raised `ValueError` during *module import* (hence at server startup) rather than degrading a single request.

Same defect shape as the training mem-log fix in #64 (import-time environment capture): the documented knob exists, the freeze defeats it.

## Fix

- New `haute._env` with `float_env` / `int_env` / `optional_int_env` — parse-with-fallback accessors that read `os.environ` at call time and degrade a malformed value to the default with a `warning` log instead of raising.
- Each frozen constant replaced by a small per-module accessor (`_trace_timeout()`, `_default_train_timeout()`, …), resolved per request — cheap (once per request, not a hot loop) and matching the existing lazy idiom in `executor.py` / `_dataframe_execution_cache.py`.
- The two `FrontierAutoRangeContext` dataclass defaults become `dataclasses.field(default_factory=...)`, so the env is read at instantiation rather than at class definition.
- `routes/modelling.py` imports the new `_default_train_timeout` accessor in place of the removed `_DEFAULT_TIMEOUT` constant.

## Tests

- New `tests/test_env_lazy_accessors.py` (34 tests): the helpers directly (unset / valid / malformed), and every one of the eleven accessors proving a **post-import** override takes effect **and** a malformed value degrades to the default; plus the optional-solver-timeout `None` semantics and `FrontierAutoRangeContext()` reading env at instantiation.
- Existing route-timeout tests converted from `monkeypatch.setattr(module, "_X_TIMEOUT", ...)` to `setenv` / `patch.dict(os.environ, ...)`, so they now drive the real 504 paths through the ASGI routes with a post-import override — the exact regression scenario.

Full backend suite green (12,586 passed); `_env.py` at 100% line+branch coverage; ruff + mypy clean. Forward-merged onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)