### PR TITLE
Fold artifact byte identity into the in-process model cache key

### DIFF
--- a/src/haute/_mlflow_io.py
+++ b/src/haute/_mlflow_io.py
@@ -308,10 +308,41 @@ def _model_cache_key(
     version: str,
     artifact_path: str,
     task: str,
+    artifact_fingerprint: str,
 ) -> tuple[str, ...]:
+    """Build the in-process model cache key.
+
+    ``artifact_fingerprint`` folds the identity of the model artifact
+    *bytes* into the key (see :func:`_local_artifact_fingerprint`), so a
+    re-logged run or a ``version="latest"`` retrain-in-place — same run
+    reference, different bytes — misses instead of serving the previously
+    loaded model on a long-lived server.  It is a required keyword so no
+    call site can silently drop the byte-identity component.  Pass ``""``
+    only where no local artifact file exists to fingerprint (pyfunc
+    models loaded through MLflow by URI — a documented residual).
+
+    ``run_id`` stays in slot 1: targeted ``clear_model_cache(run_id=...)``
+    eviction matches on ``key[1]``.
+    """
     if version:
-        return (source_type, run_id, version, artifact_path, task)
-    return (source_type, run_id, artifact_path, task)
+        return (source_type, run_id, version, artifact_path, task, artifact_fingerprint)
+    return (source_type, run_id, artifact_path, task, artifact_fingerprint)
+
+
+def _local_artifact_fingerprint(artifact_path: str, local_path: str) -> str:
+    """Byte-identity fingerprint of the local model artifact file.
+
+    Reuses the deploy path's
+    :func:`~haute.deploy._scorer.artifact_identity_fingerprint` derivation
+    (stat-gated content hash) rather than minting a parallel one, so the
+    serve-path in-process cache and the deploy output-schema cache agree
+    on what "the same artifact" means.  Imported lazily to avoid a
+    module-import cycle (``haute.deploy._scorer`` imports from this
+    module's dependents).
+    """
+    from haute.deploy._scorer import artifact_identity_fingerprint
+
+    return artifact_identity_fingerprint({artifact_path: local_path})
 
 
 # ---------------------------------------------------------------------------
@@ -781,7 +812,8 @@ def clear_model_cache(run_id: str | None = None) -> int:
         _model_cache.clear()
         _reset_model_cache_stats()
     else:
-        # Cache keys are ``(source_type, resolved_run_id, version_or_artifact, task)``.
+        # Cache keys are ``(source_type, resolved_run_id, [version,]
+        # artifact, task, artifact_fingerprint)`` — run_id is always slot 1.
         # Evict every entry whose run_id slot matches (may be multiple,
         # different task / version per run) and let the cascade handle
         # feature-validation-cache invalidation.  Counters are left
