### PR TITLE
docs: correct deploy secrets, haute init behaviour, and stale claims; pin with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Pricing models sit at the centre of regulated businesses. They determine what cu
 
 Open source changes that relationship. The engine that calculates your prices is fully visible. Anyone on your team can inspect how it works, verify its behaviour, or extend it. There is no hidden logic, no opaque compilation step, no proprietary runtime sitting between your model and your output.
 
-This also means your work is portable. Your pipelines are Python files. Your models are standard formats. Your data stays in your infrastructure. If you ever want to stop using Haute, everything you've built still works - it's just Python.
+This also means your work is portable. Your pipelines are Python files. Your models are standard formats. Your data stays in your infrastructure. If you ever want to stop using Haute, everything you've built still works: your pipelines are ordinary Python files (with JSON config saved alongside) that run with the open-source library - there's no hosted service or proprietary runtime to lose access to.
 
 Being open source and code means Haute can lean on best-in-class tools and engineering practices instead of reinventing them. Polars, Catboost, MLFlow, GIT, CI/CD, Haute doesn't try to rebuild these things behind a proprietary wall. It connects them and wraps them in an interface designed for pricing work.
 
@@ -148,7 +148,7 @@ Behind the scenes, it uses Git with guardrails. Protected branches can't be over
 
 Before training a model on a large dataset, Haute probes a sample of your data to estimate how much memory the full run will need. If it would exceed your machine's available memory, it tells you before you start - and suggests a safe dataset size.
 
-This is a small detail, but it prevents the kind of silent crash that can lose work.
+This is a small detail, but it catches the kind of silent crash that can lose work before it happens. The estimate reads your machine's available memory directly; inside a memory-capped container it can't see the cap, and where it can't read memory at all it falls back to a conservative default.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ pipeline = haute.Pipeline("motor_pricing_v2")
 
 ### 3.2 Nodes
 
-Nodes are the building blocks. Each node is a decorated Python function with defined inputs, outputs, and logic. There are 19 node types grouped by function:
+Nodes are the building blocks. Each node is a decorated Python function with defined inputs, outputs, and logic. There are 21 node types grouped by function:
 
 #### Entry / Exit (singleton — max 1 per pipeline)
 
@@ -60,6 +60,8 @@ Nodes are the building blocks. Each node is a decorated Python function with def
 | Node Type | Enum | Purpose |
 |---|---|---|
 | **Data Source** | `dataSource` | Read from local CSV/Parquet or Databricks Unity Catalog table |
+| **Data Input** | `dataInput` | Read data via any native polars `read_*`/`scan_*` function (full argument width) |
+| **Data Output** | `dataOutput` | Write data via any native polars `write_*`/`sink_*` function (full argument width) |
 | **Data Sink** | `dataSink` | Write results to parquet, CSV, or directory |
 | **External File** | `externalFile` | Load pickle, JSON, or joblib file as a DataFrame |
 | **Constant** | `constant` | Named constant values injected as a 1-row DataFrame |
@@ -92,7 +94,7 @@ Nodes are the building blocks. Each node is a decorated Python function with def
 | **Submodel** | `submodel` | Reusable sub-pipeline (drill-down in GUI, flattened at execution) |
 | **Submodel Port** | `submodelPort` | Input/output port for submodel boundary wiring |
 
-All 19 types are defined in `_types.py` as a `NodeType(StrEnum)` enum, with per-type `TypedDict` config schemas, registered builder functions in `_builders.py`, and code generators in `codegen.py`.
+All 21 types are defined in `_types.py` as a `NodeType(StrEnum)` enum, with per-type `TypedDict` config schemas, registered builder functions in `_builders.py`, and code generators in `codegen.py`.
 
 ### 3.3 External Config Files
 
@@ -104,12 +106,14 @@ def vehicle_age_band(df):
     ...
 ```
 
-14 of the 19 node types store external config (all except `polars`, `edgeJoin`, `explore`, `submodel`, and `submodelPort`). The folder-per-type mapping is defined in `_config_io.py`:
+16 of the 21 node types store external config (all except `polars`, `edgeJoin`, `explore`, `submodel`, and `submodelPort`). The folder-per-type mapping is defined in `_config_io.py`:
 
 | Node Type | Config Folder |
 |---|---|
 | Quote Input | `config/quote_input/` |
 | Data Source | `config/data_source/` |
+| Data Input | `config/data_input/` |
+| Data Output | `config/data_output/` |
 | Source Switch | `config/source_switch/` |
 | Model Scoring | `config/model_scoring/` |
 | Banding | `config/banding/` |
@@ -797,8 +801,8 @@ pipeline.connect("load_claims", "clean_vehicle")
 pipeline.connect("clean_vehicle", "score_frequency")
 ```
 
