### PR TITLE
Source-tag the graph-embedded column stashes; invalidate on source mismatch

### DIFF
--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -569,6 +569,9 @@ describe("App integration — load a pipeline with nodes", () => {
     const sourceNode = makeNode("source_0", "Claims Source", "dataSource")
     sourceNode.data._columns = [{ name: "premium", dtype: "i64" }]
     sourceNode.data._availableColumns = [{ name: "premium", dtype: "i64" }]
+    // Tag the stash with its capture source — untagged stashes are treated
+    // as unknown provenance and invalidated on mount (cache-key completeness).
+    sourceNode.data._columnsSource = "live"
     vi.mocked(api.loadPipeline).mockResolvedValueOnce({
       nodes: [
         sourceNode,

--- a/frontend/src/hooks/__tests__/columnStashSourceIdentity.test.ts
+++ b/frontend/src/hooks/__tests__/columnStashSourceIdentity.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Key-contract pin — source identity of the graph-embedded column stashes.
+ *
+ * `node.data._columns` / `_availableColumns` are a cache: captured from a
+ * preview run against ONE data source, then read by editors (NodePanel,
+ * ColumnsTab, OutputEditor, edge-join validation) and by the lazy-refresh
+ * machinery. The cache key must include every input that affects the cached
+ * output — and the active source is such an input. These tests pin the
+ * contract that the stash carries the source it was captured under
+ * (`_columnsSource`) and is invalidated, not served stale, when the active
+ * source changes.
+ *
+ *   1. Capture stamps the stash with the source of the preview run.
+ *   2. Switching the active source invalidates a stash captured under a
+ *      different source (the key-contract pin).
+ *   3. A stash captured under the CURRENT source survives a re-set of the
+ *      same source — no gratuitous invalidation (render-gate: persisted
+ *      editor state must not disappear as a side effect).
+ *   4. An untagged stash (unknown provenance — e.g. loaded from a save
+ *      made before tagging existed) is treated as stale on source switch.
+ *   5. refreshPreview treats an upstream stash captured under a different
+ *      source as missing and re-previews that upstream node.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, cleanup, act, waitFor } from "@testing-library/react"
+import type { Node, Edge } from "@xyflow/react"
+import usePipelineAPI from "../usePipelineAPI"
+import useToastStore from "../../stores/useToastStore"
+import useSettingsStore from "../../stores/useSettingsStore"
+import useGraphStore from "../../stores/useGraphStore"
+import useNodeResultsStore from "../../stores/useNodeResultsStore"
+
+vi.mock("../../api/client", () => ({
+  loadPipeline: vi.fn(),
+  previewNode: vi.fn(),
+  savePipeline: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number
+    detail?: string
+
+    constructor(msg: string, status?: number, detail?: string) {
+      super(msg)
+      this.name = "ApiError"
+      this.status = status ?? 0
+      this.detail = detail
+    }
+  },
+}))
+
+import { loadPipeline, previewNode } from "../../api/client"
+import { makeNode, makeEdge } from "../../test-utils/factories"
+
+const mockLoad = vi.mocked(loadPipeline)
+const mockPreview = vi.mocked(previewNode)
+
+function makeParams(overrides: Partial<Parameters<typeof usePipelineAPI>[0]> = {}) {
+  return {
+    selectedNode: null as Node | null,
+    graphRef: { current: { nodes: [] as Node[], edges: [] as Edge[] } },
+    parentGraphRef: { current: null },
+    submodelsRef: { current: {} },
+    setNodesRaw: vi.fn(),
+    setEdgesRaw: vi.fn(),
+    setPreamble: vi.fn(),
+    preambleRef: { current: "" },
+    pipelineNameRef: { current: "test" },
+    descriptionRef: { current: "" },
+    sourceFileRef: { current: "test.py" },
+    nodeIdCounter: { current: 0 },
+    ...overrides,
+  }
+}
+
+type SetNodesRaw = Parameters<typeof usePipelineAPI>[0]["setNodesRaw"]
+
+/** Apply every setNodesRaw call (value or updater) to a node array. */
+function applySetNodesCalls(setNodesRaw: SetNodesRaw, initial: Node[]): Node[] {
+  let nodes = initial
+  for (const [arg] of vi.mocked(setNodesRaw).mock.calls) {
+    nodes = typeof arg === "function" ? arg(nodes) : arg
+  }
+  return nodes
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+const LIVE_COLUMNS = [{ name: "premium", dtype: "f64" }]
+
+function makeStashedNode(id: string, source?: string): Node {
+  const node = makeNode(id)
+  node.data = {
+    ...node.data,
+    _columns: LIVE_COLUMNS,
+    _availableColumns: LIVE_COLUMNS,
+    _schemaWarnings: [],
+    ...(source !== undefined ? { _columnsSource: source } : {}),
+  }
+  return node
+}
+
+describe("column-stash source identity (cache-key completeness)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useToastStore.setState({ toasts: [], _toastCounter: 0 })
+    useSettingsStore.setState({ rowLimit: 1000, activeSource: "live", sources: ["live", "staging"] })
+    useGraphStore.setState({
+      nodes: [],
+      edges: [],
+      preamble: "",
+      lastSavedSnapshot: null,
+      undoStack: [],
+      redoStack: [],
+    })
+    useNodeResultsStore.setState({ previews: {}, columnCache: {} })
+    mockLoad.mockReset()
+    mockLoad.mockResolvedValue({ nodes: [], edges: [] })
+    mockPreview.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it("stamps the stash with the source the preview ran under", async () => {
+    vi.useRealTimers()
+    mockPreview.mockResolvedValue({
+      node_id: "A",
+      status: "ok",
+      columns: LIVE_COLUMNS,
+      available_columns: LIVE_COLUMNS,
+      preview: [],
+    })
+    const A = makeNode("A")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [A], edges: [] }
+    mockLoad.mockResolvedValue({ nodes: [A], edges: [] })
+    useSettingsStore.setState({ activeSource: "staging" })
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { result.current.refreshPreview(A) })
+    await flushAsyncWork()
+    await waitFor(() => expect(result.current.previewBusy).toBe(false))
+
+    const nodes = applySetNodesCalls(params.setNodesRaw, [])
+    expect(nodes[0].data._columns).toEqual(LIVE_COLUMNS)
+    expect(nodes[0].data._columnsSource).toBe("staging")
+  })
+
+  it("invalidates a stash captured under a different source when the active source changes", async () => {
+    vi.useRealTimers()
+    const A = makeStashedNode("A", "live")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [A], edges: [] }
+    mockLoad.mockResolvedValue({ nodes: [A], edges: [] })
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { useSettingsStore.getState().setActiveSource("staging") })
+
+    const nodes = applySetNodesCalls(params.setNodesRaw, [])
+    expect(nodes[0].data._columns).toBeUndefined()
+    expect(nodes[0].data._availableColumns).toBeUndefined()
+    expect(nodes[0].data._schemaWarnings).toBeUndefined()
+    expect(nodes[0].data._columnsSource).toBeUndefined()
+  })
+
+  it("keeps a stash captured under the current source (no gratuitous invalidation)", async () => {
+    vi.useRealTimers()
+    const A = makeStashedNode("A", "staging")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [A], edges: [] }
+    mockLoad.mockResolvedValue({ nodes: [A], edges: [] })
+    useSettingsStore.setState({ activeSource: "staging" })
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { useSettingsStore.getState().setActiveSource("staging") })
+
+    const nodes = applySetNodesCalls(params.setNodesRaw, [])
+    expect(nodes[0].data._columns).toEqual(LIVE_COLUMNS)
+    expect(nodes[0].data._availableColumns).toEqual(LIVE_COLUMNS)
+  })
+
+  it("treats an untagged stash as stale on source switch", async () => {
+    vi.useRealTimers()
+    const A = makeStashedNode("A") // no _columnsSource — unknown provenance
+    const params = makeParams()
+    params.graphRef.current = { nodes: [A], edges: [] }
+    mockLoad.mockResolvedValue({ nodes: [A], edges: [] })
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { useSettingsStore.getState().setActiveSource("staging") })
+
+    const nodes = applySetNodesCalls(params.setNodesRaw, [])
+    expect(nodes[0].data._columns).toBeUndefined()
+  })
+
+  it("refreshPreview re-previews an upstream node whose stash was captured under another source", async () => {
+    vi.useRealTimers()
+    mockPreview.mockResolvedValue({
+      node_id: "A",
+      status: "ok",
+      columns: LIVE_COLUMNS,
+      available_columns: LIVE_COLUMNS,
+      preview: [],
+    })
+    // Upstream A carries a live-source stash; active source is staging.
+    // The lazy-refresh gap-fill must treat A as never previewed.
+    const A = makeStashedNode("A", "live")
+    const B = makeNode("B")
+    const params = makeParams()
+    params.graphRef.current = { nodes: [A, B], edges: [makeEdge("A", "B")] }
+    useSettingsStore.setState({ activeSource: "staging" })
+
+    const { result } = renderHook(() => usePipelineAPI(params))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => { result.current.refreshPreview(B) })
+    await flushAsyncWork()
+    await waitFor(() => expect(result.current.previewBusy).toBe(false))
+
+    const previewedNodeIds = mockPreview.mock.calls.map((c) => c[0].nodeId)
+    expect(previewedNodeIds).toContain("A")
+    expect(previewedNodeIds).toContain("B")
+  })
+})

