### PR TITLE
fix(undo): make node delete and paste one atomic undo step

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -126,7 +126,7 @@ function FlowEditor() {
   // Core ReactFlow state with undo/redo
   const {
     nodes, edges,
-    setNodes, setEdges,
+    setNodes, setEdges, setNodesAndEdges,
     setNodesRaw, setEdgesRaw,
     onNodesChange, onEdgesChange,
     undo, redo, canUndo, canRedo, pushSnapshot,
@@ -432,7 +432,7 @@ function FlowEditor() {
   })
 
   useKeyboardShortcuts({
-    handleSave: requestSave, setNodes, setEdges, undo, redo, fitView,
+    handleSave: requestSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
     graphRef, clipboard, nodeIdCounter,
     setSelectedNode, setPreviewData: (d: null) => setPreviewData(d),
     clearTrace,
@@ -507,7 +507,7 @@ function FlowEditor() {
     handleCreateInstance, handleRenameNode, handleAutoLayout, isAutoLayouting,
   } = useNodeHandlers({
     graphRef, nodeIdCounter, lastSelectedNodeRef,
-    setNodes, setEdges, setSelectedNode,
+    setNodes, setNodesAndEdges, setSelectedNode,
     setPreviewData, fitView,
   })
 

--- a/frontend/src/hooks/__tests__/useGraphCanvasState.test.ts
+++ b/frontend/src/hooks/__tests__/useGraphCanvasState.test.ts
@@ -37,6 +37,29 @@ describe("useGraphCanvasState", () => {
     expect(result.current.canUndo).toBe(true)
   })
 
+  it("setNodesAndEdges applies both node and edge changes as one undo entry", () => {
+    const initial = [makeNode("n1"), makeNode("n2")]
+    const initialEdges = [makeEdge("n1", "n2", { id: "e1" })]
+    const { result } = renderHook(() => useGraphCanvasState(initial, initialEdges))
+    // Delete n1 and its edge in a single combined gesture.
+    act(() => {
+      result.current.setNodesAndEdges(
+        (nds) => nds.filter((n) => n.id !== "n1"),
+        (eds) => eds.filter((e) => e.source !== "n1" && e.target !== "n1"),
+      )
+    })
+    expect(result.current.nodes.map((n) => n.id)).toEqual(["n2"])
+    expect(result.current.edges).toHaveLength(0)
+    // Exactly one undo entry — a single undo restores nodes AND edges together.
+    expect(result.current.canUndo).toBe(true)
+    act(() => {
+      result.current.undo()
+    })
+    expect(result.current.nodes).toHaveLength(2)
+    expect(result.current.edges).toHaveLength(1)
+    expect(result.current.canUndo).toBe(false)
+  })
+
   it("undo restores previous state", () => {
     const initial = [makeNode("n1")]
     const { result } = renderHook(() => useGraphCanvasState(initial, []))

--- a/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -10,6 +10,7 @@ function makeParams(overrides: Partial<Parameters<typeof useKeyboardShortcuts>[0
     handleSave: vi.fn(),
     setNodes: vi.fn(),
     setEdges: vi.fn(),
+    setNodesAndEdges: vi.fn(),
     undo: vi.fn(),
     redo: vi.fn(),
     fitView: vi.fn(),
@@ -149,8 +150,12 @@ describe("useKeyboardShortcuts", () => {
       edges: [],
     }
     fireKey("v", { ctrlKey: true })
-    expect(params.setNodes).toHaveBeenCalledOnce()
-    expect(params.setEdges).toHaveBeenCalledOnce()
+    // Undo-atomicity: paste adds nodes + their edges in ONE combined call, so
+    // a single ⌘/Ctrl-Z removes the whole paste — never separate setNodes +
+    // setEdges (two undo snapshots).
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setEdges).not.toHaveBeenCalled()
     const toasts = useToastStore.getState().toasts
     expect(toasts[toasts.length - 1]).toMatchObject({ type: "info", text: "Pasted 1 node" })
   })
@@ -167,8 +172,8 @@ describe("useKeyboardShortcuts", () => {
       edges: [],
     }
     fireKey("v", { ctrlKey: true })
-    expect(params.setNodes).toHaveBeenCalledOnce()
-    const updater = vi.mocked(params.setNodes).mock.calls[0][0] as (nds: Node[]) => Node[]
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
+    const updater = vi.mocked(params.setNodesAndEdges).mock.calls[0][0] as (nds: Node[]) => Node[]
     const result = updater(params.graphRef.current.nodes)
     // Original node + 1 pasted (polars), singleton (apiInput) filtered out
     expect(result).toHaveLength(2)
@@ -186,7 +191,7 @@ describe("useKeyboardShortcuts", () => {
       edges: [],
     }
     fireKey("v", { ctrlKey: true })
-    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
   })
 
   it("Ctrl+V allows pasting singleton when it does not exist in graph", () => {
@@ -198,12 +203,12 @@ describe("useKeyboardShortcuts", () => {
       edges: [],
     }
     fireKey("v", { ctrlKey: true })
-    expect(params.setNodes).toHaveBeenCalledOnce()
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
   })
 
   it("Ctrl+V with empty clipboard does nothing", () => {
     fireKey("v", { ctrlKey: true })
-    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
   })
 
   it("Delete removes selected nodes", () => {
@@ -216,8 +221,11 @@ describe("useKeyboardShortcuts", () => {
       { id: "e1", source: "n1", target: "n2" } as Edge,
     ]
     fireKey("Delete")
-    expect(params.setNodes).toHaveBeenCalled()
-    expect(params.setEdges).toHaveBeenCalled()
+    // Undo-atomicity: node + its edges removed in ONE combined call — never
+    // separate setNodes + setEdges (two undo snapshots).
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setEdges).not.toHaveBeenCalled()
     expect(params.setSelectedNode).toHaveBeenCalledWith(null)
     expect(params.setPreviewData).toHaveBeenCalledWith(null)
   })
@@ -228,7 +236,9 @@ describe("useKeyboardShortcuts", () => {
     ]
     params.graphRef.current.edges = []
     fireKey("Delete")
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
     expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setEdges).not.toHaveBeenCalled()
   })
 
   it("Ctrl+G with 2+ selected opens submodel dialog", () => {
@@ -389,6 +399,7 @@ describe("useKeyboardShortcuts", () => {
     params.graphRef.current.nodes = []
     params.graphRef.current.edges = []
     fireKey("Delete")
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
     expect(params.setNodes).not.toHaveBeenCalled()
     expect(params.setEdges).not.toHaveBeenCalled()
   })
@@ -412,6 +423,7 @@ describe("useKeyboardShortcuts", () => {
     const input = document.createElement("input")
     document.body.appendChild(input)
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "Delete", bubbles: true }))
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
     expect(params.setNodes).not.toHaveBeenCalled()
     document.body.removeChild(input)
   })
@@ -484,8 +496,9 @@ describe("useKeyboardShortcuts", () => {
       { id: "e1", source: "n1", target: "n2" } as Edge,
     ]
     fireKey("Backspace")
-    expect(params.setNodes).toHaveBeenCalled()
-    expect(params.setEdges).toHaveBeenCalled()
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setEdges).not.toHaveBeenCalled()
     expect(params.setSelectedNode).toHaveBeenCalledWith(null)
   })
 })

