### PR TITLE
De-flake the contract-overhead smoke: min-of-N + gross-blowup bound

### DIFF
--- a/tests/test_column_contracts_adoption.py
+++ b/tests/test_column_contracts_adoption.py
@@ -990,9 +990,23 @@ class TestContractOverheadBenchmark:
         passes contiguously followed by all N with-enforce passes.
 
         The default-suite smoke test runs under xdist, so it also
-        alternates the measurement order and uses the median per mode
-        rather than trusting a tiny mean sample that one noisy worker
-        slice could skew.
+        alternates the measurement order and compares the MINIMUM per
+        mode: contention noise on a loaded runner only ever adds time,
+        so the fastest observed pass is the closest estimate of each
+        mode's true cost, and comparing minima largely cancels
+        scheduler interference (a median of five ~60ms passes cannot
+        resolve a tight ratio under ``-n 4`` on a 2-vCPU runner).
+
+        The threshold here is deliberately loose: the real product
+        bound is the perf lane's 100-node <5% benchmark below. This
+        smoke exists only to catch gross blowups (per-row or quadratic
+        contract checks read as 5-50x, not 1.4x) on every PR, so it
+        asserts enforcement must not approach doubling the runtime —
+        and only when the absolute delta is large enough to be a real
+        cost rather than measurement noise on a ~60ms workload (the
+        median-of-5/30% version flaked at 34%/44% on the contended
+        3.11/3.14 full-suite legs, 17 July 2026, on a tree whose other
+        legs passed the same test).
         """
         import polars as pl_
 
@@ -1028,14 +1042,16 @@ class TestContractOverheadBenchmark:
                 else:
                     without_samples.append(elapsed)
 
-        t_without = statistics.median(without_samples)
-        t_with = statistics.median(with_samples)
+        t_without = min(without_samples)
+        t_with = min(with_samples)
         overhead = ((t_with - t_without) / t_without) if t_without > 0 else 0.0
-        assert overhead < 0.30, (
+        delta_ms = (t_with - t_without) * 1000
+        assert overhead < 0.75 or delta_ms < 100, (
             f"Contract enforcement overhead is {overhead:.1%} "
-            f"({t_without * 1000:.1f}ms → {t_with * 1000:.1f}ms), exceeds "
-            "the 30% smoke-test threshold. Run pytest -m perf for the "
-            "full 100-node, <5% benchmark."
+            f"({t_without * 1000:.1f}ms → {t_with * 1000:.1f}ms, "
+            f"delta {delta_ms:.1f}ms), exceeds the gross-blowup smoke "
+            "bound (>=75% AND >=100ms slower). Run pytest -m perf for "
+            "the full 100-node, <5% benchmark."
         )
 
     @pytest.mark.perf


### PR DESCRIPTION
The default-suite contract-overhead smoke compared medians of five ~60ms passes against a 30% ratio — unresolvable under `-n 4` xdist on a 2-vCPU runner, where a single ordinary scheduler preemption moves the median by a third of the allowed band. It flaked at 34%/44% on the contended 3.11/3.14 full-suite legs (17 July 2026, run 29599519168) on a tree whose other legs passed the same test minutes apart.

The smoke's job is catching gross blowups (per-row or quadratic contract checks read as 5–50×, not 1.4×); the real <5% product bound stays in the perf lane's 100-node benchmark, unchanged. Changes:

- Compare the **minimum** per mode instead of the median: contention only ever adds time, so the fastest pass is the closest estimate of true cost, and comparing minima cancels scheduler interference.
- Fail only when enforcement approaches doubling the runtime (**≥75%**) **and** the absolute delta is **≥100ms** — a 19ms delta on a 54ms base can never be a real product regression.

Verified: passes solo, with its module under `-n 4`, and across three stressed repeats; ruff lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)