### PR TITLE
Fail loud when trace row relocation matches duplicate rows

### DIFF
--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -502,6 +502,9 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
         if detail.startswith("Trace data does not match"):
             logger.warning("trace_row_mismatch", error=detail)
             raise HTTPException(status_code=409, detail=detail)
+        if detail.startswith("Trace row match is ambiguous"):
+            logger.warning("trace_row_match_ambiguous", error=detail)
+            raise HTTPException(status_code=409, detail=detail)
         if detail.startswith("row_index ") and "out of range" in detail:
             logger.warning("trace_row_out_of_range", error=detail)
             raise HTTPException(status_code=400, detail=detail)

--- a/src/haute/trace.py
+++ b/src/haute/trace.py
@@ -265,10 +265,23 @@ def _find_target_row_index(df: pl.DataFrame, row_values: dict[str, Any]) -> int 
     if not shared:
         return None
 
-    for idx, row in enumerate(df.select(shared).iter_rows(named=True)):
-        if all(_trace_values_match(row.get(col), row_values.get(col)) for col in shared):
-            return idx
-    return None
+    # Duplicate rows on the shared columns are ambiguous: silently
+    # anchoring to the first match would correlate upstream from the
+    # wrong row.  Mirror the W4 policy (_record_ambiguous_row_match)
+    # and fail loud instead.
+    matches = [
+        idx
+        for idx, row in enumerate(df.select(shared).iter_rows(named=True))
+        if all(_trace_values_match(row.get(col), row_values.get(col)) for col in shared)
+    ]
+    if len(matches) > 1:
+        raise ValueError(
+            "Trace row match is ambiguous: "
+            f"{len(matches)} rows match the clicked values on "
+            f"columns {shared}. The preview data may have changed. "
+            "Please click the node to refresh, then retry."
+        )
+    return matches[0] if matches else None
 
 
 def _requested_preview_columns_from_row(

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -157,6 +157,19 @@ class TestTraceJsonSafeRowMatching:
         assert _find_target_row_index(df, {"value": INF_SENTINEL}) == 2
         assert _find_target_row_index(df, {"value": NEG_INF_SENTINEL}) == 3
 
+    def test_target_row_lookup_fails_loud_on_duplicate_matches(self):
+        df = pl.DataFrame(
+            {
+                "x": [1, 1, 2],
+                "y": [10, 10, 30],
+            }
+        )
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            _find_target_row_index(df, {"x": 1, "y": 10})
+
+        assert _find_target_row_index(df, {"x": 2, "y": 30}) == 2
+
     def test_parent_row_matching_accepts_json_safe_frontend_values(self):
         unsafe = MAX_SAFE_INTEGER + 1
         df = pl.DataFrame(

--- a/tests/test_trace_api.py
+++ b/tests/test_trace_api.py
@@ -137,6 +137,32 @@ class TestRequestValidation:
         assert resp.status_code == 409
         assert "Trace data does not match" in resp.json()["detail"]
 
+    def test_duplicate_row_relocation_returns_conflict_not_first_match(self, client, tmp_path):
+        """Two rows identical on the clicked columns must fail loud, not
+        silently anchor the trace to the first duplicate."""
+        from haute.executor import _preview_cache
+        from haute.trace import _cache as _trace_cache
+
+        _preview_cache.invalidate()
+        _trace_cache.invalidate()
+
+        p = _simple_parquet(tmp_path, data={"x": [1, 1, 2], "y": [10, 10, 30]})
+        graph = _simple_graph(p, "df = df.with_columns(z=pl.col('x') + pl.col('y'))")
+
+        # row_index 2 does not match the clicked values, forcing the
+        # eviction-relocation path; the values then match rows 0 AND 1.
+        resp = _trace_post(
+            client,
+            graph,
+            row_index=2,
+            target_node_id="t",
+            column="z",
+            row_values={"x": 1, "y": 10, "z": 11},
+        )
+
+        assert resp.status_code == 409
+        assert "ambiguous" in resp.json()["detail"]
+
     def test_empty_graph_returns_error(self, client):
         """POST with a graph containing no nodes returns an error."""
         graph = _g({"nodes": [], "edges": []}).model_dump()


### PR DESCRIPTION
## Symptom
After preview-cache eviction, the trace relocates the clicked row via `_find_target_row_index`, which silently returned the FIRST matching row. Two rows identical on the clicked columns anchored the trace to the wrong duplicate and correlated upstream from it (BUGS ledger: CRITICAL, post-W4 survivor).

## Fix
Mirror the W4 ambiguity policy: collect all matches; >1 raises "Trace row match is ambiguous…", mapped to a 409 by the trace route alongside the existing no-match conflict. A unique match relocates exactly as before.

## Tests
TDD red-first: unit pin (duplicate rows raise, unique row still resolves) + route pin (relocation onto duplicates → 409 with "ambiguous" detail). Full backend suite green (12,668 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)