--- a/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
@@ -31,7 +31,7 @@ function makeParams() {
     nodeIdCounter: { current: 10 },
     lastSelectedNodeRef: { current: null as Node | null },
     setNodes: vi.fn(),
-    setEdges: vi.fn(),
+    setNodesAndEdges: vi.fn(),
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),
@@ -106,10 +106,11 @@ describe("useNodeHandlers — cache cleanup deferred on delete (#32)", () => {
     const { result } = renderHook(() => useNodeHandlers(params))
 
     let snapshotDuringSetNodes: boolean | null = null
-    // Arrange setNodes to capture whether the cache is still intact
-    // at the moment the setter is invoked.  If clearNode runs BEFORE
-    // setNodes, snapshotDuringSetNodes will be false (bug).
-    params.setNodes.mockImplementationOnce(() => {
+    // Arrange the graph setter to capture whether the cache is still intact
+    // at the moment it is invoked.  If clearNode runs BEFORE the mutation,
+    // snapshotDuringSetNodes will be false (bug). Delete now goes through the
+    // atomic setNodesAndEdges, so hook that.
+    params.setNodesAndEdges.mockImplementationOnce(() => {
       const res = useNodeResultsStore.getState().solveResults["n1"]
       snapshotDuringSetNodes = !!res
     })
@@ -118,7 +119,7 @@ describe("useNodeHandlers — cache cleanup deferred on delete (#32)", () => {
       result.current.handleDeleteNode("n1")
     })
 
-    // Cache must still exist the instant setNodes was called.
+    // Cache must still exist the instant the graph mutation was applied.
     expect(snapshotDuringSetNodes).toBe(true)
   })
 

--- a/frontend/src/hooks/__tests__/useNodeHandlers.gaps.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.gaps.test.ts
@@ -25,7 +25,7 @@ function makeParams() {
     nodeIdCounter: { current: 10 },
     lastSelectedNodeRef: { current: null as Node | null },
     setNodes: vi.fn(),
-    setEdges: vi.fn(),
+    setNodesAndEdges: vi.fn(),
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),

--- a/frontend/src/hooks/__tests__/useNodeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.test.ts
@@ -17,7 +17,7 @@ function makeParams() {
     nodeIdCounter: { current: 10 },
     lastSelectedNodeRef: { current: null as Node | null },
     setNodes: vi.fn(),
-    setEdges: vi.fn(),
+    setNodesAndEdges: vi.fn(),
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),
@@ -37,23 +37,26 @@ describe("useNodeHandlers", () => {
     vi.restoreAllMocks()
   })
 
-  it("handleDeleteNode removes node and connected edges", () => {
+  it("handleDeleteNode removes node and connected edges in ONE atomic step", () => {
     const params = makeParams()
     const n1 = makeNode("n1")
     const n2 = makeNode("n2")
-    params.graphRef.current = {
-      nodes: [n1, n2],
-      edges: [{ id: "e1", source: "n1", target: "n2" } as Edge],
-    }
+    const edges = [{ id: "e1", source: "n1", target: "n2" } as Edge]
+    params.graphRef.current = { nodes: [n1, n2], edges }
     const { result } = renderHook(() => useNodeHandlers(params))
     act(() => {
       result.current.handleDeleteNode("n1")
     })
-    // setNodes/setEdges are called with updater functions
-    const nodesUpdater = params.setNodes.mock.calls[0][0] as () => Node[]
-    const edgesUpdater = params.setEdges.mock.calls[0][0] as () => Edge[]
-    expect(nodesUpdater()).toEqual([n2])
-    expect(edgesUpdater()).toEqual([])
+    // Undo-atomicity: exactly one combined setNodesAndEdges call — never a
+    // separate setNodes then setEdges (that would be two undo snapshots).
+    expect(params.setNodesAndEdges).toHaveBeenCalledOnce()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    const [nodesUpdater, edgesUpdater] = params.setNodesAndEdges.mock.calls[0] as [
+      (nds: Node[]) => Node[],
+      (eds: Edge[]) => Edge[],
+    ]
+    expect(nodesUpdater([n1, n2])).toEqual([n2])
+    expect(edgesUpdater(edges)).toEqual([])
   })
 
   it("handleDeleteNode clears selected node if it was selected", () => {

--- a/frontend/src/hooks/useGraphCanvasState.ts
+++ b/frontend/src/hooks/useGraphCanvasState.ts
@@ -106,6 +106,18 @@ export default function useGraphCanvasState(
     [],
   )
 
+  // Combined node+edge mutation as one undo step. Delete/paste gestures must
+  // use this instead of setNodes-then-setEdges (which pushes two snapshots).
+  const setNodesAndEdges = useCallback(
+    (
+      nodesUpdater: Node[] | ((nds: Node[]) => Node[]),
+      edgesUpdater: Edge[] | ((eds: Edge[]) => Edge[]),
+    ) => {
+      useGraphStore.getState().setNodesAndEdges(nodesUpdater, edgesUpdater)
+    },
+    [],
+  )
+
   const setNodesRaw = useCallback((updater: Node[] | ((nds: Node[]) => Node[])) => {
     useGraphStore.getState().setNodesRaw(updater)
   }, [])
@@ -133,6 +145,7 @@ export default function useGraphCanvasState(
     edges,
     setNodes,
     setEdges,
+    setNodesAndEdges,
     setNodesRaw,
     setEdgesRaw,
     onNodesChange,

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -10,6 +10,10 @@ interface KeyboardShortcutsParams {
   handleSave: () => void
   setNodes: (updater: Node[] | ((nds: Node[]) => Node[])) => void
   setEdges: (updater: Edge[] | ((eds: Edge[]) => Edge[])) => void
+  setNodesAndEdges: (
+    nodes: Node[] | ((nds: Node[]) => Node[]),
+    edges: Edge[] | ((eds: Edge[]) => Edge[]),
+  ) => void
   undo: () => void
   redo: () => void
   fitView: (options?: { padding?: number }) => void
@@ -24,7 +28,7 @@ interface KeyboardShortcutsParams {
 }
 
 export default function useKeyboardShortcuts({
-  handleSave, setNodes, setEdges, undo, redo, fitView,
+  handleSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
   graphRef, clipboard, nodeIdCounter,
   setSelectedNode, setPreviewData, clearTrace, closePanel,
   isInsideSubmodel,
@@ -112,8 +116,13 @@ export default function useKeyboardShortcuts({
           if (!newSource || !newTarget) return []
           return [{ ...ed, id: `e-${newSource}-${newTarget}`, source: newSource, target: newTarget }]
         })
-        setNodes((nds) => [...nds.map((n) => ({ ...n, selected: false })), ...newNodes])
-        setEdges((eds) => [...eds, ...newEdges])
+        // Pasted nodes + their internal edges added in ONE undo step, so a
+        // single ⌘/Ctrl-Z removes the whole paste (the undo-atomicity bug
+        // class — setNodes-then-setEdges would push two snapshots).
+        setNodesAndEdges(
+          (nds) => [...nds.map((n) => ({ ...n, selected: false })), ...newNodes],
+          (eds) => [...eds, ...newEdges],
+        )
         addToast("info", `Pasted ${newNodes.length} node${newNodes.length > 1 ? "s" : ""}`)
         return
       }
@@ -177,8 +186,13 @@ export default function useKeyboardShortcuts({
         const selectedEdgeIds = new Set(currentEdges.filter((ed) => ed.selected).map((ed) => ed.id))
         if (selectedNodeIds.size === 0 && selectedEdgeIds.size === 0) return
         if (selectedNodeIds.size > 0) {
-          setNodes(currentNodes.filter((n) => !selectedNodeIds.has(n.id)))
-          setEdges(currentEdges.filter((ed) => !selectedNodeIds.has(ed.source) && !selectedNodeIds.has(ed.target)))
+          // Nodes + their edges removed in ONE undo step. setNodes-then-setEdges
+          // would push two snapshots, so one delete would take two undos to
+          // reverse (the undo-atomicity bug class).
+          setNodesAndEdges(
+            currentNodes.filter((n) => !selectedNodeIds.has(n.id)),
+            currentEdges.filter((ed) => !selectedNodeIds.has(ed.source) && !selectedNodeIds.has(ed.target)),
+          )
           setSelectedNode(null)
           setPreviewData(null)
           // Clean up store state for deleted nodes
@@ -186,6 +200,8 @@ export default function useKeyboardShortcuts({
             useNodeResultsStore.getState().clearNode(nid)
           }
         } else {
+          // Pure-edge delete: only edges selected, no nodes — a single setEdges
+          // is already one snapshot.
           setEdges(currentEdges.filter((ed) => !selectedEdgeIds.has(ed.id)))
         }
       }
@@ -193,7 +209,7 @@ export default function useKeyboardShortcuts({
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
   }, [
-    handleSave, setNodes, setEdges, undo, redo, fitView,
+    handleSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
     graphRef, clipboard, nodeIdCounter,
     setSelectedNode, setPreviewData, clearTrace, closePanel,
     addToast, setShortcutsOpen, setSubmodelDialog, setNodeSearchOpen, isInsideSubmodel,

--- a/frontend/src/hooks/useNodeHandlers.ts
+++ b/frontend/src/hooks/useNodeHandlers.ts
@@ -20,7 +20,10 @@ type UseNodeHandlersParams = {
   nodeIdCounter: MutableRefObject<number>
   lastSelectedNodeRef: MutableRefObject<Node | null>
   setNodes: (updater: (nds: Node[]) => Node[]) => void
-  setEdges: (updater: (eds: Edge[]) => Edge[]) => void
+  setNodesAndEdges: (
+    nodes: (nds: Node[]) => Node[],
+    edges: (eds: Edge[]) => Edge[],
+  ) => void
   setSelectedNode: (updater: React.SetStateAction<Node | null>) => void
   setPreviewData: (updater: React.SetStateAction<PreviewData | null>) => void
   fitView: (opts?: { padding?: number }) => void
@@ -31,7 +34,7 @@ export default function useNodeHandlers({
   nodeIdCounter: nodeIdCounterRef,
   lastSelectedNodeRef,
   setNodes,
-  setEdges,
+  setNodesAndEdges,
   setSelectedNode,
   setPreviewData,
   fitView,
@@ -44,9 +47,13 @@ export default function useNodeHandlers({
   const setSubmodelDialog = useUIStore((s) => s.setSubmodelDialog)
 
   const handleDeleteNode = useCallback((id: string) => {
-    const { nodes: n, edges: e } = graphRef.current
-    setNodes(() => n.filter((node) => node.id !== id))
-    setEdges(() => e.filter((edge) => edge.source !== id && edge.target !== id))
+    // Node + its edges removed as ONE undo step. setNodes-then-setEdges would
+    // push two snapshots, so a single delete would need two undos to reverse
+    // (the undo-atomicity bug class).
+    setNodesAndEdges(
+      (nds) => nds.filter((node) => node.id !== id),
+      (eds) => eds.filter((edge) => edge.source !== id && edge.target !== id),
+    )
     setSelectedNode((prev) => (prev?.id === id ? null : prev))
     setPreviewData((prev) => (prev?.nodeId === id ? null : prev))
     // Defer cache cleanup by one task tick (Issue #32). If `clearNode(id)`
@@ -63,7 +70,7 @@ export default function useNodeHandlers({
     if (uiState.renameDialog?.nodeId === id) setRenameDialog(null)
     const subDlg = uiState.submodelDialog
     if (subDlg && subDlg.nodeIds.includes(id)) setSubmodelDialog(null)
-  }, [graphRef, lastSelectedNodeRef, setNodes, setEdges, setSelectedNode, setPreviewData, clearNode, setRenameDialog, setSubmodelDialog])
+  }, [setNodesAndEdges, lastSelectedNodeRef, setSelectedNode, setPreviewData, clearNode, setRenameDialog, setSubmodelDialog])
 
   const handleDuplicateNode = useCallback((id: string) => {
     const { nodes: n } = graphRef.current

--- a/frontend/src/stores/__tests__/useGraphStore.undoAtomicity.test.ts
+++ b/frontend/src/stores/__tests__/useGraphStore.undoAtomicity.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Undo-atomicity regression suite (the "two-snapshot collapse").
+ *
+ * Guards the bug class where one user gesture that mutates BOTH nodes and
+ * edges recorded TWO undo entries (setNodes then setEdges each snapshotting),
+ * so a single ⌘/Ctrl-Z only rewound half the gesture. The fix routes such
+ * gestures through the combined `setNodesAndEdges`, which snapshots exactly
+ * once.
+ *
+ * Per Nick's 2026-06-19 testing note on BUGS.md §"Deleting a node is not one
+ * atomic undo": the count was a CONSTANT two regardless of selection size, so
+ * the fix must be regression-tested against multi-node deletes MIXING
+ * connected and unconnected nodes, and pure-edge deletes — to prove the
+ * collapse is genuinely gone, not papered over for the 1-node case. These
+ * tests assert the actual undo-stack depth and a single-undo restoration,
+ * which is the real contract (a hook-level "called once" assertion cannot see
+ * the snapshot count).
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { act } from "@testing-library/react"
+import useGraphStore from "../useGraphStore"
+import { makeNode, makeEdge } from "../../test-utils/factories"
+import type { Node, Edge } from "@xyflow/react"
+
+function resetStore() {
+  useGraphStore.setState({
+    nodes: [],
+    edges: [],
+    preamble: "",
+    lastSavedSnapshot: null,
+    undoStack: [],
+    redoStack: [],
+    structuralVersion: 0,
+    structuralFingerprint: "nodes:||edges:||preamble:\"\"",
+    panelContextVersion: 0,
+    panelContextFingerprint: "nodes:||edges:",
+    persistedFingerprint: "nodes:[]|edges:[]|preamble:\"\"",
+    savedPersistedFingerprint: null,
+    dirty: false,
+  })
+}
+
+/** Load a graph without history, then clear the stacks for a clean baseline. */
+function seed(nodes: Node[], edges: Edge[]) {
+  const store = useGraphStore.getState()
+  act(() => {
+    store.setNodesRaw(nodes)
+    store.setEdgesRaw(edges)
+  })
+  useGraphStore.setState({ undoStack: [], redoStack: [] })
+}
+
+/** The exact node+edge filter the delete handlers apply for a selection. */
+function deleteSelection(selectedIds: Set<string>) {
+  act(() => {
+    useGraphStore.getState().setNodesAndEdges(
+      (nds) => nds.filter((n) => !selectedIds.has(n.id)),
+      (eds) => eds.filter((e) => !selectedIds.has(e.source) && !selectedIds.has(e.target)),
+    )
+  })
+}
+
+const ids = (arr: { id: string }[]) => arr.map((x) => x.id).sort()
+
+describe("useGraphStore — undo atomicity", () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it("single-node delete (with edges) is ONE undo entry; one undo restores node AND edges", () => {
+    // a -> b -> c ; delete the middle node b (edges on both sides).
+    seed(
+      [makeNode("a"), makeNode("b"), makeNode("c")],
+      [makeEdge("a", "b"), makeEdge("b", "c")],
+    )
+
+    deleteSelection(new Set(["b"]))
+
+    // Exactly one snapshot for the whole gesture — the crux of the bug class.
+    expect(useGraphStore.getState().undoStack).toHaveLength(1)
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "c"])
+    expect(useGraphStore.getState().edges).toHaveLength(0)
+
+    // A SINGLE undo brings back the node and BOTH its edges together.
+    act(() => useGraphStore.getState().undo())
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "b", "c"])
+    expect(ids(useGraphStore.getState().edges)).toEqual(["e_a_b", "e_b_c"])
+
+    // And there is no leftover second snapshot — the undo stack is empty and
+    // the whole gesture sits as one entry on the redo stack.
+    expect(useGraphStore.getState().undoStack).toHaveLength(0)
+    expect(useGraphStore.getState().redoStack).toHaveLength(1)
+  })
+
+  it("multi-node delete mixing CONNECTED and UNCONNECTED nodes is ONE undo entry", () => {
+    // a -> b -> c, a -> e, plus isolated node d.
+    // Delete { b (connected, mid-chain), d (unconnected) } in one gesture.
+    // Expect: b removes edges a->b and b->c; d removes nothing; a->e survives.
+    seed(
+      [makeNode("a"), makeNode("b"), makeNode("c"), makeNode("d"), makeNode("e")],
+      [makeEdge("a", "b"), makeEdge("b", "c"), makeEdge("a", "e")],
+    )
+
+    deleteSelection(new Set(["b", "d"]))
+
+    expect(useGraphStore.getState().undoStack).toHaveLength(1)
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "c", "e"])
+    expect(ids(useGraphStore.getState().edges)).toEqual(["e_a_e"])
+
+    // One undo restores every deleted node (connected + unconnected) and every
+    // deleted edge, atomically.
+    act(() => useGraphStore.getState().undo())
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "b", "c", "d", "e"])
+    expect(ids(useGraphStore.getState().edges)).toEqual(["e_a_b", "e_a_e", "e_b_c"])
+    expect(useGraphStore.getState().undoStack).toHaveLength(0)
+  })
+
+  it("selection size does not scale undo entries — 4 nodes deleted is still ONE undo", () => {
+    // Nick's note: the count was a CONSTANT two before the fix, so it must be
+    // a CONSTANT one after — independent of how many nodes/edges are removed.
+    seed(
+      [makeNode("a"), makeNode("b"), makeNode("c"), makeNode("d"), makeNode("e")],
+      [makeEdge("a", "b"), makeEdge("b", "c"), makeEdge("c", "d"), makeEdge("d", "e")],
+    )
+
+    deleteSelection(new Set(["a", "b", "c", "d"]))
+
+    expect(useGraphStore.getState().undoStack).toHaveLength(1)
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["e"])
+    expect(useGraphStore.getState().edges).toHaveLength(0)
+
+    act(() => useGraphStore.getState().undo())
+    expect(useGraphStore.getState().nodes).toHaveLength(5)
+    expect(useGraphStore.getState().edges).toHaveLength(4)
+    expect(useGraphStore.getState().undoStack).toHaveLength(0)
+  })
+
+  it("pure-edge delete (no nodes) is ONE undo entry; one undo restores the edge", () => {
+    // The pure-edge path keeps a single setEdges (already one snapshot). Nick
+    // asked for it to be regression-covered alongside the node cases.
+    seed([makeNode("a"), makeNode("b")], [makeEdge("a", "b")])
+
+    act(() => {
+      useGraphStore.getState().setEdges((eds) => eds.filter((e) => e.id !== "e_a_b"))
+    })
+
+    expect(useGraphStore.getState().undoStack).toHaveLength(1)
+    expect(useGraphStore.getState().edges).toHaveLength(0)
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "b"])
+
+    act(() => useGraphStore.getState().undo())
+    expect(ids(useGraphStore.getState().edges)).toEqual(["e_a_b"])
+    expect(useGraphStore.getState().undoStack).toHaveLength(0)
+  })
+
+  it("paste (nodes + internal edges) is ONE undo entry; one undo removes the whole paste", () => {
+    seed([makeNode("keep")], [])
+
+    const pastedNodes = [makeNode("p1"), makeNode("p2")]
+    const pastedEdge = makeEdge("p1", "p2")
+    act(() => {
+      useGraphStore.getState().setNodesAndEdges(
+        (nds) => [...nds, ...pastedNodes],
+        (eds) => [...eds, pastedEdge],
+      )
+    })
+
+    expect(useGraphStore.getState().undoStack).toHaveLength(1)
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["keep", "p1", "p2"])
+    expect(ids(useGraphStore.getState().edges)).toEqual(["e_p1_p2"])
+
+    // One undo removes both pasted nodes AND the pasted edge together.
+    act(() => useGraphStore.getState().undo())
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["keep"])
+    expect(useGraphStore.getState().edges).toHaveLength(0)
+  })
+
+  it("redo re-applies the combined gesture in one step", () => {
+    seed(
+      [makeNode("a"), makeNode("b"), makeNode("c")],
+      [makeEdge("a", "b"), makeEdge("b", "c")],
+    )
+    deleteSelection(new Set(["b"]))
+    act(() => useGraphStore.getState().undo())
+    // Back to full graph.
+    expect(useGraphStore.getState().nodes).toHaveLength(3)
+
+    act(() => useGraphStore.getState().redo())
+    // One redo re-removes the node and both edges together.
+    expect(ids(useGraphStore.getState().nodes)).toEqual(["a", "c"])
+    expect(useGraphStore.getState().edges).toHaveLength(0)
+    expect(useGraphStore.getState().redoStack).toHaveLength(0)
+  })
+
+  it("setNodesAndEdges pushes exactly one snapshot per call (store-level gesture contract)", () => {
+    // DYLE §Undo atomicity candidate②: any public gesture helper that mutates
+    // graph state pushes exactly one snapshot. Three successive combined
+    // gestures => three undo entries (one each), never six.
+    seed([makeNode("a"), makeNode("b"), makeNode("c")], [])
+    const store = useGraphStore.getState()
+
+    act(() => store.setNodesAndEdges((nds) => nds.filter((n) => n.id !== "a"), (eds) => eds))
+    act(() => store.setNodesAndEdges((nds) => nds.filter((n) => n.id !== "b"), (eds) => eds))
+    act(() => store.setNodesAndEdges((nds) => nds.filter((n) => n.id !== "c"), (eds) => eds))
+
+    expect(useGraphStore.getState().undoStack).toHaveLength(3)
+    expect(useGraphStore.getState().nodes).toHaveLength(0)
+  })
+})

--- a/frontend/src/stores/useGraphStore.ts
+++ b/frontend/src/stores/useGraphStore.ts
@@ -99,6 +99,17 @@ export interface GraphStore {
   // History-aware actions
   setNodes: (updater: Node[] | ((nds: Node[]) => Node[])) => void
   setEdges: (updater: Edge[] | ((eds: Edge[]) => Edge[])) => void
+  /**
+   * Mutate nodes AND edges in a single history-aware step: one snapshot, one
+   * `set()`. Use this for any gesture that touches both (delete, paste, cut)
+   * so it collapses to exactly one undo entry — calling `setNodes` then
+   * `setEdges` pushes TWO snapshots, so one delete would take two undos to
+   * reverse (the undo-atomicity bug class).
+   */
+  setNodesAndEdges: (
+    nodes: Node[] | ((nds: Node[]) => Node[]),
+    edges: Edge[] | ((eds: Edge[]) => Edge[]),
+  ) => void
   setPreamble: (value: string) => void
 
   // Raw actions (skip history push — for mid-drag, WS sync, load)
@@ -516,6 +527,40 @@ const useGraphStore = create<GraphStore>()((set, get) => {
           }
         })(),
       }))
+    },
+
+    setNodesAndEdges: (nodesUpdater, edgesUpdater) => {
+      set((state) => {
+        // One snapshot for the whole gesture, captured BEFORE either mutation
+        // (pushSnapshotInternal reads current state), then both node and edge
+        // updaters applied in this single set() — so nodes and edges never
+        // render in an inconsistent in-between state, and a single undo
+        // restores both.
+        const undoStack = pushSnapshotInternal()
+        const nodes = applyUpdater(state.nodes, nodesUpdater)
+        const edges = applyUpdater(state.edges, edgesUpdater)
+        const nextPersistedFingerprint = computePersistedFingerprint(nodes, edges, state.preamble)
+        const nextFingerprint = computeStructuralFingerprint(nodes, edges, state.preamble)
+        return {
+          undoStack,
+          redoStack: [],
+          nodes,
+          edges,
+          ...computePanelContextPatch(state, nodes, edges),
+          persistedFingerprint: nextPersistedFingerprint,
+          dirty: computeDirty(
+            state.lastSavedSnapshot,
+            state.savedPersistedFingerprint,
+            nextPersistedFingerprint,
+          ),
+          ...(nextFingerprint === state.structuralFingerprint
+            ? {}
+            : {
+                structuralFingerprint: nextFingerprint,
+                structuralVersion: state.structuralVersion + 1,
+              }),
+        }
+      })
     },
 
     setPreamble: (value) => {


### PR DESCRIPTION
## Problem

Deleting a node (keyboard **Delete** or context-menu) and **pasting** nodes each called the history-aware `setNodes` then `setEdges`, and both store setters push an undo snapshot — so one user gesture recorded **two** undo entries. A single ⌘/Ctrl-Z only rewound the edge removal; a second was needed to restore the node.

## Fix

Added a combined history-aware store action `setNodesAndEdges` (`frontend/src/stores/useGraphStore.ts`) that captures **one** snapshot and applies both the node and edge updaters in a single `set()` — so nodes and edges never render in an in-between state, and a single undo restores both. Routed keyboard Delete, context-menu delete (`handleDeleteNode`), and keyboard paste through it. Pure-edge delete keeps its single `setEdges` (already one snapshot). Removed the now-dead `setEdges` param from `useNodeHandlers`.

This matches the pre-existing house pattern (`onNodesChange` / `useEdgeHandlers`: `pushSnapshot()` once then raw-set), expressed as one atomic node+edge store primitive.

## Scope

Delete (keyboard + context-menu) and paste. The related **per-keystroke inline-field undo** flood (same bug class) is a **separate follow-up PR** — a different code path (~17 sidebar editors) with a typing-UX implication, kept out of this tight change.

## Tests

- New store-level regression battery `frontend/src/stores/__tests__/useGraphStore.undoAtomicity.test.ts`: asserts the undo stack grows by exactly one per combined gesture and that a single `undo()` restores both nodes and edges, across single-node-with-edges, **multi-node mixing connected + unconnected nodes**, a 4-node delete (size-independence), **pure-edge delete**, paste, and redo.
- Hook suites (`useKeyboardShortcuts`, `useNodeHandlers`) updated to assert both delete paths and paste call `setNodesAndEdges` **once**, never `setNodes` then `setEdges`.

## Verification

- Full frontend suite green (**270 files, 5225 passed**) and `tsc -b --noEmit` clean, on this branch forward-merged onto the current `main` tip.
- Live in the running app: selecting a node with edges and pressing Delete, then ⌘Z **once**, restored the node and all its edges together in a single undo (store `undoStack: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
