### PR TITLE
Trace warm-click perf: stat-gated utility hash memo, off-loop key, single serialisation pass

### DIFF
--- a/src/haute/_cache.py
+++ b/src/haute/_cache.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from haute._hashing import content_hash, content_hash_bytes
 from haute._logging import get_logger
+from haute._stat_gated_cache import StatGatedCache, artifact_cache_key
 from haute._types import GraphNode, NodeType, PipelineGraph
 
 logger = get_logger(component="cache")
@@ -393,27 +394,46 @@ def _stat_key_for_utility_file(path: Path) -> _UtilityFileStatKey:
     return _UtilityFileStatKey(path=path.resolve(), mtime_ns=stat.st_mtime_ns, size=stat.st_size)
 
 
+# Process-wide stat-gated memo over utility file content hashes, so EVERY
+# preamble fingerprint caller (supersession keys, execute_trace, preview
+# keys, future call sites) hits the memo by construction rather than by
+# parameter-threading etiquette.  Same invalidation contract as
+# :func:`haute.execution._stat_gated_runtime_path_fingerprint`: a digest is
+# reused while ``(st_mtime_ns, st_size)`` is unchanged; any metadata change
+# re-hashes content; a gate that moves during the read is retried once and
+# then fails loudly.  A rewrite that preserves both mtime_ns and size is
+# below the gate's resolution — the documented trade the deploy path
+# already accepts.
+_utility_file_hash_cache: StatGatedCache[str, str] = StatGatedCache(
+    artifact_kind="Preamble utility file"
+)
+
+
 def _utility_file_hash(path: Path, memo: GraphFingerprintMemo | None) -> str:
-    """Return a content hash for *path*.
+    """Return a content hash for *path* via the process-wide stat-gated memo.
 
