### PR TITLE
Preserve # haute:preserve blocks through the regex fallback parser

### DIFF
--- a/src/haute/_parser_regex.py
+++ b/src/haute/_parser_regex.py
@@ -24,6 +24,7 @@ from haute._ast_helpers import (
     _extract_connect_calls,
     _extract_pipeline_meta,
     _extract_preamble,
+    _extract_preserved_blocks,
     _get_docstring,
 )
 from haute._config_builder import (
@@ -931,6 +932,10 @@ def fallback_parse(
         pipeline_name=pipeline_name,
         pipeline_description=pipeline_desc,
         preamble=preamble,
+        # The marker scan is a pure line scan, so it works on the
+        # syntactically-broken source that triggered this fallback; without
+        # it a fallback-parse -> save cycle deletes every preserve block.
+        preserved_blocks=_extract_preserved_blocks(source),
         source_file=source_file,
         warning=f"File has syntax errors (line {syntax_error.lineno}); parsed via regex fallback",
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -558,6 +558,47 @@ def transform(load_data: pl.DataFrame) -> pl.DataFrame:
         # Regex fallback must still find the first (valid) node
         assert len(graph.nodes) >= 1
         assert graph.pipeline_name == "broken"
+
+    def test_fallback_keeps_preserved_blocks(self, tmp_path):
+        """A preserve block must survive a fallback-parse -> codegen cycle.
+
+        Production failure: saving a half-edited file (syntax error) went
+        through the regex fallback, which built its graph without
+        ``preserved_blocks`` — silently deleting every ``# haute:preserve``
+        block on the next save.
+        """
+        from haute.codegen import graph_to_code
+
+        code = '''\
+import polars as pl
+import haute
+
+pipeline = haute.Pipeline("broken_preserve")
+
+# haute:preserve-start
+KEEP_ME = True
+# haute:preserve-end
+
+
+@pipeline.polars
+def transform() -> pl.DataFrame:
+    """Transform."""
+    return pl.DataFrame()
+
+
+broken = (
+'''  # <-- unclosed paren = SyntaxError
+        p = _write_pipeline(tmp_path, code)
+        graph = parse_pipeline_file(p)
+
+        assert graph.warning  # proves the fallback path fired
+        assert len(graph.preserved_blocks) == 1
+        assert "KEEP_ME" in graph.preserved_blocks[0]
+
+        generated = graph_to_code(graph, pipeline_name="broken_preserve")
+        assert "KEEP_ME = True" in generated
+        assert "# haute:preserve-start" in generated
+        assert "# haute:preserve-end" in generated
         assert graph.warning is not None
         assert "syntax error" in graph.warning.lower()
 


### PR DESCRIPTION
## Symptom (B039, MUST-FIX)

`fallback_parse` constructed its `PipelineGraph` with no `preserved_blocks=` kwarg, while the healthy path extracts them and codegen re-emits them. A parse-via-regex-fallback → save cycle therefore silently deleted every `# haute:preserve` block, with only a generic warning as signal — silent data loss on the save path.

## Fix

Pass `preserved_blocks=_extract_preserved_blocks(source)` in the fallback graph construction. The extractor is a pure line-marker scan needing no valid AST, so it works unconditionally on the syntactically-broken source that triggers the fallback.

Site audit: `merge_submodels` propagates via `model_copy` (safe); the execution cache copies the field explicitly (safe); submodel parsing extracts preserve blocks on neither the healthy nor the fallback path — symmetric, so not an instance of this bug.

## Tests

TDD: `TestRegexFallbackPath::test_fallback_keeps_preserved_blocks` (syntax-error file with a preserve block must round-trip fallback-parse → codegen with block and markers intact) shown red first, green after. Parser + codegen suites 366 passed; full `scripts/preflight.sh` green; forward-merged onto main tip `a603c4ad` (frontend-only delta) with the regression re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)