### PR TITLE
Reject null objective/constraint/scenario values in optimiser input

### DIFF
--- a/src/haute/routes/_optimiser_service.py
+++ b/src/haute/routes/_optimiser_service.py
@@ -170,8 +170,10 @@ _FRONTIER_AUTO_RANGE_JOB_TYPE = "frontier_auto_range"
 _GRAPH_NODE_SETUP_COORDINATION_TYPE = "optimiser_graph_node_setup"
 _NULL_QUOTE_ID_DETAIL_PREFIX = "Null quote_id values found in optimiser input"
 _NON_FINITE_DETAIL_PREFIX = "Non-finite values found in optimiser input"
+_NULL_VALUE_DETAIL_PREFIX = "Null values found in optimiser input"
 _QUOTE_ID_NULL_COUNT_ALIAS = "__haute_quote_id_null_count"
 _NON_FINITE_COUNT_ALIAS_PREFIX = "__haute_non_finite_count_"
+_NULL_COUNT_ALIAS_PREFIX = "__haute_null_count_"
 _AUTO_RANGE_BUCKET_COLUMN = "__haute_frontier_auto_range_bucket"
 _FRONTIER_AUTO_RANGE_CANCELLED_STATUS = "cancelled"
 _FRONTIER_AUTO_RANGE_SUPERSEDED_STATUS = "superseded"
@@ -241,11 +243,16 @@ def _non_finite_check_columns(schema: Any, column_names: Iterable[str]) -> list[
     ]
 
 
+def _null_check_columns(schema: Any, column_names: Iterable[str]) -> list[str]:
+    return [cname for cname in dict.fromkeys(column_names) if cname in schema]
+
+
 def _value_contract_validation_exprs(
     *,
     quote_id_col: str,
     validate_quote_id_nulls: bool,
     non_finite_check_cols: list[str],
+    null_check_cols: list[str],
     cast_to_float32_cols: set[str],
 ) -> list[Any]:
     import polars as pl
@@ -260,6 +267,13 @@ def _value_contract_validation_exprs(
         )
         validation_exprs.append(
             checked.is_infinite().sum().alias(f"{_NON_FINITE_COUNT_ALIAS_PREFIX}inf_{index}")
+        )
+    # Nulls are checked on the source dtype: is_nan()/is_infinite() return
+    # null for null inputs, so sum() skips them and the finite check alone
+    # cannot see a genuinely-null value.
+    for index, cname in enumerate(null_check_cols):
+        validation_exprs.append(
+            pl.col(cname).null_count().alias(f"{_NULL_COUNT_ALIAS_PREFIX}{index}")
         )
     return validation_exprs
 
@@ -289,6 +303,26 @@ def _non_finite_detail_from_counts(
         f"{_NON_FINITE_DETAIL_PREFIX}: {', '.join(non_finite_summaries)}. "
         "The optimiser requires finite objective, constraint, and scenario values; "
         "check upstream joins and calculations for division by zero or overflow."
+    )
+
+
+def _null_value_detail_from_counts(
+    validation_counts: Any,
+    null_check_cols: list[str],
+) -> str | None:
+    null_summaries = []
+    for index, cname in enumerate(null_check_cols):
+        null_count = int(validation_counts.get_column(f"{_NULL_COUNT_ALIAS_PREFIX}{index}").item())
+        if null_count > 0:
+            null_summaries.append(
+                f"'{cname}' ({null_count} null row{'s' if null_count != 1 else ''})"
+            )
+    if not null_summaries:
+        return None
+    return (
+        f"{_NULL_VALUE_DETAIL_PREFIX}: {', '.join(null_summaries)}. "
+        "The optimiser requires non-null objective, constraint, and scenario values; "
+        "check upstream joins and filters for rows with missing values."
     )
 
 
@@ -4464,6 +4498,8 @@ class OptimiserSolveService:
             # so float columns are checked at that precision to also reject
             # Float64 values that overflow to ±inf on the cast. scenario_index
             # is cast to Int32 downstream, so its source values are checked.
+            # Genuinely-null values (any dtype) are rejected in the same pass:
+            # the external aggregation's treatment of null is undefined.
             self._validate_input_value_contracts(
                 source_lf,
                 schema,
@@ -4508,11 +4544,14 @@ class OptimiserSolveService:
         streaming_chunk_size: int | None,
         profile: ExecutionProfile,
     ) -> None:
+        finite_columns = list(finite_columns)
         non_finite_check_cols = _non_finite_check_columns(schema, finite_columns)
+        null_check_cols = _null_check_columns(schema, finite_columns)
         validation_exprs = _value_contract_validation_exprs(
             quote_id_col=quote_id_col,
             validate_quote_id_nulls=validate_quote_id_nulls,
             non_finite_check_cols=non_finite_check_cols,
+            null_check_cols=null_check_cols,
             cast_to_float32_cols=set(cast_to_float32_columns),
         )
         if not validation_exprs:
@@ -4548,6 +4587,19 @@ class OptimiserSolveService:
                 execution_context=execution_context,
             )
             raise HTTPException(status_code=400, detail=non_finite_detail)
+
+        null_value_detail = _null_value_detail_from_counts(
+            validation_counts,
+            null_check_cols,
+        )
+        if null_value_detail is not None:
+            self._record_http_setup_failure(
+                job_id,
+                status_code=400,
+                detail=null_value_detail,
+                execution_context=execution_context,
+            )
+            raise HTTPException(status_code=400, detail=null_value_detail)
 
     def _validate_and_project_auto_range(
         self,

--- a/tests/test_optimiser_routes.py
+++ b/tests/test_optimiser_routes.py
@@ -1261,6 +1261,82 @@ class TestEstimateRoute:
         ]
         assert running_jobs == [], f"Validation failure left running job(s) behind: {running_jobs}"
 