-    Without a caller-scoped memo this always reads the file so independent
-    fingerprint calls cannot reuse stale digests when metadata is preserved.
-    With a memo, unchanged metadata can reuse a digest inside the same request.
+    The optional request-scoped *memo* additionally pins the FIRST digest
+    observed for a given ``(path, mtime_ns, size)`` within one request, so a
+    file changing mid-request cannot make one fingerprint call disagree with
+    an earlier one inside the same operation.
     """
-    for _ in range(2):
-        key = _stat_key_for_utility_file(path)
-        cached = memo.utility_file_hashes.get(key) if memo is not None else None
-        if cached is not None:
-            return cached
+    key = _stat_key_for_utility_file(path)
+    cached = memo.utility_file_hashes.get(key) if memo is not None else None
+    if cached is not None:
+        return cached
 
-        digest = content_hash(path)
-        after_key = _stat_key_for_utility_file(path)
-        if after_key == key:
-            if memo is not None:
-                memo.utility_file_hashes[after_key] = digest
-            return digest
-
-    raise RuntimeError(f"Utility file changed while hashing: {path!s}")
+    resolved = key.path
+    digest = _utility_file_hash_cache.get_or_load(
+        artifact_cache_key(resolved),
+        str(resolved),
+        lambda: content_hash(resolved),
+    )
+    if memo is not None:
+        # Re-stat for the memo slot: if the gate moved during the load the
+        # StatGatedCache already retried against the settled state, so the
+        # digest belongs to the CURRENT gate, not the pre-load one.
+        memo.utility_file_hashes[_stat_key_for_utility_file(path)] = digest
+    return digest
 
 
 def _hash_utility_candidate(

--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -11,7 +11,9 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import JSONResponse
 
+from haute._cache import GraphFingerprintMemo
 from haute._env import float_env
 from haute._execution_admission import (
     ExecutionAdmissionError,
@@ -206,12 +208,14 @@ def _supersession_key(
     operation: str,
     graph: PipelineGraph,
     source: str,
+    *,
+    memo: GraphFingerprintMemo | None = None,
 ) -> tuple[str, ...]:
     return (
         operation,
         graph.source_file or "",
         source,
-        graph_fingerprint(graph),
+        graph_fingerprint(graph, memo=memo),
     )
 
 
@@ -256,9 +260,11 @@ def _trace_supersession_key(
     column: str | None,
     row_limit: int,
     row_values: dict[str, Any] | None,
+    *,
+    memo: GraphFingerprintMemo | None = None,
 ) -> tuple[str, ...]:
     return (
-        *_supersession_key("trace", graph, source),
+        *_supersession_key("trace", graph, source, memo=memo),
         "target",
         target_node_id or "",
         "row_index",
@@ -423,7 +429,7 @@ async def read_json_file(body: ReadJsonRequest) -> ReadJsonResponse:
 
 
 @router.post("/pipeline/trace", response_model=TraceResponse)
-async def trace_row(body: TraceRequest) -> TraceResponse:
+async def trace_row(body: TraceRequest) -> JSONResponse:
     """Trace a single row through the pipeline, returning per-node snapshots."""
     graph = flatten_graph(body.graph)
     _ensure_source_file(graph)
@@ -433,13 +439,32 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
     _validate_runtime_input_paths(graph)
 
     try:
+        # One memo per request: the supersession key below and every
+        # graph_fingerprint call inside execute_trace share it, so the
+        # preamble's utility/**/*.py files are read and hashed at most
+        # once per trace click instead of once per fingerprint call.
+        fingerprint_memo = GraphFingerprintMemo()
+        # Key computation hashes preamble utility files from disk and
+        # json-dumps row_values — off the event loop.
+        supersession_key = await run_in_threadpool(
+            lambda: _trace_supersession_key(
+                graph,
+                body.source,
+                body.target_node_id,
+                body.row_index,
+                body.column,
+                body.row_limit,
+                body.row_values,
+                memo=fingerprint_memo,
+            )
+        )
 
-        async def _run_trace() -> Any:
+        async def _run_trace() -> dict[str, Any]:
             chunk_size = body.streaming_chunk_size or DEFAULT_STREAMING_CHUNK_SIZE
 
-            def _execute_trace_with_chunk_size() -> Any:
+            def _execute_trace_with_chunk_size() -> dict[str, Any]:
                 with temporary_streaming_chunk_size(chunk_size):
-                    return execute_trace(
+                    result = execute_trace(
                         graph,
                         row_index=body.row_index,
                         target_node_id=body.target_node_id,
@@ -454,7 +479,12 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
                         # protocol - its ``try_get`` returns the slot dict on hit
                         # or ``None`` on miss.
                         preview=_preview_cache,
+                        fingerprint_memo=fingerprint_memo,
                     )
+                    # Serialise to a JSON-safe dict here, still in the
+                    # worker thread, so the event loop never walks the
+                    # full trace payload.
+                    return trace_result_to_dict(result)
 
             return await run_blocking_with_response_timeout(
                 _execute_trace_with_chunk_size,
@@ -462,24 +492,18 @@ async def trace_row(body: TraceRequest) -> TraceResponse:
                 operation="pipeline_trace",
             )
 
-        result = await _trace_supersession.run_latest(
-            _trace_supersession_key(
-                graph,
-                body.source,
-                body.target_node_id,
-                body.row_index,
-                body.column,
-                body.row_limit,
-                body.row_values,
-            ),
+        trace_dict = await _trace_supersession.run_latest(
+            supersession_key,
             _run_trace,
             limiter=_trace_work_slots,
             superseded_message="Trace request superseded by a newer request",
         )
-        return TraceResponse(
-            status="ok",
-            trace=trace_result_to_dict(result),  # type: ignore[arg-type]
-        )
+        # ``trace_dict`` is already JSON-safe (``trace_result_to_dict``
+        # ends in ``to_json_safe``).  Encode it directly instead of
+        # re-validating through the ``TraceResponse`` model and encoding
+        # again — ``response_model`` is kept for the OpenAPI schema, and
+        # FastAPI skips model validation for explicit ``Response``s.
+        return JSONResponse({"status": "ok", "trace": trace_dict})
     except SupersededRequestError as e:
         raise HTTPException(status_code=409, detail=str(e)) from None
     except TimeoutError:

--- a/src/haute/trace.py
+++ b/src/haute/trace.py
@@ -330,6 +330,7 @@ def execute_trace(
     row_values: dict[str, Any] | None = None,
     preamble_ns: dict[str, Any] | None = None,
     preview: PreviewReader | dict[str, Any] | None = None,
+    fingerprint_memo: GraphFingerprintMemo | None = None,
 ) -> TraceResult:
     """Execute a pipeline graph and return a single-row trace.
 
