### PR TITLE
ci: nightly frontend-shuffle lane to guard against test-order dependence

### DIFF
--- a/.github/workflows/frontend-shuffle.yml
+++ b/.github/workflows/frontend-shuffle.yml
@@ -1,0 +1,107 @@
+name: Frontend Shuffle
+
+# Nightly guard against WITHIN-FILE test-order dependence in the frontend
+# vitest suite. The default `frontend` lane in ci.yml runs tests in file
+# order, so a test that leaks state into a sibling (an uncleared module-level
+# mock spy, an unconsumed mockImplementationOnce, accumulated DOM) passes there
+# and only fails under a different ordering. This lane runs the same suite under
+# `--sequence.shuffle` so those regressions surface. It is intentionally NOT a
+# required per-PR check (ruled 2026-07-15) — order-dependence is a slow-moving
+# class and a nightly catch is enough; keeping it off the PR critical path
+# avoids charging every PR for a probabilistic check.
+#
+# Loud: a failure finds-or-creates a `shuffle-watch` issue with the run URL and
+# the exact seed, so a red night is reproducible with one command.
+
+on:
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Explicit shuffle seed (reproduce a specific nightly failure). Blank = random."
+        type: string
+        default: ""
+      force_fail:
+        description: "Fail deliberately to prove the alarm path rings"
+        type: boolean
+        default: false
+  schedule:
+    # 02:07 UTC daily — offset from the Monday scheduled lanes
+    # (performance 03:17, dependencies 04:41, mutation 05:00).
+    - cron: "7 2 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-shuffle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Forced failure (alarm-path test)
+        if: inputs.force_fail
+        run: |
+          echo "force_fail input set — failing deliberately to exercise the alarm step"
+          exit 1
+
+      # Bare `--sequence.shuffle` (no seed) makes vitest pick and PRINT a random
+      # seed each night, maximising ordering coverage over time while staying
+      # reproducible from the log. A dispatch-supplied seed pins the ordering.
+      - name: Run frontend suite under shuffle
+        id: shuffle
+        env:
+          SEED: ${{ inputs.seed }}
+        run: |
+          set -o pipefail
+          npm run test:shuffle -- ${SEED:+--sequence.seed=$SEED} 2>&1 | tee ../shuffle-run.log
+
+      # Surface the seed vitest used (from its "Running tests with seed ..."
+      # banner) as a step output, so the alarm can embed the exact repro command.
+      - name: Capture shuffle seed
+        id: seed
+        if: always()
+        run: |
+          value="$(sed -n 's/.*Running tests with seed "\([0-9]*\)".*/\1/p' ../shuffle-run.log 2>/dev/null | head -1)"
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
+          echo "shuffle seed: ${value:-<not found>}"
+
+      # Ring on real nightly failures and on a deliberate force_fail test, but
+      # NOT on an ordinary reproduce-a-seed dispatch (the developer is already
+      # watching that run — no need to open a tracker issue).
+      - name: Raise the alarm (find-or-create shuffle-watch issue)
+        if: failure() && (github.event_name == 'schedule' || inputs.force_fail)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SEED: ${{ steps.seed.outputs.value }}
+        run: |
+          title="Nightly frontend-shuffle lane is red"
+          body="The frontend vitest suite failed under --sequence.shuffle. Run: ${RUN_URL}
+
+          Reproduce locally (from frontend/):
+              npm ci
+              npm run test:shuffle -- --sequence.seed=${SEED:-<see run log>}
+
+          Likely cause: a test with within-file order dependence — an uncleared module-level mock spy, an unconsumed mockImplementationOnce, or DOM/store state leaking into a sibling test. See PRs #70/#74/#80 for the pattern and the standard fixes (clear the spy / reset the mock / register afterEach(cleanup) in the offending test's beforeEach)."
+          gh label create shuffle-watch --color FBCA04 --force \
+            --description "Automated: nightly frontend-shuffle lane failures"
+          existing="$(gh issue list --state open --label shuffle-watch \
+            --search "in:title \"${title}\"" --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body "Still red: ${RUN_URL} (seed ${SEED:-unknown})"
+          else
+            gh issue create --title "${title}" --label shuffle-watch --body "${body}"
+          fi

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:shuffle": "vitest run --sequence.shuffle",
     "test:coverage": "vitest run --coverage && node scripts/check-critical-coverage.mjs",
     "test:benchmark:pr": "vitest run src/__tests__/App.shallowHash.test.ts src/hooks/__tests__/columnsEqual.fingerprint.test.ts src/hooks/__tests__/nodesWithStatus.memo.test.tsx src/utils/__tests__/graphPerformance.test.ts",
     "test:e2e": "playwright test --grep-invert @benchmark",


### PR DESCRIPTION
## What

A scheduled (nightly, 02:07 UTC) + dispatchable workflow that runs the frontend vitest suite under `--sequence.shuffle`, plus a `test:shuffle` npm script so it's runnable identically locally. **Non-blocking** — not in any PR's critical path (ruled 2026-07-15: within-file order-dependence is slow-moving, so a nightly catch suffices).

## Why

The default `frontend` lane runs tests in file order, so a test that leaks state into a sibling (uncleared module-level mock spy, unconsumed `mockImplementationOnce`, accumulated DOM) passes there and only fails under a different ordering. This lane runs the same suite shuffled so those regressions surface. Motivated by the shuffle-order audit: **#70/#74** fixed two real leaks (uncleared `markSaved` spy; leaked `mockImplementationOnce`), **#80** hardened 8 latent ones.

## Design

- **Random seed nightly** — bare `--sequence.shuffle` makes vitest pick and print a fresh seed each night (max ordering coverage over time); it's captured from the log into the failure issue for reproduction. A `workflow_dispatch` `seed` input pins the ordering to reproduce a specific red.
- **Loud failure** — on a scheduled failure the lane finds-or-creates a `shuffle-watch` issue with the run URL and exact seed (repro: `npm run test:shuffle -- --sequence.seed=N`), mirroring the `dependencies.yml` alarm pattern. A `force_fail` dispatch input ring-tests the alarm; ordinary reproduce-dispatches don't file issues.
- **`test:shuffle` script** — keeps invocation lockfile-respecting and reproducible locally.

## Verified

- **Lane payload green:** `npm run test:shuffle` (the exact command the lane runs) on the full suite — **269 files / 5218 tests pass** (seed `1784121535918`).
- YAML parses cleanly; mechanics unit-checked (seed passthrough, empty-seed→random, seed-capture sed vs real vitest output, alarm `if` condition).
- **Not exercised by this PR's CI:** the workflow is `schedule`+`dispatch` only, so it does not run on the PR (PR CI runs the `frontend` lane because package.json changed, but not the shuffle lane). Post-merge I'll `workflow_dispatch` it once to confirm a green runner-side run, and optionally `force_fail` once to prove the alarm files an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)