@@ -895,7 +927,10 @@ def load_mlflow_model(
     with categorical feature support.  All other models are loaded via
     MLflow's pyfunc flavor.
 
-    Cached by ``(source_type, identifier, version/artifact, task)``.
+    Cached by ``(source_type, identifier, version/artifact, task,
+    artifact_fingerprint)`` — the fingerprint is the byte identity of the
+    local model artifact, so re-logging a run or retraining a
+    ``version="latest"`` model in place invalidates the in-process entry.
 
     Args:
         source_type: ``"run"`` to load from a specific run, or ``"registered"``
@@ -921,25 +956,33 @@ def load_mlflow_model(
     # resolve_mlflow_source() (which hits the MLflow tracking server)
     # on every invocation when the model is already cached.
     # For source_type="run" with a known artifact_path, the cache key
-    # components are fully determined without any network call.
+    # components are fully determined without any network call.  The
+    # artifact-fingerprint component is derived from the disk-cached file,
+    # so the in-process entry can never outlive the bytes it was loaded
+    # from; a fingerprint change (re-log / retrain-in-place) is a miss.
     if source_type == "run" and run_id and artifact_path:
-        fast_key = _model_cache_key(
-            source_type=source_type,
-            run_id=run_id,
-            version="",
-            artifact_path=artifact_path,
-            task=task,
-        )
-        cached = _model_cache.get(fast_key)
-        if cached is not None:
-            _record_cache_hit(
-                run_id=run_id,
-                artifact_path=artifact_path,
-                flavor=_flavor_from_artifact(artifact_path),
-            )
-            return cached
         flavor = _flavor_from_artifact(artifact_path)
-        if flavor in ("catboost", "rustystats"):
+        if flavor == "pyfunc":
+            # No local artifact file exists to fingerprint — pyfunc loads
+            # by MLflow URI.  Keyed without byte identity (documented
+            # residual in _model_cache_key).
+            fast_key = _model_cache_key(
+                source_type=source_type,
+                run_id=run_id,
+                version="",
+                artifact_path=artifact_path,
+                task=task,
+                artifact_fingerprint="",
+            )
+            cached = _model_cache.get(fast_key)
+            if cached is not None:
+                _record_cache_hit(
+                    run_id=run_id,
+                    artifact_path=artifact_path,
+                    flavor=flavor,
+                )
+                return cached
+        else:
             with _disk_cache_run_in_use(run_id):
                 local_path = _artifact_cache_path(
                     Path.cwd() / ".cache" / "models",
@@ -947,6 +990,24 @@ def load_mlflow_model(
                     artifact_path,
                 )
                 if local_path.is_file():
+                    fast_key = _model_cache_key(
+                        source_type=source_type,
+                        run_id=run_id,
+                        version="",
+                        artifact_path=artifact_path,
+                        task=task,
+                        artifact_fingerprint=_local_artifact_fingerprint(
+                            artifact_path, str(local_path)
+                        ),
+                    )
+                    cached = _model_cache.get(fast_key)
+                    if cached is not None:
+                        _record_cache_hit(
+                            run_id=run_id,
+                            artifact_path=artifact_path,
+                            flavor=flavor,
+                        )
+                        return cached
                     with _artifact_io_lock(run_id, artifact_path):
                         # Single-flight: a concurrent caller may have loaded
                         # this exact model while we waited for the lock.
@@ -997,12 +1058,30 @@ def load_mlflow_model(
     # Detect flavor from artifact path
     flavor = _flavor_from_artifact(resolved_artifact)
 
+    # Resolve the local artifact up front so its byte identity can be part
+    # of the cache key: a "latest" retrain or re-logged run must miss, not
+    # serve the previously loaded model.  For a cached artifact this is a
+    # stat-gated memo lookup; only a genuinely new artifact downloads here.
+    # Pyfunc models load by MLflow URI with no local file to fingerprint —
+    # keyed without byte identity (documented residual in _model_cache_key).
+    local_artifact_path: str | None = None
+    artifact_fp = ""
+    if flavor in ("catboost", "rustystats"):
+        with _disk_cache_run_in_use(resolved_run_id):
+            local_artifact_path = _resolve_artifact_local(
+                mlflow_mod,
+                resolved_run_id,
+                resolved_artifact,
+            )
+            artifact_fp = _local_artifact_fingerprint(resolved_artifact, local_artifact_path)
+
     cache_key = _model_cache_key(
         source_type=source_type,
         run_id=resolved_run_id,
         version=resolved_version,
         artifact_path=resolved_artifact,
         task=task,
+        artifact_fingerprint=artifact_fp,
     )
 
     cached = _model_cache.get(cache_key)
@@ -1052,6 +1131,21 @@ def load_mlflow_model(
                     artifact=resolved_artifact,
                     flavor=flavor,
                     task=task,
+                )
+                # The bounded retry may have deleted and re-downloaded the
+                # artifact; re-derive the fingerprint so the entry is keyed
+                # by the bytes that were actually loaded (stat-gated memo —
+                # a no-op stat when nothing changed).
+                assert local_artifact_path is not None
+                cache_key = _model_cache_key(
+                    source_type=source_type,
+                    run_id=resolved_run_id,
+                    version=resolved_version,
+                    artifact_path=resolved_artifact,
+                    task=task,
+                    artifact_fingerprint=_local_artifact_fingerprint(
+                        resolved_artifact, local_artifact_path
+                    ),
                 )
         else:
             raw_model = _load_pyfunc_model(mlflow_mod, resolved_run_id, resolved_artifact)

--- a/tests/test_mlflow_io.py
+++ b/tests/test_mlflow_io.py
@@ -18,7 +18,9 @@ from haute._mlflow_io import (
     _find_cbm_artifact,
     _find_model_artifact,
     _load_rustystats_model,
+    _local_artifact_fingerprint,
     _model_cache,
+    _model_cache_key,
     _prepare_predict_frame,
     _wrap_catboost,
     _wrap_pyfunc,
@@ -220,10 +222,21 @@ class TestInvalidSourceType:
 
 
 class TestModelCache:
-    def test_cache_hit(self, mock_mlflow_env):
+    def test_cache_hit(self, mock_mlflow_env, tmp_path, monkeypatch):
         """Second call with same args returns cached model without re-download."""
+        monkeypatch.chdir(tmp_path)
+        cached_file = _artifact_cache_path(tmp_path / ".cache" / "models", "abc123", "model.cbm")
+        cached_file.parent.mkdir(parents=True)
+        cached_file.write_bytes(b"model bytes")
         fake_sm = ScoringModel(MagicMock(), ["a"], frozenset(), "catboost")
-        cache_key = ("run", "abc123", "model.cbm", "regression")
+        cache_key = _model_cache_key(
+            source_type="run",
+            run_id="abc123",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(cached_file)),
+        )
         _model_cache.put(cache_key, fake_sm)
 
         mock_mlflow, _, modules_patch, resolve_patch = mock_mlflow_env
@@ -244,11 +257,13 @@ class TestModelCache:
         # download_artifacts should NOT be called (cache hit)
         mock_mlflow.artifacts.download_artifacts.assert_not_called()
 
-    def test_cache_lru_eviction(self, mock_mlflow_env):
+    def test_cache_lru_eviction(self, mock_mlflow_env, tmp_path):
         """Exceeding max cache size evicts oldest entry."""
         for i in range(_MODEL_CACHE_MAX_SIZE + 2):
-            _model_cache.put(("run", f"run_{i}", f"art_{i}", "regression"), MagicMock())
+            _model_cache.put(("run", f"run_{i}", f"art_{i}", "regression", ""), MagicMock())
 
+        local_file = tmp_path / "model.cbm"
+        local_file.write_bytes(b"model bytes")
         fake_model = MagicMock()
         fake_model.feature_names_ = ["a"]
         fake_model.get_cat_feature_indices.return_value = []
@@ -258,7 +273,7 @@ class TestModelCache:
             modules_patch,
             resolve_patch,
             patch("haute._mlflow_io._load_catboost_model", return_value=fake_model),
-            patch("haute._mlflow_io._resolve_artifact_local", return_value="/tmp/model.cbm"),
+            patch("haute._mlflow_io._resolve_artifact_local", return_value=str(local_file)),
             patch("haute._mlflow_io._find_cbm_artifact", return_value="model.cbm"),
         ):
             load_mlflow_model(
@@ -268,7 +283,15 @@ class TestModelCache:
                 task="regression",
             )
 
-        assert ("run", "new_run", "model.cbm", "regression") in _model_cache
+        expected_key = _model_cache_key(
+            source_type="run",
+            run_id="new_run",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(local_file)),
+        )
+        assert expected_key in _model_cache
 
 
 # ---------------------------------------------------------------------------
@@ -1637,10 +1660,21 @@ class TestClearModelCache:
 class TestLoadMlflowModelFastCache:
     """Tests for the fast-path cache check in load_mlflow_model."""
 
-    def test_fast_path_cache_hit_for_run_with_artifact(self):
+    def test_fast_path_cache_hit_for_run_with_artifact(self, tmp_path, monkeypatch):
         """source_type=run with artifact_path hits fast-path cache."""
+        monkeypatch.chdir(tmp_path)
+        cached_file = _artifact_cache_path(tmp_path / ".cache" / "models", "abc123", "model.cbm")
+        cached_file.parent.mkdir(parents=True)
+        cached_file.write_bytes(b"model bytes")
         fake_sm = ScoringModel(MagicMock(), ["a"], frozenset(), "catboost")
-        cache_key = ("run", "abc123", "model.cbm", "regression")
+        cache_key = _model_cache_key(
+            source_type="run",
+            run_id="abc123",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(cached_file)),
+        )
         _model_cache.put(cache_key, fake_sm)
 
         result = load_mlflow_model(
@@ -1682,14 +1716,31 @@ class TestLoadMlflowModelFastCache:
         load_local.assert_called_once_with(str(cached), task="regression")
         resolve_source.assert_not_called()
 
-        cache_key = ("run", "abc123", "model.cbm", "regression")
+        cache_key = _model_cache_key(
+            source_type="run",
+            run_id="abc123",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(cached)),
+        )
         assert _model_cache.get(cache_key) is fake_sm
 
-    def test_post_resolve_cache_hit(self):
+    def test_post_resolve_cache_hit(self, tmp_path):
         """Cache hit after resolve_mlflow_source (second cache check, line 469)."""
+        local_file = tmp_path / "model.cbm"
+        local_file.write_bytes(b"model bytes")
         fake_sm = ScoringModel(MagicMock(), ["a"], frozenset(), "catboost")
-        # Key uses resolved version "" for run-based, artifact_path as third element
-        cache_key = ("run", "abc123", "model.cbm", "regression")
+        # Key uses resolved version "" for run-based; the fingerprint is the
+        # byte identity of the resolved local artifact.
+        cache_key = _model_cache_key(
+            source_type="run",
+            run_id="abc123",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(local_file)),
+        )
         _model_cache.put(cache_key, fake_sm)
 
         with (
@@ -1700,6 +1751,10 @@ class TestLoadMlflowModelFastCache:
             patch(
                 "haute._mlflow_io._find_model_artifact",
                 return_value=("model.cbm", "catboost"),
+            ),
+            patch(
+                "haute._mlflow_io._resolve_artifact_local",
+                return_value=str(local_file),
             ),
         ):
             # No artifact_path → forces resolve + auto-discover, then second cache check hits