-### 8.3 Rating tables → All in Databricks
-All rating tables (even small ones) live in Databricks Unity Catalog. Referenced by `catalog.schema.table` URI. Viewable/editable in the GUI. This keeps a single source of truth and avoids CSV sprawl in git.
+### 8.3 Rating tables → In-repo JSON, versioned with the pipeline
+Rating tables live as JSON schema-mapping files in the repository, under `config/rating_step/` beside the pipeline `.py` (lookup entries stored as compact factor-value maps). Viewable/editable in the GUI, and versioned in git alongside the code that uses them - so a pipeline commit is self-contained and reviewable as one diff, with no external table dependency. (An early design placed rating tables in Databricks Unity Catalog; that was superseded by the in-repo sidecar model.)
 
 ### 8.4 Shared preprocessing logic
 Preprocessing transforms (e.g., categorical grouping) are defined once in `utility/` and reused across both modelling pipelines (for training) and rating pipelines (for deployment). The rating pipeline is the deployable unit; modelling pipelines are a separate workflow that produces MLflow-registered models.

--- a/docs/deployment/ci/azure-devops.md
+++ b/docs/deployment/ci/azure-devops.md
@@ -110,8 +110,8 @@ Azure DevOps stores shared secrets in **Variable Groups**. Haute's generated pip
 
 | Name | Value | Secret? |
 |---|---|---|
-| `DATABRICKS_HOST` | Your workspace URL | ✓ Lock |
-| `DATABRICKS_TOKEN` | Your personal access token | ✓ Lock |
+| `DATABRICKS_RATING_HOST` | Your workspace URL | ✓ Lock |
+| `DATABRICKS_RATING_TOKEN` | Your personal access token | ✓ Lock |
 
 **For Docker/Container targets:**
 

--- a/docs/deployment/ci/github-actions.md
+++ b/docs/deployment/ci/github-actions.md
@@ -114,8 +114,8 @@ Your CI/CD workflows need credentials stored securely in GitHub.
 
 | Secret name | Value |
 |---|---|
-| `DATABRICKS_HOST` | Your workspace URL (e.g. `https://adb-xxx.12.azuredatabricks.net`) |
-| `DATABRICKS_TOKEN` | Your personal access token (starts with `dapi`) |
+| `DATABRICKS_RATING_HOST` | Your workspace URL (e.g. `https://adb-xxx.12.azuredatabricks.net`) |
+| `DATABRICKS_RATING_TOKEN` | Your personal access token (starts with `dapi`) |
 
 **For Docker/Container targets:**
 

--- a/docs/deployment/ci/gitlab.md
+++ b/docs/deployment/ci/gitlab.md
@@ -109,8 +109,8 @@ Your pipeline needs credentials to deploy. In GitLab, these are stored as **CI/C
 
 | Variable | Value | Options |
 |---|---|---|
-| `DATABRICKS_HOST` | Your workspace URL | Mask variable ✓ |
-| `DATABRICKS_TOKEN` | Your personal access token | Mask variable ✓ |
+| `DATABRICKS_RATING_HOST` | Your workspace URL | Mask variable ✓ |
+| `DATABRICKS_RATING_TOKEN` | Your personal access token | Mask variable ✓ |
 
 **For Docker/Container targets:**
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -6,7 +6,7 @@ Deployment is how your pricing pipeline goes from a Python file on your laptop t
     If you haven't installed Haute yet, start with **[Getting Started](../getting-started/index.md)** - it covers installing everything and running your first `haute serve`. If you don't know what a pull request, CI/CD, or staging means, read **[Before You Start](before-you-start.md)** next - it explains every deployment concept in plain English.
 
 !!! tip "Haven't built your pipeline yet?"
