### PR TITLE
fix: make preamble cache population single-flight

### DIFF
--- a/src/haute/executor.py
+++ b/src/haute/executor.py
@@ -135,6 +135,19 @@ _preamble_lock = threading.Lock()
 # Non-utility preambles still take the same lock for their short path
 # reprioritisation so they cannot change import precedence while a utility
 # preamble is paused between path setup and ``exec``.
+#
+# Hot cache hits must NOT pass through this lock (pinned by
+# ``test_hot_cache_hit_does_not_wait_for_import_lock``): a slow preamble exec
+# holding the lock for seconds must not stall unrelated hot-path scoring.
+# At the same time, cache population must be single-flight (pinned by
+# ``test_concurrent_compiles_do_not_double_evaluate``): ``functools.lru_cache``
+# is thread-safe at the lookup level but does NOT serialise the wrapped
+# function — two threads that both miss would each exec the preamble and each
+# return their own distinct namespace dict (CPython returns the caller's own
+# result rather than re-reading the cache).  Both invariants are delivered by
+# storing per-key ``_PreambleCell`` slots in the ``lru_cache`` and computing
+# the namespace into the cell under ``_preamble_lock`` with a double-check —
+# see ``_compile_preamble``.
 
 
 def _pipeline_dir(graph: PipelineGraph) -> Path | None:  # pragma: no mutate
@@ -342,14 +355,41 @@ def _exec_preamble_namespace(preamble: str) -> dict[str, Any]:
     }
 
 
+class _PreambleCell:
+    """Single-flight slot for one preamble cache key.
+
+    The ``lru_cache`` stores one cell per key (so eviction, ``cache_info``
+    and ``cache_clear`` bookkeeping stay stdlib); the compiled namespace is
+    computed INTO the cell under ``_preamble_lock`` with a double-check, so
+    all concurrent first-callers of a key observe the same dict.  ``ns`` is
+    ``None`` until the first successful compile; a failed compile leaves it
+    ``None`` so the next call retries (matching lru_cache's
+    exceptions-are-not-cached semantics, at the cost of the failed key
+    occupying a cache slot until evicted).
+    """
+
+    __slots__ = ("ns",)
+
+    def __init__(self) -> None:
+        self.ns: dict[str, Any] | None = None
+
+
+# Guards cell creation only — held for a cache lookup / tiny allocation,
+# never during validation or exec, so hot hits can't stall behind a slow
+# compile.  Needed because lru_cache does not serialise the wrapped factory:
+# without it, two threads missing the same key could each mint their own
+# cell and the single-flight guarantee would be lost one level up.
+_preamble_cells_guard = threading.Lock()
+
+
 @functools.lru_cache(maxsize=128)
 def _compile_preamble_cached(
     preamble: str,
     cwd: str,
     pipeline_dir_str: str | None,  # pragma: no mutate
     _execution_fingerprint: str,
-) -> dict[str, Any]:
-    """Pure cache-facing worker — compiles preamble bytes into a namespace.
+) -> _PreambleCell:
+    """Cache-facing worker — returns the per-key single-flight cell.
 
     Keyed on ``(preamble, cwd, pipeline_dir_str, _execution_fingerprint)``
     so different pipelines sharing an identical preamble text but different