--- a/frontend/src/hooks/usePipelineAPI.ts
+++ b/frontend/src/hooks/usePipelineAPI.ts
@@ -136,7 +136,7 @@ function canPreviewNode(node: Node): boolean {
   return !NON_EXECUTABLE_PREVIEW_TYPES.has(effectiveNodeType(node))
 }
 
-function applyPreviewColumnsToNodes(nodes: Node[], nodeId: string, columns: ColumnDef[], result: NodeResult): Node[] {
+function applyPreviewColumnsToNodes(nodes: Node[], nodeId: string, columns: ColumnDef[], result: NodeResult, source: string): Node[] {
   return nodes.map((n) =>
     n.id === nodeId
       ? {
@@ -146,13 +146,14 @@ function applyPreviewColumnsToNodes(nodes: Node[], nodeId: string, columns: Colu
           _columns: columns,
           _availableColumns: result.available_columns ?? columns,
           _schemaWarnings: result.schema_warnings ?? [],
+          _columnsSource: source,
         },
       }
       : n,
   )
 }
 
-function applyPreviewSchemaMapsToNodes(nodes: Node[], result: NodeResult): Node[] {
+function applyPreviewSchemaMapsToNodes(nodes: Node[], result: NodeResult, source: string): Node[] {
   const nodeColumns = result.node_columns ?? {}
   if (Object.keys(nodeColumns).length === 0) return nodes
   const nodeAvailableColumns = result.node_available_columns ?? {}
@@ -167,15 +168,41 @@ function applyPreviewSchemaMapsToNodes(nodes: Node[], result: NodeResult): Node[
         _columns: columns,
         _availableColumns: nodeAvailableColumns[n.id] ?? columns,
         _schemaWarnings: nodeSchemaWarnings[n.id] ?? [],
+        _columnsSource: source,
       },
     }
   })
 }
 