-    These docs assume you already have a working pricing pipeline (`main.py`). If you haven't created one yet, start with the **Building Pipelines** guide first, then come back here when you're ready to deploy.
+    These docs assume you already have a working pricing pipeline (`rating/main.py`). If you haven't created one yet, start with the **Building Pipelines** guide first, then come back here when you're ready to deploy.
 
 Haute handles the entire deployment process for you. You **merge your changes to main** (apply them to the main version of the project - see [Before You Start](before-you-start.md#5-accept-the-changes-merge)) and Haute's [CI/CD pipeline](before-you-start.md#what-is-cicd) (an automated process that tests and deploys your code) does the rest - packaging, uploading, testing, and promoting to production. No Docker knowledge, no cloud consoles, no DevOps tickets. You never need to run a deploy command yourself.
 
@@ -60,16 +60,20 @@ This generates all the deployment files you need. You don't write them by hand -
 ```
 Before haute init:          After haute init:
 my-project/                 my-project/
-  main.py                     main.py
-  pyproject.toml              pyproject.toml
-                              haute.toml           ← deployment config
+  main.py                     pyproject.toml       ← haute added as a dependency
+  pyproject.toml              haute.toml           ← project, deploy & CI config
                               .env.example         ← credential template
                               .gitignore           ← keeps .env safe
+                              rating/main.py       ← starter pipeline
+                              rating/utility/      ← project-level utility functions
+                              data/                ← put your data files here
+                              prompts/             ← reusable AI prompts
                               tests/quotes/        ← test data for validation
+                              .githooks/           ← auto-format on commit
                               .github/workflows/   ← CI/CD pipeline files
 ```
 
-Nothing is overwritten - `haute init` only adds new files. If a file already exists (e.g. `.gitignore`), Haute appends to it rather than replacing it.
+Two existing files are touched: a root `main.py` left over from `uv init` is **removed** (your pipeline lives at `rating/main.py` instead), and `pyproject.toml` is updated to list `haute` as a dependency. Everything else is additive - if a file like `.gitignore` already exists, Haute appends to it rather than replacing it. If the project is already initialised (a `haute.toml` exists), `haute init` refuses to run unless you pass `--force`.
 
 !!! tip "Not sure which target to pick?"
     If your organisation uses Databricks, start with the **Databricks** target - it's the most mature and requires the least infrastructure setup. If you don't have Databricks, use **Docker** to start and move to a cloud target later.
@@ -83,7 +87,7 @@ The most important generated file is `haute.toml` - a plain text file that says 
 ```toml
 [project]
 name = "motor-pricing"
-pipeline = "main.py"
+pipeline = "rating/main.py"
 
 [deploy]
 target = "databricks"
@@ -99,6 +103,18 @@ serving_scale_to_zero = true
 
 [test_quotes]
 dir = "tests/quotes"
+
+[safety]
+impact_dataset = "data/portfolio_sample.parquet"
+
+[safety.approval]
+min_approvers = 2
+
+[ci]
+provider = "github"
+
+[ci.staging]
+endpoint_suffix = "-staging"
 ```
 
 Each section is explained in detail on the target-specific pages. The key idea is: **`haute.toml` says *what* gets deployed and *where***. It never contains passwords or secrets.

--- a/docs/deployment/targets/aws.md
+++ b/docs/deployment/targets/aws.md
@@ -38,7 +38,7 @@ haute init --target aws-ecs --ci github
 ```toml
 [project]
 name = "motor-pricing"
-pipeline = "main.py"
+pipeline = "rating/main.py"
 
 [deploy]
 target = "aws-ecs"

--- a/docs/deployment/targets/azure.md
+++ b/docs/deployment/targets/azure.md
@@ -38,7 +38,7 @@ haute init --target azure-container-apps --ci github
 ```toml
 [project]
 name = "motor-pricing"
-pipeline = "main.py"
+pipeline = "rating/main.py"
 
 [deploy]
 target = "azure-container-apps"

--- a/docs/deployment/targets/databricks.md
+++ b/docs/deployment/targets/databricks.md
@@ -93,8 +93,11 @@ The two values you need are:
 
 | Secret name | Value |
 |---|---|
-| `DATABRICKS_HOST` | Your workspace URL from Step 1 |
-| `DATABRICKS_TOKEN` | Your personal access token from Step 2 |
+| `DATABRICKS_RATING_HOST` | Your workspace URL from Step 1 |
+| `DATABRICKS_RATING_TOKEN` | Your personal access token from Step 2 |
+
+!!! note "Why the `RATING` in the name?"
+    The deploy pipeline uses these `DATABRICKS_RATING_*` names for the production serving credentials, keeping them separate from the general `DATABRICKS_HOST`/`DATABRICKS_TOKEN` pair the editor uses for data access and MLflow. The values can be the same workspace URL and token - only the names differ, and the deploy will fail with a clear error if the `RATING` names are missing.
 
 How to add them depends on your CI provider:
 
@@ -200,7 +203,7 @@ Here's what your complete `haute.toml` should look like:
 ```toml
 [project]
 name = "motor-pricing"
-pipeline = "main.py"
+pipeline = "rating/main.py"
 
 [deploy]
 target = "databricks"
@@ -350,7 +353,7 @@ Or in the Databricks UI: click **Serving** in the left sidebar and look for your
 
 ### Token expired
 
-Tokens have a lifetime (default 90 days). If your deploy suddenly fails with an authentication error, generate a new token (Step 2) and update the `DATABRICKS_TOKEN` secret in your CI provider.
+Tokens have a lifetime (default 90 days). If your deploy suddenly fails with an authentication error, generate a new token (Step 2) and update the `DATABRICKS_RATING_TOKEN` secret in your CI provider.
 
 ### Slow first request (cold start)
 
@@ -368,7 +371,7 @@ Before your first deploy, confirm:
 
 - [ ] You have your Databricks workspace URL
 - [ ] You have a Personal Access Token
-- [ ] Both are added as CI secrets (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`)
+- [ ] Both are added as CI secrets (`DATABRICKS_RATING_HOST`, `DATABRICKS_RATING_TOKEN`)
 - [ ] Unity Catalog is enabled with a catalog and schema
 - [ ] `haute.toml` has the correct `experiment_name`, `catalog`, and `schema`
 - [ ] Model Serving is available in your workspace

--- a/docs/deployment/targets/docker.md
+++ b/docs/deployment/targets/docker.md
@@ -70,7 +70,7 @@ Here's what the container section of your `haute.toml` looks like:
 ```toml
 [project]
 name = "motor-pricing"
-pipeline = "main.py"
+pipeline = "rating/main.py"
 
 [deploy]
 target = "container"
@@ -79,7 +79,7 @@ model_name = "motor-pricing"
 [deploy.container]
 registry = ""
 port = 8080
-base_image = "python:3.11-slim"
+base_image = "python:3.11.9-slim"
 
 [test_quotes]
 dir = "tests/quotes"
@@ -93,7 +93,7 @@ dir = "tests/quotes"
 | `model_name` | Used as the Docker image name | `"motor-pricing"` |
 | `registry` | Where to push the image. Leave empty for local-only. | `"ghcr.io/myorg"` or `""` |
 | `port` | The [port](../before-you-start.md#quick-glossary) the API server listens on inside the container (like an extension number on a phone system) | `8080` |
-| `base_image` | The base Docker image to build from | `"python:3.11-slim"` |
+| `base_image` | The base Docker image to build from | `"python:3.11.9-slim"` |
 
 The `registry` value is the address your IT team gave you for where Docker images are stored. If you don't know it, ask them: *"What's our container registry URL?"* They'll give you something like `ghcr.io/yourorg` or `myregistry.azurecr.io`. Put that value in `haute.toml`.
 

--- a/tests/test_docs_accuracy.py
+++ b/tests/test_docs_accuracy.py
@@ -1,0 +1,91 @@
+"""Pin user-facing doc claims to the code they describe.
+
+Docs stating machine-checkable facts (node-type counts, CI secret names,
+scaffold paths) have drifted from the code before — a by-the-book setup
+following the deployment guides failed its first deploy because the guides
+named the wrong secrets. These tests make that class of drift fail CI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from haute._config_io import NODE_TYPE_TO_FOLDER
+from haute._scaffold import TARGETS, haute_toml
+from haute._types import NodeType
+
+ROOT = Path(__file__).resolve().parents[1]
+ARCHITECTURE = ROOT / "docs" / "ARCHITECTURE.md"
+DEPLOYMENT_DOCS = sorted((ROOT / "docs" / "deployment").rglob("*.md"))
+
+DATABRICKS_SECRET_DOCS = [
+    ROOT / "docs" / "deployment" / "targets" / "databricks.md",
+    ROOT / "docs" / "deployment" / "ci" / "github-actions.md",
+    ROOT / "docs" / "deployment" / "ci" / "gitlab.md",
+    ROOT / "docs" / "deployment" / "ci" / "azure-devops.md",
+]
+
+
+def test_architecture_node_type_count_matches_enum() -> None:
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    counts = re.findall(r"There are (\d+) node types", text)
+    counts += re.findall(r"All (\d+) types are defined", text)
+    assert counts, "ARCHITECTURE.md no longer states the node-type count"
+    for count in counts:
+        assert int(count) == len(NodeType)
+
+
+def test_architecture_node_type_table_lists_every_enum_value() -> None:
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    for node_type in NodeType:
+        assert f"`{node_type.value}`" in text, (
+            f"ARCHITECTURE.md node-type tables are missing `{node_type.value}`"
+        )
+
+
+def test_architecture_sidecar_config_count_matches_mapping() -> None:
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    match = re.search(r"(\d+) of the (\d+) node types store external config", text)
+    assert match, "ARCHITECTURE.md no longer states the sidecar-config count"
+    assert int(match.group(1)) == len(NODE_TYPE_TO_FOLDER)
+    assert int(match.group(2)) == len(NodeType)
+
+
+def test_architecture_config_folder_table_matches_mapping() -> None:
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+    for folder in NODE_TYPE_TO_FOLDER.values():
+        assert f"`config/{folder}/`" in text, (
+            f"ARCHITECTURE.md config-folder table is missing `config/{folder}/`"
+        )
+
+
+def test_deployment_docs_name_the_real_databricks_secrets() -> None:
+    secrets = TARGETS["databricks"]["secrets"]
+    assert isinstance(secrets, list)
+    for doc in DATABRICKS_SECRET_DOCS:
+        text = doc.read_text(encoding="utf-8")
+        for secret in secrets:
+            assert secret in text, f"{doc.name} does not mention CI secret {secret}"
+        # The deploy path reads only the RATING-prefixed pair; a secret table
+        # row naming the bare pair sends the reader through a failing setup.
+        for stale in ("`DATABRICKS_HOST` |", "`DATABRICKS_TOKEN` |"):
+            assert stale not in text, (
+                f"{doc.name} lists {stale.strip('` |')} as a CI secret; the deploy "
+                "reads the DATABRICKS_RATING_* names (see haute._scaffold.TARGETS)"
+            )
+
+
+def test_deployment_docs_use_scaffolded_pipeline_path() -> None:
+    scaffolded = haute_toml("motor-pricing", "databricks", "github")
+    match = re.search(r'^pipeline = "(.*)"$', scaffolded, flags=re.MULTILINE)
+    assert match is not None
+    real_path = match.group(1)
+    for doc in DEPLOYMENT_DOCS:
+        for shown in re.findall(
+            r'^pipeline = "(.*)"$', doc.read_text(encoding="utf-8"), flags=re.MULTILINE
+        ):
+            assert shown == real_path, (
+                f'{doc.name} shows pipeline = "{shown}" but haute init '
+                f'scaffolds pipeline = "{real_path}"'
+            )