@@ -361,22 +401,33 @@ def _compile_preamble_cached(
     ``Path("/x")`` and ``"/x"`` — normalisation happens at the public
     entry point.
 
-    All cache misses run under ``_preamble_lock`` for the entire
-    path-prioritisation/import/exec window. Even preambles without literal
-    import statements execute with ``allow_imports=True`` and can consult
-    process-global import state via helpers such as ``__import__``.
+    Callers must hold ``_preamble_cells_guard`` (see ``_compile_preamble``).
+    """
+    return _PreambleCell()
+
+
+def _compile_preamble_into_cell(
+    preamble: str,
+    cwd: str,
+    pipeline_dir_str: str | None,  # pragma: no mutate
+) -> dict[str, Any]:
+    """Compile preamble bytes into a namespace. Caller holds ``_preamble_lock``.
+
+    The lock covers the entire path-prioritisation/import/exec window. Even
+    preambles without literal import statements execute with
+    ``allow_imports=True`` and can consult process-global import state via
+    helpers such as ``__import__``.
     """
     validate_user_code(preamble, allow_imports=True)
     imports_utility = preamble_imports_utility(preamble)
-    with _preamble_lock:
-        _prioritise_preamble_import_paths(cwd, pipeline_dir_str)
-        if imports_utility:
-            # Evict cached utility modules so digest-keyed cache misses pick up
-            # GUI edits. Clearing matching pyc files prevents same-size,
-            # same-mtime edits from being hidden by timestamp-based bytecode
-            # validation.
-            _evict_utility_import_state(pipeline_dir_str)
-        return _exec_preamble_namespace(preamble)
+    _prioritise_preamble_import_paths(cwd, pipeline_dir_str)
+    if imports_utility:
+        # Evict cached utility modules so digest-keyed cache misses pick up
+        # GUI edits. Clearing matching pyc files prevents same-size,
+        # same-mtime edits from being hidden by timestamp-based bytecode
+        # validation.
+        _evict_utility_import_state(pipeline_dir_str)
+    return _exec_preamble_namespace(preamble)
 
 
 def _compile_preamble(
@@ -448,12 +499,29 @@ def _compile_preamble(
     else:
         execution_fingerprint = _PREAMBLE_NO_REFRESH_FINGERPRINT
 
-    return _compile_preamble_cached(
-        preamble,
-        cwd,
-        pipeline_dir_str,
-        execution_fingerprint,
-    )
+    # Cell lookup under its own tiny guard (never held during exec), so a
+    # hot hit returns without touching ``_preamble_lock`` — a slow compile
+    # in another thread cannot stall it.
+    with _preamble_cells_guard:
+        cell = _compile_preamble_cached(
+            preamble,
+            cwd,
+            pipeline_dir_str,
+            execution_fingerprint,
+        )
+    ns = cell.ns
+    if ns is not None:
+        return ns
+
+    # Single-flight population: first caller compiles under ``_preamble_lock``
+    # (which also serialises the process-global sys.path / sys.modules
+    # mutation); concurrent first-callers block, re-check, and return the
+    # SAME dict the winner stored — never a second exec producing a
+    # semantically-equal-but-distinct namespace.
+    with _preamble_lock:
+        if cell.ns is None:
+            cell.ns = _compile_preamble_into_cell(preamble, cwd, pipeline_dir_str)
+        return cell.ns
 
 
 # Expose the cache diagnostics (``cache_info``, ``cache_clear``) directly on

--- a/tests/test_cache_perf_fixes.py
+++ b/tests/test_cache_perf_fixes.py
@@ -54,6 +54,7 @@ import gc
 import hashlib
 import os
 import secrets
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -403,6 +404,60 @@ class TestPreambleCacheCorrectness:
                 "concurrent compiles produced semantically different "
                 "namespaces — race in cache population"
             )
+
+    def test_concurrent_compiles_single_flight_under_thread_churn(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Stress form of the test above: single-flight must hold even when
+        the OS preempts a thread between cache lookup and cache store.
+
+        The plain barrier test only catches the population race when a
+        thread happens to be preempted inside a ~one-GIL-slice window, so it
+        passed on idle machines and flaked rarely in CI (observed 2026-07-15,
+        PR #80 backend shard).  Shrinking the switch interval widens that
+        window enough that the unfixed race reproduced in ~99% of
+        iterations, making this a deterministic regression guard.
+
+        Asserts *identity*, not just equality: single-flight population
+        means every concurrent caller of the same key gets the SAME dict —
+        the guarantee the pre-lru_cache ``OrderedDict`` implementation gave
+        (lookup and store both under ``_preamble_lock``).
+        """
+        monkeypatch.chdir(tmp_path)
+        _clear_preamble_cache()
+        old_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)  # force frequent preemption
+        try:
+            n_threads = 8
+            for i in range(150):
+                # Unique source per iteration -> fresh cache key each time,
+                # so every iteration exercises the concurrent-miss path.
+                source = f"def churn_helper_{i}(x):\n    return x * 3\n"
+                results: list[dict[str, Any]] = []
+                errors: list[BaseException] = []
+                barrier = threading.Barrier(n_threads)
+
+                def worker() -> None:
+                    try:
+                        barrier.wait()
+                        results.append(_compile_preamble(source, force_refresh=False))
+                    except BaseException as exc:  # pragma: no cover — failure path
+                        errors.append(exc)
+
+                with ThreadPoolExecutor(max_workers=n_threads) as pool:
+                    for _ in range(n_threads):
+                        pool.submit(worker)
+
+                assert not errors, f"iteration {i}: concurrent compile crashed: {errors!r}"
+                assert len(results) == n_threads
+                identities = {id(ns) for ns in results}
+                assert len(identities) == 1, (
+                    f"iteration {i}: concurrent compiles returned "
+                    f"{len(identities)} distinct namespace objects — cache "
+                    "population is not single-flight"
+                )
+        finally:
+            sys.setswitchinterval(old_interval)
 
     def test_empty_preamble_does_not_fill_cache(self) -> None:
         """Empty / whitespace preamble short-circuits before the cache.


### PR DESCRIPTION
## Problem

`tests/test_cache_perf_fixes.py::TestPreambleCacheCorrectness::test_concurrent_compiles_do_not_double_evaluate` is intermittently flaky in CI (observed 2026-07-15 on the PR #80 backend-coverage shard):

```
AssertionError: concurrent compiles produced semantically different namespaces — race in cache population
```

## Root cause — a real race, not a test problem

The Wave 6C perf refactor (`bde1d825`) replaced the preamble cache's `OrderedDict` (lookup **and** store under `_preamble_lock` — true single-flight) with `functools.lru_cache`. `lru_cache` is thread-safe at the lookup level but does **not** serialise the wrapped function: threads racing through the same miss each execute the preamble and each get their **own** namespace dict. The namespaces are semantically equal but contain function objects, so `==` degenerates to identity and the test's cross-thread comparison fails.

The race window is ~one GIL switch slice, hence flaky-only-under-CI-load. Under `sys.setswitchinterval(1e-6)` it reproduces near-deterministically: **296/300 iterations** on unfixed code.

## Fix

The `lru_cache` now stores per-key `_PreambleCell` slots (eviction / `cache_info` / `cache_clear` bookkeeping stays stdlib); the namespace is computed into the cell under `_preamble_lock` with a double-check. This preserves **both** pinned invariants:

- **single-flight miss**: concurrent first-callers block, re-check, and return the *same* dict the winner stored (`test_concurrent_compiles_do_not_double_evaluate`)
- **lock-free hot hit**: cache hits never touch `_preamble_lock`, so they don't stall behind a slow compile (`test_hot_cache_hit_does_not_wait_for_import_lock`) — a naive lock-around-the-lookup fix breaks this test

## New regression guard

`test_concurrent_compiles_single_flight_under_thread_churn`: a deterministic stress form of the flaky test — 150 iterations under a 1e-6 switch interval asserting namespace **identity**. Fails at iteration 0 on unfixed code; passes on the fix.

## Verification

- Full backend suite: **12557 passed** (coverage gate green)
- Originally-flaky test: 10/10 consecutive passes
- New stress test: 5/5 consecutive passes (and red-tested against unfixed executor)
- `ruff check` + `mypy` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)