### PR TITLE
fix(frontend): include source + structuralVersion in solve/train staleness key

### DIFF
--- a/frontend/src/__tests__/App.backgroundJobsIsolation.test.tsx
+++ b/frontend/src/__tests__/App.backgroundJobsIsolation.test.tsx
@@ -211,8 +211,8 @@ function resetStores(): void {
 }
 
 function startBackgroundJobs(): void {
-  useNodeResultsStore.getState().startSolveJob("optimizer_1", "solve-job-1", "Optimizer", {}, "solve-config")
-  useNodeResultsStore.getState().startTrainJob("model_1", "train-job-1", "Model", "train-config")
+  useNodeResultsStore.getState().startSolveJob("optimizer_1", "solve-job-1", "Optimizer", {}, "solve-config", "live", 0)
+  useNodeResultsStore.getState().startTrainJob("model_1", "train-job-1", "Model", "train-config", "live", 0)
 }
 
 function updateBackgroundJobProgress(): void {

--- a/frontend/src/__tests__/adversarial/resilience.test.ts
+++ b/frontend/src/__tests__/adversarial/resilience.test.ts
@@ -131,7 +131,7 @@ describe("1. API returns unexpected shapes", () => {
 
     it("completeSolveJob with minimal result shape does not crash", () => {
       const store = useNodeResultsStore.getState()
-      store.startSolveJob("n1", "j1", "Node", {}, "h")
+      store.startSolveJob("n1", "j1", "Node", {}, "h", "live", 0)
       // Simulate server returning only partial result
       const minimalResult = {
         total_objective: 0,
@@ -147,7 +147,7 @@ describe("1. API returns unexpected shapes", () => {
 
     it("completeTrainJob with minimal result shape does not crash", () => {
       const store = useNodeResultsStore.getState()
-      store.startTrainJob("t1", "tj1", "Train", "h")
+      store.startTrainJob("t1", "tj1", "Train", "h", "live", 0)
       const minimalResult = {
         status: "completed",
         metrics: {},
@@ -812,7 +812,7 @@ describe("10. Store state after unmount", () => {
     const store = useNodeResultsStore.getState()
     store.setPreview("n1", makePreviewData("n1", "Test"), 0)
     store.setColumns("n1", [{ name: "a", dtype: "float64" }], 0)
-    store.startSolveJob("n1", "j1", "N1", {}, "h")
+    store.startSolveJob("n1", "j1", "N1", {}, "h", "live", 0)
 
     // Simulate "unmount" by just calling cleanup (no actual React tree here)
     cleanup()

--- a/frontend/src/__tests__/hooks/useBackgroundJobs.gaps.test.ts
+++ b/frontend/src/__tests__/hooks/useBackgroundJobs.gaps.test.ts
@@ -115,8 +115,8 @@ describe("useBackgroundJobs — gap tests", () => {
 
       // Start both jobs
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("s1", "solve-1", "Solve Node", {}, "h1")
-        useNodeResultsStore.getState().startTrainJob("t1", "train-1", "Train Node", "h2")
+        useNodeResultsStore.getState().startSolveJob("s1", "solve-1", "Solve Node", {}, "h1", "live", 0)
+        useNodeResultsStore.getState().startTrainJob("t1", "train-1", "Train Node", "h2", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -174,8 +174,8 @@ describe("useBackgroundJobs — gap tests", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("a", "job-a", "Node A", {}, "h")
-        useNodeResultsStore.getState().startSolveJob("b", "job-b", "Node B", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("a", "job-a", "Node A", {}, "h", "live", 0)
+        useNodeResultsStore.getState().startSolveJob("b", "job-b", "Node B", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -212,7 +212,7 @@ describe("useBackgroundJobs — gap tests", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "GLM Node", "th")
+        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "GLM Node", "th", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -247,7 +247,7 @@ describe("useBackgroundJobs — gap tests", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -285,7 +285,7 @@ describe("useBackgroundJobs — gap tests", () => {
         })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())

--- a/frontend/src/__tests__/hooks/useBackgroundJobs.test.ts
+++ b/frontend/src/__tests__/hooks/useBackgroundJobs.test.ts
@@ -152,7 +152,7 @@ describe("useBackgroundJobs", () => {
 
       // Start a job in the store
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "hash-a")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "hash-a", "live", 0)
       })
 
       // Render the hook (triggers useEffect -> createJobPoller -> schedulePoll)
@@ -188,7 +188,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -210,7 +210,7 @@ describe("useBackgroundJobs", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "sj-missing", "Solve Node", {}, "sh")
+        useNodeResultsStore.getState().startSolveJob("n1", "sj-missing", "Solve Node", {}, "sh", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -244,7 +244,7 @@ describe("useBackgroundJobs", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "sj-gone", "Solve Node", {}, "sh")
+        useNodeResultsStore.getState().startSolveJob("n1", "sj-gone", "Solve Node", {}, "sh", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -270,7 +270,7 @@ describe("useBackgroundJobs", () => {
         .mockResolvedValueOnce(makeSolveProgress({ status: "running", progress: 0.3, message: "30%" }))
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -307,7 +307,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "th")
+        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "th", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -329,7 +329,7 @@ describe("useBackgroundJobs", () => {
         .mockResolvedValueOnce(makeTrainProgress({ status: "running", progress: 0.3, message: "30%" }))
 
       act(() => {
-        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "th")
+        useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "th", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -354,7 +354,7 @@ describe("useBackgroundJobs", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startTrainJob("t1", "tj-missing", "Train Node", "th")
+        useNodeResultsStore.getState().startTrainJob("t1", "tj-missing", "Train Node", "th", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -390,7 +390,7 @@ describe("useBackgroundJobs", () => {
         .mockResolvedValueOnce(makeTrainProgress({ status: "running", progress: 0.4 }))
 
       act(() => {
-        useNodeResultsStore.getState().startTrainJob("t1", "tj-retry", "Train Node", "th")
+        useNodeResultsStore.getState().startTrainJob("t1", "tj-retry", "Train Node", "th", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -496,7 +496,7 @@ describe("useBackgroundJobs", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -550,7 +550,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -581,7 +581,7 @@ describe("useBackgroundJobs", () => {
       })
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       const { rerender } = renderHook(() => useBackgroundJobs())
@@ -624,7 +624,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -649,7 +649,7 @@ describe("useBackgroundJobs", () => {
         )
 
         act(() => {
-          useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+          useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
         })
 
         renderHook(() => useBackgroundJobs())
@@ -672,7 +672,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())
@@ -708,7 +708,7 @@ describe("useBackgroundJobs", () => {
       )
 
       act(() => {
-        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h")
+        useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       })
 
       renderHook(() => useBackgroundJobs())

--- a/frontend/src/__tests__/stores/useNodeResultsStore.renderPurity.test.tsx
+++ b/frontend/src/__tests__/stores/useNodeResultsStore.renderPurity.test.tsx
@@ -58,7 +58,7 @@ describe("useNodeResultsStore render-pure preview getters", () => {
   it("does not refresh optimiser LRU recency when read during StrictMode render", () => {
     const store = useNodeResultsStore.getState()
     for (let i = 0; i < MAX_CACHED_SOLVE_RESULTS; i += 1) {
-      store.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`)
+      store.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`, "live", 0)
       store.completeSolveJob(`s${i}`, makeSolveResult({ total_objective: i }))
     }
 
@@ -73,7 +73,7 @@ describe("useNodeResultsStore render-pure preview getters", () => {
       </StrictMode>,
     )
 
-    store.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new")
+    store.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new", "live", 0)
     store.completeSolveJob("s-new", makeSolveResult({ total_objective: 999 }))
 
     const { solveResults } = useNodeResultsStore.getState()
@@ -86,7 +86,7 @@ describe("useNodeResultsStore render-pure preview getters", () => {
   it("does not refresh modelling LRU recency when read during StrictMode render", () => {
     const store = useNodeResultsStore.getState()
     for (let i = 0; i < MAX_CACHED_TRAIN_RESULTS; i += 1) {
-      store.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`)
+      store.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`, "live", 0)
       store.completeTrainJob(`t${i}`, makeTrainResult({ metrics: { rmse: i } }))
     }
 
@@ -101,7 +101,7 @@ describe("useNodeResultsStore render-pure preview getters", () => {
       </StrictMode>,
     )
 
-    store.startTrainJob("t-new", "job-new", "Train new", "hash-new")
+    store.startTrainJob("t-new", "job-new", "Train new", "hash-new", "live", 0)
     store.completeTrainJob("t-new", makeTrainResult({ metrics: { rmse: 999 } }))
 
     const { trainResults } = useNodeResultsStore.getState()

--- a/frontend/src/__tests__/stores/useNodeResultsStore.test.ts
+++ b/frontend/src/__tests__/stores/useNodeResultsStore.test.ts
@@ -112,7 +112,7 @@ describe("useNodeResultsStore", () => {
   describe("solve job lifecycle", () => {
     it("startSolveJob creates an active job entry", () => {
       const { startSolveJob } = useNodeResultsStore.getState()
-      startSolveJob("n1", "job-1", "Node 1", { premium: { min: 0, max: 100 } }, "hash-a")
+      startSolveJob("n1", "job-1", "Node 1", { premium: { min: 0, max: 100 } }, "hash-a", "live", 0)
 
       const { solveJobs } = useNodeResultsStore.getState()
       expect(solveJobs["n1"]).toBeDefined()
@@ -125,7 +125,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateSolveProgress attaches progress to active job", () => {
       const state = useNodeResultsStore.getState()
-      state.startSolveJob("n1", "job-1", "Node 1", {}, "h")
+      state.startSolveJob("n1", "job-1", "Node 1", {}, "h", "live", 0)
       state.updateSolveProgress("n1", {
         status: "running",
         progress: 0.5,
@@ -152,7 +152,7 @@ describe("useNodeResultsStore", () => {
 
     it("completeSolveJob moves result to solveResults and removes the job", () => {
       const state = useNodeResultsStore.getState()
-      state.startSolveJob("n1", "job-1", "Node 1", { premium: { min: 0, max: 100 } }, "hash-a")
+      state.startSolveJob("n1", "job-1", "Node 1", { premium: { min: 0, max: 100 } }, "hash-a", "live", 0)
 
       const result = makeSolveResult()
       state.completeSolveJob("n1", result)
@@ -179,7 +179,7 @@ describe("useNodeResultsStore", () => {
 
     it("full lifecycle: start → update → complete", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", { c: { min: 0, max: 1 } }, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", { c: { min: 0, max: 1 } }, "h1", "live", 0)
       s.updateSolveProgress("n1", {
         status: "running",
         progress: 0.5,
@@ -202,7 +202,7 @@ describe("useNodeResultsStore", () => {
   describe("failSolveJob", () => {
     it("removes the job from solveJobs on failure", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h", "live", 0)
       s.updateSolveProgress("n1", {
         status: "running",
         progress: 0.3,
@@ -232,7 +232,7 @@ describe("useNodeResultsStore", () => {
         execution_metrics: executionMetrics,
       }
 
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h", "live", 0)
       s.failSolveJob("n1", "Stopped", terminalStatus)
 
       const failedResult = useNodeResultsStore.getState().solveResults["n1"]
@@ -252,7 +252,7 @@ describe("useNodeResultsStore", () => {
 
   describe("train job lifecycle", () => {
     it("startTrainJob creates an active job entry", () => {
-      useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "cfg-hash")
+      useNodeResultsStore.getState().startTrainJob("t1", "tj-1", "Train Node", "cfg-hash", "live", 0)
       const job = useNodeResultsStore.getState().trainJobs["t1"]
       expect(job).toBeDefined()
       expect(job.jobId).toBe("tj-1")
@@ -264,7 +264,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateTrainProgress attaches progress to active job", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Train Node", "h")
+      s.startTrainJob("t1", "tj-1", "Train Node", "h", "live", 0)
       s.updateTrainProgress("t1", {
         status: "running",
         progress: 0.7,
@@ -295,7 +295,7 @@ describe("useNodeResultsStore", () => {
 
     it("completeTrainJob moves result to trainResults and removes the job", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Train Node", "cfg-hash")
+      s.startTrainJob("t1", "tj-1", "Train Node", "cfg-hash", "live", 0)
       const result = makeTrainResult()
       s.completeTrainJob("t1", result)
 
@@ -322,7 +322,7 @@ describe("useNodeResultsStore", () => {
 
     it("full lifecycle: start → update → complete", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Train Node", "h")
+      s.startTrainJob("t1", "tj-1", "Train Node", "h", "live", 0)
       s.updateTrainProgress("t1", {
         status: "running",
         progress: 0.5,
@@ -348,7 +348,7 @@ describe("useNodeResultsStore", () => {
   describe("failTrainJob", () => {
     it("removes job from trainJobs on failure", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Train Node", "h")
+      s.startTrainJob("t1", "tj-1", "Train Node", "h", "live", 0)
       s.updateTrainProgress("t1", {
         status: "running",
         progress: 0.3,
@@ -385,7 +385,7 @@ describe("useNodeResultsStore", () => {
         execution_metrics: executionMetrics,
       }
 
-      s.startTrainJob("t1", "tj-1", "Train Node", "h")
+      s.startTrainJob("t1", "tj-1", "Train Node", "h", "live", 0)
       s.failTrainJob("t1", "Stopped", terminalStatus)
 
       const failedResult = useNodeResultsStore.getState().trainResults["t1"]
@@ -617,15 +617,15 @@ describe("useNodeResultsStore", () => {
       // Set up data across all caches
       s.setPreview("n1", makePreviewData(), 0)
       s.setColumns("n1", [{ name: "x", dtype: "float64" }], 0)
-      s.startSolveJob("n1", "sj1", "Node 1", { c: { min: 0, max: 1 } }, "h1")
-      s.startTrainJob("n1", "tj1", "Train 1", "th1")
+      s.startSolveJob("n1", "sj1", "Node 1", { c: { min: 0, max: 1 } }, "h1", "live", 0)
+      s.startTrainJob("n1", "tj1", "Train 1", "th1", "live", 0)
 
       // Also set up a solve result (complete a second job to create it)
-      s.startSolveJob("n1b", "sj2", "Node 1b", {}, "h2")
+      s.startSolveJob("n1b", "sj2", "Node 1b", {}, "h2", "live", 0)
       // We'll directly inject a solve result for n1
       useNodeResultsStore.setState((prev) => ({
-        solveResults: { ...prev.solveResults, n1: { result: makeSolveResult(), originalResult: makeSolveResult(), jobId: "sj-old", configHash: "h-old", constraints: {}, nodeLabel: "N1", frontier: null, selectedPointIndex: null } },
-        trainResults: { ...prev.trainResults, n1: { result: makeTrainResult(), jobId: "tj-old", configHash: "th-old" } },
+        solveResults: { ...prev.solveResults, n1: { result: makeSolveResult(), originalResult: makeSolveResult(), jobId: "sj-old", configHash: "h-old", source: "live", structuralVersion: 0, constraints: {}, nodeLabel: "N1", frontier: null, selectedPointIndex: null } },
+        trainResults: { ...prev.trainResults, n1: { result: makeTrainResult(), jobId: "tj-old", configHash: "th-old", source: "live", structuralVersion: 0 } },
       }))
 
       // Verify all caches have data
@@ -770,14 +770,14 @@ describe("useNodeResultsStore", () => {
 
     it("evicts the oldest cached solve results without removing active solve jobs", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("active-solve", "active-job", "Still Running", {}, "active-hash")
+      s.startSolveJob("active-solve", "active-job", "Still Running", {}, "active-hash", "live", 0)
 
       for (let i = 0; i < MAX_CACHED_SOLVE_RESULTS; i += 1) {
-        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`)
+        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`, "live", 0)
         s.completeSolveJob(`s${i}`, makeSolveResult({ total_objective: i }))
       }
       expect(s.getOptimiserPreview("s0")).not.toBeNull()
-      s.startSolveJob(`s${MAX_CACHED_SOLVE_RESULTS}`, `job-${MAX_CACHED_SOLVE_RESULTS}`, "Solve new", {}, "hash-new")
+      s.startSolveJob(`s${MAX_CACHED_SOLVE_RESULTS}`, `job-${MAX_CACHED_SOLVE_RESULTS}`, "Solve new", {}, "hash-new", "live", 0)
       s.completeSolveJob(`s${MAX_CACHED_SOLVE_RESULTS}`, makeSolveResult({ total_objective: MAX_CACHED_SOLVE_RESULTS }))
 
       const { solveJobs, solveResults } = useNodeResultsStore.getState()
@@ -791,11 +791,11 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_SOLVE_RESULTS; i += 1) {
-        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`)
+        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`, "live", 0)
         s.completeSolveJob(`s${i}`, makeSolveResult({ total_objective: i }))
       }
       expect(s.getOptimiserPreview("s0")).not.toBeNull()
-      s.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new")
+      s.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new", "live", 0)
       s.failSolveJob("s-new", "Solver failed")
 
       const { solveResults } = useNodeResultsStore.getState()
@@ -808,12 +808,12 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_SOLVE_RESULTS; i += 1) {
-        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`)
+        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`, "live", 0)
         s.completeSolveJob(`s${i}`, makeSolveResult({ total_objective: i }))
       }
       expect(s.getOptimiserPreview("s0")).not.toBeNull()
       s.touchOptimiserPreview("s0")
-      s.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new")
+      s.startSolveJob("s-new", "job-new", "Solve new", {}, "hash-new", "live", 0)
       s.completeSolveJob("s-new", makeSolveResult({ total_objective: 999 }))
 
       const { solveResults } = useNodeResultsStore.getState()
@@ -827,13 +827,13 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_SOLVE_RESULTS; i += 1) {
-        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`)
+        s.startSolveJob(`s${i}`, `job-${i}`, `Solve ${i}`, {}, `hash-${i}`, "live", 0)
         s.completeSolveJob(`s${i}`, makeSolveResult({ total_objective: i }))
       }
       s.setPinnedPreviewNodeId("s0")
-      s.startSolveJob("s-new-1", "job-new-1", "Solve new 1", {}, "hash-new-1")
+      s.startSolveJob("s-new-1", "job-new-1", "Solve new 1", {}, "hash-new-1", "live", 0)
       s.completeSolveJob("s-new-1", makeSolveResult({ total_objective: 998 }))
-      s.startSolveJob("s-new-2", "job-new-2", "Solve new 2", {}, "hash-new-2")
+      s.startSolveJob("s-new-2", "job-new-2", "Solve new 2", {}, "hash-new-2", "live", 0)
       s.completeSolveJob("s-new-2", makeSolveResult({ total_objective: 999 }))
 
       const { solveResults } = useNodeResultsStore.getState()
@@ -847,10 +847,10 @@ describe("useNodeResultsStore", () => {
 
     it("evicts the oldest cached train results without removing active train jobs", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("active-train", "active-job", "Still Running", "active-hash")
+      s.startTrainJob("active-train", "active-job", "Still Running", "active-hash", "live", 0)
 
       for (let i = 0; i < MAX_CACHED_TRAIN_RESULTS + 1; i += 1) {
-        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`)
+        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`, "live", 0)
         s.completeTrainJob(`t${i}`, makeTrainResult({ metrics: { rmse: i } }))
       }
 
@@ -865,11 +865,11 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_TRAIN_RESULTS; i += 1) {
-        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`)
+        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`, "live", 0)
         s.completeTrainJob(`t${i}`, makeTrainResult({ metrics: { rmse: i } }))
       }
       expect(s.getModellingPreview("t0")).not.toBeNull()
-      s.startTrainJob("t-new", "job-new", "Train new", "hash-new")
+      s.startTrainJob("t-new", "job-new", "Train new", "hash-new", "live", 0)
       s.failTrainJob("t-new", "Training failed")
 
       const { trainResults } = useNodeResultsStore.getState()
@@ -882,12 +882,12 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_TRAIN_RESULTS; i += 1) {
-        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`)
+        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`, "live", 0)
         s.completeTrainJob(`t${i}`, makeTrainResult({ metrics: { rmse: i } }))
       }
       expect(s.getModellingPreview("t0")).not.toBeNull()
       s.touchModellingPreview("t0")
-      s.startTrainJob("t-new", "job-new", "Train new", "hash-new")
+      s.startTrainJob("t-new", "job-new", "Train new", "hash-new", "live", 0)
       s.completeTrainJob("t-new", makeTrainResult({ metrics: { rmse: 999 } }))
 
       const { trainResults } = useNodeResultsStore.getState()
@@ -901,13 +901,13 @@ describe("useNodeResultsStore", () => {
       const s = useNodeResultsStore.getState()
 
       for (let i = 0; i < MAX_CACHED_TRAIN_RESULTS; i += 1) {
-        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`)
+        s.startTrainJob(`t${i}`, `job-${i}`, `Train ${i}`, `hash-${i}`, "live", 0)
         s.completeTrainJob(`t${i}`, makeTrainResult({ metrics: { rmse: i } }))
       }
       s.setPinnedPreviewNodeId("t0")
-      s.startTrainJob("t-new-1", "job-new-1", "Train new 1", "hash-new-1")
+      s.startTrainJob("t-new-1", "job-new-1", "Train new 1", "hash-new-1", "live", 0)
       s.completeTrainJob("t-new-1", makeTrainResult({ metrics: { rmse: 998 } }))
-      s.startTrainJob("t-new-2", "job-new-2", "Train new 2", "hash-new-2")
+      s.startTrainJob("t-new-2", "job-new-2", "Train new 2", "hash-new-2", "live", 0)
       s.completeTrainJob("t-new-2", makeTrainResult({ metrics: { rmse: 999 } }))
 
       const { trainResults } = useNodeResultsStore.getState()
@@ -943,7 +943,7 @@ describe("useNodeResultsStore", () => {
       s.touchOptimiserPreview("missing-solve")
       s.touchModellingPreview("missing-train")
 
-      s.startTrainJob("t-error", "job-error", "Train error", "hash-error")
+      s.startTrainJob("t-error", "job-error", "Train error", "hash-error", "live", 0)
       s.failTrainJob("t-error", "Training failed")
       s.touchModellingPreview("t-error")
 
@@ -965,7 +965,7 @@ describe("useNodeResultsStore", () => {
     it("builds correct shape from completed result", () => {
       const s = useNodeResultsStore.getState()
       const constraints = { premium: { min: 0, max: 100 } }
-      s.startSolveJob("n1", "j1", "Optim Node", constraints, "h")
+      s.startSolveJob("n1", "j1", "Optim Node", constraints, "h", "live", 0)
       const result = makeSolveResult({ converged: true, iterations: 15 })
       s.completeSolveJob("n1", result)
 
@@ -985,7 +985,7 @@ describe("useNodeResultsStore", () => {
   describe("Frontier actions", () => {
     it("completeSolveJob selects and displays the first frontier point immediately", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", { vol: { min: 0.9 } }, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", { vol: { min: 0.9 } }, "h1", "live", 0)
 
       const frontier = {
         status: "ok",
@@ -1030,7 +1030,7 @@ describe("useNodeResultsStore", () => {
 
     it("completeSolveJob caches an accepted partial frontier without auto-selecting it", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", { premium: { min: 0 } }, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", { premium: { min: 0 } }, "h1", "live", 0)
 
       const result = makeSolveResult({
         total_objective: 100,
@@ -1058,7 +1058,7 @@ describe("useNodeResultsStore", () => {
 
     it("completeSolveJob sets null frontier when points empty", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
 
       const frontier = {
         status: "ok",
@@ -1079,7 +1079,7 @@ describe("useNodeResultsStore", () => {
 
     it("completeSolveJob sets null frontier when absent", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
 
       const result = makeSolveResult()
       // Ensure no frontier key on the result
@@ -1093,7 +1093,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint sets index", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult({
         frontier: {
           status: "ok",
@@ -1114,7 +1114,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint derives the selected result summary from a flattened frontier row immediately", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1182,7 +1182,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint uses point diagnostics when the frontier row provides them", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const pointStats = {
         mean: 1.08,
         std: 0.03,
@@ -1262,7 +1262,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint preserves flat scenario stats from price-contour frontier rows", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1311,7 +1311,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint uses a point-specific warning for non-converged frontier rows", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1341,7 +1341,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint accepts raw constraint columns from price-contour frontier rows", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1372,7 +1372,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint derives the selected result summary from nested frontier row maps", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1405,7 +1405,7 @@ describe("useNodeResultsStore", () => {
 
     it("selectFrontierPoint null deselects and reverts result", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const original = makeSolveResult({
         total_objective: 100,
         frontier: {
@@ -1445,7 +1445,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect updates result metrics", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult({
         total_objective: 100,
         constraints: { premium: 50 },
@@ -1476,7 +1476,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect uses the backend non-convergence warning for select responses", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult({
         converged: false,
         warning: "Stale original warning",
@@ -1498,7 +1498,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect keeps diagnostics from the selected frontier row", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1544,7 +1544,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect stores materialised ratebook factor tables on the selected point", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1595,7 +1595,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect enriches only the selected frontier point with optional detail", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1683,7 +1683,7 @@ describe("useNodeResultsStore", () => {
       // response is still allowed to enrich point-0's per-point detail in the
       // frontier so re-selecting point 0 later benefits from the data.
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const frontier = {
         status: "ok",
         points: [
@@ -1748,7 +1748,7 @@ describe("useNodeResultsStore", () => {
       // disagrees with the index the store was asked to update, that is a
       // contract violation — surface it loudly rather than mutating state.
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult({
         frontier: {
           status: "ok",
@@ -1781,7 +1781,7 @@ describe("useNodeResultsStore", () => {
 
     it("updateFrontierAfterSelect clears point diagnostics that are not in the selected point", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Node 1", {}, "h1")
+      s.startSolveJob("n1", "j1", "Node 1", {}, "h1", "live", 0)
       const original = makeSolveResult({
         iterations: 42,
         cd_iterations: 9,
@@ -1840,7 +1840,7 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview returns null when train result has error status", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Model Node", "cfg-h")
+      s.startTrainJob("t1", "tj-1", "Model Node", "cfg-h", "live", 0)
       s.completeTrainJob("t1", makeTrainResult({ status: "error", error: "OOM" }))
 
       const preview = useNodeResultsStore.getState().getModellingPreview("t1")
@@ -1849,7 +1849,7 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview returns result when status is 'completed'", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("t1", "tj-1", "Model Node", "cfg-h")
+      s.startTrainJob("t1", "tj-1", "Model Node", "cfg-h", "live", 0)
       s.completeTrainJob("t1", makeTrainResult({ status: "completed" }))
 
       const preview = useNodeResultsStore.getState().getModellingPreview("t1")
@@ -1866,10 +1866,10 @@ describe("useNodeResultsStore", () => {
     it("getModellingPreview uses active job nodeLabel if still running", () => {
       const s = useNodeResultsStore.getState()
       // Start a job, complete it, then start another job for the same node
-      s.startTrainJob("t1", "tj-1", "First Label", "h1")
+      s.startTrainJob("t1", "tj-1", "First Label", "h1", "live", 0)
       s.completeTrainJob("t1", makeTrainResult())
       // Start a new job (different config) — old result still cached
-      s.startTrainJob("t1", "tj-2", "Updated Label", "h2")
+      s.startTrainJob("t1", "tj-2", "Updated Label", "h2", "live", 0)
 
       const preview = useNodeResultsStore.getState().getModellingPreview("t1")
       expect(preview).not.toBeNull()
@@ -1939,8 +1939,8 @@ describe("useNodeResultsStore", () => {
 
     it("concurrent solve and train jobs on the same nodeId are independent", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "sj-1", "Node 1", { c: { min: 0 } }, "sh1")
-      s.startTrainJob("n1", "tj-1", "Node 1", "th1")
+      s.startSolveJob("n1", "sj-1", "Node 1", { c: { min: 0 } }, "sh1", "live", 0)
+      s.startTrainJob("n1", "tj-1", "Node 1", "th1", "live", 0)
 
       // Both should exist
       expect(useNodeResultsStore.getState().solveJobs["n1"]).toBeDefined()
@@ -1960,8 +1960,8 @@ describe("useNodeResultsStore", () => {
 
     it("failing solve does not affect concurrent train job", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "sj-1", "Node 1", {}, "sh1")
-      s.startTrainJob("n1", "tj-1", "Node 1", "th1")
+      s.startSolveJob("n1", "sj-1", "Node 1", {}, "sh1", "live", 0)
+      s.startTrainJob("n1", "tj-1", "Node 1", "th1", "live", 0)
 
       s.failSolveJob("n1", "Solver diverged")
 
@@ -1973,8 +1973,8 @@ describe("useNodeResultsStore", () => {
 
     it("multiple solve jobs on different nodes simultaneously", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "sj-1", "Node 1", { c: { min: 0 } }, "h1")
-      s.startSolveJob("n2", "sj-2", "Node 2", { d: { max: 1 } }, "h2")
+      s.startSolveJob("n1", "sj-1", "Node 1", { c: { min: 0 } }, "h1", "live", 0)
+      s.startSolveJob("n2", "sj-2", "Node 2", { d: { max: 1 } }, "h2", "live", 0)
 
       expect(useNodeResultsStore.getState().solveJobs["n1"]).toBeDefined()
       expect(useNodeResultsStore.getState().solveJobs["n2"]).toBeDefined()
@@ -2000,8 +2000,8 @@ describe("useNodeResultsStore", () => {
 
     it("failing one solve does not affect other nodes' solve jobs", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "sj-1", "Node 1", {}, "h1")
-      s.startSolveJob("n2", "sj-2", "Node 2", {}, "h2")
+      s.startSolveJob("n1", "sj-1", "Node 1", {}, "h1", "live", 0)
+      s.startSolveJob("n2", "sj-2", "Node 2", {}, "h2", "live", 0)
 
       s.failSolveJob("n1", "Diverged")
 
@@ -2014,7 +2014,7 @@ describe("useNodeResultsStore", () => {
     it("getOptimiserPreview includes frontier and selectedPointIndex", () => {
       const s = useNodeResultsStore.getState()
       const constraints = { vol: { min: 0.9 } }
-      s.startSolveJob("n1", "j1", "Optim Node", constraints, "h1")
+      s.startSolveJob("n1", "j1", "Optim Node", constraints, "h1", "live", 0)
 
       const frontier = {
         status: "ok",
@@ -2048,7 +2048,7 @@ describe("useNodeResultsStore", () => {
   describe("derived getter caching (Issue #13)", () => {
     it("resetNodeResultsDerivedCaches clears module-scope derived caches and recency state", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Label", {}, "h1")
+      s.startSolveJob("n1", "j1", "Label", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult())
       const stalePreview = s.getOptimiserPreview("n1")
 
@@ -2060,6 +2060,8 @@ describe("useNodeResultsStore", () => {
             originalResult: makeSolveResult({ total_objective: 999 }),
             jobId: "j2",
             configHash: "h2",
+            source: "live",
+            structuralVersion: 0,
             constraints: {},
             nodeLabel: "Fresh Label",
             frontier: null,
@@ -2076,7 +2078,7 @@ describe("useNodeResultsStore", () => {
 
     it("getOptimiserPreview returns same reference on repeated calls", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Label", {}, "h1")
+      s.startSolveJob("n1", "j1", "Label", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult())
 
       const a = useNodeResultsStore.getState().getOptimiserPreview("n1")
@@ -2086,7 +2088,7 @@ describe("useNodeResultsStore", () => {
 
     it("getOptimiserPreview returns new reference after state change", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Label", {}, "h1")
+      s.startSolveJob("n1", "j1", "Label", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult())
 
       const a = useNodeResultsStore.getState().getOptimiserPreview("n1")
@@ -2098,7 +2100,7 @@ describe("useNodeResultsStore", () => {
 
     it("getOptimiserPreview returns null after clearNode", () => {
       const s = useNodeResultsStore.getState()
-      s.startSolveJob("n1", "j1", "Label", {}, "h1")
+      s.startSolveJob("n1", "j1", "Label", {}, "h1", "live", 0)
       s.completeSolveJob("n1", makeSolveResult())
 
       expect(useNodeResultsStore.getState().getOptimiserPreview("n1")).not.toBeNull()
@@ -2108,7 +2110,7 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview returns same reference on repeated calls", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("n1", "j1", "Model", "h1")
+      s.startTrainJob("n1", "j1", "Model", "h1", "live", 0)
       s.completeTrainJob("n1", makeTrainResult())
 
       const a = useNodeResultsStore.getState().getModellingPreview("n1")
@@ -2118,7 +2120,7 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview returns new reference after state change", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("n1", "j1", "Model", "h1")
+      s.startTrainJob("n1", "j1", "Model", "h1", "live", 0)
       s.completeTrainJob("n1", makeTrainResult())
 
       const a = useNodeResultsStore.getState().getModellingPreview("n1")
@@ -2130,9 +2132,9 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview keeps its reference across active job progress updates", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("n1", "j1", "Initial Label", "h1")
+      s.startTrainJob("n1", "j1", "Initial Label", "h1", "live", 0)
       s.completeTrainJob("n1", makeTrainResult())
-      s.startTrainJob("n1", "j2", "Updated Label", "h2")
+      s.startTrainJob("n1", "j2", "Updated Label", "h2", "live", 0)
 
       const beforeProgress = useNodeResultsStore.getState().getModellingPreview("n1")
       expect(beforeProgress!.nodeLabel).toBe("Updated Label")
@@ -2155,7 +2157,7 @@ describe("useNodeResultsStore", () => {
 
     it("getModellingPreview returns null for error results", () => {
       const s = useNodeResultsStore.getState()
-      s.startTrainJob("n1", "j1", "Model", "h1")
+      s.startTrainJob("n1", "j1", "Model", "h1", "live", 0)
       s.failTrainJob("n1", "boom")
 
       expect(useNodeResultsStore.getState().getModellingPreview("n1")).toBeNull()

--- a/frontend/src/components/__tests__/BackgroundJobPolling.renderIsolation.test.tsx
+++ b/frontend/src/components/__tests__/BackgroundJobPolling.renderIsolation.test.tsx
@@ -68,7 +68,7 @@ describe("BackgroundJobPolling", () => {
     expect(getByTestId("node-count")).toHaveTextContent("1")
 
     act(() => {
-      useNodeResultsStore.getState().startSolveJob("solve-node", "solve-job", "Solve Node", {}, "hash-a")
+      useNodeResultsStore.getState().startSolveJob("solve-node", "solve-job", "Solve Node", {}, "hash-a", "live", 0)
     })
     expect(EditorShell).toHaveBeenCalledTimes(2)
 
@@ -83,7 +83,7 @@ describe("BackgroundJobPolling", () => {
     expect(EditorShell).toHaveBeenCalledTimes(2)
 
     act(() => {
-      useNodeResultsStore.getState().startTrainJob("train-node", "train-job", "Train Node", "hash-b")
+      useNodeResultsStore.getState().startTrainJob("train-node", "train-job", "Train Node", "hash-b", "live", 0)
     })
     expect(EditorShell).toHaveBeenCalledTimes(2)
 

--- a/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
@@ -95,6 +95,8 @@ describe("useNodeHandlers — cache cleanup deferred on delete (#32)", () => {
           },
           jobId: "j1",
           configHash: "h1",
+          source: "live",
+          structuralVersion: 0,
           constraints: {},
           nodeLabel: "N1",
           frontier: null,

--- a/frontend/src/hooks/__tests__/useStaleConfigEstimate.sourceKey.test.ts
+++ b/frontend/src/hooks/__tests__/useStaleConfigEstimate.sourceKey.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, waitFor, cleanup } from "@testing-library/react"
+import { useStaleConfigEstimate } from "../useStaleConfigEstimate"
+import useToastStore from "../../stores/useToastStore"
+import useNodeResultsStore, { hashConfig } from "../../stores/useNodeResultsStore"
+
+// Key-contract pin (Maginot: fingerprint / cache-key completeness).
+// The solve/train staleness key must cover every input that affects the
+// cached result: node config, active data source, and structuralVersion.
+// A result computed against source A must be marked stale when the active
+// source switches to B, even though the node config is untouched.
+
+interface FakeEstimate {
+  estimated_mb: number
+}
+
+const config = { algorithm: "catboost", gpu: false }
+const sampleEstimate: FakeEstimate = { estimated_mb: 1024 }
+
+beforeEach(() => {
+  useToastStore.setState({ toasts: [], _toastCounter: 0 })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("useStaleConfigEstimate staleness key completeness", () => {
+  it("marks the cached result stale when the active source switches", async () => {
+    const endpoint = vi.fn().mockResolvedValue(sampleEstimate)
+    const cachedOnSourceA = {
+      configHash: hashConfig(config),
+      source: "source_a",
+      structuralVersion: 1,
+    }
+
+    const { result, rerender } = renderHook(
+      ({ source }: { source: string }) =>
+        useStaleConfigEstimate<FakeEstimate>(
+          "node_1",
+          config,
+          cachedOnSourceA,
+          endpoint,
+          { source, structuralVersion: 1 },
+        ),
+      { initialProps: { source: "source_a" } },
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.isStale).toBe(false)
+
+    rerender({ source: "source_b" })
+    expect(result.current.isStale).toBe(true)
+  })
+
+  it("marks the cached result stale when structuralVersion advances", async () => {
+    const endpoint = vi.fn().mockResolvedValue(sampleEstimate)
+    const cached = {
+      configHash: hashConfig(config),
+      source: "source_a",
+      structuralVersion: 1,
+    }
+
+    const { result, rerender } = renderHook(
+      ({ structuralVersion }: { structuralVersion: number }) =>
+        useStaleConfigEstimate<FakeEstimate>(
+          "node_1",
+          config,
+          cached,
+          endpoint,
+          { source: "source_a", structuralVersion },
+        ),
+      { initialProps: { structuralVersion: 1 } },
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.isStale).toBe(false)
+
+    rerender({ structuralVersion: 2 })
+    expect(result.current.isStale).toBe(true)
+  })
+
+  it("treats a legacy cached result with no source field as stale", async () => {
+    const endpoint = vi.fn().mockResolvedValue(sampleEstimate)
+
+    const { result } = renderHook(() =>
+      useStaleConfigEstimate<FakeEstimate>(
+        "node_1",
+        config,
+        { configHash: hashConfig(config) },
+        endpoint,
+        { source: "source_a", structuralVersion: 1 },
+      ),
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.isStale).toBe(true)
+  })
+})
+
+describe("solve/train cached results carry source identity", () => {
+  beforeEach(() => {
+    useNodeResultsStore.setState({
+      solveJobs: {},
+      solveResults: {},
+      trainJobs: {},
+      trainResults: {},
+    })
+  })
+
+  it("completeSolveJob stamps the job's source and structuralVersion onto the cached result", () => {
+    const store = useNodeResultsStore.getState()
+    store.startSolveJob("node_1", "job_1", "Optimiser", {}, "hash_a", "source_a", 3)
+    useNodeResultsStore.getState().completeSolveJob("node_1", {
+      status: "completed",
+      total_objective: 1,
+      baseline_objective: 1,
+      constraints: {},
+      baseline_constraints: {},
+      lambdas: {},
+      converged: true,
+    } as never)
+
+    const cached = useNodeResultsStore.getState().solveResults["node_1"]
+    expect(cached.source).toBe("source_a")
+    expect(cached.structuralVersion).toBe(3)
+  })
+
+  it("completeTrainJob stamps the job's source and structuralVersion onto the cached result", () => {
+    const store = useNodeResultsStore.getState()
+    store.startTrainJob("node_1", "job_1", "Model Training", "hash_a", "source_a", 3)
+    useNodeResultsStore.getState().completeTrainJob("node_1", {
+      status: "completed",
+      metrics: {},
+      feature_importance: [],
+      model_path: "m",
+      train_rows: 1,
+      test_rows: 1,
+    } as never)
+
+    const cached = useNodeResultsStore.getState().trainResults["node_1"]
+    expect(cached.source).toBe("source_a")
+    expect(cached.structuralVersion).toBe(3)
+  })
+})

--- a/frontend/src/hooks/__tests__/useStaleConfigEstimate.test.ts
+++ b/frontend/src/hooks/__tests__/useStaleConfigEstimate.test.ts
@@ -32,6 +32,7 @@ describe("useStaleConfigEstimate", () => {
         configA,
         { configHash: "old-hash" },
         endpoint,
+        { source: "source_a", structuralVersion: 1 },
       ),
     )
 
@@ -51,8 +52,9 @@ describe("useStaleConfigEstimate", () => {
       useStaleConfigEstimate<FakeEstimate>(
         "node_1",
         configA,
-        { configHash: hashConfig(configA) },
+        { configHash: hashConfig(configA), source: "source_a", structuralVersion: 1 },
         endpoint,
+        { source: "source_a", structuralVersion: 1 },
       ),
     )
 
@@ -64,7 +66,7 @@ describe("useStaleConfigEstimate", () => {
     const endpoint = vi.fn().mockResolvedValue(sampleEstimate)
 
     renderHook(() =>
-      useStaleConfigEstimate<FakeEstimate>("", configA, null, endpoint),
+      useStaleConfigEstimate<FakeEstimate>("", configA, null, endpoint, { source: "source_a", structuralVersion: 1 }),
     )
 
     await act(async () => {})
@@ -79,7 +81,7 @@ describe("useStaleConfigEstimate", () => {
 
     const { result, rerender } = renderHook(
       ({ config }: { config: Record<string, unknown> }) =>
-        useStaleConfigEstimate<FakeEstimate>("node_1", config, null, endpoint),
+        useStaleConfigEstimate<FakeEstimate>("node_1", config, null, endpoint, { source: "source_a", structuralVersion: 1 }),
       { initialProps: { config: configA } },
     )
 
@@ -108,6 +110,7 @@ describe("useStaleConfigEstimate", () => {
           configA,
           null,
           endpoint,
+          { source: "source_a", structuralVersion: 1 },
           { estimateKey },
         ),
       { initialProps: { estimateKey: "live:1" } },
@@ -133,7 +136,7 @@ describe("useStaleConfigEstimate", () => {
 
     const { rerender } = renderHook(
       ({ config }: { config: Record<string, unknown> }) =>
-        useStaleConfigEstimate<FakeEstimate>("node_1", config, null, endpoint),
+        useStaleConfigEstimate<FakeEstimate>("node_1", config, null, endpoint, { source: "source_a", structuralVersion: 1 }),
       { initialProps: { config: configA } },
     )
 
@@ -155,7 +158,7 @@ describe("useStaleConfigEstimate", () => {
       })
 
     const { unmount, result } = renderHook(() =>
-      useStaleConfigEstimate<FakeEstimate>("node_1", configA, null, endpoint),
+      useStaleConfigEstimate<FakeEstimate>("node_1", configA, null, endpoint, { source: "source_a", structuralVersion: 1 }),
     )
 
     await waitFor(() => expect(endpoint).toHaveBeenCalled())
@@ -171,7 +174,7 @@ describe("useStaleConfigEstimate", () => {
     const endpoint = vi.fn().mockRejectedValue(new Error("Server unreachable"))
 
     const { result } = renderHook(() =>
-      useStaleConfigEstimate<FakeEstimate>("node_1", configA, null, endpoint),
+      useStaleConfigEstimate<FakeEstimate>("node_1", configA, null, endpoint, { source: "source_a", structuralVersion: 1 }),
     )
 
     await waitFor(() => expect(result.current.loading).toBe(false))

--- a/frontend/src/hooks/useStaleConfigEstimate.ts
+++ b/frontend/src/hooks/useStaleConfigEstimate.ts
@@ -21,6 +21,25 @@ export interface UseStaleConfigEstimateOptions {
   enabled?: boolean
 }
 
+/**
+ * The non-config inputs that affect a cached solve/train result. Staleness
+ * key contract: a cached result is current only if its configHash, source,
+ * AND structuralVersion all match the live values — the same identity
+ * Explore checks (config+source folded into its hash, source re-checked on
+ * the cached result). Omitting either field here re-opens the wrong-source
+ * staleness bug pinned in useStaleConfigEstimate.sourceKey.test.ts.
+ */
+export interface StaleEstimateContext {
+  source: string
+  structuralVersion: number
+}
+
+export interface StaleCachedResult {
+  configHash: string
+  source?: string
+  structuralVersion?: number
+}
+
 interface EstimateState<TEstimate> {
   estimate: TEstimate | null
   loading: boolean
@@ -51,13 +70,20 @@ const INITIAL_STATE = { estimate: null, loading: false, error: null }
 export function useStaleConfigEstimate<TEstimate>(
   nodeId: string,
   config: Record<string, unknown>,
-  cachedResult: { configHash: string } | null | undefined,
+  cachedResult: StaleCachedResult | null | undefined,
   endpoint: ConfigEstimateEndpoint<TEstimate>,
+  context: StaleEstimateContext,
   options: UseStaleConfigEstimateOptions = {},
 ): UseStaleConfigEstimateResult<TEstimate> {
   const { toastLabel = "Estimate failed", estimateKey = "", enabled = true } = options
   const configHash = useMemo(() => hashConfig(config), [config])
-  const isStale = !!cachedResult && cachedResult.configHash !== configHash
+  // A cached result missing source/structuralVersion (pre-contract shape)
+  // fails the comparison and reads as stale — fail-safe, never fail-current.
+  const isStale =
+    !!cachedResult &&
+    (cachedResult.configHash !== configHash ||
+      cachedResult.source !== context.source ||
+      cachedResult.structuralVersion !== context.structuralVersion)
   const [state, dispatch] = useReducer(
     estimateReducer<TEstimate>,
     INITIAL_STATE as EstimateState<TEstimate>,
@@ -98,7 +124,7 @@ export function useStaleConfigEstimate<TEstimate>(
       })
 
     return () => controller.abort()
-  }, [nodeId, configHash, estimateKey, enabled])
+  }, [nodeId, configHash, context.source, context.structuralVersion, estimateKey, enabled])
 
   return { ...state, configHash, isStale }
 }

--- a/frontend/src/panels/ModellingConfig.tsx
+++ b/frontend/src/panels/ModellingConfig.tsx
@@ -94,9 +94,9 @@ export default function ModellingConfig({ config, onUpdate, upstreamColumns }: M
     config,
     cachedResult,
     estimateEndpoint,
+    { source: activeSource, structuralVersion },
     {
       toastLabel: "RAM estimate failed",
-      estimateKey: `${activeSource}:${structuralVersion}`,
     },
   )
 
@@ -133,6 +133,8 @@ export default function ModellingConfig({ config, onUpdate, upstreamColumns }: M
 
   const handleTrain = useCallback(async () => {
     const nodeLabel = allNodes.find(n => n.id === nodeId)?.data.label || "Model Training"
+    const trainSource = useSettingsStore.getState().activeSource
+    const trainStructuralVersion = useGraphStore.getState().structuralVersion
     setSubmitting(true)
     try {
       const result = await trainModel({
@@ -144,7 +146,7 @@ export default function ModellingConfig({ config, onUpdate, upstreamColumns }: M
 
       if (result.status === "started" && result.job_id) {
         // Register job in store — background hook picks up polling
-        startTrainJob(nodeId, result.job_id as string, nodeLabel, currentConfigHash)
+        startTrainJob(nodeId, result.job_id as string, nodeLabel, currentConfigHash, trainSource, trainStructuralVersion)
       } else if (result.status === "error") {
         // Immediate validation error — store as completed with error result
         useNodeResultsStore.getState().completeTrainJob(nodeId, result as unknown as TrainResult)

--- a/frontend/src/panels/OptimiserConfig.tsx
+++ b/frontend/src/panels/OptimiserConfig.tsx
@@ -310,9 +310,9 @@ export default function OptimiserConfig({
     config,
     cachedResult,
     solveEstimateEndpoint,
+    { source: activeSource, structuralVersion },
     {
       toastLabel: "Solve estimate failed",
-      estimateKey: `${activeSource}:${structuralVersion}`,
       enabled: !deferColumnFetch,
     },
   )
@@ -342,6 +342,8 @@ export default function OptimiserConfig({
   const handleSolve = useCallback(async () => {
     setSubmitting(true)
     const nodeLabel = allNodes.find(n => n.id === nodeId)?.data.label || "Optimiser"
+    const solveSource = useSettingsStore.getState().activeSource
+    const solveStructuralVersion = useGraphStore.getState().structuralVersion
     try {
       const result = await solveOptimiser({
         graph: buildGraphCb(),
@@ -350,15 +352,15 @@ export default function OptimiserConfig({
       })
       if (result.status === "started" && result.job_id) {
         // Register job in store — background hook picks up polling
-        startSolveJob(nodeId, result.job_id, nodeLabel, constraints, currentConfigHash)
+        startSolveJob(nodeId, result.job_id, nodeLabel, constraints, currentConfigHash, solveSource, solveStructuralVersion)
       } else if (result.status === "error") {
-        startSolveJob(nodeId, `startup-failure:${nodeId}`, nodeLabel, constraints, currentConfigHash)
+        startSolveJob(nodeId, `startup-failure:${nodeId}`, nodeLabel, constraints, currentConfigHash, solveSource, solveStructuralVersion)
         useNodeResultsStore.getState().failSolveJob(nodeId, result.error || "Unknown error")
       }
     } catch (e) {
       const errorMessage = requestErrorDetail(e)
       const terminalStatus = solveFailureStatus(e, errorMessage)
-      startSolveJob(nodeId, `startup-failure:${nodeId}`, nodeLabel, constraints, currentConfigHash)
+      startSolveJob(nodeId, `startup-failure:${nodeId}`, nodeLabel, constraints, currentConfigHash, solveSource, solveStructuralVersion)
       useNodeResultsStore.getState().failSolveJob(nodeId, errorMessage, terminalStatus)
     } finally {
       setSubmitting(false)

--- a/frontend/src/panels/__tests__/ModellingConfig.test.tsx
+++ b/frontend/src/panels/__tests__/ModellingConfig.test.tsx
@@ -541,6 +541,8 @@ describe("ModellingConfig", () => {
             progress: null,
             error: null,
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -622,6 +624,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult(),
             jobId: "job_1",
             configHash: "old_hash_that_wont_match",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -673,6 +677,8 @@ describe("ModellingConfig", () => {
             },
             error: null,
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -687,6 +693,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult({ status: "error", error: "OOM: out of memory" }),
             jobId: "job_1",
             configHash: "irrelevant",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -702,6 +710,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult(),
             jobId: "job_1",
             configHash: "irrelevant",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -719,6 +729,8 @@ describe("ModellingConfig", () => {
             progress: null,
             error: null,
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
         trainResults: {
@@ -726,6 +738,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult(),
             jobId: "job_1",
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -740,6 +754,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult({ status: "error", error: "fail" }),
             jobId: "job_1",
             configHash: "irrelevant",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })

--- a/frontend/src/panels/__tests__/ModellingConfig.test.tsx
+++ b/frontend/src/panels/__tests__/ModellingConfig.test.tsx
@@ -640,6 +640,8 @@ describe("ModellingConfig", () => {
             result: makeTrainResult(),
             jobId: "job_1",
             configHash: hash,
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })

--- a/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
+++ b/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
@@ -750,6 +750,8 @@ describe("OptimiserConfig", () => {
             error: null,
             constraints: {},
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -1030,6 +1032,8 @@ describe("OptimiserConfig", () => {
             },
             jobId: "job_42",
             configHash: "definitely_stale_hash",
+            source: "live",
+            structuralVersion: 0,
             constraints: {},
             nodeLabel: "Optimiser",
             originalResult: {
@@ -1090,6 +1094,8 @@ describe("OptimiserConfig", () => {
       },
       frontier: null,
       selectedPointIndex: null,
+      source: "live",
+      structuralVersion: 0,
     }
 
     it("shows convergence status when solveResult exists", () => {
@@ -1177,6 +1183,8 @@ describe("OptimiserConfig", () => {
             error: "Solver exploded",
             constraints: {},
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -1228,6 +1236,8 @@ describe("OptimiserConfig", () => {
             error: null,
             constraints: {},
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -1255,6 +1265,8 @@ describe("OptimiserConfig", () => {
             error: null,
             constraints: {},
             configHash: "abc",
+            source: "live",
+            structuralVersion: 0,
           },
         },
       })
@@ -1288,6 +1300,8 @@ describe("OptimiserConfig", () => {
             },
             jobId: "job_42",
             configHash: "definitely_stale_hash",
+            source: "live",
+            structuralVersion: 0,
             constraints: {},
             nodeLabel: "Optimiser",
             originalResult: {

--- a/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
+++ b/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
@@ -992,6 +992,8 @@ describe("OptimiserConfig", () => {
             },
             jobId: "job_42",
             configHash: matchingHash,
+            source: "live",
+            structuralVersion: 0,
             constraints: {},
             nodeLabel: "Optimiser",
             originalResult: {

--- a/frontend/src/panels/__tests__/OptimiserPreview.storeIntegration.test.tsx
+++ b/frontend/src/panels/__tests__/OptimiserPreview.storeIntegration.test.tsx
@@ -69,7 +69,7 @@ describe("OptimiserPreview store integration", () => {
 
   it("re-renders from the result store when a frontier point is clicked", async () => {
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "My Optimiser", { loss_ratio: { max: 1.05 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "My Optimiser", { loss_ratio: { max: 1.05 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -120,7 +120,7 @@ describe("OptimiserPreview store integration", () => {
       error: null,
     })
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -187,7 +187,7 @@ describe("OptimiserPreview store integration", () => {
       error: null,
     })
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -260,7 +260,7 @@ describe("OptimiserPreview store integration", () => {
         error: null,
       })
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -317,7 +317,7 @@ describe("OptimiserPreview store integration", () => {
       error: null,
     })
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -361,7 +361,7 @@ describe("OptimiserPreview store integration", () => {
       }),
     )
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({
@@ -446,7 +446,7 @@ describe("OptimiserPreview store integration", () => {
     )
 
     const store = useNodeResultsStore.getState()
-    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1")
+    store.startSolveJob("opt_1", "job_123", "Ratebook Optimiser", { volume: { min: 0.9 } }, "h1", "live", 0)
     store.completeSolveJob(
       "opt_1",
       makeSolveResult({

--- a/frontend/src/stores/useNodeResultsStore.ts
+++ b/frontend/src/stores/useNodeResultsStore.ts
@@ -106,6 +106,9 @@ interface CachedSolveResult {
   terminalStatus?: SolveProgress | null
   jobId: string
   configHash: string
+  /** Staleness key contract: configHash + source + structuralVersion (see useStaleConfigEstimate) */
+  source: string
+  structuralVersion: number
   /** Constraint config snapshot for OptimiserPreview */
   constraints: Record<string, Record<string, number>>
   nodeLabel: string
@@ -122,6 +125,8 @@ interface ActiveSolveJob {
   /** Constraint config snapshot for OptimiserPreview */
   constraints: Record<string, Record<string, number>>
   configHash: string
+  source: string
+  structuralVersion: number
 }
 
 interface CachedTrainResult {
@@ -129,6 +134,9 @@ interface CachedTrainResult {
   terminalStatus?: TrainProgress | null
   jobId: string
   configHash: string
+  /** Staleness key contract: configHash + source + structuralVersion (see useStaleConfigEstimate) */
+  source: string
+  structuralVersion: number
 }
 
 interface ActiveTrainJob {
@@ -138,6 +146,8 @@ interface ActiveTrainJob {
   progress: TrainProgress | null
   error: string | null
   configHash: string
+  source: string
+  structuralVersion: number
 }
 
 interface CachedExploreResult {
@@ -573,7 +583,7 @@ interface NodeResultsState {
   setPinnedPreviewNodeId: (nodeId: string | null) => void
 
   // ── Optimiser actions ──
-  startSolveJob: (nodeId: string, jobId: string, nodeLabel: string, constraints: Record<string, Record<string, number>>, configHash: string) => void
+  startSolveJob: (nodeId: string, jobId: string, nodeLabel: string, constraints: Record<string, Record<string, number>>, configHash: string, source: string, structuralVersion: number) => void
   updateSolveProgress: (nodeId: string, progress: SolveProgress) => void
   completeSolveJob: (nodeId: string, result: SolveResult, terminalStatus?: SolveProgress) => void
   failSolveJob: (nodeId: string, error: string, terminalStatus?: SolveProgress) => void
@@ -581,7 +591,7 @@ interface NodeResultsState {
   updateFrontierAfterSelect: (nodeId: string, pointIndex: number, selectResult: FrontierSelectResponse) => void
 
   // ── Training actions ──
-  startTrainJob: (nodeId: string, jobId: string, nodeLabel: string, configHash: string) => void
+  startTrainJob: (nodeId: string, jobId: string, nodeLabel: string, configHash: string, source: string, structuralVersion: number) => void
   updateTrainProgress: (nodeId: string, progress: TrainProgress) => void
   completeTrainJob: (nodeId: string, result: TrainResult, terminalStatus?: TrainProgress) => void
   failTrainJob: (nodeId: string, error: string, terminalStatus?: TrainProgress) => void
@@ -678,11 +688,11 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
 
   // ── Optimiser ──
 
-  startSolveJob: (nodeId, jobId, nodeLabel, constraints, configHash) =>
+  startSolveJob: (nodeId, jobId, nodeLabel, constraints, configHash, source, structuralVersion) =>
     set((s) => ({
       solveJobs: {
         ...s.solveJobs,
-        [nodeId]: { jobId, nodeId, nodeLabel, progress: null, error: null, constraints, configHash },
+        [nodeId]: { jobId, nodeId, nodeLabel, progress: null, error: null, constraints, configHash, source, structuralVersion },
       },
     })),
 
@@ -720,6 +730,8 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
         terminalStatus: terminalStatus ?? null,
         jobId: job.jobId,
         configHash: job.configHash,
+        source: job.source,
+        structuralVersion: job.structuralVersion,
         constraints: job.constraints,
         nodeLabel: job.nodeLabel,
         frontier,
@@ -764,6 +776,8 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
         terminalStatus: terminalStatus ?? null,
         jobId: job.jobId,
         configHash: job.configHash,
+        source: job.source,
+        structuralVersion: job.structuralVersion,
         constraints: job.constraints,
         nodeLabel: job.nodeLabel,
         frontier: null,
@@ -904,9 +918,9 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
 
   // ── Training ──
 
-  startTrainJob: (nodeId, jobId, nodeLabel, configHash) =>
+  startTrainJob: (nodeId, jobId, nodeLabel, configHash, source, structuralVersion) =>
     set((s) => {
-      const nextJob = { jobId, nodeId, nodeLabel, progress: null, error: null, configHash }
+      const nextJob = { jobId, nodeId, nodeLabel, progress: null, error: null, configHash, source, structuralVersion }
       const cached = s.trainResults[nodeId]
       if (cached && cached.result.status !== "error") {
         cacheModellingPreview(nodeId, cached, nextJob)
@@ -940,6 +954,10 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
         terminalStatus: terminalStatus ?? null,
         jobId: job?.jobId ?? "",
         configHash: job?.configHash ?? "",
+        // Direct completion with no active job has no recorded source; the
+        // empty sentinel never matches a real source, so it reads as stale.
+        source: job?.source ?? "",
+        structuralVersion: job?.structuralVersion ?? -1,
       }
       const bounded = trimCacheByRecency(
         {
@@ -975,6 +993,8 @@ const useNodeResultsStore = create<NodeResultsState>()((set, get) => ({
         terminalStatus: terminalStatus ?? null,
         jobId: job.jobId,
         configHash: job.configHash,
+        source: job.source,
+        structuralVersion: job.structuralVersion,
       }
       const bounded = trimCacheByRecency(
         {


### PR DESCRIPTION
## Bug

Optimiser and Modelling staleness was decided by `cachedResult.configHash !== hashConfig(config)` (`useStaleConfigEstimate.ts`) — a hash of the node config only. Neither the active data source nor `structuralVersion` participated, and `CachedSolveResult`/`CachedTrainResult` carried no `source` field. Run a solve/train against source A, switch the active source to B without touching config: the result computed on A rendered as current for B, with no stale marker. (The Explore panel already keys on config + source and re-checks `cachedResult.source` — the in-house correct pattern.)

## Fix

Mirrors Explore's key derivation rather than inventing a new one:

- `useStaleConfigEstimate` takes a required `StaleEstimateContext { source, structuralVersion }`; a cached result is current only if `configHash`, `source`, AND `structuralVersion` all match. The key contract is documented at the definition site. A cached result missing the new fields reads as stale (fail-safe, never fail-current).
- `ActiveSolveJob`/`CachedSolveResult` and `ActiveTrainJob`/`CachedTrainResult` carry `source` + `structuralVersion`; `startSolveJob`/`startTrainJob` stamp them at job start and `complete*`/`fail*` copy them onto the cached result.
- `OptimiserConfig`/`ModellingConfig` capture the active source and structuralVersion at gesture time and pass the context to the hook; the `estimateKey` source/version duplication is folded into the hook's effect deps.

## Tests

Key-contract pin (`useStaleConfigEstimate.sourceKey.test.ts`): switches the active source and asserts the cached result is marked stale; same for a structuralVersion advance; legacy cached results without a source field read as stale; store-level tests assert completed solve/train jobs carry their source identity. All five pinned red on the pre-fix key before the fix was applied.

Full frontend suite: 274 files / 5262 tests green; tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)