-function applyPreviewResultColumnsToNodes(nodes: Node[], nodeId: string, result: NodeResult): Node[] {
-  const mapped = applyPreviewSchemaMapsToNodes(nodes, result)
+function applyPreviewResultColumnsToNodes(nodes: Node[], nodeId: string, result: NodeResult, source: string): Node[] {
+  const mapped = applyPreviewSchemaMapsToNodes(nodes, result, source)
   if (!result.columns || result.node_columns?.[nodeId]) return mapped
-  return applyPreviewColumnsToNodes(mapped, nodeId, result.columns as ColumnDef[], result)
+  return applyPreviewColumnsToNodes(mapped, nodeId, result.columns as ColumnDef[], result, source)
+}
+
+/**
+ * Drop column stashes whose capture source no longer matches the active
+ * source. The stash is a cache keyed (implicitly) by node id; the active
+ * source is an input that affects its contents, so a stash captured under
+ * another source — or under an unknown one (no `_columnsSource` tag) —
+ * must be invalidated, never served. Stripped nodes return to the
+ * never-previewed state the lazy gap-fill in `refreshPreview` already
+ * handles; editors see "columns not loaded yet", exactly as on first load.
+ * Returns the input array unchanged when nothing is stale.
+ */
+function invalidateStaleColumnStashes(nodes: Node[], activeSource: string): Node[] {
+  const isStale = (n: Node) => {
+    const data = nodeData(n)
+    return (data._columns !== undefined || data._availableColumns !== undefined) &&
+      data._columnsSource !== activeSource
+  }
+  if (!nodes.some(isStale)) return nodes
+  return nodes.map((n) => {
+    if (!isStale(n)) return n
+    const { _columns, _availableColumns, _schemaWarnings, _columnsSource, ...rest } = n.data
+    void _columns; void _availableColumns; void _schemaWarnings; void _columnsSource
+    return { ...n, data: rest }
+  })
 }
 
 function isAbortError(err: unknown): boolean {
@@ -235,6 +262,14 @@ export default function usePipelineAPI({
   useEffect(() => { streamingChunkSizeRef.current = streamingChunkSize }, [streamingChunkSize])
   const activeSourceRef = useRef(activeSource)
   useEffect(() => { activeSourceRef.current = activeSource }, [activeSource])
+
+  // Source switch invalidates column stashes captured under other sources.
+  // Runs on mount too: the invariant is "no stash disagrees with the active
+  // source", not just "clean up after a toggle" — a pipeline loaded with
+  // stashes of unknown provenance gets them stripped and lazily re-filled.
+  useEffect(() => {
+    setNodesRaw((nds) => invalidateStaleColumnStashes(nds, activeSource))
+  }, [activeSource, setNodesRaw])
 
   // Initial pipeline load
   useEffect(() => {
@@ -482,8 +517,8 @@ export default function usePipelineAPI({
                 return
               }
               const newColumns = result.columns as ColumnDef[]
-              cascadeNodes = applyPreviewResultColumnsToNodes(cascadeNodes, nodeId, result)
-              setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, nodeId, result))
+              cascadeNodes = applyPreviewResultColumnsToNodes(cascadeNodes, nodeId, result, snapshotSource)
+              setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, nodeId, result, snapshotSource))
               settleNode(nodeId, !columnsEqual(oldColumns, newColumns))
             })
             .catch((err: unknown) => {
@@ -558,8 +593,8 @@ export default function usePipelineAPI({
         if (result.columns) {
           const oldColumns = nodeData(node)._columns
           const newColumns = result.columns as ColumnDef[]
-          cascadeNodes = applyPreviewResultColumnsToNodes(cascadeNodes, node.id, result)
-          setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, node.id, result))
+          cascadeNodes = applyPreviewResultColumnsToNodes(cascadeNodes, node.id, result, snapshotSource)
+          setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, node.id, result, snapshotSource))
           // Cascade to downstream nodes if columns changed.
           if (!columnsEqual(oldColumns, newColumns)) {
             propagationDone = propagate(node.id)
@@ -668,12 +703,17 @@ export default function usePipelineAPI({
     const nodeMap = new Map(nodes.map((n) => [n.id, n]))
 
     // Find direct upstream nodes that have never been previewed (no _columns)
+    // or whose stash was captured under a different source (stale — the
+    // invalidation effect strips these, but the graph ref may not have
+    // flushed yet, so the filter checks the source tag directly too).
     const upstreamIds = edges
       .filter((e) => e.target === node.id)
       .map((e) => e.source)
     const staleUpstream = upstreamIds
       .map((id) => nodeMap.get(id))
-      .filter((n): n is Node => !!n && canPreviewNode(n) && !nodeData(n)._columns)
+      .filter((n): n is Node =>
+        !!n && canPreviewNode(n) &&
+        (!nodeData(n)._columns || nodeData(n)._columnsSource !== activeSourceRef.current))
 
     if (staleUpstream.length === 0) {
       // No upstream gaps — just preview the selected node directly
@@ -732,7 +772,7 @@ export default function usePipelineAPI({
             .then((result) => {
               if (!requestStillCurrent()) return
               if (result.columns) {
-                setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, upstream.id, result))
+                setNodesRaw((nds) => applyPreviewResultColumnsToNodes(nds, upstream.id, result, snapshotSource))
               }
             })
             .catch((err: unknown) => {

--- a/frontend/src/panels/NodePanel.tsx
+++ b/frontend/src/panels/NodePanel.tsx
@@ -598,6 +598,7 @@ const CACHED_PREVIEW_KEYS: readonly (keyof HauteNodeData)[] = [
   "_columns",
   "_availableColumns",
   "_schemaWarnings",
+  "_columnsSource",
 ]
 
 function clearCachedResultShape(data: HauteNodeData): HauteNodeData {

--- a/frontend/src/types/node.ts
+++ b/frontend/src/types/node.ts
@@ -39,6 +39,10 @@ export interface HauteNodeData extends Record<string, unknown> {
   _availableColumns?: ColumnInfo[]
   /** Schema warnings from last preview — set by usePipelineAPI */
   _schemaWarnings?: { column: string; status: string }[]
+  /** Active source the column stash (_columns/_availableColumns/_schemaWarnings)
+   *  was captured under — set by usePipelineAPI. A stash whose source no longer
+   *  matches the active source is stale and gets invalidated, never served. */
+  _columnsSource?: string
   /** Node execution status — set by useTracing */
   _status?: NodeStatus
   _traceActive?: boolean


### PR DESCRIPTION
## What

`node.data._columns` / `_availableColumns` / `_schemaWarnings` are a cache captured from a preview run against one data source, but carried no source identity: column lists captured under one source kept serving editors, pickers, and edge-join validation after the active source changed, and the lazy gap-fill in `refreshPreview` skipped re-previewing upstream nodes precisely because the stale columns existed. (Cache-key completeness: the active source is an input that affects the cached output but was missing from the key.)

## How

- Stamp `node.data._columnsSource` at the single write chokepoint (the `applyPreview*` helpers in `usePipelineAPI` — the only writers of `_columns`), with the snapshot source of the preview run. This reuses the source-in-the-key shape the store-level `columnCache` already uses (`nodeId:source`) rather than minting a new derivation.
- Invalidate on mismatch: an `activeSource` effect strips the stash from any node whose tag disagrees with the active source; an untagged stash (unknown provenance) counts as stale. Runs on mount too — the invariant is "no stash disagrees with the active source". Stripped nodes return to the never-previewed state every editor and the lazy gap-fill already handle, so no persisted config entry disappears from the UI.
- `refreshPreview`'s stale-upstream filter also treats a mismatched tag as missing (covers the window before the effect flushes).
- `NodePanel.CACHED_PREVIEW_KEYS` clears the tag together with the stash on config edits. `shallowNodeHash`/`structuralVersion` and the panel-context fingerprint are allowlist-based and unaffected.

## Verified

- Key-contract pins (characterization-first, red then green) in `frontend/src/hooks/__tests__/columnStashSourceIdentity.test.ts`: switch source → stash invalidated, not served; capture stamps the source; same-source stash survives (no gratuitous invalidation); untagged treated as stale; `refreshPreview` re-previews a mismatched-source upstream node.
- Full frontend suite green pre-merge (5261/5262 — the single failure, plus a second under file-combination runs, reproduces identically on unmodified `main`: pre-existing `App.integration` apiInput emit / W1.3 flake, machine-load-dependent). `tsc -b`, ESLint, and production build clean; hook/NodePanel suites re-run green on the forward-merged tree (543/543).
- Browser-validated end-to-end against a live worktree server: preview under `live` captures columns; add + switch to a second source; the next refresh of the downstream node re-previews the upstream apiInput under the new source (network-confirmed fresh cache miss), and a second refresh skips it (stash now stamped with the new source) — the once-per-switch fingerprint of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)