### PR TITLE
Trace through multi-frame apiInput sources instead of an opaque 500

### DIFF
--- a/src/haute/_trace_correlation.py
+++ b/src/haute/_trace_correlation.py
@@ -668,6 +668,7 @@ def _correlate_rows_posthoc(
     *,
     node_map: Mapping[str, GraphNode],
     diagnostics: list[dict[str, Any]] | None = None,
+    source_frame_of: Mapping[tuple[str, str], str | None] | None = None,
 ) -> dict[str, dict[str, Any] | None]:
     """Extract the correct row from each node using post-hoc correlation.
 
@@ -726,6 +727,29 @@ def _correlate_rows_posthoc(
             result[nid] = None
             row_indices[nid] = -1
             continue
+
+        # Multi-frame sources store dict[label, DataFrame]. The edge's
+        # sourceHandle names the frame each child consumes (the same
+        # selection _pick_source_frame makes at execution time) — resolve
+        # to that frame before correlating.
+        if isinstance(parent_df, dict):
+            handle = (source_frame_of or {}).get((nid, resolved_child_id))
+            frame = parent_df.get(handle) if handle is not None else None
+            if frame is None or len(frame) == 0:
+                if diagnostics is not None:
+                    diagnostics.append(
+                        {
+                            "code": "unresolved_source_frame",
+                            "node_id": nid,
+                            "child_id": resolved_child_id,
+                            "source_handle": handle,
+                            "frames": sorted(parent_df.keys()),
+                        }
+                    )
+                result[nid] = None
+                row_indices[nid] = -1
+                continue
+            parent_df = frame
 
         child_row = result[resolved_child_id]
         child_row_idx = row_indices.get(resolved_child_id, 0)

--- a/src/haute/_trace_enrichment.py
+++ b/src/haute/_trace_enrichment.py
@@ -1015,7 +1015,7 @@ def _fix_upstream_values(
             # Step has null but we know the correct value — try to find
             # the right row in the source DataFrame using the known value.
             df = eager_outputs.get(s.node_id)
-            if df is None or col_name not in df.columns:
+            if not isinstance(df, pl.DataFrame) or col_name not in df.columns:
                 break
             try:
                 # Filter to rows where this column matches the known value.
@@ -1772,8 +1772,16 @@ def enrich_steps(
                         factor_input_dtypes: dict[str, Any] = {}
                         for pid in parents_of.get(step.node_id, []):
                             pdf = eager_outputs.get(pid)
-                            if pdf is not None:
-                                for cname, cdtype in pdf.schema.items():
+                            # Multi-frame parents store dict[label, DataFrame]
+                            frames = (
+                                pdf.values()
+                                if isinstance(pdf, dict)
+                                else [pdf]
+                                if pdf is not None
+                                else []
+                            )
+                            for frame in frames:
+                                for cname, cdtype in frame.schema.items():
                                     factor_input_dtypes.setdefault(cname, cdtype)
                         detail = trace_mod.enrich_banding(
                             cfg,
@@ -1799,7 +1807,7 @@ def enrich_steps(
                         input_frames = [
                             eager_outputs[pid]
                             for pid in parent_ids
-                            if pid in eager_outputs and eager_outputs[pid] is not None
+                            if isinstance(eager_outputs.get(pid), pl.DataFrame)
                         ]
                         source_names = [
                             _sanitize_func_name(node_map[pid].data.label)
@@ -1847,7 +1855,10 @@ def enrich_steps(
                     parent_row_count = 0
                     for pid in parent_ids:
                         df = eager_outputs.get(pid)
-                        if df is not None:
+                        if isinstance(df, dict):
+                            for frame in df.values():
+                                parent_row_count = max(parent_row_count, len(frame))
+                        elif df is not None:
                             parent_row_count = max(parent_row_count, len(df))
                     child_df = eager_outputs.get(step.node_id)
                     child_row_count = len(child_df) if child_df is not None else 0

--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -505,6 +505,9 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
         if detail.startswith("row_index ") and "out of range" in detail:
             logger.warning("trace_row_out_of_range", error=detail)
             raise HTTPException(status_code=400, detail=detail)
+        if detail.startswith("Target node") and "multiple frames" in detail:
+            logger.warning("trace_target_multi_frame", error=detail)
+            raise HTTPException(status_code=400, detail=detail)
         if detail.startswith("Target node ") and "not found in graph" in detail:
             logger.warning("trace_target_not_found", error=detail)
             raise HTTPException(status_code=404, detail=detail)

--- a/src/haute/trace.py
+++ b/src/haute/trace.py
@@ -289,7 +289,7 @@ def _is_integer_output_column(
     column: str,
 ) -> bool:
     df = eager_outputs.get(node_id)
-    if df is None or column not in df.schema:
+    if not isinstance(df, pl.DataFrame) or column not in df.schema:
         return False
     is_integer = getattr(df.schema[column], "is_integer", None)
     return bool(is_integer()) if callable(is_integer) else False
@@ -462,6 +462,20 @@ def execute_trace(
             source_ids=source_ids,
         )
 
+    # Multi-frame sources (e.g. a ≥2-table apiInput) store a
+    # dict[label, DataFrame] in eager_outputs; a trace must target a node
+    # downstream of a specific frame, never the bundle itself.
+    if isinstance(eager_outputs.get(target_node_id), dict):
+        raise ValueError(
+            f"Target node {target_node_id!r} emits multiple frames; "
+            "trace a node downstream of a specific frame instead."
+        )
+
+    # Edge sourceHandles record which frame of a multi-frame source each
+    # child consumes (the selection _pick_source_frame makes at execution
+    # time); the correlation walk makes the same per-edge selection.
+    source_frame_of = {(e.source, e.target): e.sourceHandle for e in graph.edges}
+
     # ---------- Verify row identity ----------
     # If the frontend sent the clicked row's values, verify that the
     # DataFrame at the target node has the same values at row_index.
@@ -509,12 +523,13 @@ def execute_trace(
             row_index,
             node_map=node_map,
             diagnostics=correlation_diagnostics,
+            source_frame_of=source_frame_of,
         )
     else:
         # Target node execution failed — build partial rows from available nodes
         cached_rows = {}
         for nid in order:
-            if nid in eager_outputs:
+            if nid in eager_outputs and not isinstance(eager_outputs[nid], dict):
                 df = eager_outputs[nid]
                 if row_index < len(df):
                     cached_rows[nid] = _jsonify_row(df.row(row_index, named=True))

--- a/tests/test_trace_multi_frame.py
+++ b/tests/test_trace_multi_frame.py
@@ -1,0 +1,132 @@
+"""Trace through a multi-frame (≥2-table) apiInput.
+
+Multi-frame sources store ``dict[label, DataFrame]`` in ``eager_outputs``,
+but the trace correlation assumed bare DataFrames and crashed with
+``AttributeError: 'dict' object has no attribute 'columns'`` — surfaced to
+the user as an opaque 500. The edge's ``sourceHandle`` names the frame each
+child consumes (per ``_pick_source_frame``); the correlation walk must use
+the same selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from haute._json_flatten import _json_cache_dir
+from haute._json_shred import build_per_port_cache
+from haute._sandbox import _get_project_root, set_project_root
+from haute.executor import _preview_cache
+from haute.trace import execute_trace
+from tests.conftest import make_graph
+from tests.test_output_nested_roundtrip import _FIXTURE, _api_input_config
+
+
+def _multi_frame_graph(api_config: dict[str, Any], code: str) -> dict[str, Any]:
+    """A multi-frame apiInput feeding a transform via the ``policies`` frame."""
+    return {
+        "nodes": [
+            {
+                "id": "api",
+                "data": {"label": "api", "nodeType": "apiInput", "config": api_config},
+            },
+            {
+                "id": "t",
+                "data": {"label": "t", "nodeType": "polars", "config": {"code": code}},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "source": "api", "target": "t", "sourceHandle": "policies"},
+        ],
+    }
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolated tmp project with the nested data-model fixture + built cache."""
+    monkeypatch.chdir(tmp_path)
+    original = _get_project_root()
+    set_project_root(tmp_path)
+    _preview_cache.invalidate()
+
+    data_path = tmp_path / "data" / "data_model_example.json"
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    data_path.write_text(_FIXTURE.read_text())
+    build_per_port_cache(
+        data_path,
+        _api_input_config(data_path),
+        _json_cache_dir(data_path, "working"),
+    )
+    yield data_path
+    set_project_root(original)
+    _preview_cache.invalidate()
+
+
+def test_trace_through_multi_frame_source_succeeds(project: Path) -> None:
+    """Tracing a node downstream of a multi-frame apiInput must correlate
+    through the frame the edge's sourceHandle names — not crash."""
+    graph = make_graph(
+        _multi_frame_graph(
+            _api_input_config(project),
+            "df = df.with_columns(pid2=pl.col('policy_id') * 2)",
+        )
+    )
+
+    result = execute_trace(graph, row_index=0, target_node_id="t", column="pid2")
+
+    steps = {s.node_id: s for s in result.steps}
+    assert "t" in steps and "api" in steps
+    t_row = steps["t"].output_values
+    api_row = steps["api"].output_values
+    # The api step's row comes from the policies frame and matches the
+    # traced child row on the shared key.
+    assert api_row.get("policy_id") == t_row.get("policy_id")
+    assert t_row.get("pid2") == t_row.get("policy_id") * 2
+
+
+def test_trace_target_on_multi_frame_source_is_clear_error(project: Path) -> None:
+    """Tracing the bundle node itself cannot pick a frame — must be a clear
+    ValueError, not an AttributeError crash."""
+    graph = make_graph(
+        _multi_frame_graph(
+            _api_input_config(project),
+            "df = df.with_columns(pid2=pl.col('policy_id') * 2)",
+        )
+    )
+
+    with pytest.raises(ValueError, match="multiple frames"):
+        execute_trace(graph, row_index=0, target_node_id="api", column="policy_id")
+
+
+def test_trace_route_multi_frame_not_opaque_500(project: Path) -> None:
+    """The trace route must not map a multi-frame trace to an opaque 500."""
+    from haute.server import app
+
+    client = TestClient(app)
+    graph = _multi_frame_graph(
+        _api_input_config(project),
+        "df = df.with_columns(pid2=pl.col('policy_id') * 2)",
+    )
+
+    resp = client.post(
+        "/api/pipeline/trace",
+        json={"graph": graph, "row_index": 0, "target_node_id": "t", "column": "pid2"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Bundle-node target: a clear 4xx naming the problem, not a 500.
+    resp = client.post(
+        "/api/pipeline/trace",
+        json={
+            "graph": graph,
+            "row_index": 0,
+            "target_node_id": "api",
+            "column": "policy_id",
+        },
+    )
+    assert resp.status_code == 400
+    assert "frame" in resp.json()["detail"]


### PR DESCRIPTION
## Symptom
Any trace through a ≥2-table apiInput crashed with `AttributeError: 'dict' object has no attribute 'columns'` in `_correlate_rows_posthoc`, surfaced as an opaque 500 — a whole node class was untraceable, with zero multi-frame trace tests.

## Fix
Thread the edge's `sourceHandle` frame selection (the same pick `_pick_source_frame` makes at execution time) into the correlation walk as a per-edge mapping, so a bundle-valued parent resolves to the frame its resolved child actually consumes (unresolvable → diagnostics entry + unresolved step, never a crash). Targeting the bundle node itself raises a clear ValueError mapped to a 400. Enrichment and integer-column helpers guard dict-valued outputs.

## Tests
TDD red-first with the exact AttributeError; adds the first multi-frame trace tests (unit + route level) on the 4-table data-model fixture — trace succeeds and correlates on the shared key; bundle target → clear 400. Full backend suite green (12,694 passed); mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)