+    @pytest.mark.parametrize(
+        ("column", "null_series", "expected_fragment"),
+        [
+            pytest.param(
+                "volume",
+                pl.Series([0.9, None, 1.0, 0.9], dtype=pl.Float32),
+                "'volume' (1 null row)",
+                id="constraint-null",
+            ),
+            pytest.param(
+                "scenario_value",
+                pl.Series([0.9, None, 0.9, 1.1], dtype=pl.Float32),
+                "'scenario_value' (1 null row)",
+                id="scenario-value-null",
+            ),
+            pytest.param(
+                "scenario_index",
+                pl.Series([0, None, 0, 1], dtype=pl.Int32),
+                "'scenario_index' (1 null row)",
+                id="scenario-index-null",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("_widen_sandbox_root")
+    def test_solve_rejects_null_input_values(
+        self,
+        client,
+        tmp_path,
+        clean_job_store,
+        column,
+        null_series,
+        expected_fragment,
+    ):
+        """A genuinely-null objective/constraint/scenario value must fail as
+        loudly as NaN does.
+
+        The non-finite gate only sees NaN/inf: ``is_nan()``/``is_infinite()``
+        return null for null inputs, so ``sum()`` skips them and a null value
+        sails through to the solver, where the external aggregation's
+        treatment of null is undefined (silent-corruption risk). Pin the
+        contract: nulls are rejected before any solve, with a 400-class
+        contract error naming the offending column, and no running job is
+        left behind.
+        """
+        df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q1", "q2", "q2"],
+                "scenario_index": pl.Series([0, 1, 0, 1], dtype=pl.Int32),
+                "scenario_value": pl.Series([0.9, 1.0, 0.9, 1.1], dtype=pl.Float32),
+                "expected_income": pl.Series([100.0, 110.0, 80.0, 90.0], dtype=pl.Float32),
+                "volume": pl.Series([0.9, 0.95, 1.0, 0.9], dtype=pl.Float32),
+            }
+        ).with_columns(null_series.alias(column))
+        path = tmp_path / f"null_{column}.parquet"
+        df.write_parquet(path)
+        graph = _make_optimiser_graph(str(path))
+
+        resp = client.post(
+            "/api/optimiser/solve",
+            json={"graph": graph, "node_id": "opt"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        status = _poll_until_done(client, resp.json()["job_id"])
+        assert status["status"] == "contract_error"
+        detail = status["message"]
+        assert "Null values found in optimiser input" in detail
+        assert expected_fragment in detail, (
+            f"Error detail does not name the offending column: {detail!r}"
+        )
+
+        running_jobs = [
+            (jid, j) for jid, j in clean_job_store.jobs.items() if j.get("status") == "running"
+        ]
+        assert running_jobs == [], f"Validation failure left running job(s) behind: {running_jobs}"
+
     def test_estimate_rejects_unknown_node_loudly(self, client, scored_data):
         graph = _make_optimiser_graph(scored_data)
         resp = client.post(
@@ -1528,6 +1604,63 @@ class TestEstimateRoute:
         assert "Non-finite values found in optimiser input" in exc_info.value.detail
         assert expected_fragment in exc_info.value.detail
         assert "finite objective, constraint, and scenario values" in exc_info.value.detail
+        status = service.frontier_auto_range_status(job_id)
+        assert status.status == "contract_error"
+        assert status.http_status_code == 400
+        assert status.error_detail == exc_info.value.detail
+
+    @pytest.mark.parametrize(
+        ("column", "expected_fragment"),
+        [
+            pytest.param("expected_income", "'expected_income' (1 null row)", id="objective-null"),
+            pytest.param("volume", "'volume' (1 null row)", id="constraint-null"),
+        ],
+    )
+    def test_frontier_auto_range_rejects_null_values_before_deriving_ranges(
+        self,
+        scored_data,
+        column,
+        expected_fragment,
+    ):
+        """Null objective/constraint values must fail as loudly as NaN: the
+        finite check skips nulls, so without a dedicated null gate they reach
+        the range estimator silently."""
+        from haute.routes._job_store import JobStore
+        from haute.routes._optimiser_service import OptimiserSolveService
+        from haute.schemas import OptimiserFrontierAutoRangeRequest
+
+        graph = _make_optimiser_graph(scored_data)
+        body = OptimiserFrontierAutoRangeRequest(graph=graph, node_id="opt")
+        source_df = pl.DataFrame(
+            {
+                "quote_id": ["q1", "q1"],
+                "expected_income": pl.Series([100.0, 110.0], dtype=pl.Float32),
+                "volume": pl.Series([1.0, 2.0], dtype=pl.Float32),
+            }
+        )
+        values = source_df[column].to_list()
+        values[1] = None
+        source_lf = source_df.with_columns(pl.Series(column, values, dtype=pl.Float32)).lazy()
+        store = JobStore()
+        service = OptimiserSolveService(store)
+        job_id = store.create_job({"status": "running", "job_type": "frontier_auto_range"})
+        prepared = service._prepare_frontier_auto_range(body)
+        prepared["streaming_plan"] = None
+
+        with (
+            patch.object(service, "_execute_pipeline", return_value={"opt": source_lf}),
+            patch(
+                "haute.routes._optimiser_service._estimate_scenario_frontier_ranges",
+                side_effect=AssertionError("range derivation should not run"),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            service._run_frontier_auto_range_job(body, job_id, **prepared)
+
+        assert exc_info.value.status_code == 400
+        assert "Null values found in optimiser input" in exc_info.value.detail
+        assert expected_fragment in exc_info.value.detail
+        assert "non-null objective, constraint, and scenario values" in exc_info.value.detail
         status = service.frontier_auto_range_status(job_id)
         assert status.status == "contract_error"
         assert status.http_status_code == 400


### PR DESCRIPTION
## Symptom

The optimiser's value-contract gate caught NaN/inf but not genuine nulls: `is_nan()`/`is_infinite()` return null for null inputs, so `sum()` skipped them and a null constraint/objective/scenario value sailed through to the solver, where the external aggregation's treatment of null is undefined (silent-corruption risk). In a live repro the null surfaced later as a confusing grid-construction error instead of a named contract error.

## Fix

Add `pl.col(c).null_count()` per checked column to the existing single streaming validation pass in `_validate_input_value_contracts`, checked on the source dtype and for every requested column (not just floats — a null Int32 `scenario_index` is caught too). Rejection mirrors the non-finite gate: a 400-class contract error naming the offending column and row count. Both the solve and frontier auto-range paths share the pass, so both are covered. No extra data scan.

## Tests

- TDD: new tests first, confirmed red (null reached the grid builder), then green.
- Solve path: constraint / scenario_value / scenario_index nulls → `contract_error` naming the column, no stuck running job.
- Auto-range path: objective / constraint nulls → HTTP 400 before range derivation.
- All optimiser suites pass (462 tests); full `scripts/preflight.sh` gate green.
- End-to-end against a fresh live server: null input → `contract_error` with the exact message; clean input → `completed`.

## Risk

Low, purely additive: the only behaviour change is that previously-passing null-bearing inputs now fail loud. Deliberate widening: nulls are checked on all value columns (any dtype), not just the float finite-check set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)