--- a/tests/test_mlflow_io_concurrency.py
+++ b/tests/test_mlflow_io_concurrency.py
@@ -913,9 +913,7 @@ class TestLockAcquisitionRaces:
                 version="",
                 artifact_path="model.cbm",
                 task="regression",
-                artifact_fingerprint=_local_artifact_fingerprint(
-                    "model.cbm", str(local_file)
-                ),
+                artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(local_file)),
             )
             _model_cache.put(cache_key, winner_model)
 

--- a/tests/test_mlflow_io_concurrency.py
+++ b/tests/test_mlflow_io_concurrency.py
@@ -41,7 +41,9 @@ from haute._mlflow_io import (
     _active_disk_cache_runs,
     _artifact_cache_path,
     _evict_disk_cache,
+    _local_artifact_fingerprint,
     _model_cache,
+    _model_cache_key,
     _resolve_artifact_local,
     load_mlflow_model,
 )
@@ -783,17 +785,18 @@ class TestLockAcquisitionRaces:
     """
 
     @staticmethod
-    def _hooked_lock(hook):
-        """Return a drop-in for ``_artifact_io_lock`` running *hook* once."""
+    def _hooked_lock(hook, fire_on: int = 1):
+        """Return a drop-in for ``_artifact_io_lock`` running *hook* once,
+        at the *fire_on*-th acquisition."""
         from haute import _mlflow_io
 
         real_lock = _mlflow_io._artifact_io_lock
-        fired = []
+        calls = [0]
 
         def locked(run_id: str, artifact_path: str):
             lock = real_lock(run_id, artifact_path)
-            if not fired:
-                fired.append(True)
+            calls[0] += 1
+            if calls[0] == fire_on:
                 hook()
             return lock
 
@@ -812,7 +815,14 @@ class TestLockAcquisitionRaces:
         cached_file.parent.mkdir(parents=True)
         cached_file.write_bytes(b"bytes")
         winner_model = ScoringModel(_StubCatBoost(), ["a"], frozenset(), "catboost")
-        fast_key = ("run", "run-h", "model.cbm", "regression")
+        fast_key = _model_cache_key(
+            source_type="run",
+            run_id="run-h",
+            version="",
+            artifact_path="model.cbm",
+            task="regression",
+            artifact_fingerprint=_local_artifact_fingerprint("model.cbm", str(cached_file)),
+        )
 
         def winner_populates_cache() -> None:
             _model_cache.put(fast_key, winner_model)
@@ -880,19 +890,42 @@ class TestLockAcquisitionRaces:
 
     def test_resolve_path_waiter_reuses_model_cached_while_waiting(self, tmp_path, monkeypatch):
         """No disk file (resolve path); the 'winner' populates the cache
