### PR TITLE
Use pre-assignment inputs for self-referential trace calculations

### DIFF
--- a/src/haute/_trace_enrichment.py
+++ b/src/haute/_trace_enrichment.py
@@ -1554,6 +1554,7 @@ def enrich_steps(
                 # Check if the column is a keyword arg or appears as an alias target
                 _col_in_code = bool(re.search(rf"\b{re.escape(column)}\s*=", raw_code))
             if column and (_col_in_schema or _col_in_code):
+                parsed = None
                 try:
                     parsed = trace_mod.parse_expression(code, column)
                     if parsed is not None:
@@ -1575,41 +1576,73 @@ def enrich_steps(
                         "error_type": type(exc).__name__,
                         "target_column": column,
                     }
-                try:
-                    evaluated = trace_mod.evaluate_expression(
-                        code,
-                        column,
-                        {**step.input_values, **step.output_values},
-                        preamble_ns=preamble_ns,
-                    )
-                    if evaluated is not None:
-                        calc_dict = dataclasses.asdict(evaluated)
-                        # Add taken_branch info to calculation dict
-                        if evaluated.taken_branch is not None:
-                            calc_dict["taken_branch"] = evaluated.taken_branch
-                        if evaluated.taken_branch_index is not None:
-                            calc_dict["taken_branch_index"] = evaluated.taken_branch_index
-                        # For window functions, use the actual output value
-                        if evaluated.expression_type == "window" and column in step.output_values:
-                            calc_dict["result_value"] = step.output_values[column]
-                        step.calculation = calc_dict
-                except Exception as exc:
-                    logger.warning(
-                        "expression_eval_failed",
-                        node_id=step.node_id,
-                        column=column,
-                        error=str(exc),
-                        error_type=type(exc).__name__,
-                        exc_info=True,
-                    )
-                    # Seed calculation with a visible error marker that
-                    # persists even if later enrichment stages (chain,
-                    # input_sources) add more fields to the dict.
-                    step.calculation = {
-                        "error": f"evaluate_expression failed: {exc}",
-                        "error_type": type(exc).__name__,
-                        "target_column": column,
-                    }
+                # Self-referential assignment (premium = premium * ...):
+                # the post-assignment output value must not clobber the
+                # RHS input, or the substitution shows the OUTPUT on the
+                # right-hand side and a result contradicting the
+                # displayed value.  Same guard as the input-sources path
+                # (``self_referential_modification`` above).
+                eval_values = {**step.input_values, **step.output_values}
+                self_referential = (
+                    column in step.schema_diff.columns_modified
+                    and parsed is not None
+                    and column in parsed.referenced_columns
+                )
+                skip_evaluation = False
+                if self_referential:
+                    if column in step.input_values:
+                        eval_values[column] = step.input_values[column]
+                    else:
+                        # No pre-assignment value available: showing a
+                        # substitution would require the input we don't
+                        # have, so present the output value directly
+                        # rather than an arithmetically false eval.
+                        result = step.output_values.get(column)
+                        step.calculation = {
+                            "target_column": column,
+                            "substituted_text": f"{column} = {_quote_trace_value(result)}",
+                            "result_value": result,
+                        }
+                        skip_evaluation = True
+                if not skip_evaluation:
+                    try:
+                        evaluated = trace_mod.evaluate_expression(
+                            code,
+                            column,
+                            eval_values,
+                            preamble_ns=preamble_ns,
+                        )
+                        if evaluated is not None:
+                            calc_dict = dataclasses.asdict(evaluated)
+                            # Add taken_branch info to calculation dict
+                            if evaluated.taken_branch is not None:
+                                calc_dict["taken_branch"] = evaluated.taken_branch
+                            if evaluated.taken_branch_index is not None:
+                                calc_dict["taken_branch_index"] = evaluated.taken_branch_index
+                            # For window functions, use the actual output value
+                            if (
+                                evaluated.expression_type == "window"
+                                and column in step.output_values
+                            ):
+                                calc_dict["result_value"] = step.output_values[column]
+                            step.calculation = calc_dict
+                    except Exception as exc:
+                        logger.warning(
+                            "expression_eval_failed",
+                            node_id=step.node_id,
+                            column=column,
+                            error=str(exc),
+                            error_type=type(exc).__name__,
+                            exc_info=True,
+                        )
+                        # Seed calculation with a visible error marker that
+                        # persists even if later enrichment stages (chain,
+                        # input_sources) add more fields to the dict.
+                        step.calculation = {
+                            "error": f"evaluate_expression failed: {exc}",
+                            "error_type": type(exc).__name__,
+                            "target_column": column,
+                        }
 
                 # --- Expression chain (intra-node dependencies) ---
                 try:
@@ -1617,7 +1650,22 @@ def enrich_steps(
                     if chain and len(chain) > 1:
                         if step.calculation is None:
                             step.calculation = {}
+                        # Evaluate chain entries in order, feeding each
+                        # result forward.  Seeding every entry from the
+                        # final output values instead is wrong for
+                        # self-referential assignments: the entry that
+                        # rewrites ``premium`` would see the
+                        # post-assignment premium on its own RHS.  Chain
+                        # target columns therefore start from their
+                        # PRE-node input values (absent if newly created)
+                        # and are filled in as each entry evaluates.
                         combined_values = {**step.input_values, **step.output_values}
+                        chain_targets = {p.target_column for p in chain}
+                        for target in chain_targets:
+                            if target in step.input_values:
+                                combined_values[target] = step.input_values[target]
+                            else:
+                                combined_values.pop(target, None)
                         enriched_chain: list[dict[str, Any]] = []
                         for p in chain:
                             entry = dataclasses.asdict(p)
@@ -1632,6 +1680,7 @@ def enrich_steps(
                                 if ev is not None:
                                     entry["substituted_text"] = ev.substituted_text
                                     entry["result_value"] = ev.result_value
+                                    combined_values[p.target_column] = ev.result_value
                             except Exception as inner_exc:
                                 logger.warning(
                                     "chain_entry_eval_failed",
@@ -1644,7 +1693,10 @@ def enrich_steps(
                                 entry["error"] = f"chain entry evaluation failed: {inner_exc}"
                                 entry["error_type"] = type(inner_exc).__name__
                                 entry.setdefault("substituted_text", p.expression_text)
-                                fallback = combined_values.get(p.target_column)
+                                fallback = combined_values.get(
+                                    p.target_column,
+                                    step.output_values.get(p.target_column),
+                                )
                                 entry.setdefault("result_value", fallback)
                             enriched_chain.append(entry)
                         step.calculation["expression_chain"] = enriched_chain

--- a/tests/test_trace_calculation_hero.py
+++ b/tests/test_trace_calculation_hero.py
@@ -2087,3 +2087,66 @@ class TestCalculationValueVerification:
         input_vals = step.calculation.get("input_values", {})
         assert input_vals.get("price") == 25.0
         assert input_vals.get("tax_rate") == 0.2
+
+
+class TestSelfReferentialCalculation:
+    """A column assigned from itself must substitute the PRE-assignment
+    input value, not the post-assignment output (which produced e.g.
+    ``200.0 * 2.0 = 400`` for a displayed output of 200)."""
+
+    def test_self_referential_multiply_uses_input_value(self, tmp_path):
+        p = tmp_path / "data.parquet"
+        pl.DataFrame({"premium": [100.0], "factor": [2.0]}).write_parquet(p)
+
+        graph = _g(
+            {
+                "nodes": [
+                    _source_node("src", str(p)),
+                    _transform_node(
+                        "t",
+                        "df = df.with_columns(premium=pl.col('premium') * pl.col('factor'))",
+                    ),
+                ],
+                "edges": [_edge("src", "t")],
+            }
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id="t", column="premium")
+        step = _step_by_id(result, "t")
+
+        assert step.calculation is not None
+        assert step.calculation["result_value"] == 200.0
+        assert "100" in step.calculation["substituted_text"]
+        assert "200.0 * 2.0" not in step.calculation["substituted_text"]
+
+    def test_self_referential_chain_feeds_intermediates_forward(self, tmp_path):
+        p = tmp_path / "data.parquet"
+        pl.DataFrame({"premium": [100.0], "factor": [2.0], "burn": [50.0]}).write_parquet(p)
+
+        graph = _g(
+            {
+                "nodes": [
+                    _source_node("src", str(p)),
+                    _transform_node(
+                        "t",
+                        "df = df.with_columns(premium=pl.col('premium') * pl.col('factor'))"
+                        ".with_columns(margin=pl.col('premium') - pl.col('burn'))",
+                    ),
+                ],
+                "edges": [_edge("src", "t")],
+            }
+        )
+
+        result = execute_trace(graph, row_index=0, target_node_id="t", column="margin")
+        step = _step_by_id(result, "t")
+
+        assert step.calculation is not None
+        chain = step.calculation.get("expression_chain")
+        assert isinstance(chain, list) and len(chain) == 2
+        by_col = {entry["target_column"]: entry for entry in chain}
+
+        # premium entry: input premium (100) * factor (2) = 200 — not 400
+        assert by_col["premium"]["result_value"] == 200.0
+        assert "100" in by_col["premium"]["substituted_text"]
+        # margin entry consumes the fed-forward intermediate: 200 - 50
+        assert by_col["margin"]["result_value"] == 150.0


### PR DESCRIPTION
## Symptom
For `premium = pl.col('premium') * pl.col('factor')` with premium=100, factor=2, the trace calculation showed `200.0 * 2.0` and result 400 against a displayed output of 200: the main calculation eval merged output_values over input_values, so the post-assignment value clobbered the RHS input. The self-referential guard existed only in the input-sources path.

## Fix
Replicate the guard at the main calculation eval (pre-assignment input wins; output-value display fallback when no input exists), and make the expression-chain eval evaluate entries in order feeding each result forward — chain target columns start from their pre-node input values, so a self-referential entry and its downstream consumers both substitute correctly.

## Tests
TDD red-first reproducing the exact 400-vs-200 case (main calc + 2-entry chain). Trace/enrichment suites 478 passed; full backend suite green (12,693 passed); mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)