### PR DESCRIPTION
Closes remediation item **P0-8** (docs-accuracy) from the code-review programme. Every audited claim was re-verified against the current tree before editing — the audit ran on a 2026-06-19 baseline and several code fixes have since landed.

## What was false → what it now says

1. **Databricks deploy secret names** ([targets/databricks.md](docs/deployment/targets/databricks.md), [ci/github-actions.md](docs/deployment/ci/github-actions.md), [ci/gitlab.md](docs/deployment/ci/gitlab.md), [ci/azure-devops.md](docs/deployment/ci/azure-devops.md)): guides told readers to create `DATABRICKS_HOST`/`DATABRICKS_TOKEN`, but the generated workflows read `DATABRICKS_RATING_HOST`/`DATABRICKS_RATING_TOKEN` — by-the-book setup failed the first deploy. All four guides now name the RATING-prefixed pair, with a note explaining the split from the editor's general pair.
2. **`haute init` tree** ([deployment/index.md](docs/deployment/index.md) + target pages): the before/after tree was fabricated and claimed "nothing is overwritten". Now shows the real scaffold (`rating/main.py`, `rating/utility/`, `data/`, `prompts/`, `.githooks/`, full `haute.toml` incl. `[safety]`/`[ci]`) and states plainly that root `main.py` is removed, `pyproject.toml` edited, and re-init needs `--force`. `pipeline = "main.py"` snippets corrected to `rating/main.py` across databricks/docker/aws/azure pages.
3. **README portability claim**: codegen passthrough is largely fixed on main; reworded to what is precisely true (ordinary Python files + JSON config, runs with the open-source library) without overclaiming standalone codegen while the OUTPUT-body fix is in flight.
4. **README test-before-live**: verified accurate on current main (`artifact_identity_fingerprint` threaded through) — left standing.
5. **README RAM estimator**: still cgroup-blind with a fixed fallback; claim rescoped honestly instead of "prevents silent crash".
6. **ARCHITECTURE.md**: node-type count 19→21 (dataInput/dataOutput landed since the audit), tables extended, sidecar-config count 14→16; §8.3 corrected — rating tables are in-repo JSON sidecars under `config/rating_step/`, not Databricks Unity Catalog.

## Test-pinned

New [tests/test_docs_accuracy.py](tests/test_docs_accuracy.py) pins the machine-checkable claims so they cannot drift again: node-type count + full enum listing, sidecar count + config-folder table vs `NODE_TYPE_TO_FOLDER`, secret names vs `haute._scaffold.TARGETS` (and absence of the stale bare pair), and every `pipeline = "…"` snippet vs the actual scaffolded `haute.toml`. All 6 pass locally; full backend suite green.

Docs + one test file only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)