-        while this caller waits — no download, no load."""
+        while this caller waits for the load lock — no model load.
+
+        The artifact download itself happens before the cache check (its
+        byte identity is part of the cache key), so the winner's entry is
+        keyed at hook time from the freshly downloaded file, and this
+        caller's single download is expected.
+        """
         monkeypatch.chdir(tmp_path)
         winner_model = ScoringModel(_StubCatBoost(), ["a"], frozenset(), "catboost")
-        cache_key = ("run", "run-r", "model.cbm", "regression")
         transport = _FakeTransport()
+        local_file = _artifact_cache_path(
+            tmp_path / ".cache" / "models",
+            "run-r",
+            "model.cbm",
+        )
 
         def winner_populates_cache() -> None:
+            cache_key = _model_cache_key(
+                source_type="run",
+                run_id="run-r",
+                version="",
+                artifact_path="model.cbm",
+                task="regression",
+                artifact_fingerprint=_local_artifact_fingerprint(
+                    "model.cbm", str(local_file)
+                ),
+            )
             _model_cache.put(cache_key, winner_model)
 
         with (
             patch(
                 "haute._mlflow_io._artifact_io_lock",
-                side_effect=self._hooked_lock(winner_populates_cache),
+                # First acquisition is the download lock inside
+                # _resolve_artifact_local (file not yet present); the load
+                # lock is the second — that's where the winner races us.
+                side_effect=self._hooked_lock(winner_populates_cache, fire_on=2),
             ),
             patch(
                 "haute._mlflow_io.resolve_mlflow_source",
@@ -908,5 +941,5 @@ class TestLockAcquisitionRaces:
             )
 
         assert result is winner_model
-        assert transport.calls == 0, "cache hit under the lock must skip the download"
+        assert transport.calls == 1, "byte-identity keying requires exactly one download"
         load_catboost.assert_not_called()

--- a/tests/test_mlflow_model_cache_key_contract.py
+++ b/tests/test_mlflow_model_cache_key_contract.py
@@ -73,9 +73,7 @@ class TestFastPathArtifactPerturbation:
                 task="regression",
             )
 