@@ -356,6 +357,12 @@ def execute_trace(
                  upstream graph; when ``None`` (tests, CLI, cold requests)
                  the trace falls back to a fresh execution.  This keeps the
                  trace module decoupled from ``haute.executor._preview_cache``.
+        fingerprint_memo: Optional request-scoped
+                 :class:`~haute._cache.GraphFingerprintMemo` shared with the
+                 caller (the trace route reuses the memo from its
+                 supersession-key computation) so preamble utility files are
+                 hashed at most once per request.  ``None`` creates a fresh
+                 memo scoped to this call.
 
     Returns:
         TraceResult with per-node steps showing how the row was produced.
@@ -383,7 +390,11 @@ def execute_trace(
     # The pipeline structure doesn't change between trace clicks — only the
     # row_index and column change.  Cache the materialized DataFrames and
     # reuse them: first click ~1.7s, subsequent clicks <10ms.
-    fingerprint_memo = GraphFingerprintMemo()
+    # A caller (the trace route) may pass in the request-scoped memo it
+    # already used for the supersession key, so the preamble's utility
+    # files are hashed once per request rather than once per call.
+    if fingerprint_memo is None:
+        fingerprint_memo = GraphFingerprintMemo()
     # Runtime-input extras (flat-file dataSource / external-file / model-
     # artifact signatures + the apiInput JSON-cache state) are part of the
     # trace key so an out-of-band re-export or cache rebuild invalidates

--- a/tests/test_cache_perf_fixes.py
+++ b/tests/test_cache_perf_fixes.py
@@ -52,7 +52,6 @@ from __future__ import annotations
 
 import gc
 import hashlib
-import os
 import secrets
 import sys
 import threading
@@ -251,24 +250,30 @@ class TestPreambleCacheCorrectness:
         tmp_path,
         monkeypatch,
     ) -> None:
-        """Utility content edits must refresh even when mtime/size are unchanged."""
+        """Same-size utility edits refresh whenever the mtime_ns gate moves.
+
+        Utility hashing is stat-gated at ``(mtime_ns, size)`` granularity
+        (the ``_stat_gated_runtime_path_fingerprint`` contract), which is far
+        finer than timestamp-based pyc validation: a same-byte-length edit
+        still refreshes because the write moves ``mtime_ns``.  An edit that
+        preserves BOTH mtime_ns and size is below the gate's resolution —
+        the documented trade the deploy path already accepts.
+        """
         monkeypatch.chdir(tmp_path)
         util_dir = tmp_path / "utility"
         util_dir.mkdir()
         (util_dir / "__init__.py").write_text("", encoding="utf-8")
         helper = util_dir / "helpers.py"
         helper.write_text("VALUE = 1\n", encoding="utf-8")
-        fixed_mtime = 1_700_000_000
-        os.utime(helper, (fixed_mtime, fixed_mtime))
 
         source = "from utility.helpers import VALUE\n"
         ns_before = _compile_preamble(source, force_refresh=True)
         assert ns_before["VALUE"] == 1
 
-        # Same byte length and same integer mtime: timestamp-based pyc
-        # validation would otherwise be allowed to reuse stale bytecode.
+        # Same byte length: only the nanosecond mtime distinguishes the
+        # edit — timestamp-based pyc validation could reuse stale bytecode
+        # here, the stat gate must not.
         helper.write_text("VALUE = 2\n", encoding="utf-8")
-        os.utime(helper, (fixed_mtime, fixed_mtime))
 
         ns_after = _compile_preamble(source, force_refresh=True)
 

--- a/tests/test_graph_fingerprint_cached.py
+++ b/tests/test_graph_fingerprint_cached.py
@@ -388,13 +388,21 @@ class TestUtilityFileContentHashMemo:
         assert fp_replaced != fp_deleted
         assert calls == [replaced.resolve()]
 
-    def test_independent_calls_detect_same_size_same_mtime_utility_edit(
+    def test_independent_calls_share_the_stat_gated_utility_hash_memo(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Independent fingerprints must not trust preserved file metadata."""
-        import os
+        """Independent fingerprints hit the process-wide stat-gated memo.
+
+        Utility hashing is memoised at the same ``(mtime_ns, size)``
+        granularity as ``_stat_gated_runtime_path_fingerprint`` — every
+        caller reuses the digest while the gate holds (hashing once), and
+        any metadata change re-hashes.  A byte edit that preserves both
+        mtime_ns and size is below the gate's resolution: the documented
+        trade the deploy path already accepts.
+        """
+        import haute._cache as cache_mod
 
         monkeypatch.chdir(tmp_path)
         utility_dir = tmp_path / "utility"
@@ -402,8 +410,6 @@ class TestUtilityFileContentHashMemo:
         (utility_dir / "__init__.py").write_text("", encoding="utf-8")
         helper = utility_dir / "helpers.py"
         helper.write_text("VALUE = 1\n", encoding="utf-8")
-        fixed_mtime = 1_700_000_000
-        os.utime(helper, (fixed_mtime, fixed_mtime))
         graph = PipelineGraph(
             nodes=[_make_node("a", {"code": "df = df"})],
             edges=[],
@@ -411,11 +417,29 @@ class TestUtilityFileContentHashMemo:
             source_file=str(tmp_path / "pipeline.py"),
         )
 
-        fp_before = graph_fingerprint(graph)
-        helper.write_text("VALUE = 2\n", encoding="utf-8")
-        os.utime(helper, (fixed_mtime, fixed_mtime))
+        calls: list[Path] = []
+        original_content_hash = cache_mod.content_hash
 
+        def counting_content_hash(path: Path) -> str:
+            calls.append(Path(path).resolve())
+            return original_content_hash(path)
+
+        monkeypatch.setattr(cache_mod, "content_hash", counting_content_hash)
+
+        fp_before = graph_fingerprint(graph)
+        first_round = len(calls)
+        assert first_round > 0
+
+        # Memoless repeat: unchanged gates reuse digests by construction.
+        assert graph_fingerprint(graph) == fp_before
+        assert len(calls) == first_round
+
+        # A metadata-visible edit re-hashes only the changed file and
+        # changes the fingerprint.
+        helper.write_text("VALUE = 2_000\n", encoding="utf-8")  # size moves the gate
+        calls.clear()
         assert graph_fingerprint(graph) != fp_before
+        assert calls == [helper.resolve()]
 
 
 class _CallCountingFingerprint:

--- a/tests/test_pipeline_route_supersession.py
+++ b/tests/test_pipeline_route_supersession.py
@@ -1458,6 +1458,42 @@ def test_preview_trace_concurrency_limit_env_must_be_positive_integer(
             route_mod._positive_int_from_env("HAUTE_PREVIEW_MAX_CONCURRENCY", 2)
 
 
+def test_trace_supersession_key_shared_memo_pins_memoless_key(tmp_path) -> None:
+    """Pin: a request-scoped fingerprint memo must not change the key.
+
+    The trace route computes its supersession key with a
+    ``GraphFingerprintMemo`` that is then shared with ``execute_trace``.
+    The memo is a pure read-cache — the key it produces must equal the
+    memoless key on the same graph, including when the preamble imports
+    the project ``utility`` module (the path where the memo actually
+    caches file hashes).
+    """
+    from haute._cache import GraphFingerprintMemo
+    from haute.routes.pipeline import _trace_supersession_key
+
+    (tmp_path / "utility.py").write_text("X = 1\n")
+    graph = make_graph(
+        {
+            "nodes": [make_transform_node("target")],
+            "edges": [],
+            "preamble": "import utility\n",
+            "source_file": str(tmp_path / "pipeline.py"),
+        }
+    )
+
+    key_args = (graph, "live", "target", 0, None, 100, {"a": 1})
+    memoless = _trace_supersession_key(*key_args)
+    memo = GraphFingerprintMemo()
+    first_with_memo = _trace_supersession_key(*key_args, memo=memo)
+    # Second call with the same memo hits the memoised utility hashes —
+    # the key must still be byte-identical.
+    second_with_memo = _trace_supersession_key(*key_args, memo=memo)
+
+    assert first_with_memo == memoless
+    assert second_with_memo == memoless
+    assert memo.utility_file_hashes, "expected the utility hash memo to be populated"
+
+
 @pytest.mark.asyncio
 async def test_trace_worker_limit_serializes_different_keys(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Symptom

Per warm trace click (BUGS.md §Reported, "Warm trace click: on-loop fingerprint recompute + triple serialization (residual)", session 6cf7ad59):

- `_supersession_key` recomputed `graph_fingerprint` from cold **on the event loop**, reading and hashing preamble `utility/**/*.py` from disk;
- the row-values `json.dumps` fingerprint also ran on the loop;
- the response was serialised three layers deep (`trace_result_to_dict` → Pydantic `TraceResponse` re-validation → FastAPI encode);
- the trace fingerprint was computed again inside `execute_trace`.

Perf only, no wrongness.

## Fix

**Durable form (design steer):** utility-file content hashing now lives in a process-wide `StatGatedCache` — the established `_stat_gated_runtime_path_fingerprint` idiom — so every `preamble_execution_fingerprint` caller (supersession keys, `execute_trace`, preview keys, future call sites) hits the memo **by construction**, not by parameter-threading etiquette.

**Request plumbing:** the trace route computes its supersession key off-loop (`run_in_threadpool`), shares one request-scoped `GraphFingerprintMemo` with `execute_trace` (intra-request first-digest pin), builds the JSON-safe dict in the worker thread, and returns a `JSONResponse` directly — the Pydantic re-validation layer is dropped (`response_model=TraceResponse` kept for the OpenAPI schema).

**Deliberate contract change:** an edit preserving BOTH `mtime_ns` and size is now below the gate's resolution — the documented trade the deploy scorer and runtime-path fingerprints already accept. Two tests pinning always-re-read semantics are re-pinned to the stat-gated contract (same-size edits still refresh via nanosecond mtime).

## Tests

- New pin: the memoised supersession key is byte-identical to the memoless key on the same graph, including the utility-importing preamble path (`tests/test_pipeline_route_supersession.py`).
- Re-pinned: `test_graph_fingerprint_cached.py` (process-wide memo semantics + per-file invalidation), `test_cache_perf_fixes.py` (same-size edit refreshes via mtime_ns gate).
- Full backend gate green locally: 12 705 passed, coverage 92.66% ≥ 90%, critical-coverage sub-gate OK, ruff + mypy clean.

## Measured (before/after)

In-process ASGI, 30 warm clicks, 50k rows, 41 utility files, 11 nodes, two runs each way:

| metric | before (main) | after |
|---|---|---|
| warm-click latency, median | 45 / 23 ms | ~15 ms |
| event-loop stall over the run | 1004 / 461 ms | ~66 ms |
| max single loop stall | 25 / 43 ms | ~3 ms |

(The review's unverified 3–6×/10 ms figures were not reused.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)