### PR TITLE
Scan the test corpus once in the write-sandbox lint gate

### DIFF
--- a/tests/test_write_sandbox_lint.py
+++ b/tests/test_write_sandbox_lint.py
@@ -50,6 +50,8 @@ import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 from tests._write_sandbox import ENV_ROOT, STRICT_FILES
 
 _TESTS_DIR = Path(__file__).resolve().parent
@@ -525,11 +527,16 @@ EXPECTED_VIOLATIONS: dict[str, int] = {
 }
 
 
+@pytest.mark.timeout(180)
 def test_write_apis_derive_from_scratch_fixture() -> None:
-    observed = {rel: len(violations) for rel, violations in scan_tests().items()}
+    # The full-corpus AST scan is slow and load-sensitive under `-n 4` +
+    # coverage, so scan once and give the test headroom beyond the default
+    # pytest-timeout.
+    scanned = scan_tests()
+    observed = {rel: len(violations) for rel, violations in scanned.items()}
     details = {
         rel: [f"  {v.file}:{v.line} {v.kind} ({v.detail})" for v in violations]
-        for rel, violations in scan_tests().items()
+        for rel, violations in scanned.items()
     }
 
     unexpected = {


### PR DESCRIPTION
## Summary
- `test_write_apis_derive_from_scratch_fixture` called `scan_tests()` twice — once for `observed` and again inside the `details` dict comprehension — doubling a full AST scan of every test file. With the test corpus growth from the mid-July merges, the doubled scan pushed past the 60s pytest-timeout under the preflight gate's `-n 4` + coverage load (failed 2/2 post-merge runs; passed in isolation).
- Fix: scan once, reuse the result for both the assertion set and the failure-detail map. Also raised this test's explicit timeout for headroom under parallel load.

## Testing
- `uv run pytest tests/test_write_sandbox_lint.py -q` green
- Full `scripts/preflight.sh` green (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)