-    def test_relogged_artifact_bytes_invalidate_in_process_cache(
-        self, tmp_path, monkeypatch
-    ):
+    def test_relogged_artifact_bytes_invalidate_in_process_cache(self, tmp_path, monkeypatch):
         """Re-log under the same run ref → the NEW model is served, not stale."""
         monkeypatch.chdir(tmp_path)
         local = _artifact_cache_path(tmp_path / ".cache" / "models", RUN_ID, ARTIFACT)

--- a/tests/test_mlflow_model_cache_key_contract.py
+++ b/tests/test_mlflow_model_cache_key_contract.py
@@ -1,0 +1,199 @@
+"""Key-contract tests for the in-process MLflow model cache.
+
+Pins cache-key COMPLETENESS: the model's artifact bytes are an input that
+affects the cached output (the loaded ``ScoringModel``), so perturbing them
+under an unchanged run reference MUST invalidate the in-process cache.
+Without this, a re-logged MLflow run or a ``version="latest"`` retrain keeps
+serving the previously loaded model on a long-lived server until
+``clear_model_cache`` is called by hand.
+
+Each perturbation test rewrites the local artifact bytes in place (the
+disk-cache file for the fast path; the resolved local path for the full
+path) and asserts the next ``load_mlflow_model`` call returns a model built
+from the NEW bytes, not the cached one.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from haute._mlflow_io import (
+    ScoringModel,
+    _artifact_cache_path,
+    _model_cache,
+    _model_cache_key,
+    clear_model_cache,
+    load_mlflow_model,
+)
+
+RUN_ID = "run_relog"
+ARTIFACT = "model.cbm"
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    _model_cache.clear()
+    yield
+    _model_cache.clear()
+
+
+def _fake_load_local(path: str, task: str = "regression") -> ScoringModel:
+    """Loader stub whose model identity is the artifact file's bytes."""
+    payload = Path(path).read_bytes().decode()
+    return ScoringModel(
+        model=f"model:{payload}",
+        feature_names=["x"],
+        flavor="catboost",
+    )
+
+
+def _write_artifact(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _bump_mtime(path: Path) -> None:
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+
+class TestFastPathArtifactPerturbation:
+    """source_type="run" fast path (disk-cache-backed CatBoost/RustyStats)."""
+
+    def _load(self):
+        with patch("haute._mlflow_io.load_local_model", side_effect=_fake_load_local):
+            return load_mlflow_model(
+                source_type="run",
+                run_id=RUN_ID,
+                artifact_path=ARTIFACT,
+                task="regression",
+            )
+
+    def test_relogged_artifact_bytes_invalidate_in_process_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """Re-log under the same run ref → the NEW model is served, not stale."""
+        monkeypatch.chdir(tmp_path)
+        local = _artifact_cache_path(tmp_path / ".cache" / "models", RUN_ID, ARTIFACT)
+        _write_artifact(local, b"weights-v1")
+
+        first = self._load()
+        assert first.raw_model == "model:weights-v1"
+
+        # Simulate the re-log / retrain-in-place: same run_id, same artifact
+        # path, different bytes on disk.
+        _write_artifact(local, b"weights-v2-relogged")
+        _bump_mtime(local)
+
+        second = self._load()
+        assert second.raw_model == "model:weights-v2-relogged", (
+            "in-process model cache served the stale pre-relog model: the "
+            "cache key does not fold in artifact identity"
+        )
+
+    def test_unchanged_artifact_still_hits_cache(self, tmp_path, monkeypatch):
+        """No perturbation → second call is an in-process hit (same object)."""
+        monkeypatch.chdir(tmp_path)
+        local = _artifact_cache_path(tmp_path / ".cache" / "models", RUN_ID, ARTIFACT)
+        _write_artifact(local, b"weights-v1")
+
+        first = self._load()
+        with patch(
+            "haute._mlflow_io.load_local_model",
+            side_effect=AssertionError("unchanged artifact must not reload"),
+        ):
+            second = load_mlflow_model(
+                source_type="run",
+                run_id=RUN_ID,
+                artifact_path=ARTIFACT,
+                task="regression",
+            )
+        assert second is first
+
+
+class TestFullPathArtifactPerturbation:
+    """Resolve-based path (registered model / version="latest")."""
+
+    def _load(self, local_file: Path):
+        mock_mlflow = MagicMock()
+        with (
+            patch(
+                "haute._mlflow_io.resolve_mlflow_source",
+                return_value=(RUN_ID, "latest", mock_mlflow, MagicMock()),
+            ),
+            patch(
+                "haute._mlflow_io._resolve_artifact_local",
+                return_value=str(local_file),
+            ),
+            patch(
+                "haute._mlflow_io._load_catboost_model",
+                side_effect=lambda path, task: f"raw:{Path(path).read_bytes().decode()}",
+            ),
+            patch(
+                "haute._mlflow_io._wrap_catboost",
+                side_effect=lambda raw: ScoringModel(
+                    model=raw, feature_names=["x"], flavor="catboost"
+                ),
+            ),
+        ):
+            return load_mlflow_model(
+                source_type="registered",
+                registered_model="pricing_model",
+                version="latest",
+                artifact_path=ARTIFACT,
+                task="regression",
+            )
+
+    def test_latest_retrain_in_place_invalidates_cache(self, tmp_path):
+        local = tmp_path / ARTIFACT
+        _write_artifact(local, b"weights-v1")
+
+        first = self._load(local)
+        assert first.raw_model == "raw:weights-v1"
+
+        _write_artifact(local, b"weights-v2-retrained")
+        _bump_mtime(local)
+
+        second = self._load(local)
+        assert second.raw_model == "raw:weights-v2-retrained", (
+            'version="latest" retrain served the stale in-process model'
+        )
+
+
+class TestKeyContract:
+    """Direct pins on the key derivation and eviction compatibility."""
+
+    def test_key_folds_artifact_fingerprint(self):
+        base = dict(
+            source_type="run",
+            run_id=RUN_ID,
+            version="",
+            artifact_path=ARTIFACT,
+            task="regression",
+        )
+        key_a = _model_cache_key(artifact_fingerprint="fp-a", **base)
+        key_b = _model_cache_key(artifact_fingerprint="fp-b", **base)
+        assert key_a != key_b
+        assert key_a == _model_cache_key(artifact_fingerprint="fp-a", **base)
+
+    def test_targeted_clear_still_evicts_by_run_id(self, tmp_path, monkeypatch):
+        """clear_model_cache(run_id=...) matches the run slot in the new key."""
+        monkeypatch.chdir(tmp_path)
+        key = _model_cache_key(
+            source_type="run",
+            run_id=RUN_ID,
+            version="",
+            artifact_path=ARTIFACT,
+            task="regression",
+            artifact_fingerprint="fp-a",
+        )
+        _model_cache.put(
+            key,
+            ScoringModel(model="m", feature_names=["x"], flavor="catboost"),
+        )
+        clear_model_cache(run_id=RUN_ID)
+        assert _model_cache.get(key) is None

--- a/tests/test_write_sandbox_lint.py
+++ b/tests/test_write_sandbox_lint.py
@@ -513,7 +513,10 @@ EXPECTED_VIOLATIONS: dict[str, int] = {
     "tests/test_json_cache_coverage_uplift.py": 19,
     "tests/test_json_cache_integrity.py": 1,
     "tests/test_json_shred_mut_stragglers.py": 1,
-    "tests/test_mlflow_io.py": 2,
+    # 2 pre-existing + 2 cache-key-contract tests writing through
+    # _artifact_cache_path(tmp_path / ...) results (tmp_path-rooted, but the
+    # static taint cannot see through the helper call).
+    "tests/test_mlflow_io.py": 4,
     "tests/test_mlflow_io_concurrency.py": 12,
     "tests/test_model_score_executor.py": 1,
     "tests/test_optimiser_routes.py": 2,


### PR DESCRIPTION
The in-process ScoringModel LRU keyed on `(source_type, run_id, version, artifact_path, task)` only — artifact bytes were unrepresented, so a re-logged MLflow run or a `version="latest"` retrain served the stale model on a long-lived server until `clear_model_cache` was called by hand. The deploy path was already insulated by its artifact-identity fingerprint; this closes the serve-path sibling.

## Fix

- `_model_cache_key` now takes a **required** `artifact_fingerprint` component — required so no call site can silently drop byte identity. It reuses the deploy path's `artifact_identity_fingerprint` derivation (stat-gated content hash), not a new parallel mint, so the serve-path cache and the deploy output-schema cache agree on what "the same artifact" means.
- The fast path fingerprints the disk-cached file before the cache probe; the resolve path materialises the local artifact up front so its identity is part of the key, and re-derives the fingerprint after the corrupt-retry loop so the entry is keyed by the bytes actually loaded.
- Targeted `clear_model_cache(run_id=...)` semantics are unchanged (`run_id` stays in key slot 1).
- **Documented residual:** pyfunc models load by MLflow URI with no local file to fingerprint — they remain keyed without byte identity (noted in the `_model_cache_key` docstring).

## Testing

- New key-contract pin `tests/test_mlflow_model_cache_key_contract.py`: perturbs artifact bytes under an unchanged run reference (fast disk-cache path AND resolve/`version="latest"` path) and asserts the next load serves the new model; plus unchanged-bytes cache-hit, key-derivation, and targeted-eviction pins. Characterisation-first: the stale-serve was pinned failing before the fix.
- Existing suites updated to the new key contract (four cache tests, two concurrency interleaving tests); write-sandbox lint allowlist row for `test_mlflow_io.py` bumped 2→4 (writes through `_artifact_cache_path(tmp_path/...)` results the static taint cannot see through).
- Full pytest suite green (12,680 passed), ruff + mypy clean, fresh-process re-verification of the invalidation, server import smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)