### PR TITLE
Converge API Input identity and make caching optional

### DIFF
--- a/docs/roadmap/api-input-ui-issues.md
+++ b/docs/roadmap/api-input-ui-issues.md
@@ -1,0 +1,362 @@
+# API Input UI issue notes
+
+**Status:** Resolved — implemented in v0.5.0 (branch `api-input`, ships the v0.4.1
+presentation foundation and the input-identity convergence as one release). The v0.4.1 work
+(`docs/trip/plans/F_0.4.1_api-input-frame-identity.plan.md`) addressed issues 1–4 visually;
+field-testing then exposed the underlying display-vs-executable naming split (panel listed
+`quotes`, generated code bound `Quote_Input_1`/`Quote_Input_1_2`, plus a latent edge-reorder
+silent-rebind hazard). Ralph ruled full convergence — a node's listed inputs ARE its argument
+names, 1:1, no hidden names — implemented via
+`docs/trip/plans/F_0.5.0_input-identity-convergence.plan.md`: one shared derivation
+(`edge_input_name` / `edgeInputName`) feeds codegen, the executor, projection, deploy, and
+every panel surface; frame labels are validated as ASCII Python identifiers (invariant B4);
+labelled handles exist from one frame up; duplicate input names fail loudly at drag, save,
+and run time; and frame renames migrate edges, `input_scenario_map` keys, and instance
+`inputMapping` entries in one undoable commit. The issue bodies below predate the fix and
+refer to since-retired helpers (`apiInputEmitPortLabels`, `varName`/`displayLabel`) — they
+are retained as the historical record. New observations can continue to be collected here.
+
+**Current as of:** 2026-07-21
+
+## Purpose
+
+This is a lightweight holding list for user-facing API Input issues observed while
+working with the node. It captures the symptom and the outcome we want without
+committing to an implementation. The issues can be investigated, specified, and
+scheduled in a later session.
+
+## Issues
+
+### Cross-issue layout requirement
+
+Any replacement layout or handle-positioning method must be data-driven rather
+than tailored to the two-frame example. It must behave predictably for one, two,
+and any supported number of emitted frames. In particular, adding or removing an
+emitted frame must keep every remaining name, handle, and edge association
+correct without special-case pixel positions.
+
+### 1. Multi-frame connection lines do not align with their output names
+
+**Observed behaviour**
+
+When an API Input emits multiple frames, the expanded canvas node lists their
+names on the right side of the node body. In the observed two-frame example the
+outputs are `quote_id` and `driver_claims`, but the two connection lines leave
+the node at heights that do not line up with those names. The upper connection
+appears to leave near the header/body boundary, and the lower connection appears
+closer to the first name than the second. It is therefore difficult to tell which
+line belongs to which emitted frame.
+
+This is especially confusing when both outputs connect to the same downstream
+node: line direction cannot compensate for the missing visual association.
+
+**Likely reason / investigation starting point**
+
+The output names and output handles share the same ordered label source, so this
+does not initially look like a frame-order or persisted-handle identity problem.
+The likely issue is that they use different layout coordinate systems:
+
+- `PipelineNode` renders the names as a compact vertical list inside the node
+  body.
+- `_SourceHandles` independently spaces the handles at percentages of the full
+  node height, including the header.
+
+The two layouts can consequently have the same ordering while still having
+different vertical positions. Changes to body height, status content, trace
+content, label wrapping, or the number of emitted frames may make the mismatch
+more obvious.
+
+Relevant starting points:
+
+- `frontend/src/nodes/PipelineNode.tsx` — `_SourceHandles`, `showBodyLabels`, and
+  the emitted-label list in the full-detail node body.
+- `frontend/src/utils/apiInputPorts.ts` — the shared derivation of eligible
+  emitted-frame labels. This identity logic should remain authoritative.
+- `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx` — current handle count,
+  ID, and label coverage.
+- `frontend/src/nodes/__tests__/PipelineNode.test.tsx` — general node/handle
+  rendering coverage.
+
+**Desired outcome**
+
+Each visible emitted-frame name should have one clearly associated output dot on
+the same visual row, and every outgoing line should begin at that dot. A user
+should be able to identify the source frame of an edge without selecting the
+edge, opening the editor, or relying on line order.
+
+**Things to preserve**
+
+- The raw frame label remains the React Flow handle ID and runtime source port.
+- Existing saved edges remain connected to the same frames.
+- Blank, duplicate, or otherwise invalid labels do not gain synthetic handles.
+- Single-frame API Inputs retain their default single-handle connection
+  semantics, while issue 2 makes the emitted frame's name visible.
+- Re-alignment does not regress node zoom/detail modes or ordinary non-API nodes.
+
+**Suggested acceptance coverage for the later implementation**
+
+- Exercise two, three, four, and a larger representative number of emitted
+  frames and verify label-to-handle ordering and visual alignment. The layout
+  method must derive positions from the rendered frame rows rather than contain
+  a separate arrangement for each frame count.
+- Cover different label lengths and node-body height changes, including status,
+  warnings, and trace content where those can affect layout.
+- Verify edges still carry the correct `sourceHandle` after render, save/reload,
+  and an in-place frame rename.
+- Add a browser-level or visual assertion for the geometry. DOM-only component
+  tests that check handle count and IDs cannot prove that the lines visually
+  align with their labels.
+
+### 2. A single emitted frame does not show its output name
+
+**Observed behaviour**
+
+When two or more frames are emitted, their names appear in grey on the right of
+the expanded API Input node. When exactly one frame is emitted, the node keeps a
+single output dot but does not show that frame's name. The canvas therefore hides
+useful information that is visible as soon as a second frame is enabled.
+
+**Likely reason / investigation starting point**
+
+This is explicit in the current canvas rendering contract rather than a styling
+failure. `PipelineNode` only enables its body-label list for a multi-frame API
+Input. In addition, `apiInputEmitPortLabels` deliberately returns an empty list
+for zero or one eligible frame because that helper currently signals when named
+multi-port handles are required. As a result, the render path has no singleton
+label to display even though the table config still has one.
+
+The investigation should separate two concepts that are currently represented
+by the same derived list:
+
+- which eligible frame names should be visible to the user; and
+- whether React Flow needs named multi-port handles or the legacy single default
+  handle.
+
+Showing the singleton name should not require changing the persisted/default
+handle identity unless a later design decision explicitly calls for that.
+
+Relevant starting points:
+
+- `frontend/src/nodes/PipelineNode.tsx` — `emitTableLabels`,
+  `showBodyLabels`, `_SourceHandles`, and the full-detail body.
+- `frontend/src/utils/apiInputPorts.ts` — `apiInputEmitPortLabels` and its
+  zero/one-frame fallback contract.
+- `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx` — tests that currently
+  expect the default single handle for a single emitted frame.
+
+**Desired outcome**
+
+When exactly one valid frame is emitted, its raw name is shown in the same grey
+style used for multi-frame output names and is visually associated with the
+single output dot. The node should present output identity consistently whether
+one frame or several frames are enabled.
+
+**Things to preserve**
+
+- A single emitted frame continues to use the existing default single-output
+  handle unless handle semantics are deliberately redesigned separately.
+- No name is fabricated when there are no eligible emitted frames.
+- Invalid or duplicate persisted labels do not produce synthetic display names
+  or handles.
+- Moving between zero, one, and multiple emitted frames does not orphan or
+  silently rebind existing edges.
+
+**Suggested acceptance coverage for the later implementation**
+
+- Show the grey name for exactly one emitted frame and align it with the default
+  output dot.
+- Preserve the correct names and associations while transitioning through
+  one → two → many → one emitted frames.
+- Cover one emitted table alongside additional non-emitted tables so visibility
+  follows runtime eligibility rather than total table count.
+- Cover long labels and the relevant node zoom/detail modes, with a browser or
+  visual assertion for the final geometry.
+
+### 3. The generic node name dominates the emitted-frame names
+
+**Observed behaviour**
+
+In the expanded API Input node, the body gives a large, bold area to the generic
+instance name (for example, `Quote Input 1`). The emitted-frame names are placed
+in a small grey column beside it. With several frames, the generic name consumes
+space that would be more useful for the outputs, while important frame names are
+visually secondary and can be heavily truncated.
+
+The header already identifies the node as `QUOTE IN` and carries the API badge,
+so repeating a default instance name in the body provides little additional
+information. On the canvas, users primarily need to see which named frames can
+be connected downstream.
+
+**Proposed product direction**
+
+When an API Input has at least one eligible emitted frame:
+
+- remove the generic node instance name from the visible body; and
+- use the body as a prominent emitted-frame list, with each frame name clearly
+  associated with its output handle and connection line.
+
+“Remove” here means suppress the instance name in this canvas presentation. It
+must not delete or rewrite the persisted node label: that identity may still be
+needed by the editor, selection model, generated code, tracing, diagnostics,
+accessibility, and test automation.
+
+The later design should decide the empty state explicitly. If there are no
+eligible emitted frames, retaining the instance name or replacing it with a
+clear `No emitted frames` state may be more useful than rendering an empty body.
+
+**Relationship to issues 1 and 2**
+
+These three issues should be designed together. A strong candidate is a single
+rendered output-row primitive that owns the visible name and corresponding
+handle position. That could simultaneously:
+
+- make frame names the primary body content;
+- show the same treatment for one or many frames; and
+- ensure each connection starts on the row carrying its name.
+
+This is a direction to investigate, not a requirement to use a specific DOM or
+CSS implementation. Any chosen method still has to satisfy the cross-issue
+one/two/many-frame requirement above.
+
+Relevant starting points:
+
+- `frontend/src/nodes/PipelineNode.tsx` — the full-detail body currently renders
+  `nodeData.label` as the dominant left column and emitted labels as a small
+  right-aligned column.
+- `frontend/src/types/node.ts` and graph persistence — confirm every non-visual
+  consumer of the node label before changing presentation.
+- Existing canvas accessibility and node tests — confirm that removing visible
+  text does not remove the node's accessible name or stable automation identity.
+
+**Desired outcome**
+
+The expanded API Input node reads as a source with named outputs, rather than as
+one large generic node name with incidental metadata. Emitted-frame names should
+be immediately scannable, less aggressively truncated, and visually stronger
+than they are today. Their alignment with handles should make the source of each
+edge unambiguous.
+
+**Things to preserve**
+
+- The persisted node label and every non-visual identity derived from it.
+- A useful accessible name for the node after the visible instance label is
+  suppressed.
+- Frame-label handle IDs, edge routing semantics, and save/reload behaviour.
+- Clear empty, single-frame, and multi-frame states.
+- Sensible node sizing at larger frame counts without covering nearby canvas
+  content or making handles overlap.
+
+**Suggested acceptance coverage for the later implementation**
+
+- Prove the generic instance name is visually absent when emitted frames are
+  present, while the node retains its accessible and persisted identity.
+- Verify one, two, and several emitted-frame names receive the new prominent
+  treatment and remain paired with their handles.
+- Cover long frame names: truncation, tooltip/full-name access, and node-width or
+  wrapping behaviour should be intentional rather than accidental.
+- Exercise zero emitted frames and define the body fallback explicitly.
+- Add visual/browser evidence at the relevant zoom levels and with status,
+  warning, and trace adornments present.
+
+### 4. Downstream inputs show the parent node name instead of the connected frame
+
+**Observed behaviour**
+
+After connecting an emitted API Input frame to another node, the downstream
+editor describes its input as `Quote_Input_1`. It does not show the individual
+dataframe/frame name selected on the connection. This loses the most important
+part of the edge identity: which output of the multi-frame source is actually
+feeding the node.
+
+If two frames from the same API Input are connected to one downstream node, the
+problem is worse: both can appear to have the same `Quote_Input_1` identity even
+though they carry different dataframes.
+
+**Likely reason / investigation starting point**
+
+`NodePanel` currently builds each `InputSource` from the upstream node's label:
+
+- `varName` is the sanitised upstream node label; and
+- `sourceLabel` is the upstream node label.
+
+The incoming edge's `sourceHandle` is not included in `InputSource` or consulted
+when these names are derived. For a multi-frame API Input, however,
+`edge.sourceHandle` is the raw emitted-frame label and is the canonical identity
+of the selected dataframe throughout canvas persistence and runtime routing.
+
+There are two adjacent details to audit during implementation:
+
+- `InputSourcesBar` currently keys rendered chips by `varName`, so two edges from
+  the same parent node can also produce duplicate display keys.
+- `upstreamLabelSignature` tracks the edge ID and source-node label but not the
+  source handle. A frame rename/rebind may therefore need an explicit dependency
+  so memoised downstream input metadata cannot remain stale.
+
+`OutputEditor` already contains a useful precedent: it uses `sourceHandle` as the
+frame identity for multi-frame edges and resolves the sole eligible emitted table
+for the null-handle single-frame fallback.
+
+Relevant starting points:
+
+- `frontend/src/panels/NodePanel.tsx` — `upstreamLabelSignature` and the
+  `inputSources` derivation.
+- `frontend/src/panels/editors/_shared.tsx` — `InputSource` and
+  `InputSourcesBar`.
+- `frontend/src/panels/editors/OutputEditor.tsx` — existing edge-to-frame name
+  resolution for multi-frame and single-frame API Inputs.
+- `frontend/src/utils/apiInputPorts.ts` — source-handle/frame identity and
+  rename reconciliation.
+- `frontend/src/panels/__tests__/NodePanel.test.tsx` and editor tests consuming
+  `InputSource`.
+
+**Desired outcome**
+
+A downstream node should identify an API Input connection by the dataframe it
+receives:
+
+- a named multi-frame edge displays the edge's emitted-frame label;
+- a single-frame fallback displays the sole eligible emitted-frame label even
+  though its React Flow `sourceHandle` remains null; and
+- ordinary single-output nodes continue to display their upstream node name.
+
+For example, connections from `quote_id` and `driver_claims` should appear as two
+distinct inputs with those names, not as two copies of `Quote_Input_1`.
+
+**Display identity versus executable identity**
+
+The implementation must explicitly establish whether `InputSource.varName` is
+only a UI/code-hint label or is expected to mirror an executable function
+argument. The user-facing label must use the connected frame name, but changing
+an executable variable contract accidentally would break existing editor code or
+generated pipelines. If those identities differ, `InputSource` should represent
+them separately rather than overloading one string for both purposes.
+
+**Things to preserve**
+
+- `edge.sourceHandle` remains the canonical persisted/runtime frame identity for
+  named multi-frame edges.
+- The null-handle single-frame compatibility path remains valid.
+- Existing Polars/editor code and generated function arguments are not silently
+  renamed by a presentation-only change.
+- Frame renames update downstream presentation and edge binding together.
+- Multiple edges from one API Input remain distinct and removable individually.
+
+**Suggested acceptance coverage for the later implementation**
+
+- Connect two different frames from one API Input to one downstream node and
+  verify two distinct frame names, edge identities, and remove actions.
+- Cover a single emitted frame with a null source handle and verify its real
+  frame label is displayed rather than the parent node label.
+- Cover ordinary non-API sources to ensure their existing node-name presentation
+  remains unchanged.
+- Rename an emitted frame in place and verify the canvas edge, downstream input
+  label, memoised panel state, save/reload result, and runtime routing all move to
+  the new name together.
+- Verify duplicate-looking labels cannot create React key collisions or make the
+  wrong edge get removed.
+
+## Further issues to capture
+
+Add subsequent observations here before turning this list into an implementation
+plan. Keep each issue focused on the user-visible problem, reproduction context,
+desired outcome, invariants, and the evidence needed to close it.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -25,6 +25,14 @@ roadmap item is implemented and verified.
 The Price Contour ratebook factor-context work is implemented and retired. It
 has no active roadmap because it no longer has remaining delivery work.
 
+## Working issue notes
+
+- [API Input UI issue notes](api-input-ui-issues.md) — the four captured issues
+  were designed and implemented as v0.4.1 (frame-row node body, frame-named
+  downstream inputs); see
+  `docs/trip/plans/F_0.4.1_api-input-frame-identity.plan.md`. The note stays as
+  the collection point for any further API Input observations.
+
 ## Sequencing and ownership
 
 Test-suite hardening and Frontend UI quality are cross-cutting evidence tracks;

--- a/docs/specs/codegen/high-level.md
+++ b/docs/specs/codegen/high-level.md
@@ -86,6 +86,18 @@ Out of scope (owned by neighbouring components):
   (`_error_on_name_collisions`), checked globally across the root graph and
   every submodel — not per file — because the flattened runtime graph is
   keyed by the sanitized name across module boundaries.
+- **Function parameters are the listed input names, 1:1.** Each parameter of a
+  generated node function is the *input name* of one incoming edge, derived by
+  `haute._graph_utils.edge_input_name` in edge order: an `apiInput`-frame edge
+  contributes its frame label verbatim (labels are validated as ASCII Python
+  identifiers by the api-input schema), every other edge the sanitised
+  source-node label. A frame emitted as `quotes` is therefore callable as
+  `quotes` in every downstream body — the same string the editor lists as the
+  input. Two incoming edges of one node deriving the same parameter name are a
+  hard `ParseError` at codegen time; parameters are never disambiguated with
+  hidden numeric suffixes. Every `apiInput` edge emits an explicit
+  `source_port` in its connect call — including a sole-frame source — so the
+  file itself always names the frame each parameter binds.
 - **Submodel-aware.** A graph with no `graph.submodels` produces exactly one
   file. A graph with submodels produces one file per submodel (default path
   `modules/<name>.py`) plus a main file that imports them via
@@ -168,11 +180,17 @@ Out of scope (owned by neighbouring components):
   comments, string literals containing the word "return," and multi-line
   `return (...)` all defeat a textual scan. `_code_extraction._outermost_returns`
   walks the AST and stops descending at any node that opens a new scope.
-- **De-duplication of function parameters is cosmetic only.** Multiple edges
-  from the same upstream node produce duplicate `source_names`; binding is
-  positional, so `_dedup_param_names` only needs to keep the emitted
-  parameter list syntactically valid (no repeated identifiers), not
-  semantically meaningful.
+- **Parameter names are semantic, never cosmetically deduplicated.** An
+  earlier design derived every parameter from the source-*node* label and
+  suffixed duplicates (`name_2`) because binding is positional and the names
+  were "cosmetic". That made the two frames of one `apiInput`
+  indistinguishable in code (`Quote_Input_1` vs `Quote_Input_1_2`), hid the
+  real frame names the editor displays, and — worse — meant reconnecting
+  edges in a different order silently re-bound an unchanged body to different
+  frames. Deriving each name from its own edge (`edge_input_name`) makes the
+  name travel with the frame: binding is still positional in mechanism, but a
+  reorder reorders the signature rather than re-meaning a name, and a
+  collision is a loud error instead of a hidden rename.
 
 ## Interactions
 
@@ -231,6 +249,13 @@ execution time on a mis-wired pipeline). Concretely:
   Python identifier, anywhere in the root graph or any submodel) →
   `ParseError` enumerating every colliding bucket, from
   `_error_on_name_collisions`.
+- **Input-name collisions on one node** (two incoming edges deriving the same
+  parameter name — e.g. a frame labelled `clean_data` alongside an upstream
+  node whose label sanitises to `clean_data`) → `ParseError` naming the
+  target node and the colliding input name; never a silent `_2` suffix. The
+  frontend rejects creating such a connection at drag time with the same
+  rule, so this backend error is the authoritative backstop, not the first
+  line of defence.
 - **Malformed submodel cross-boundary edge** (missing/wrong-prefixed handle,
   or a handle referencing a child id that doesn't exist in that submodel) →
   `ParseError` from `graph_to_code_multi` / `_resolve_submodel_endpoint`,

--- a/docs/specs/codegen/low-level.md
+++ b/docs/specs/codegen/low-level.md
@@ -5,14 +5,14 @@
 | File | Responsibility |
 |---|---|
 | `src/haute/codegen.py` | Public orchestration API (`graph_to_code`, `graph_to_code_multi`); single-node dispatch (`_node_to_code`, `_generate_node_code`); instance-node handling; contract kwarg formatting/injection (`_format_contract_kwarg`, `_format_contract_source`, `_inject_contract_kwarg`, `_matching_close_paren`); pipeline/submodel file assembly (`_generate_pipeline_lines`); the final parse gate (`_assert_emitted_files_parse`). |
-| `src/haute/_codegen_builders.py` | One `_gen_*` builder per `NodeType`, registered into `haute._registry.NODE_REGISTRY` via `@_register_codegen`. String-safety helpers (`_safe_str`, `_safe_path`, `_portable_path_expr`), shared field extraction (`_common_node_fields`, `_build_params`, `_dedup_param_names`), docstring sanitization (`_sanitize_description`), and per-type template strings (`_MODEL_SCORE`, `_BANDING_SINGLE`, `_SINK_PARQUET`, etc.). |
+| `src/haute/_codegen_builders.py` | One `_gen_*` builder per `NodeType`, registered into `haute._registry.NODE_REGISTRY` via `@_register_codegen`. String-safety helpers (`_safe_str`, `_safe_path`, `_portable_path_expr`), shared field extraction (`_common_node_fields`, `_build_params` — parameters are the per-edge input names supplied by the orchestrator via `edge_input_name`, with a loud duplicate-name guard replacing the former `_dedup_param_names` suffixing), docstring sanitization (`_sanitize_description`), and per-type template strings (`_MODEL_SCORE`, `_BANDING_SINGLE`, `_SINK_PARQUET`, etc.). |
 | `src/haute/_code_extraction.py` | Reverse direction of `_codegen_builders`' body wrapping: strips generated boilerplate back out of a persisted function body so the user-facing code editor shows only what the user actually typed. Consolidated engine (`extract_user_code`) dispatches through `BOILERPLATE_MATCHERS`/`_FINALISERS` registries keyed by node "kind." |
 | `src/haute/_ast_helpers.py` | Stateless AST/source utilities with no node/graph knowledge: literal evaluation (`_eval_ast_literal`), decorator introspection (`_get_decorator_kwargs`, `_is_pipeline_node_decorator`, `_get_decorator_node_type`), docstring/whitespace handling (`_strip_docstring`, `_dedent`), and whole-file extraction helpers (`_extract_function_bodies`, `_extract_connect_calls`, `_extract_meta`, `_extract_preamble`, `_extract_preserved_blocks`) shared with the parser. |
 
 ## Key types and data structures
 
-- **`_NodeCodeFn`** (`codegen.py`) — `Callable[[GraphNode, list[str] | None, list[str] | None], str]`; the injected per-node code generator (`_node_to_code` for pipelines, `_submodel_node_to_code` for submodel files), parameterizing `_generate_pipeline_lines` so both file kinds share one assembly routine.
-- **`_ConnectPair`** (`codegen.py`) — `tuple[str, str, str | None, str | None]`: `(src_func, tgt_func, source_port, target_port)`. `source_port`/`target_port` are `None` for the single-frame bare `connect("a", "b")` form, or the frame name for the multi-frame `connect("a", "b", source_port=..., target_port=...)` form.
+- **`_NodeCodeFn`** (`codegen.py`) — `Callable[[GraphNode, list[str] | None, list[str] | None, list[str] | None], str]`; the injected per-node code generator (`_node_to_code` for pipelines, `_submodel_node_to_code` for submodel files), parameterizing `_generate_pipeline_lines` so both file kinds share one assembly routine. The fourth argument carries the per-edge source *function* names, kept alongside the edge-derived input names so edge-join role kwargs (`base_input`/`join_input`) can reference the connected source functions for parser reconstruction while the signature uses the input names.
+- **`_ConnectPair`** (`codegen.py`) — `tuple[str, str, str | None, str | None]`: `(src_func, tgt_func, source_port, target_port)`. `source_port`/`target_port` are `None` for the bare `connect("a", "b")` form used by ordinary single-output sources. Every `apiInput` edge — including one from a sole-frame source — carries its frame label as `source_port`, so the generated file always names the frame each connection delivers; a bare connect from an `apiInput` is not emitted.
 - **`CodegenBuilder`** (`_codegen_builders.py`) — `Callable[[GraphNode, list[str]], str]`; the signature every `_gen_*` function implements. Registered per `NodeType` into `NODE_REGISTRY[node_type].codegen` (see `haute._registry`); `NODE_REGISTRY` pairs each type's codegen builder with its exec-side runtime builder from `haute._builders`, and `validate_registry_complete` enforces both are present for every type.
 - **`MatcherResult`** (`_code_extraction.py`) — `NamedTuple(start_idx: int, return_vars: tuple[str, ...], generated_scaffold: bool = False)`. Output of a `BoilerplateMatcher`: `start_idx` is the first line of `cleaned_lines` considered user code; `return_vars` are variable names whose trailing `return <var>` should be stripped; `generated_scaffold=True` means a generated `df = <helper>(...)` line already produced `df`, so the polars finaliser must not treat the node's first parameter as a strippable alias.
 - **`BoilerplateMatcher`** (`_code_extraction.py`) — `Callable[[list[str], tuple[str, ...]], MatcherResult]`. One matcher per "kind" (`polars`, `source`, `scenario_expander`, `model_score`, `rating_step`, `external`), registered in `BOILERPLATE_MATCHERS` with aliases for both NodeType-style and Python-snake-style kind spellings.
@@ -33,9 +33,14 @@
 4. **No-submodel path:** order edges (`_order_edge_join_incoming_edges` puts
    each edge-join's two incoming edges in base-then-join order), topo-sort
    nodes (`_topo_sort` via `haute._topo.topo_sort_ids`), build
-   id→func-name / node→sources / node→source-ids maps, build `connect_pairs`
-   directly from edges, call `_generate_pipeline_lines(kind="pipeline", ...)`,
-   then `_assert_emitted_files_parse` on the single resulting file.
+   id→func-name maps and each node's per-edge input-name list
+   (`edge_input_name(edge, source_node)` in edge order — the same list the
+   executor derives, so signature and binding can never disagree), raising
+   `ParseError` on a duplicate input name within one node (via the shared
+   `duplicate_input_names` detector in `_graph_utils.py`), build
+   `connect_pairs` directly from edges, call
+   `_generate_pipeline_lines(kind="pipeline", ...)`, then
+   `_assert_emitted_files_parse` on the single resulting file.
 5. **Submodel path:** for each submodel, rehydrate its stored
    `GraphNode`/`GraphEdge` list (submodels may be stored as dicts or already-
    validated models — `GraphNode.model_validate` is applied conditionally),
@@ -144,11 +149,13 @@ unchanged, avoiding a full re-parse on every save for the common case.
 
 ## Edge cases and invariants
 
-- **Multi-edge into one node** (the same upstream function feeding a node
-  through two distinct edges) — `_dedup_param_names` suffixes the second
-  occurrence (`name_2`, `name_3`, ...); binding is positional so the exact
-  names are cosmetic. Zero sources yields the single default parameter
-  name `"df"`.
+- **Multi-edge into one node** (the same upstream `apiInput` feeding a node
+  through two frame edges) — each edge contributes its own frame label as the
+  parameter name, so the parameters are distinct by the api-input schema's
+  label-uniqueness rule; no suffixing exists. A derived duplicate across
+  *different* sources (frame label colliding with another input's name) is a
+  `ParseError`, never a rename. Zero sources still yields the single default
+  parameter name `"df"`.
 - **User-controlled text inside decorator arg lists** (a column literally
   named `"price (gbp)"`, or containing `":)"`) — `_matching_close_paren`
   tokenizes rather than character-scans, so parens inside string literals
@@ -229,6 +236,8 @@ unchanged, avoiding a full re-parse on every save for the common case.
 | Contract computation hits a non-infra exception (`TypeError`, `KeyError`, `HauteError` incl. `ContractMismatchError`) | propagated unchanged | `codegen._format_contract_kwarg` |
 | `inputs_by_parent` ambiguous key collision | `ParseError` | `codegen._format_contract_source` |
 | Duplicate sanitized function names across root graph + submodels | `ParseError` (all colliding buckets listed) | `codegen._error_on_name_collisions` |
+| Duplicate derived input names among one node's incoming edges | `ParseError` (target node + colliding input name) | `codegen.graph_to_code_multi` (per-edge input-name assembly) |
+| An `apiInput` edge carrying no `source_port`/`sourceHandle` (only reachable via a hand-edited file — the editor cannot create one) | `ParseError` naming the edge and source node | `codegen.graph_to_code_multi` (per-edge input-name assembly) |
 | `edgeJoin` codegen source names/ids desynced | `ParseError` | `codegen._role_order_node_sources` |
 | Submodel cross-boundary edge with missing/malformed `in__`/`out__` handle, or referencing an unknown child id | `ParseError` | `codegen.graph_to_code_multi`, `codegen._resolve_submodel_endpoint` |
 | `graph_to_code` called on a graph that actually produces >1 file | `ConfigError` | `codegen.graph_to_code` |
@@ -258,6 +267,14 @@ than one file per module:
   ambiguous/missing-target error cases), submodel pipeline replacement,
   special-character labels, connect-call deduplication, contract-source
   collision handling, and an explicit single-file guard for `graph_to_code`.
+  The input-identity scenarios live here: frame-labelled parameters for
+  multi- and sole-frame `apiInput` edges (signature names equal the frame
+  labels, in edge order), the explicit `source_port` on every `apiInput`
+  connect call including sole-frame, the duplicate-input-name `ParseError`
+  (frame vs frame is unreachable by schema validation; frame vs
+  sanitised-node-label is the reachable case), and the round-trip fixpoint
+  (`test_codegen_roundtrip_property.py`) regenerated under frame-named
+  parameters.
 - **`test_codegen_builders.py`** — per-builder unit tests (`_gen_api_input`,
   `_gen_banding`, `_gen_scenario_expander`, `_gen_optimiser`, `_gen_explore`,
   `_gen_data_sink`) plus `TestCodegenExecValidation`, which executes

--- a/docs/specs/deploy/low-level.md
+++ b/docs/specs/deploy/low-level.md
@@ -74,9 +74,12 @@
    `config.output=True`, else `ValueError`.
 5. `prune_for_deploy(full_graph, output_node_id)` → `pruned_graph`, kept ids, removed ids.
    Internally: `_live_only_edges()` first drops every non-live input edge into each
-   `liveSwitch` node (matched by `input_scenario_map` or, as a fallback, by matching
-   `inputs[0]` against an edge's source label), then `ancestors()` walks backward from the
-   output node over the filtered edge set.
+   `liveSwitch` node — selection is **per edge**, matching `input_scenario_map`'s
+   `"live"`-valued key against each edge's input name
+   (`haute._graph_utils.edge_input_name`), never per source node, so two frames from
+   one apiInput mapped `quotes=live, drivers=batch` keep exactly the `quotes` edge (the
+   legacy fallback matches `inputs[0]` the same way) — then `ancestors()` walks backward
+   from the output node over the filtered edge set.
 6. `find_deploy_input_nodes(pruned_graph)` — nodes with `nodeType="apiInput"`. If none,
    fall back to the single source node in the pruned graph (`ValueError` if zero or
    multiple non-apiInput sources exist).
@@ -221,12 +224,15 @@ JSON have separate structured payloads. A body exactly at the configured limit i
   mutation via `.override()`, env overrides, or direct attribute writes after
   construction — the actual last chokepoint before a build is committed).
 - **`liveSwitch` live-branch resolution has two paths**: primary is matching
-  `input_scenario_map`'s `"live"`-valued key against a connected edge's source label; if
-  no `input_scenario_map` exists, fallback matches `config["inputs"][0]` (positional) the
-  same way. If an explicit `input_scenario_map` names a live input that doesn't match any
-  connected edge, `ValueError`. If the legacy `inputs[0]` fallback matches nothing, the
-  current implementation records no live source and silently drops all incoming switch
-  edges.
+  `input_scenario_map`'s `"live"`-valued key against a connected edge's **input name**
+  (`haute._graph_utils.edge_input_name` — the frame label for an apiInput-frame edge,
+  the sanitised source label otherwise; the same derivation the executor, projection,
+  and codegen use, so two frames from one apiInput are individually routable); if no
+  `input_scenario_map` exists, fallback matches `config["inputs"][0]` (positional) the
+  same way. Both paths fail loud: if an explicit `input_scenario_map` names a live input
+  that doesn't match any connected edge, or the legacy `inputs[0]` fallback is absent or
+  matches no edge, a `ValueError` names the switch and the unmatched input — the pruner
+  never records an empty live set and silently drops all incoming switch edges.
 - **Feature-contract bundling filename convention**: the bundler only looks for a bare
   `feature_contract.json` sitting next to a downloaded model (the MLflow-download-cache
   convention); training itself writes per-model `{name}.feature_contract.json` and never

--- a/docs/specs/engineering-quality/low-level.md
+++ b/docs/specs/engineering-quality/low-level.md
@@ -26,6 +26,7 @@
 | `frontend/e2e/job-progress-render.benchmark.spec.ts` | `@benchmark` Playwright coverage for job-progress rendering. |
 | `frontend/e2e/large-graph-drag.benchmark.spec.ts` | `@benchmark` Playwright coverage for dragging large graphs. |
 | `frontend/e2e/migration/v1-to-v2-node-continuity.spec.ts` | Playwright coverage for node-continuity migration behaviour. |
+| `frontend/e2e/persistence/api-input-frame-alignment.spec.ts` | Playwright geometry coverage for API-input frame-row/handle alignment and downstream frame naming. |
 | `frontend/e2e/persistence/api-input-render-gate.spec.ts` | Playwright persistence/render-gate coverage for API input. |
 | `frontend/e2e/persistence/api-input-v2-native.spec.ts` | Playwright persistence coverage for native v2 API input. |
 | `frontend/e2e/smoke.spec.ts` | Tagged smoke Playwright coverage, including the Firefox smoke project. |

--- a/docs/specs/execution-engine/high-level.md
+++ b/docs/specs/execution-engine/high-level.md
@@ -124,6 +124,18 @@ running heavy work in a child process the parent can kill on timeout or memory l
   offending node rather than as an opaque Polars error three nodes later. Missing
   columns use `ContractMismatchError`; join-key dtype disagreement uses
   `SchemaMismatchError`, with the eager-preview reporting asymmetry noted above.
+- **Input identity is 1:1 and edge-derived.** Every incoming edge of a node has
+  exactly one *input name*, derived by `edge_input_name` (`_graph_utils.py`): an
+  `apiInput`-frame edge's name is its frame label verbatim (frame labels are
+  validated as ASCII Python identifiers by the api-input schema); every other edge's name
+  is the sanitised source-node label. That name is simultaneously the name listed in
+  the editor, the generated function's parameter, and the key used by
+  name-referencing configs (`input_scenario_map`, instance `inputMapping`,
+  `config["inputs"]`) — there are no hidden names, positional suffixes, or
+  display-vs-executable mappings. Two incoming edges deriving the same input name on
+  one node are a loud validation error, never silently suffixed. Binding remains
+  positional in mechanism, but because each name derives from its own edge, edge
+  reordering can never re-mean a name.
 
 ## Design rationale
 

--- a/docs/specs/execution-engine/low-level.md
+++ b/docs/specs/execution-engine/low-level.md
@@ -13,7 +13,7 @@
 | `src/haute/_node_apply.py` | Config-driven implementations of `liveSwitch` input selection, `scenarioExpander` row expansion, `optimiserApply` artifact dispatch, and `OUTPUT` response-document assembly (`assemble_output_from_config`) — the single code path both the canvas executor (via `_builders.py`) and codegen-generated `.py` files call. |
 | `src/haute/_topo.py` | `topo_sort_ids` (graphlib-backed topological sort with a custom multi-cycle reporter), `ancestors` (BFS over reversed edges). |
 | `src/haute/graph_utils.py` | Canonical re-export facade for graph models, execution helpers, topo helpers, and IO helpers used by generated pipeline code and application modules. |
-| `src/haute/_graph_utils.py` | Pure-function graph helpers decoupled from the Pydantic models: `build_parents_of`, `upstream_node_ids`, `_sanitize_func_name`, `build_instance_mapping`, `resolve_orig_source_names`, edge-id construction, sink-path normalisation. |
+| `src/haute/_graph_utils.py` | Pure-function graph helpers decoupled from the Pydantic models: `build_parents_of`, `upstream_node_ids`, `_sanitize_func_name`, `edge_input_name` (the single edge→input-name derivation: apiInput-frame edge → its frame label verbatim, else sanitised source-node label; consumed by the executor, codegen, projection, and the deploy scorer so all four agree byte-for-byte), `build_instance_mapping`, `resolve_orig_source_names`, edge-id construction, sink-path normalisation. |
 | `src/haute/_worker_isolation.py` | `run_isolated_worker()` — spawn a child process for one function call with an optional `RLIMIT_AS` cap, timeout, and cooperative stop-reason polling; typed error hierarchy for every terminal state. |
 | `src/haute/chunking.py` | `ChunkPlanRequest`/`chunk_plan()` (proves a graph suffix is chunk-safe, sizes chunks), `iter_chunked_frames()`/`run_chunked_reduce()`/`collect_chunked()` (the serial runner), the per-`NodeType` `ChunkCapability` registry, and the AST-based row-local user-code whitelist. |
 | `src/haute/_ram_estimate.py` | `available_ram_bytes()`/`available_vram_bytes()` (OS-level memory probing), `estimate_safe_training_rows()` (parquet-metadata-based peak-memory estimate and downsample decision). |
@@ -200,15 +200,53 @@ rather than replacing it.
 
 ## Edge cases and invariants
 
-- **Multi-frame sources.** An `apiInput` with 2+ emit-true tables returns
-  `dict[port_label, Frame]` instead of a bare frame. Both eager and lazy paths route
-  per-edge via `_pick_source_frame(source_output, edge)`, keyed on
-  `edge.sourceHandle`; a `None` `sourceHandle` against a multi-frame source raises
-  `ValueError`, an unknown `sourceHandle` raises `KeyError`, and an empty-dict source
-  (no emit-true tables configured) raises a `RuntimeError` blaming the source node,
-  not the edge. Column caches for these are keyed `(node_id, port_label)` instead of
-  just `node_id` so two consumers of different frames from the same source don't
-  collide on contract-check state.
+- **Frame sources are uniform from one frame up.** An `apiInput` with ≥1
+  emit-eligible table returns `dict[frame_label, Frame]` — there is no bare-frame
+  single-table special case, so one frame and eight frames route identically. Every
+  `apiInput` edge carries its frame label as `sourceHandle`/`source_port`. Both eager
+  and lazy paths route per-edge via `_pick_source_frame(source_output, edge)`, keyed
+  on `edge.sourceHandle`; a `None` `sourceHandle` against a dict source raises
+  `ValueError` (a legacy or hand-edited edge that names no frame), an unknown
+  `sourceHandle` raises `KeyError`, and an empty-dict source (no eligible tables
+  configured) raises a `RuntimeError` blaming the source node, not the edge. Column
+  caches for these are keyed `(node_id, frame_label)` instead of just `node_id` so
+  two consumers of different frames from the same source don't collide on
+  contract-check state.
+- **Per-edge input names, not per-source names.** `_build_funcs` derives each
+  node's `source_names` per incoming edge via `edge_input_name(edge, source_node)`
+  (`_graph_utils.py`) — an apiInput edge contributes its frame label, every other
+  edge its sanitised source label — in the same edge-declaration order the frames
+  are bound in, so parameter i's name always describes frame i. **Every production
+  caller supplies incoming-edge metadata**: `_execute_lazy` (lazy and eager cores),
+  `executor.py`'s preview path, `execution.py`'s linear/optimiser execution, and
+  `chunking.py`'s chunked runner all pass their node's incoming edges through the
+  same derivation — a caller with no edge metadata is a test-only convenience, never
+  a production path. `resolve_orig_source_names` likewise derives an instance's
+  *original* input names from the original node's incoming edges (edge-derived, not
+  parent-node-id-derived), so instance alias injection speaks the same names as the
+  original's signature. Duplicate derived names among one node's incoming edges
+  raise `ConfigError` naming the node and the colliding name (matching codegen's
+  save-time rejection); the executor never suffixes or renames. Detection is
+  the shared pure helper `duplicate_input_names(names)` (`_graph_utils.py`):
+  given one target's derived input names in edge order it returns the names
+  appearing more than once — each once, in first-duplicate-occurrence order,
+  `[]` when all unique — and never raises itself; the executor wraps a
+  non-empty result in `ConfigError`, codegen in `ParseError`, so both
+  surfaces report the same collision identically.
+- **The standalone `Pipeline.run()`/`score()` executor binds ports the same way.**
+  `src/haute/pipeline.py`'s live-object runner consults each `RegisteredEdge`'s
+  `source_port` through the shared `_pick_source_frame` selection before calling a
+  node function — a generated one-frame apiInput pipeline run standalone receives
+  its frame, not the `{label: frame}` dict — keeping the single-execution-engine
+  invariant across in-process, standalone, and deploy contexts (see
+  [pipeline-config](../pipeline-config/low-level.md) for the module owner).
+  `score(df)`'s seed follows the complete shape × port-count matrix owned by
+  [pipeline-config](../pipeline-config/high-level.md): bare frame for zero
+  (source-only) or one connected port; an exactly-matching
+  `{frame_label: DataFrame}` dict for one or more ports; everything else —
+  bare frame at 2+ ports, missing/unknown dict keys, any dict at zero ports —
+  raises `ExecutionError` naming the ports. Never a silent fan-out of one
+  frame to every port.
 - **Contract-resolution degradation is scoped narrowly.** `_effective_contract()`
   catches `ConfigError`/`OSError`/`MlflowException` from the builder's contract
   callback and falls back to `Contract.opaque()` — skipping only the boundary check,
@@ -361,7 +399,13 @@ Tests live in `tests/` (flat layout, no package-per-component subdirectories).
   detection, cache-satisfies-request logic) that the big integration suites don't
   exercise branch-by-branch.
 - **`test_executor_builders.py`**, **`test_port_aware_executor.py`** — per-`NodeType`
-  builder dispatch and multi-port/multi-frame routing through the executor.
+  builder dispatch and multi-port/multi-frame routing through the executor; the
+  input-identity scenarios live here: `edge_input_name` derivation (apiInput frame
+  label verbatim incl. the single-frame dict source, sanitised label for ordinary
+  nodes, flattened submodel child edges), per-edge `source_names` order matching
+  frame binding order under edge reordering (delete + reconnect in reverse order
+  keeps every name bound to its own frame), duplicate-input-name `ConfigError`, and
+  the loud `ValueError` for a null-handle edge against a dict source.
 - **`test_preview_cache_byte_awareness.py`**, **`test_preview_cache_regressions.py`**,
   **`test_preview_cache_hint.py`**, **`test_preview_json_serialization.py`** —
   preview-cache eviction-by-bytes, pinned regression scenarios, and JSON payload

--- a/docs/specs/frontend-graph-canvas/high-level.md
+++ b/docs/specs/frontend-graph-canvas/high-level.md
@@ -7,8 +7,9 @@ DAG surface where a pipeline (data sources, transforms, sinks, submodels, and
 special nodes like edge-joins and live switches) is built by placing nodes and
 wiring edges between them. This component owns three things: (1) how a node
 renders on the canvas across zoom levels and states, (2) the single
-in-memory source of truth for the graph (nodes, edges, preamble text) with
-undo/redo history and derived dirty tracking, and (3) a read-only context
+in-memory source of truth for the graph (nodes, edges, preamble text, and
+the nested submodel metadata) with undo/redo history and derived dirty
+tracking, and (3) a read-only context
 bridge that hands a graph snapshot to the node-inspector panel without prop
 drilling. Every other panel, preview pane, and editor in the app reads the
 graph through one of these two channels (the ReactFlow canvas or
@@ -29,8 +30,9 @@ In scope:
   handlers, selection, connect/drag/drop entry points, context menu and
   keyboard-shortcut wiring, active-node/preview-pane selection, and the
   save/commit gate — [`App.tsx`](../../../frontend/src/App.tsx).
-- The graph-shaped Zustand store: nodes, edges, preamble, undo/redo history
-  (including interleaved version-control entries), and derived dirty state —
+- The graph-shaped Zustand store: nodes, edges, preamble, submodel
+  metadata, undo/redo history (including interleaved version-control
+  entries), and derived dirty state —
   [`stores/useGraphStore.ts`](../../../frontend/src/stores/useGraphStore.ts).
 - The read-only graph context exposed to the node inspector —
   [`panels/GraphContext.tsx`](../../../frontend/src/panels/GraphContext.tsx) and
@@ -119,9 +121,40 @@ Out of scope (owned by neighbouring components, linked where they exist):
   they don't have. Edge-join nodes render a base target handle, a join
   target handle that repositions (top/bottom/both) based on the live
   geometry of whatever is connected to it, and one output handle. API-input
-  nodes can render *multiple* labelled source handles — one per table marked
-  `emit: true` in their config — so a single node can feed multiple
-  downstream frames; the handle id is always the table's own label.
+  nodes render one labelled source handle per eligible frame — every table
+  marked `emit: true` with at least one selected column and a valid
+  identifier label — **from one frame up**: the handle id is always the
+  frame's raw label, a sole frame included, so every edge an API-input
+  creates names the frame it delivers and there is no null-id single-frame
+  mode. Only a node with zero eligible frames (nothing emitted yet, or a
+  backend-invalid config whose labels are all invalid) renders the legacy
+  default null-id handle alongside the zero-frame body — and that handle is
+  **not connectable in either direction** (`isConnectable` false — start
+  AND end, since `ConnectionMode.Loose` normalises reverse target→source
+  drags into ordinary edges), and the graph-level `isValidConnection`
+  validator independently rejects any API-input connection with a null
+  handle, covering every gesture path: a source that emits nothing cannot
+  be wired, so a persisted API-input edge always names a frame.
+  Reconciliation enforces the same rule from the other side: a null-handle
+  API-input edge (only reachable through a hand-edited file) is pruned with
+  the standard warning toast, never kept. At the full zoom
+  level the labelled handles are mounted on the body's frame rows, so each
+  dot sits at the vertical centre of the row naming its frame; at
+  medium/compact zoom, where no frame rows render, the same handles fall
+  back to even spacing down the right edge. The handle id set is identical
+  at every zoom level, so edges stay bound across zoom changes.
+- **API-input body.** At full detail, an API-input node with at least one
+  eligible emitted frame uses its body as the frame list: each visible
+  frame name is a full-width row paired with its output handle, and the
+  generic instance name is suppressed (presentation only — the persisted
+  label still drives the accessible name, `data-testid`, editor,
+  selection, codegen, and tracing identities). Exactly one visible frame
+  shows that frame's name the same way, on its own labelled handle. Zero
+  eligible frames keeps the
+  instance name and adds a muted "No emitted frames" hint. Visibility
+  mirrors runtime eligibility — `emit: true`, at least one selected
+  column, and a valid (non-blank, non-duplicate) raw label — and a long
+  name truncates with the full name available as a tooltip.
 - **Visual state.** Nodes show: a selection border; a dashed border for
   submodel instances; a "LIVE" badge on live-switch nodes when the active
   data source is live; a status dot for ok/error/running; a warning dot for
@@ -138,12 +171,17 @@ Out of scope (owned by neighbouring components, linked where they exist):
   flows out of it into the submodel body); an output port shows a target
   handle.
 - **Graph state.** `useGraphStore` is the sole owner of `nodes`, `edges`,
-  and `preamble`. All mutation goes through one of two tiers: history-aware
-  actions (`setNodes`, `setEdges`, `setNodesAndEdges`, `setPreamble`) that
-  push one undo snapshot per call, or raw actions (`setNodesRaw`,
-  `setEdgesRaw`, `setPreambleRaw`) that skip history — used for mid-drag
-  position churn, WebSocket sync, pipeline load, and the continuously edited
-  imports preamble.
+  `preamble`, and the `submodels` metadata (nested submodel graphs — store
+  state so a root-frame rename that migrates nested mappings is one
+  coherent, undoable transaction). All mutation goes through one of two
+  tiers: history-aware actions (`setNodes`, `setEdges`, `setNodesAndEdges`,
+  `setNodesAndEdgesAndSubmodels`, `setPreamble`) that push one undo snapshot
+  per call, or raw actions (`setNodesRaw`, `setEdgesRaw`, `setSubmodelsRaw`,
+  `setPreambleRaw`) that skip history — used for mid-drag position churn,
+  WebSocket sync, pipeline load, and the continuously edited imports
+  preamble. History snapshots carry `submodels` alongside nodes/edges/
+  preamble, and undo/redo restores all four together (older snapshots
+  without the field restore an empty metadata map).
 - **Undo/redo** operates over a single stack that can hold either a graph
   snapshot or a version-control history entry, so a branch switch and a
   graph edit interleave and reverse in the order they actually happened.
@@ -268,10 +306,47 @@ Out of scope (owned by neighbouring components, linked where they exist):
 - **API-input handle ids are the raw configured table labels, never
   synthesized ids.** The backend's codegen round-trips through those exact
   labels, so a synthesized `port_<idx>` id would silently fail to resolve at
-  execution time. A blank or duplicate label therefore gets *no* handle at
-  all rather than a fabricated one — consistent with the codebase-wide
-  preference for loud failure over a fallback that's wrong and hard to
-  notice.
+  execution time. A blank, duplicate, or non-identifier label therefore gets
+  *no* handle at all rather than a fabricated one — consistent with the
+  codebase-wide preference for loud failure over a fallback that's wrong and
+  hard to notice. The editor mirrors the backend's identifier rule exactly
+  (ASCII identifier `/^[A-Za-z_][A-Za-z0-9_]*$/`, no Python hard keyword)
+  before commit, because the label is also the downstream code argument
+  name; the backend rule is ASCII-only precisely so this mirror can be
+  exact rather than an approximation of Unicode `str.isidentifier()`.
+- **Connections that would duplicate an input name are rejected at drag
+  time.** Every incoming edge contributes exactly one input name (its frame
+  label for API frames, the sanitised source label otherwise); a connection
+  whose derived name duplicates an existing input on the target is refused
+  with a named toast, mirroring the backend's save-time `ParseError`. The
+  alternative — accepting the edge and letting codegen suffix a parameter —
+  is the hidden-rename behaviour this design exists to eliminate.
+- **API-input frame rows own both the name and the handle.** The earlier
+  layout computed the body's label column and the handle positions in two
+  unrelated coordinate systems — a stacked list inside the body vs.
+  percentages of the full node height including the header — which kept
+  the same order but drifted vertically as status/trace/label content
+  changed the body height, so a user could not tell which line left which
+  frame. Mounting each handle inside the row that names it makes the
+  alignment structural: it holds for one, two, or any number of frames
+  because there are no longer two layouts to keep in sync, and no
+  per-frame-count constants exist to go stale.
+- **One frame-label derivation, one identity.** `apiInputFrameLabels` is
+  the single ordered list of eligible frame labels (no minimum count); the
+  rendered handles, the body rows, downstream input chips, and the
+  generated function parameters all read from it, so none of them can
+  disagree. The earlier design split "visible names" from "multi-port
+  handle mode" (labelled handles only from two frames up, a null-id
+  default handle for one) to avoid touching persisted edge identity in a
+  presentation-only release; the convergence release deliberately retired
+  that split — a sole frame's edge now carries the frame label like any
+  other, because a name that exists on screen but not in the persisted
+  edge or the code argument is exactly the hidden-mapping class this
+  design removes.
+- **The zero-frame body states the absence explicitly** — "No emitted
+  frames" beside the retained instance name — rather than rendering an
+  empty body or keeping the old name-only layout: an unconfigured
+  API-input should say what is missing.
 - **Comparison-view diff, trace, and hover visuals reuse the same
   border/ring element used for selection**, rather than each state owning
   its own overlay shape, so every node type — including pill-shaped
@@ -341,7 +416,10 @@ Out of scope (owned by neighbouring components, linked where they exist):
 - [frontend-node-editors](../frontend-node-editors/high-level.md) — the node
   inspector panel and its per-type editors consume the graph exclusively
   through `useGraph()`/`GraphProvider`, never via props, and call back into
-  `App.tsx`'s `onUpdateNode` to commit config changes.
+  `App.tsx`'s `onUpdateNode` to commit config changes. They also consume
+  this component's frame display resolution (`utils/apiInputPorts.ts`) to
+  label downstream inputs and output frames by the dataframe an edge
+  delivers.
 - [server-api](../server-api/high-level.md) — the backend counterpart to
   `usePipelineAPI` (`/api/pipeline/*` load/save/preview) and
   `useWebSocketSync` (`/ws/sync`); both hooks feed the store via
@@ -389,11 +467,14 @@ Out of scope (owned by neighbouring components, linked where they exist):
   naming `GraphProvider` in its message. `App.tsx` wraps the node panel in
   an `ErrorBoundary` (`name="NodePanel"`), so this surfaces as a caught
   render error, not a silent empty-graph render.
-- API-input handle-id resolution never fabricates an id for a blank or
-  duplicate table label — such a table renders no handle, so no edge can be
-  created against a non-existent id. When a config edit orphans an
-  *existing* edge (a table's `emit` flag is turned off, a table is deleted,
-  or a single/multi-frame transition removes a bound label),
+- API-input handle-id resolution never fabricates an id for a blank,
+  duplicate, or non-identifier table label — such a table renders no handle,
+  so no edge can be created against a non-existent id. The visible frame
+  list obeys the same rule — an invalid label gets no row and no fabricated
+  display name — so the body can never advertise a frame that does not
+  exist. When a config edit orphans an *existing* edge (a table's `emit`
+  flag is turned off, a table is deleted, or the last eligible frame
+  disappears and a labelled edge no longer resolves),
   `App.tsx`'s `onUpdateNode` prunes the edge and raises a named `warning`
   toast rather than persisting a broken edge to disk.
 - A version-control history entry whose async `undo()`/`redo()` leg rejects

--- a/docs/specs/frontend-graph-canvas/low-level.md
+++ b/docs/specs/frontend-graph-canvas/low-level.md
@@ -5,12 +5,12 @@
 | File | Responsibility |
 | --- | --- |
 | `frontend/src/App.tsx` | `FlowEditor` — the canvas orchestrator: wires `<ReactFlow>` event props to interaction hooks, owns local selection/context-menu/dialog state, picks the active preview pane, handles `onUpdateNode` (including api-input edge reconciliation), and gates Save/Save-&-Commit on git working-branch status. Exports `App`, which mounts `FlowEditor` inside `ReactFlowProvider`. |
-| `frontend/src/nodes/PipelineNode.tsx` | Renders every non-submodel node type across three zoom LODs and the edge-join marker variant; computes source/target `Handle` sets, including multi-frame api-input handles and edge-join geometry-dependent handle placement. |
+| `frontend/src/nodes/PipelineNode.tsx` | Renders every non-submodel node type across three zoom LODs and the edge-join marker variant; computes source/target `Handle` sets, including multi-frame api-input handles (row-mounted on the full-detail frame-row body, evenly spaced at medium/compact) and edge-join geometry-dependent handle placement; owns the api-input frame-row body with instance-name suppression and the zero-frame "No emitted frames" state. |
 | `frontend/src/nodes/SubmodelNode.tsx` | Renders a submodel boundary card: label, child count, file path, and hidden per-port target/source handles mirroring `config.inputPorts`/`config.outputPorts`. |
 | `frontend/src/nodes/SubmodelPortNode.tsx` | Renders the input/output port marker shown when a submodel is drilled into; input ports get a source handle, output ports get a target handle. |
 | `frontend/src/panels/useGraph.ts` | Defines `GraphContext` (`React.Context<GraphContextValue \| undefined>`) and the `useGraph()` consumer hook, which throws when called outside a provider. |
 | `frontend/src/panels/GraphContext.tsx` | `GraphProvider` component; memoises the context value on `{allNodes, edges, submodels, preamble}` identity. |
-| `frontend/src/stores/useGraphStore.ts` | Zustand store owning `nodes`/`edges`/`preamble`, undo/redo history (graph snapshots interleaved with VC entries), and three derived fingerprints (`structuralFingerprint`, `panelContextFingerprint`, `persistedFingerprint`) plus the `dirty` boolean derived from them. |
+| `frontend/src/stores/useGraphStore.ts` | Zustand store owning `nodes`/`edges`/`preamble`/`submodels`, undo/redo history (four-field graph snapshots interleaved with VC entries), and three derived fingerprints (`structuralFingerprint`, `panelContextFingerprint`, `persistedFingerprint`) plus the `dirty` boolean derived from them. |
 | `frontend/src/hooks/useNodeHandlers.ts` | Node CRUD handlers: `handleDeleteNode` (atomic node+edges delete, deferred cache cleanup), `handleDuplicateNode`, `handleCreateInstance`, `handleRenameNode` (opens the rename dialog), `handleAutoLayout` (ELK, in-flight guarded). |
 | `frontend/src/hooks/useEdgeHandlers.ts` | Connection/gesture handlers: `commitConnection`/`onConnectEnd` (interprets React Flow handle-drag endings into a normal edge or an edge-join insertion), `onSelectionChange`/`onNodeClick` (panel + debounced preview), `handleDeleteEdge`, `onNodeContextMenu`, `onDragOver`/`onDrop` (palette node creation). |
 | `frontend/src/hooks/usePipelineAPI.ts` | Pipeline load-on-mount; debounced, cache-first, concurrency-limited-cascade preview fetching (`fetchPreview`/`fetchPreviewImmediate`/`refreshPreview`/`previewNodeFrame`); an active-source-change effect (`invalidateStaleColumnStashes`) that strips any node's column stash tagged with a different (or no) `_columnsSource`; and `handleSave` (config-ref/edge-join pre-save validation, snapshot-scoped save-concurrency guard, `markSaved`). |
@@ -25,7 +25,7 @@
 | `frontend/src/utils/activePreview.ts` | `previewForActiveNode` — filters preview data to the currently active node. |
 | `frontend/src/utils/validateConfigRefs.ts` | `validateConfigRefs`/`formatConfigRefWarnings` — flags `data_input`/`banding_source`/`instanceOf` config fields pointing at non-existent node ids (graph-level or submodel-internal). |
 | `frontend/src/utils/layout.ts` | `getLayoutedElements` — lazily-imported ELK layered layout plus `clusterSnap`/`alignPositions` coordinate snapping. |
-| `frontend/src/utils/connectionValidation.ts` | `isPipelineConnectionValid` — the graph-level `isValidConnection` React Flow validator. |
+| `frontend/src/utils/connectionValidation.ts` | `isPipelineConnectionValid` — the graph-level `isValidConnection` React Flow validator, including the input-name uniqueness rule (a candidate connection whose `edgeInputName` duplicates an existing input name on the target node is invalid, surfaced as a named toast at commit time) and the null-API-handle rejection (an apiInput connection with no source handle is invalid in every gesture direction, the validator-level twin of the zero-frame handle's `isConnectable` false under `ConnectionMode.Loose`). |
 | `frontend/src/utils/flowElements.ts` | `appNode`/`appEdge`/`nodeLabel`/`edgeId`/`deselectNodes`/`selectOnlyNode` — node/edge factories and id/selection helpers. |
 | `frontend/src/utils/flowHandles.ts` | `DEFAULT_TARGET_HANDLE`/`normalizeDefaultTargetHandle` — collapses React Flow's synthetic default-target-handle id to `null`. |
 | `frontend/src/utils/nodeTypes.ts` | `NODE_TYPES`/`NODE_TYPE_META` and derived lookups (`SOURCE_ONLY_TYPES`, `SINK_ONLY_TYPES`, `SINGLETON_TYPES`, `PALETTE_TYPES`, `nodeTypeIcons`/`Colors`/`Labels`, `PILL_TYPES`) — the single source of truth for node-type metadata. |
@@ -59,7 +59,7 @@ is the authoritative module map for their responsibilities:
 | `frontend/src/hooks/useGraphCanvasState.ts` | React Flow adapter over `useGraphStore`: converts `NodeChange[]`/`EdgeChange[]` into raw graph updates, takes one snapshot at a drag's first structural position change, and avoids history churn for per-frame movement and selection-only changes. |
 | `frontend/src/hooks/usePanelGraphContext.ts` | Produces the typed, render-stable `PanelGraphContextSnapshot` (`allNodes`, `edges`, `nodeById`, `getNode`) only when the graph store's panel-context version changes, isolating editor consumers from React Flow UI-only updates. |
 | `frontend/src/hooks/useKeyboardShortcuts.ts` | App-level canvas keyboard bindings for save, undo/redo, copy/paste, delete, search, and panel dismissal; honours editable controls so keystrokes do not leak from a text field into graph mutation. |
-| `frontend/src/utils/apiInputPorts.ts` | Mirrors backend api-input frame identity: derives only runtime-emittable raw-label handles, validates blank/duplicate/filesystem-colliding labels, migrates edges on a conservative in-place table rename, then prunes only genuinely orphaned handles while preserving input array identity on no-op. |
+| `frontend/src/utils/apiInputPorts.ts` | Mirrors backend api-input frame identity: `apiInputFrameLabels` is the single ordered eligible-frame-label list (no minimum count) that drives handles, body rows, and downstream input names alike; `edgeInputName` derives an edge's input/argument name (frame label verbatim for api-input edges, sanitised source label otherwise, submodel `out__` edges resolved to the child's sanitised label) in lockstep with the backend's `edge_input_name`; validates blank/duplicate/non-identifier/keyword labels (`apiInputLabelIssue`, mirroring backend invariant B4 exactly — ASCII identifier `/^[A-Za-z_][A-Za-z0-9_]*$/` plus the Python hard-keyword list — with duplicates compared case-insensitively to match backend B2's casefolded parquet-stem rule); migrates edges on a conservative in-place table rename, then prunes only genuinely orphaned handles while preserving input array identity on no-op. |
 | `frontend/src/utils/edgeJoinRoles.ts` | Defines edge-join base/join handle roles and canonical role resolution, including compatibility handling for legacy/default handle ids. |
 | `frontend/src/utils/edgeJoinGraph.ts` | Pure edge-join insertion/rewrite helpers: split an existing edge or combine source gestures into a correctly configured join node and its role-bound edges. |
 | `frontend/src/utils/edgeJoinValidation.ts` | Save-time edge-join graph validation and readable warnings; rejects incomplete, duplicate, or otherwise inconsistent role/edge representations before the backend receives them. |
@@ -153,19 +153,31 @@ is the authoritative module map for their responsibilities:
    `pushSnapshot()` once, then applies the swap's resulting nodes/edges via
    the *raw* setters — deliberately, so the whole swap is one undo entry
    despite not using `setNodesAndEdges`.
-5. **Config commit (`App.tsx`'s `onUpdateNode`).** Captures `prevNode` from
-   `graphRef.current` *before* mutating (so the diff below compares against
-   the true pre-commit config), calls `setNodes` (history-aware — one
-   snapshot), updates `selectedNode` if it's the edited node, then — only
-   for `NODE_TYPES.API_INPUT` — calls `applyApiInputConfigChange` (owned by
-   `utils/apiInputPorts.ts`) to diff old vs. new frame labels. The
-   resulting rebind/removal is applied via `setEdgesRaw` *on purpose*: the
-   `setNodes` call above already captured the one pre-commit snapshot, so
-   applying the edge consequences raw keeps the entire config commit —
-   rename-and-rebind, or removal-and-prune — to a single undo entry.
+5. **Config commit (`App.tsx`'s `onUpdateNode`) — compute, preflight, then
+   commit.** Captures `prevNode` from `graphRef.current`, then **before any
+   store mutation** computes the complete tentative result: the new config,
+   `applyApiInputConfigChange`'s edge rebind/prune outcome (owned by
+   `utils/apiInputPorts.ts`), and — for a frame rename — the migrated
+   `input_scenario_map` keys and instance `inputMapping` entries on every
+   affected node. The preflight then checks each affected target's
+   post-commit input-name set for duplicates. On a collision the commit
+   returns `{ ok: false, error }` and **nothing mutates** — no snapshot, no
+   config, no edges, no mappings; `NodePanel` passes the result through
+   `OnUpdateConfig` so the ApiInputEditor surfaces `error` inline at the
+   label field (see
+   [frontend-node-editors](../frontend-node-editors/low-level.md)), clearing
+   it on the next successful commit. On success the whole tentative result —
+   the migrated root nodes (config, ISM keys, instance mappings), edges, AND
+   the migrated nested submodel metadata — lands through the single
+   history-aware combined setter (`setNodesAndEdgesAndSubmodels`, one
+   snapshot) plus the `selectedNode` update, as a single undo entry; undo
+   restores root and nested state coherently, never a root-only revert.
 6. **Store internals, history-aware path.** Every history-aware setter calls
-   `pushSnapshotInternal()` (deep-clones the pre-mutation state via
-   `captureGraphSnapshot`/`cloneGraphValue`, evicting the oldest entry once
+   `pushSnapshotInternal()` (deep-clones the pre-mutation state — nodes,
+   edges, preamble, and submodels — via `captureGraphSnapshot`, which
+   delegates to the shared transient-stripping `cloneGraphSnapshot` in
+   `graphSnapshot.ts` so React Flow presentation fields never enter
+   history, evicting the oldest entry once
    `undoStack.length >= MAX_HISTORY`), then always recomputes
    `persistedFingerprint` and `dirty` (via `computeDirty` against
    `lastSavedSnapshot`/`savedPersistedFingerprint`), recomputes
@@ -191,9 +203,11 @@ is the authoritative module map for their responsibilities:
    stack, run its async `undo()`/`redo()` closure, and on rejection restore
    it to its original stack (retry path) before clearing `vcBusy` in
    `.finally`. If it's a `GraphSnapshot`, synchronously swap
-   `nodes`/`edges`/`preamble` to the target snapshot, recompute all three
-   fingerprints and `dirty` from it, and push the *current* (pre-undo) state
-   onto the opposite stack via `captureGraphSnapshot`.
+   `nodes`/`edges`/`preamble`/`submodels` to the target snapshot (a legacy
+   snapshot without the `submodels` field restores an empty metadata map),
+   recompute all three fingerprints and `dirty` from it, and push the
+   *current* (pre-undo) state onto the opposite stack via
+   `captureGraphSnapshot`.
 9. **`markSaved(snapshot?)`.** Captures `lastSavedSnapshot` (defaults to the
    current state) and `savedPersistedFingerprint`, then recomputes `dirty`.
    This is the only place `savedPersistedFingerprint` is updated; it's
@@ -202,20 +216,42 @@ is the authoritative module map for their responsibilities:
 10. **Panel context refresh.** `usePanelGraphContext` rebuilds its snapshot
     only when `panelContextVersion` changes (a `useMemo` keyed on it,
     reading fresh `nodes`/`edges` from `useGraphStore.getState()` at that
-    moment). `App.tsx` passes this snapshot's `allNodes`/`edges`, plus a
-    ref-snapshotted `submodels` and the subscribed `preamble`, into
+    moment). `App.tsx` passes this snapshot's `allNodes`/`edges`, plus the
+    store-subscribed `submodels` and `preamble` values, into
     `<GraphProvider>` wrapping `NodePanel`.
 11. **`PipelineNode` render.** Derives `nodeType`/`accent`/`Icon`/`typeLabel`
     from the shared `NODE_TYPES`/`nodeTypeColors`/`nodeTypeIcons`/
-    `nodeTypeLabels` tables. `emitTableLabels` is computed via
-    `apiInputEmitPortLabels(config)`, memoized on `config` identity, and its
-    join-signature plus the live `edgeJoinJoinHandlePosition` drive a
+    `nodeTypeLabels` tables. One api-input frame list is computed, memoized
+    on `config` identity: `frameLabels` via `apiInputFrameLabels(config)`
+    (eligible frames, no minimum count) — it drives the handles AND the
+    body rows, so they cannot diverge. Its collision-safe serialised
+    signature (`JSON.stringify` — labels are validated identifiers now,
+    but the serialisation stays collision-safe by construction, same
+    rationale as `columnFingerprint`'s length-prefixing), the bucketed
+    `zoomLevel`, and the live `edgeJoinJoinHandlePosition` drive a
     `useUpdateNodeInternals(id)` effect so React Flow re-measures handle
-    positions whenever port topology changes. `zoomLevel` comes from a
-    `useStore` selector on the pane's zoom transform, bucketed into
-    `full`/`medium`/`compact` so a zoom-threshold crossing — not every pixel
-    of zoom — triggers a re-render. Edge-join nodes short-circuit to an
-    entirely separate marker/pill render before the LOD branches run.
+    positions whenever port topology changes or a zoom-threshold crossing
+    relocates the handles between the container and the frame rows.
+    `zoomLevel` comes from a `useStore` selector on the pane's zoom
+    transform, bucketed into `full`/`medium`/`compact` so a zoom-threshold
+    crossing — not every pixel of zoom — triggers a re-render. At full
+    detail an api-input with ≥1 eligible frame renders the frame-row body:
+    one relatively-positioned row per frame carrying a right-aligned
+    truncating mono name (full name as `title` tooltip) and that row's
+    labelled source `Handle` (id = the frame's raw label, a sole frame
+    included), absolutely positioned at the row's vertical midline with
+    its dot centred on the node's right border. The instance name is
+    suppressed in that body; the trace-value pill, when active, renders
+    above the rows. Zero eligible frames keeps the instance name, adds a
+    muted "No emitted frames" line, and renders the legacy default null-id
+    handle vertically centred. At medium/compact zoom no frame rows render
+    and `_SourceHandles` supplies the same handle id set — labelled
+    handles evenly spaced down the right edge, or the zero-frame default
+    handle. Positional `output-connector[<idx>]:<node label>` test
+    ids follow the visual top-to-bottom order in both modes, and the name
+    span keeps its `api-input-body-label-<label>` test id. Edge-join nodes
+    short-circuit to an entirely separate marker/pill render before the
+    LOD branches run.
 12. **Node delete (`useNodeHandlers.handleDeleteNode`).** Calls
     `setNodesAndEdges` once (node filter + edge filter closed over the same
     call, one undo entry), nulls `selectedNode`/`previewData` if they
@@ -249,7 +285,9 @@ is the authoritative module map for their responsibilities:
     with a cold-start retry policy (`INITIAL_PIPELINE_RETRY_POLICY`, 6
     retries at 250ms base delay); the response is validated through
     `parsePipelineResponse` before touching the graph. On success, applies
-    nodes/edges/preamble via the raw setters, seeds `nodeIdCounter` from
+    nodes/edges/preamble/submodels via the raw setters (`setSubmodelsRaw`
+    hydrates the store-owned submodel metadata alongside the legacy
+    `submodelsRef`), seeds `nodeIdCounter` from
     `computeNextNodeId`, and calls `useGraphStore.getState().markSaved()` —
     the just-loaded state IS the on-disk state, so it starts clean. Aborted
     via `AbortController` on unmount.
@@ -351,12 +389,45 @@ is the authoritative module map for their responsibilities:
 
 ## Edge cases and invariants
 
-- **API-input handle ids never synthesize.** Zero or one `emit: true` table
-  → legacy single unlabeled handle at index 0 (backward-compat fallback). A
-  blank-label emit table renders **no handle** (not `port_<idx>`).
+- **API-input handle ids never synthesize.** Zero eligible frames → the
+  legacy single unlabeled handle at index 0; one eligible frame or more →
+  one labelled handle per frame, ids = the raw labels. A blank, duplicate,
+  non-identifier, or keyword label renders **no handle** (not `port_<idx>`).
   Duplicate labels render **one** handle — the first occurrence only, never
   a disambiguated `label__<idx>`. (See `_SourceHandles` in `PipelineNode.tsx`
   and `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx`.)
+- **The api-input handle id set is zoom-invariant.** Full detail mounts the
+  source handles on the body's frame rows; medium/compact space the same
+  handles down the right edge. Only geometry moves across a zoom threshold
+  (node height already changes per LOD today); ids never do, so edges stay
+  bound.
+- **The visible rows and the labelled handles are the same list.** Both
+  read `apiInputFrameLabels`, so a config with two emit tables of which one
+  has an invalid label renders exactly one row and one labelled handle (the
+  valid one); a null-handle edge is orphaned under any config with ≥1
+  eligible frame, exactly as `validSourceHandleKeys` rules. A row can never
+  exist without its handle, nor a labelled handle without its row. The only
+  configs with NO labelled handles are zero-eligible ones (nothing emitted,
+  or every label invalid): the legacy default null-id handle renders and
+  the body shows the zero-frame state — no bindable id is invented for a
+  backend-invalid config.
+- **A sole eligible frame is a labelled frame.** Its row carries a handle
+  whose id is the frame label, its edges persist that label as
+  `sourceHandle`/`source_port`, and its downstream argument is that label —
+  identical to the multi-frame case. Transitions between zero and some
+  eligible frames reconcile edges the same way emit-off/table-delete
+  already do (migrate renames first, then prune with a warning toast).
+- **`validSourceHandleKeys` for an apiInput never contains the empty key.**
+  Null-handle API-input edges are always orphaned by reconciliation
+  regardless of frame count — the zero-frame default handle is rendered
+  non-connectable, so such an edge can only enter via a hand-edited file
+  and is pruned (with the warning toast) on the next config commit; the
+  backend's codegen `ParseError` for a port-less apiInput edge is the
+  authoritative backstop at save.
+- **An emit-true table with no selected column is not a frame**: no row, no
+  handle, no display name — mirroring runtime eligibility
+  (`_json_shred.load_v2_api_source`), so the body can never advertise a
+  frame the executor would not emit.
 - **Edge-join join-handle position is computed live**, not stored: it
   compares the connected join-source node's vertical centre against the
   marker's own centre (`state.nodeLookup`) and flips `Position.Top`/
@@ -527,7 +598,7 @@ is the authoritative module map for their responsibilities:
 
 ## Testing
 
-The pure connection/frame helpers are defended by `frontend/src/utils/__tests__/apiInputPorts.test.ts`, `edgeJoinGraph.test.ts`, and `edgeJoinValidation.test.ts`: they cover raw-label frame eligibility, blank/duplicate/unicode filesystem collisions, rename-before-prune migration, identity-preserving no-ops, edge-join insertion/role normalisation, and invalid saved graph diagnostics. These sit alongside the hook/store suites below because their contracts are exercised again through the editor and save paths.
+The pure connection/frame helpers are defended by `frontend/src/utils/__tests__/apiInputPorts.test.ts`, `edgeJoinGraph.test.ts`, and `edgeJoinValidation.test.ts`: they cover raw-label frame eligibility, blank/duplicate/non-identifier/keyword label rejection (mirroring backend invariant B4's ASCII rule — valid Unicode identifiers like `café` are rejected too), frame-label derivation (`apiInputFrameLabels` across zero/one/many eligible frames, invalid labels, and unselected-column tables), edge input-name derivation (`edgeInputName` for api-input frame edges verbatim, sanitised source labels for ordinary nodes, submodel `out__` edges resolving to the child's sanitised label, and per-target duplicate detection), rename-before-prune migration, identity-preserving no-ops, edge-join insertion/role normalisation, and invalid saved graph diagnostics. These sit alongside the hook/store suites below because their contracts are exercised again through the editor and save paths.
 
 - **Store — `frontend/src/stores/__tests__/`:**
   - `useGraphStore.consolidation.test.ts` — store shape and required
@@ -580,7 +651,12 @@ The pure connection/frame helpers are defended by `frontend/src/utils/__tests__/
     diff ring and moved-outline rendering; instance/LIVE/API badges;
     status dot (ok/error/running-pulse) and warning-dot behaviour
     (including error-suppresses-warning); trace dim/hover-dim/motion-disabled
-    states; aria-label composition (type, label, status, instance, trace).
+    states; aria-label composition (type, label, status, instance, trace);
+    the api-input frame-row body (instance-name suppression with ≥1
+    visible frame, the single-frame name row, the zero-frame name +
+    "No emitted frames" state, row/handle pairing and ordering, status/
+    warning/trace adornments coexisting with rows, and medium/compact
+    bodies unchanged).
   - `frontend/src/__tests__/nodes/SubmodelNode.test.tsx` — label/badge/
     child-count rendering; per-port input and output handle rendering and
     vertical positioning; file-path display and truncation; dashed-vs-solid
@@ -590,11 +666,14 @@ The pure connection/frame helpers are defended by `frontend/src/utils/__tests__/
     output); label fallback to `label` when `portName` is empty; trace
     border/glow/dim/motion states; graceful rendering with a missing
     `portDirection`.
-  - `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx` — one source
-    handle per `emit: true` table with id matching the table's label;
-    single-default-handle fallback for 0/1 emit tables or a missing
-    `tables` key; the W1.4 guarantees that blank labels render no handle
-    and duplicate labels render exactly one (first-occurrence) handle.
+  - `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx` — one labelled
+    source handle per eligible frame from one frame up, ids matching the
+    raw labels (the sole-frame labelled handle explicitly pinned);
+    default-handle fallback only for zero eligible frames (no eligible
+    tables, a missing `tables` key, or an all-invalid label set); the W1.4
+    guarantees that blank/duplicate/non-identifier labels render no
+    handle; row-mounted full-detail handles carrying the same ids as the
+    medium/compact fallback (zoom-invariant id set).
 - **App / integration — `frontend/src/__tests__/`:**
   - `App.integration.test.tsx` — mount and initial load sequencing (no
     WebSocket sync while the initial load is pending); empty-pipeline
@@ -858,6 +937,20 @@ The pure connection/frame helpers are defended by `frontend/src/utils/__tests__/
   a regression isolated to that adapter's push/no-push branching would
   surface only as a broader integration-test failure, not a targeted one.
   `utils/flowHandles.ts` has the same shape of gap — see above.
+- **`frontend/e2e/persistence/api-input-frame-alignment.spec.ts`** — the
+  Playwright geometry evidence for the frame-row body: for one, two,
+  three, and eight emitted frames, each frame row's bounding-box vertical
+  centre coincides with its output handle's centre within ≤3 CSS px —
+  asserted plain, with status and warning dots present, with a
+  trace-active value pill, and with a ≥40-character truncating label in
+  the row set; edges carry
+  the correct labelled `sourceHandle` after render, save/reload, and an
+  in-place frame rename — including a sole-frame source, whose edge
+  persists the frame label and whose generated `main.py` names it in both
+  `source_port` and the downstream signature; and a downstream node's
+  input chips name the connected frames with the exact argument names.
+  The DOM-only component suites above assert handle count/ids/order; only
+  this suite proves the rendered geometry aligns.
 - **`frontend/e2e/large-graph-drag.benchmark.spec.ts`** — a Playwright
   benchmark (tagged `@benchmark`, run via `npm run test:e2e:benchmark`, not
   the default e2e lane) that builds a 1000-node graph and drags a node across

--- a/docs/specs/frontend-node-editors/high-level.md
+++ b/docs/specs/frontend-node-editors/high-level.md
@@ -22,6 +22,14 @@ backend API modules own validation and persistence.
 - Editor updates flow through the supplied configuration callbacks. Text and numeric drafts are
   committed on blur/Enter where their controls use the shared committed-input primitives, so a
   normal edit does not create a graph mutation for each keystroke.
+- Connected inputs are listed by their **input name — the exact argument name in the node's
+  code**, 1:1 with the generated function signature: an API-input frame edge's chip shows the
+  frame label carried on the edge (`quotes` is displayed as `quotes` and callable as `quotes`),
+  an ordinary source's chip shows the sanitised node label, and a submodel-output edge's chip
+  shows the child node's sanitised label (what the flattened code actually binds). The source
+  node is named in the chip tooltip. Two frames connected from one API input render as two
+  distinct, individually removable chips with two distinct names. Live-switch mapping rows and
+  output frame blocks present the same names — there is no separate display identity anywhere.
 - Editors retain incomplete persisted rows when they can be repaired (notably API schema and
   output mappings); fresh inference data may be normalised separately from persisted data.
 - Banding exposes categorical/numeric rule editing, preview-derived suggestions and histogram
@@ -38,6 +46,15 @@ are structurally different. Shared helpers centralise the places where consisten
 commit timing, clipboard parsing, path handling, rendered input-source chips, and normalisation
 of persisted banding/rating data. Lazy dispatch keeps editor code out of the initial canvas load.
 
+Display identity and executable identity are one identity. `InputSource.name` is the input's
+single name — the chip text, the code argument, and the key persisted contracts use (the
+live-switch `input_scenario_map` and the instance `inputMapping`, both consumed by the
+backend). It is derived per edge by the shared `edgeInputName` helper, mirroring the backend's
+`edge_input_name` byte-for-byte, so the panel can never advertise a name the code does not
+recognise. (An earlier interim design split `varName` from `displayLabel` to avoid touching
+executable contracts in a presentation-only release; that split itself produced the
+name-shown-but-not-callable confusion and was deliberately retired by the convergence release.)
+
 ## Interactions
 
 The panel consumes selected-node/edge state from
@@ -45,10 +62,20 @@ The panel consumes selected-node/edge state from
 [server-api](../server-api/high-level.md), and modelling/optimiser configuration panels from
 [frontend-modelling-optimiser-ui](../frontend-modelling-optimiser-ui/high-level.md). Preview
 columns and rows are supplied by the execution/result stores, not computed by these editors.
+Frame display labels for input chips and output frame naming are resolved through the
+api-input frame-identity helpers owned by
+[frontend-graph-canvas](../frontend-graph-canvas/high-level.md)
+(`frontend/src/utils/apiInputPorts.ts`).
 
 ## Failure model
 
 Client-side parse and shape checks show inline invalid state where implemented. Server failures
 such as format, file, Databricks, or MLflow lookup errors are rendered by the invoking editor.
 Malformed config that cannot be interpreted is surfaced as a visible diagnostic or an explicit
-editor error; the component does not silently replace it with invented configuration.
+editor error; the component does not silently replace it with invented configuration. A dangling
+`sourceHandle` (an edge bound to a frame that no longer exists) is displayed **verbatim** as the
+edge's frame identity with an explicit unresolved warning state wherever the connection is
+presented (input chips, live-switch mapping rows, output frame blocks) — never silently renamed
+to the parent node and never a normal-looking entry. Null-handle API-input edges cannot be
+created (the zero-frame handle is non-connectable) and are pruned by reconciliation when read
+from a hand-edited file, so the verbatim-plus-warning rule is the complete unresolved story.

--- a/docs/specs/frontend-node-editors/low-level.md
+++ b/docs/specs/frontend-node-editors/low-level.md
@@ -4,13 +4,13 @@
 
 | File | Responsibility |
 | --- | --- |
-| `frontend/src/panels/NodePanel.tsx` | Selects configuration/columns/instance views and routes the selected node to an editor. |
+| `frontend/src/panels/NodePanel.tsx` | Selects configuration/columns/instance views, routes the selected node to an editor, and derives the per-edge `InputSource` list via `edgeInputName` (memoised on a per-edge signature covering edge id, source id/label, `sourceHandle`, the derived input name, and the `frameUnresolved` resolution state). |
 | `frontend/src/panels/NodePalette.tsx` | Renders draggable node templates. |
 | `frontend/src/panels/LazyNodeEditors.tsx` | Central dynamic-import registry and loading boundaries for editor bodies. |
 | `frontend/src/panels/PanelShell.tsx`, `frontend/src/panels/PanelHeader.tsx` | Right-panel shell/header used by node, imports and utility authoring views. |
 | `frontend/src/components/ReadOnlyNodeConfig.tsx`, `frontend/src/components/FramesTable.tsx`, `frontend/src/components/KeyPickerModal.tsx` | Inert configuration, API-frame rows and reusable API-input key picker. |
 | `frontend/src/panels/editors/index.ts` | Public editor exports. |
-| `frontend/src/panels/editors/_shared.tsx` | Shared editor types, styles, file browser, schema preview and input-source bar. |
+| `frontend/src/panels/editors/_shared.tsx` | Shared editor types, styles, file browser, schema preview and the input-source bar (chips keyed by edge id, showing each edge's input name — the code argument — with the source node named in the tooltip). |
 | `frontend/src/panels/editors/CodeEditor.tsx`, `frontend/src/panels/editors/CodeMirrorEditor.tsx`, `frontend/src/panels/editors/shared/PolarsCodePanel.tsx` | Code-editor wrappers and Polars-specific panel. |
 | `frontend/src/panels/editors/ConstantEditor.tsx`, `frontend/src/panels/editors/TransformEditor.tsx`, `frontend/src/panels/editors/EdgeJoinEditor.tsx`, `frontend/src/panels/editors/LiveSwitchEditor.tsx`, `frontend/src/panels/editors/ScenarioExpanderEditor.tsx` | Editors for scalar, transform, join, conditional-switch and scenario nodes. |
 | `frontend/src/panels/editors/DataSourceEditor.tsx`, `frontend/src/panels/editors/ExternalFileEditor.tsx`, `frontend/src/panels/editors/DataInputEditor.tsx`, `frontend/src/panels/editors/DataOutputEditor.tsx`, `frontend/src/panels/editors/SinkEditor.tsx` | File/database/IO source and destination configuration. |
@@ -34,6 +34,23 @@
 
 - `OnUpdateConfig`, `SimpleNode`, `SimpleEdge`, `SchemaInfo` and `InputSource` in
   `frontend/src/panels/editors/_shared.tsx` define the editor-to-panel contract.
+  `OnUpdateConfig` returns a commit result — `{ ok: true } | { ok: false; error: string }` —
+  from `App.onUpdateNode`'s preflight: editors whose edits can trigger a frame rename (the
+  ApiInputEditor label commit) surface `error` inline beside the offending field and clear it
+  on the next successful commit; edits that cannot fail preflight may ignore the return value
+  unchanged. Every production supplier of the callback migrates with the type — including the
+  read-only inspector (`frontend/src/components/ReadOnlyNodeConfig.tsx`), whose inert no-op
+  callback returns `{ ok: true }` — so the contract change is compile-time loud, not
+  runtime-discovered. `InputSource`
+  carries one identity: `name` is the input's single name — chip text, code argument, and the
+  key persisted contracts use (the live-switch `input_scenario_map`, the instance
+  `inputMapping`) — derived per edge by `edgeInputName` (an API-input edge's frame label
+  verbatim; a submodel `out__` edge's child sanitised label; else the sanitised source-node
+  label). `sourceLabel` is the raw source-node label used in tooltips and removal titles;
+  `edgeId` is the stable chip key and removal target; `frameUnresolved` marks an API-input edge
+  whose frame could not be resolved, rendering the chip in its warning state. `name` is
+  required, so every fixture constructing an `InputSource` fails to compile until it declares
+  one — the former `varName`/`displayLabel` pair no longer exists.
 - API schemas have separate persisted read/write and inferred/reconciled representations in
   `frontend/src/panels/editors/apiInputSchema.ts` and `frontend/src/panels/editors/apiInputInherit.ts`.
   Output mappings use the equivalent conversion boundary in
@@ -46,6 +63,18 @@
 
 1. `frontend/src/panels/NodePanel.tsx` receives selection and graph context, chooses an editor
    or generic tab, and passes config mutation callbacks and available preview/connection data.
+   For each upstream edge it builds an `InputSource`: `name` via
+   `edgeInputName(edge, sourceNode, submodels)` (from frontend-graph-canvas's
+   `frontend/src/utils/apiInputPorts.ts`, mirroring the backend's `edge_input_name`). An
+   API-input edge whose non-null `sourceHandle` names no currently-eligible frame — the only
+   unresolved case the editor can transiently observe, since null-handle API edges are always
+   pruned by reconciliation — keeps that handle **verbatim** as `name` and sets
+   `frameUnresolved: true`, so the chip shows the stale frame identity with its warning state
+   instead of impersonating a resolved input or renaming it to the parent. The memo's
+   staleness signature covers edge id, source id, source label, `sourceHandle`, the derived
+   name, and the resolution state — so a frame rename (which rebinds the edge's
+   `sourceHandle`) refreshes downstream chips, and a frame becoming resolvable under an
+   unchanged name string clears the warning.
 2. `frontend/src/panels/LazyNodeEditors.tsx` loads the selected editor module. React suspense
    displays its loading boundary while that import is unresolved; already-loaded modules are
    reused by the module loader.
@@ -72,6 +101,47 @@
   it, while the rating/banding grids validate their target coordinates and numeric values.
 - Path tools preserve/rewrite only recognised path prefixes. JSON path validation and
   canonicalisation hints are advisory client checks, not an alternative backend execution grammar.
+- Input chips and live-switch mapping rows are keyed by `edgeId`, so a removal can never route
+  to the wrong edge. Live-switch rows display `name` (with the same `frameUnresolved` warning
+  state as chips) and read/write `input_scenario_map` by that same `name` — two frames from one
+  API input are two distinct map keys, individually routable for the first time. A frame
+  rename's atomic commit updates every name-referencing config in the same pass that rebinds
+  the edges: `input_scenario_map` keys on downstream live-switches, instance `inputMapping`
+  **values** on downstream instance nodes, and instance `inputMapping` **keys** on every node
+  whose `instanceOf` references an affected *original* (the original's input names are the
+  mapping keys, so renaming a frame feeding the original would otherwise stale-key every
+  instance). The commit is **preflighted**: before anything mutates, every affected target's
+  post-rename input-name set is checked for duplicates (the new name colliding with another
+  input already on that target), and a collision rejects the entire rename with an inline
+  error naming the target and the colliding name — no config, edge, or mapping mutation
+  occurs. Name-referencing config can never half-apply or overwrite an existing key.
+- `edgeInputName` treats only API-input sources' handles as frame names; a submodel
+  `out__`-prefixed source handle resolves to the referenced child node's sanitised label (via
+  the graph context's `submodels`) — the same name the flattened code binds — and every other
+  node type derives the sanitised source label.
+- The API-input editor rejects a frame label that fails backend invariant B4 (not an ASCII
+  identifier, or a Python hard keyword) at commit time with the same inline validation used
+  for blank/duplicate labels (`apiInputLabelIssue` — the exact ASCII mirror) — the label is
+  the downstream argument name, so an invalid label never reaches the config.
+- Null-handle API-input edges never survive reconciliation (the zero-frame default handle is
+  non-connectable and `validSourceHandleKeys` for an apiInput never contains the empty key),
+  so the only unresolved state the panel can observe is transient: an edge whose non-null
+  `sourceHandle` names a frame that no longer resolves. Its chip keeps the handle text
+  verbatim with the `frameUnresolved` warning; at run time the executor's `KeyError` is the
+  loud backstop, and at save time codegen's port-less-edge `ParseError` covers hand-edited
+  files.
+- `frontend/src/panels/editors/OutputEditor.tsx`'s per-frame block label is the edge's input
+  name via the same shared helper, and the persisted `source_port` key (`framePortId`) now
+  *equals* that name by construction — the frame label for API-input edges, the sanitised
+  source label otherwise — so display and persisted identity cannot diverge. An unresolvable
+  API-input edge renders the block header in the explicit unresolved state (parent label
+  retained as identifying text plus a visible warning marker), never a normal-looking fallback.
+
+(The former NOTE here — two frames of one API input sharing one sanitised `varName`, leaving
+`input_scenario_map` unable to distinguish them — is resolved by the input-identity
+convergence: scenario-map keys are now the frame-derived input names, and the backend's
+matching in `executor.py`, `projection.py`, and the deploy pruner consumes the same
+`edge_input_name` derivation.)
 
 ## Error handling
 
@@ -90,7 +160,31 @@ schema paths, output paths, banding and rating editing, clipboard-related grid b
 Databricks/MLflow selection, panel dispatch/lazy loading and accessibility. There is no dedicated
 test file for every small barrel/style/helper module; those are covered through their consumers.
 
+The input-identity work is pinned by `frontend/src/panels/__tests__/NodePanel.test.tsx`
+(`name` derivation for API-frame edges — sole frame included — ordinary sources, and submodel
+`out__` edges resolving to child labels; the `frameUnresolved` warning chip for a
+zero-eligible-frame API source; the unresolved→resolved transition under an unchanged name
+string clearing the warning; signature-driven refresh on a frame rename; two frames from one
+API input rendering two distinct, independently removable chips whose names equal the
+generated argument names), by LiveSwitch cases (two frames from one API input render two rows
+with two distinct names and two independent `input_scenario_map` keys; a frame rename migrates
+its map key atomically with the edge rebind; a zero-eligible-frame API `InputSource` renders
+the row's unresolved warning marker/tooltip), by the ApiInputEditor identifier-validation
+cases (non-identifier and keyword labels rejected inline before commit, and a rename
+collision preflight rejection surfaced inline via the `OnUpdateConfig` result with the graph
+asserted unchanged), by the editor suites
+that render `InputSourcesBar` (`ModelScoreEditor`, `OptimiserApplyEditor`,
+`ScenarioExpanderEditor`, `BandingEditor`, and the hover suite), by the OutputEditor suite's
+name-equals-`framePortId` and unresolved-block-header cases, and by
+`frontend/src/utils/__tests__/apiInputPorts.test.ts` for the shared `edgeInputName`
+derivation. Because `InputSource.name` replaces the former `varName`/`displayLabel` pair,
+every suite constructing `InputSource` fixtures (Transform, RatingStep, LiveSwitch,
+ScenarioExpander, ModelScore, OptimiserApply, Banding, ExternalFile, ExploreCode, and the
+hover suite) migrates its fixtures — a compile-time-loud migration, not a runtime fallback.
+
 Browser coverage for authoring flows is in `frontend/e2e/data-io-nodes.spec.ts`,
 `frontend/e2e/migration/v1-to-v2-node-continuity.spec.ts`,
-`frontend/e2e/persistence/api-input-render-gate.spec.ts`, and
-`frontend/e2e/persistence/api-input-v2-native.spec.ts`.
+`frontend/e2e/persistence/api-input-render-gate.spec.ts`,
+`frontend/e2e/persistence/api-input-v2-native.spec.ts`, and
+`frontend/e2e/persistence/api-input-frame-alignment.spec.ts` (downstream frame-naming chips
+alongside its canvas geometry assertions).

--- a/docs/specs/json-shredding/high-level.md
+++ b/docs/specs/json-shredding/high-level.md
@@ -8,7 +8,8 @@ are grouped here:
 
 1. **JSON API-input shredding** — a JSON/JSONL document (arbitrarily nested objects
    and arrays) is "shredded" into one or more flat, typed tables (Polars frames),
-   cached on disk as parquet so the pipeline never re-parses raw JSON at run time.
+   using a valid parquet cache as a fast path when present and otherwise parsing
+   the source directly for that execution.
 2. **JSON output assembly** — flat frames plus output-path mappings can be
    structurally validated and are re-nested into one deterministic array-outer
    response document without cross-multiplying independent sibling arrays.
@@ -57,9 +58,14 @@ dotted columns; only an array (of objects, or of scalars) starts a child table. 
 scalar array produces a one-column child table (`value`) with one row per element.
 Building the cache writes one parquet per emitting table plus a `meta.json`
 manifest; the manifest carries a content fingerprint of the schema and a signature
-of the source data file, so a later request can tell — without re-reading the JSON —
-whether the cache is still valid for the schema currently configured and the data
-file currently on disk. Schema inference can sniff a v2 config from a data file
+of the source data file. Every table entry also records the size and SHA-256 of its
+derived parquet, so payload corruption is rejected before the footer-only schema
+probe can accept it. Old unsigned manifests invalidate once and are repaired by the
+next optional cache build. Caching is an optional performance prewarm: runtime first
+tries signed, readable, exact-schema `working/` then `committed/` parquets; when
+neither can serve, it applies the same parsed table specs, shredding, type checks,
+skip accounting, and conservation guards directly in memory without creating or
+refreshing cache files. Schema inference can sniff a v2 config from a data file
 directly, sampling optionally, widening column types across every record seen and
 naming collision-free bare leaf keys as their own column names. Inferred table
 labels are readable identifiers derived from the source key names — the root
@@ -119,13 +125,28 @@ additionally runs a conservation assertion at the root level — emitted-plus-sk
 must equal records-read — and raises `RuntimeError` if it doesn't, treating an
 unaccounted discrepancy as a shred bug, not something to serve silently.
 
-**Cache freshness is proven by content hash, not by timestamp alone.** A build
-records the data file's size, mtime, and a full SHA-256; validity checks always
-re-verify the hash rather than trusting a matching mtime, because a rewrite that
-happens to preserve size and mtime (a deliberate `os.utime` restore, or a same-length
-edit on a coarse-resolution filesystem) must not be served as fresh. The one-time
-cost of hashing on every validity check was judged cheaper than a class of stale-data
-bugs that would be silent and hard to reproduce.
+**Cache freshness and integrity are proven by content hashes.** A build records the
+data file's size, mtime, and full SHA-256, plus each emitted parquet's size and full
+SHA-256 after writing it. Public validity re-hashes the source and every candidate
+artifact: a readable footer does not prove its data pages are intact. Runtime goes
+further to close the hash-then-reopen race: it reads each compressed parquet exactly
+once, verifies size/SHA-256 over that exact payload, and gives those same bytes to
+Polars as an in-memory lazy scan. A rewrite that preserves size and mtime, or a
+damaged data page beneath an unchanged footer, is therefore never served.
+
+The compressed byte snapshot also pins a returned LazyFrame (including derived
+plans) to the generation it selected, even if the sole on-disk cache generation is
+later rebuilt, mirrored, or explicitly cleared. Parquet decode and projection remain
+lazy, but the full compressed source is read and copied into memory up front and is
+retained while its lazy plans remain live. Disk use stays bounded to one generation;
+memory use scales with the compressed artifacts referenced by active plans.
+
+Save-time promotion first requires a well-formed v2 mode/schema fingerprint, a
+recorded source signature that still matches the data file, and intact signed working
+artifacts. It then validates the staged metadata and artifact bytes again before
+publish. Both signed layers are verified before declaring a no-op, so invalid, stale,
+or concurrently changed working state cannot replace a healthy committed cache and
+damaged committed bytes are repaired from healthy working state.
 
 **Cache writes are fully staged and same-process builds are serialized per cache
 directory.** A build writes everything (parquets + `meta.json`) into a unique sibling
@@ -144,8 +165,10 @@ shred's own build and by promoting `working/` to `committed/` at save time.
 > window (or a failed restoration) can also leave only the uniquely named backup;
 > the next successful swap only cleans the legacy fixed `.build-old` name, not those
 > UUID backups. Tests cover same-process builder serialization, staged-write failure,
-> transient rename retry, and synchronous restoration attempts, but not concurrent
-> readers, cross-process publishers, or interruption between the two renames.
+> transient rename retry, synchronous restoration attempts, staged mirror tampering,
+> and already-returned LazyFrames surviving rebuild, mirror, and clear. A brand-new
+> concurrent reader can still observe the absent live path and reject that candidate;
+> cross-process publishers and interruption between the two renames are not covered.
 
 **Silent numeric/date coercion is rejected even though the underlying columnar
 library would allow it.** Polars will silently coerce a Python `bool` into a numeric
@@ -159,9 +182,10 @@ strict build and raises a specific, column-named error instead.
 - Owns the v2 apiInput type/path boundary in `_api_input_schema.py`; the shred,
   cache route, executor, and editor consume that one validation contract.
 - The runtime entry point (`load_v2_api_source`) is called by both the eager
-  executor's source builder and the generated/deploy code path, so both paths read
-  identical cached frames — see [execution-engine](../execution-engine/high-level.md)
-  and [codegen](../codegen/high-level.md).
+  executor's source builder and the generated/deploy code path, so both paths share
+  identical cache-fast-path and direct-shred behaviour — see
+  [execution-engine](../execution-engine/high-level.md) and
+  [codegen](../codegen/high-level.md).
 - The execution engine's projection planner consumes `_edge_join.py`'s shared
   demand-narrowing rule so static planning and runtime join construction agree —
   see [execution-engine](../execution-engine/high-level.md).
@@ -202,8 +226,10 @@ strict build and raises a specific, column-named error instead.
   aborts the build with `RuntimeError` rather than writing a cache with unaccounted
   data loss.
 - At runtime, a v2 apiInput with no emit-true tables, or emit-true tables with no
-  selected columns, or a stale/missing cache in both the working and committed
-  layers, raises `RuntimeError` with a message telling the user which UI action
-  (ticking `emit`/a column, or clicking "Cache as Parquet") will fix it.
+  selected columns, raises `RuntimeError` with a message telling the user to tick
+  `emit` or select a column. A stale, missing, corrupt, or schema-mismatched cache
+  is not a runtime error: the loader tries the next layer, then shreds the raw
+  source directly. Raw-file decode, missing-file, and declared-type failures stay
+  loud and specific; the direct path never replaces them with a cache prompt.
 - `edgeJoin` node misconfiguration (ambiguous/missing base or join role, unsupported
   join strategy, mismatched key counts) raises `ConfigError` before any join runs.

--- a/docs/specs/json-shredding/high-level.md
+++ b/docs/specs/json-shredding/high-level.md
@@ -61,7 +61,12 @@ of the source data file, so a later request can tell — without re-reading the 
 whether the cache is still valid for the schema currently configured and the data
 file currently on disk. Schema inference can sniff a v2 config from a data file
 directly, sampling optionally, widening column types across every record seen and
-naming collision-free bare leaf keys as their own column names.
+naming collision-free bare leaf keys as their own column names. Inferred table
+labels are readable identifiers derived from the source key names — the root
+table is `root`, `$[:].proposer.claims[:]` becomes `claims`, and two levels
+sharing a key name qualify symmetrically (`a_items`/`b_items`) — never raw path
+strings, so an inferred schema is immediately valid under the label rule below
+and its labels read as the argument names they will become.
 
 Every array element the shred sees is accounted for: it either becomes a row in some
 table, or is counted as a skip against that table (its shape didn't match — an
@@ -69,7 +74,17 @@ object where a scalar was expected, or vice versa), or — for a non-object top-
 record — is counted as a skipped record. No element silently disappears.
 
 **V2 schema and output document.** A v2 apiInput is recognised only by a
-`tables` list. Each table has a unique non-empty label, a non-empty path,
+`tables` list. Each table has a non-empty label — unique case-insensitively,
+because labels become parquet filename stems and Windows/macOS filesystems
+fold case — that must be an ASCII Python identifier and not a hard keyword — the label is the frame's identity
+end-to-end (canvas handle, downstream input name, and the generated
+function's parameter), so it is constrained to what an argument name can be,
+with zero transformation anywhere. ASCII is deliberate, not incidental:
+Python NFKC-normalises source identifiers, so a non-NFKC Unicode label would
+silently become a *different* parameter name when the generated file is
+parsed — the exact hidden mapping this rule forbids — and ASCII lets the
+frontend mirror the rule exactly instead of approximating Unicode
+`str.isidentifier()`. Each table also carries a non-empty path,
 unique column names, known column types, and an optional row-ID column that must name one of its own
 columns. Table paths end at an array boundary; columns may live at that boundary
 or at an ancestor boundary so an ancestor value can be distributed into child

--- a/docs/specs/json-shredding/low-level.md
+++ b/docs/specs/json-shredding/low-level.md
@@ -86,7 +86,30 @@ Submodel graph expansion and boundary rewiring are owned by
 **V2 codec** — `validate_v2_schema(config)` first requires the `tables` list,
 then validates each table's label/path/columns, unique raw and sanitised
 labels, unique column names, supported column type/levels shapes, ancestor-or-own
-column paths, and `row_id_column`. `parse_table_path`/`parse_column_path_full`/
+column paths, and `row_id_column`. Labels must additionally be ASCII-only
+Python identifiers and not hard keywords — `label.isascii() and
+label.isidentifier() and not keyword.iskeyword(label)` (invariant B4): the
+label is consumed verbatim as the downstream parameter name by codegen and
+the executor, so an invalid label would only fail later and further from its
+cause. ASCII is part of the invariant, not a convenience: Python
+NFKC-normalises source identifiers (PEP 3131), so a non-NFKC Unicode label
+would silently bind under a *different* parameter name once the generated
+file is parsed — exactly the hidden mapping the label≡argument identity
+forbids — and the ASCII rule is mirrorable exactly in the frontend, where
+Unicode `str.isidentifier()` is not. Soft keywords (`match`, `case`, `type`,
+`_`) are legal parameter names and stay allowed. Under B4 the B2
+sanitised-collision check compares **casefolded** filesystem stems
+(`sanitise_label_for_filesystem(label).casefold()`): parquet caches live on
+case-insensitive filesystems (Windows/macOS), where `Items.parquet` and
+`items.parquet` are one file, so two labels differing only by case would
+silently clobber a frame at build time. ASCII identifier labels are fixed
+points of the sanitiser, so post-B4 a case-only collision is the *only* way
+two distinct valid labels can meet at one stem — B2 rejects the pair loudly,
+naming both labels and the shared stem. Inference's casefold-aware
+uniqueness pass guarantees inferred schemas never trip it. The frontend
+mirrors B4 in `apiInputLabelIssue` (ASCII-identifier regex plus the
+hard-keyword list) and treats duplicates case-insensitively to match B2,
+before commit. `parse_table_path`/`parse_column_path_full`/
 `parse_column_path` delegate grammar acceptance to `_jsonpath.py`; `make_table_path`
 delegates canonical rendering to the same writer.
 
@@ -157,8 +180,12 @@ assembly path currently does not.
 2. Resolve `working/` cache dir; if `is_per_port_cache_valid` fails, fall back to
    `committed/`; if that also fails, raise with `_STALE_CACHE_MESSAGE`.
 3. `load_per_port_cache` — `pl.scan_parquet` per emitting table's parquet.
-4. Return a bare `LazyFrame` if exactly one emitting label, else a
-   `{label: LazyFrame}` dict in schema order.
+4. Return a `{label: LazyFrame}` dict in schema order for every eligible-frame
+   count from one up — there is no bare-frame single-table special case, so a
+   sole frame routes through the same per-edge `source_port` resolution as
+   eight frames (see [execution-engine](../execution-engine/low-level.md)
+   `_pick_source_frame`), and adding or removing a sibling frame never changes
+   the shape a consumer receives.
 
 **Save-time cache promotion** — `mirror_cache_to_committed(data_path)`
 (`_json_flatten.py`):
@@ -211,6 +238,25 @@ accommodation.
    `_assign_column_names` (bare leaf where unique, else the underscore-joined full
    path, with a final numeric-suffix dedup pass) and typed via the widened
    `levels` map. Only the root level defaults `emit=True`.
+4. Label assignment — inferred `label`s are B4-valid identifiers, never raw
+   table paths (`path`/`displayPath` still carry the path). The root level is
+   labelled `root`; every other level is labelled by its innermost array key
+   through `derive_identifier_label(raw)` (`_api_input_schema.py`): the
+   `_sanitize_func_name` character pipeline (strip; spaces/hyphens → `_`;
+   ASCII alnum/underscore kept; other ASCII dropped; non-ASCII reversibly
+   encoded `_x<hex>_`) with frame-flavoured repairs — empty → `table`,
+   digit-leading → `_`-prefixed, hard keyword → trailing `_` (`class` →
+   `class_`). A uniqueness pass in the sorted table order then resolves
+   collisions symmetrically: every table whose label is shared with another
+   is re-labelled with the underscore-join of ALL its level keys (object
+   hops and array keys, each through `derive_identifier_label`) — so
+   `$[:].a.items[:]` and `$[:].b.items[:]` become `a_items`/`b_items`, not
+   `items`/`items_2`; the root's join is empty so it keeps `root`. Any
+   labels still colliding after qualification take deterministic numeric
+   suffixes (`_2`, `_3`, …) in the sorted order, first occurrence keeping
+   its label. The closure property — inference output passes
+   `validate_v2_schema` unchanged (B4 + unique labels) — is a contract, not
+   a coincidence.
 
 **Edge-join execution** — `execute_edge_join(base, join, config,
 collect_eager=False)`: normalises both frames to `LazyFrame`, calls
@@ -328,8 +374,21 @@ Shred / inference / cache lifecycle (`_json_shred.py`, `_json_flatten.py`):
   suites; each pins one specific branch/condition so a mutation-testing run can't
   silently survive a change to it.
 - `tests/test_load_v2_api_source.py` — direct coverage of the shared runtime entry
-  point: emit checks, working→committed fallback, single- vs multi-port return
-  shape.
+  point: emit checks, working→committed fallback, and the uniform
+  `{label: LazyFrame}` return shape from one eligible frame up (the former
+  bare-frame single-table case is pinned as removed). Label invariant B4
+  (ASCII-identifier-only labels; hard keywords rejected; valid *Unicode*
+  identifiers such as `café` rejected with the ASCII rule named in the error)
+  is pinned alongside the existing blank/duplicate cases in the
+  schema-validation suites; the B2 check now compares casefolded stems — a
+  case-only pair such as `Items`/`items` is rejected naming both labels and
+  the shared stem — and the former Unicode B2 witness labels are pinned as
+  B4 rejections instead. Inference label derivation is pinned in the `infer` suites:
+  `derive_identifier_label` character/repair cases (spaces, punctuation,
+  digit-leading, hard keyword, empty, non-ASCII `_x<hex>_` encoding), root →
+  `root`, innermost-key labelling, symmetric collision qualification
+  (`a_items`/`b_items`), the numeric-suffix backstop, and the closure
+  property that inferred output passes `validate_v2_schema` unchanged.
 - `tests/test_json_cache_routes.py` — API integration tests for the build/status/
   delete HTTP routes (404/422/504 shapes, progress reporting).
 - `tests/test_json_cache_integrity.py` — the Wave-2 build/validity/load rework end

--- a/docs/specs/json-shredding/low-level.md
+++ b/docs/specs/json-shredding/low-level.md
@@ -146,14 +146,17 @@ assembly path currently does not.
    in-memory schema and on-disk data file, return the existing `meta.json` payload
    without rebuilding.
 4. Record the data-file signature (`_data_file_signature`) *before* reading records.
-5. Re-derive `(label, col_specs)` per emitting table (`table_is_emitting`).
+5. Build the shared `_EmittingTableSpec`s once (`table_is_emitting` plus parsed
+   table/column paths); the walk and parquet frame construction consume the same specs.
 6. `shred_to_buffers(_counted_records(), v2_config, stats=skip_stats)` — the shred
    core (below) — consuming `_iter_records` directly (not materialised into a list).
 7. Conservation assertion at the root level: for every emit-true root table,
    `emitted + skipped_rows_by_table[label] == record_count`, else `RuntimeError`.
 8. Stage output in a unique sibling temp dir: `_buffer_to_frame` per table →
    `to_arrow()` → attach per-frame schema metadata (`_per_frame_metadata`) →
-   `pq.write_table(..., compression="zstd")`; write `meta.json`.
+   `pq.write_table(..., compression="zstd")`; after each final write, record its
+   derived filename plus `{size, sha256}` `content_signature` in the table summary;
+   then write `meta.json`.
 9. `_swap_dir_into_place(tmp_dir, cache_dir)` — recoverable two-rename publish
    (below).
 
@@ -175,12 +178,33 @@ assembly path currently does not.
 5. Returns `{table_label: [row_dict, ...]}`.
 
 **Runtime load** — `load_v2_api_source(data_path, config)`:
-1. Validate at least one emit-true table exists, and at least one has a selected
-   column (both raise `RuntimeError` with an actionable message otherwise).
-2. Resolve `working/` cache dir; if `is_per_port_cache_valid` fails, fall back to
-   `committed/`; if that also fails, raise with `_STALE_CACHE_MESSAGE`.
-3. `load_per_port_cache` — `pl.scan_parquet` per emitting table's parquet.
-4. Return a `{label: LazyFrame}` dict in schema order for every eligible-frame
+1. Validate the v2 schema at this public boundary, then require at least one
+   emit-true table and at least one selected column (the latter two raise
+   `RuntimeError` with an actionable configuration message otherwise).
+2. Construct `_EmittingTableSpec`s once: parsed table position plus every selected
+   column's name, leaf, declared type, and source array depth. Cache build, direct
+   shred, strict frame construction, and ancestor broadcast all consume these specs.
+3. Try `working/`, then `committed/`. Read each candidate manifest once. It must
+   pass fingerprint/source validity; contain exactly one entry per emitting label;
+   derive the expected filename from that label; and carry a strict size/SHA-256
+   signature. Missing, duplicate, malformed, or legacy unsigned entries invalidate
+   the candidate. Each compressed parquet is then read exactly once; size and
+   SHA-256 are verified over that exact payload, and the same bytes seed
+   `scan_parquet(BytesIO(payload))`. `LazyFrame.collect_schema()` must expose the
+   exact declared name-to-Polars-dtype mapping. Physical parquet column order is
+   irrelevant: an accepted lazy frame is projected into the current declared order.
+   An unusable candidate is logged and the next candidate is tried.
+
+   The in-memory compressed source pins the returned frame and derived lazy plans to
+   this generation across a later rebuild, mirror, or explicit clear. Decode and
+   projection remain lazy, but the full compressed file is read/copied up front and
+   retained while those plans live. The directory swap keeps disk bounded to one
+   generation; active-plan memory scales with their compressed source payloads.
+4. If no cache can serve, `_shred_data_file` streams `_iter_records` into
+   `shred_to_buffers`, preserving skip accounting and root conservation, then
+   `_buffer_to_frame(...).lazy()` creates each in-memory frame. This path does not
+   write, refresh, delete, or promote either cache layer.
+5. Return a `{label: LazyFrame}` dict in schema order for every eligible-frame
    count from one up — there is no bare-frame single-table special case, so a
    sole frame routes through the same per-edge `source_port` resolution as
    eight frames (see [execution-engine](../execution-engine/low-level.md)
@@ -194,11 +218,19 @@ assembly path currently does not.
    (`_session_consulted_hashes`, populated only by a successful build-route call) —
    guards against promoting a stale on-disk `working/` left from a previous process.
 3. Under the shred's own build lock for `working/`: if `working/` is absent, ensure
-   `committed/` is also absent (propagate deletion); else no-op if
-   `working/meta.json` and `committed/meta.json` already agree on schema
-   fingerprint, schema mode, and data-file signature; else `copytree` into a `.tmp`
-   sibling and `_swap_dir_into_place` it into `committed/` (shared with the build's
-   own publish helper).
+   `committed/` is also absent (propagate deletion). If working metadata has a
+   non-v2 mode, malformed fingerprint/source identity, or source signature that no
+   longer matches `data_path`, or if its artifacts are unsigned, malformed, missing,
+   or hash-mismatched, preserve committed state and return without promotion.
+   Otherwise no-op only when both manifests agree on
+   schema fingerprint, schema mode, source signature, and signed table summaries,
+   and both layers' actual parquet bytes match those signatures. A legacy unsigned
+   or damaged committed layer is therefore replaced from healthy working state via
+   `copytree` into a `.tmp` sibling. Before publish, the staged `meta.json` must equal
+   the captured working manifest and every staged parquet must still match that
+   manifest's signature; a concurrently changed/mixed copy is removed and committed
+   remains untouched. A valid stage is published with `_swap_dir_into_place` (shared
+   with build).
 
 **Staged publish** — `_swap_dir_into_place(tmp_dir, live_dir)`:
 renames the current `live_dir` aside to a unique `.build-old-<uuid>` name, renames
@@ -216,9 +248,11 @@ accommodation.
 > `live_dir` absent with a UUID `.build-old-<uuid>` backup. The pre-swap cleanup only
 > removes the legacy fixed `<live>.build-old` directory, not UUID backups. Existing
 > tests exercise same-process build serialization, different-cache parallelism,
-> staging-write cleanup, transient rename retry, and synchronous restoration after a
-> failed second rename; there is no concurrent-reader, cross-process-publisher, or
-> mid-swap process-death test.
+> staging-write cleanup, transient rename retry, synchronous restoration after a
+> failed second rename, staged mirror mutation rejection, and already-returned
+> LazyFrames surviving rebuild, mirror, and clear. A brand-new concurrent reader can
+> still observe an absent live path and reject that candidate; cross-process
+> publishers and mid-swap process death are not covered.
 
 **Schema inference** — `infer_v2_schema_from_data(data_path, sample_size=None)`:
 1. `_iter_records_for_inference` — full scan, or (for JSONL/root-array files) a
@@ -294,7 +328,8 @@ if both original inputs were eager *and* `collect_eager` is set.
   explicitly in `_buffer_to_frame` before the Polars build.
 - **Cache validity always re-hashes** the data file's content; there is no
   `mtime_ns`-only short-circuit, so a same-size/same-mtime content rewrite is never
-  served as fresh.
+  served as fresh. It also re-hashes every manifest-declared parquet before the
+  footer schema probe, so a footer-readable data-page corruption is rejected.
 - **The build lock is process-local**, keyed by the normcased resolved cache-dir
   path; concurrent builds of *different* caches never block each other.
 - **`mirror_cache_to_committed`'s consulted-hash gate is intentionally never
@@ -322,11 +357,11 @@ if both original inputs were eager *and* `collect_eager` is set.
   column collision, a column value that doesn't match its declared type (including
   the silent-coercion guards), and inference's unexpressible-key rejections. Always
   carries `column=`/`table=` context.
-- `RuntimeError` — raised by `build_per_port_cache` on a conservation-assertion
-  failure, and by `load_v2_api_source` for "no emitting tables", "no selected
-  columns on any emitting table", "cache changed mid-load" (a parquet vanished
-  between validity check and load), and the generic stale-cache message
-  (`_STALE_CACHE_MESSAGE`).
+- `RuntimeError` — raised by the shared file-shred path on a root conservation-
+  assertion failure, and by `load_v2_api_source` for "no emitting tables" or "no
+  selected columns on any emitting table". Missing/stale/corrupt/mismatched cache
+  artifacts are rejected as optional fast paths and do not mask the direct raw-file
+  result or its native missing/decode/type error.
 - `PermissionError` — allowed to propagate from `_rename_dir_with_retry` once all
   retry delays are exhausted (a persistent, not transient, Windows lock).
 - `haute.errors.ConfigError` — raised by `_edge_join.py` for any malformed
@@ -374,7 +409,9 @@ Shred / inference / cache lifecycle (`_json_shred.py`, `_json_flatten.py`):
   suites; each pins one specific branch/condition so a mutation-testing run can't
   silently survive a change to it.
 - `tests/test_load_v2_api_source.py` — direct coverage of the shared runtime entry
-  point: emit checks, working→committed fallback, and the uniform
+  point: emit checks, working→committed→direct resolution, cache corruption and
+  exact-schema rejection, stale post-schema changes, scalar/empty arrays, typed
+  raw-data failures, no-write direct fallback, and the uniform
   `{label: LazyFrame}` return shape from one eligible frame up (the former
   bare-frame single-table case is pinned as removed). Label invariant B4
   (ASCII-identifier-only labels; hard keywords rejected; valid *Unicode*

--- a/docs/specs/pipeline-config/high-level.md
+++ b/docs/specs/pipeline-config/high-level.md
@@ -88,7 +88,18 @@ outgoing edge is used; anything more ambiguous than that raises, naming every ca
 `score(df)` additionally seeds a live input DataFrame into whichever source is marked as the
 deploy input (`@pipeline.api_input`, or `api_input=True`) — or, when nothing is marked and
 there is exactly one source, into that source — leaving every other source to run its own
-load logic.
+load logic. Seeding is port-aware, with a complete seed-shape × port-count matrix: a **bare
+DataFrame** is accepted for zero connected ports (a source-only pipeline, where the seeded
+source is itself the output) and for exactly one distinct connected port (routed to that
+port), and raises for two or more. A **`{frame_label: DataFrame}` dict** is accepted only
+when the seeded source has one or more connected ports and the dict's keys match the
+distinct connected ports *exactly* — a missing key, an unknown extra key, a dict against a
+zero-port source (there are no ports for `{}` or anything else to match; source-only
+pipelines take a bare frame), or a bare frame against a multi-port source all raise
+`ExecutionError` naming the ports concerned. A frame is never silently fanned out to
+multiple ports. Both `run()` and `score()` resolve each edge's frame through the same
+port-aware selection the full executor uses (`_pick_source_frame` on
+`RegisteredEdge.source_port`), keeping the single-execution-engine invariant.
 
 **Project & discovery.** A Haute project is a directory containing `haute.toml` that also
 sits inside a git repository. Every CLI command resolves "which pipeline file" through the

--- a/docs/specs/pipeline-config/low-level.md
+++ b/docs/specs/pipeline-config/low-level.md
@@ -5,7 +5,7 @@
 | File | Responsibility |
 |---|---|
 | `src/haute/pipeline.py` | `Node` / `NodeRegistry` / `Pipeline` / `Submodel`: the decorator API, `connect()`, the standalone `run()`/`score()` executor, `to_graph()` (live-object → React-Flow dict). |
-| `src/haute/_config_builder.py` | Per-node-type config dict construction from decorator kwargs + function body (`_build_node_config`); sidecar resolution and the parse-time `contract=` cross-check (`_resolve_node_config`). |
+| `src/haute/_config_builder.py` | Per-node-type config dict construction from decorator kwargs + function body (`_build_node_config`); sidecar resolution and the parse-time `contract=` cross-check (`_resolve_node_config`). `config["inputs"]` records the function's parameter names verbatim — under input-identity convergence these ARE the per-edge input names (`edge_input_name`: frame labels for apiInput edges, sanitised source labels otherwise), the same strings `input_scenario_map` keys and instance `inputMapping` values reference. |
 | `src/haute/_config_io.py` | Sidecar JSON path conventions (`NODE_TYPE_TO_FOLDER`), read/write helpers, `collect_node_configs` (graph → sidecar files), Windows-reserved-filename guard. |
 | `src/haute/_config_validation.py` | `VALID_KEYS` registry derived from each node type's `TypedDict`, and `warn_unrecognized_config_keys`. |
 | `src/haute/_builders.py` | Cross-component dependency owned by [execution-engine](../execution-engine/low-level.md): registers each per-`NodeType` runtime builder and its column-contract callback in `NODE_REGISTRY`. Pipeline-config consumes those callbacks through `src/haute/_contracts.py`; it does not own the runtime closures. |
@@ -102,8 +102,9 @@ in-memory `_edges`/`_nodes` via `haute.graph_utils.topo_sort_ids` (raising `Cycl
 cycle). With no edges, `_topo_order` returns registration order; it does not create a chain.
 Execution then fails at `_execute_transform` if a non-source node has no inbound edge, rather
 than inferring one from its parameter names. Otherwise it executes each `Node`'s `fn`, threading
-DataFrames along declared edges, and resolves the return value through
-`_resolve_output_node`: an explicit `@pipeline.output` node wins if there is exactly one;
+DataFrames along declared edges — each edge's frame resolved port-aware through the shared
+`_pick_source_frame` selection on `RegisteredEdge.source_port` — and resolves the return value
+through `_resolve_output_node`: an explicit `@pipeline.output` node wins if there is exactly one;
 otherwise the single node with no outgoing edge; otherwise raise, naming every candidate node.
 `Pipeline.to_graph()` independently converts the same live objects into a React-Flow-shaped
 plain `dict`, inferring each node's display type from `config["_node_type"]` if present, else
@@ -254,7 +255,12 @@ artifact paths (from the `_CI_ARTIFACTS` map) and removes the resulting empty
   `topo_sort_ids` through `Pipeline._topo_order` with the participating node names.
 - **`ExecutionError`** (`haute.errors`) — live node arity mismatch; multiple explicit output
   nodes; ambiguous terminal nodes; multiple or ambiguous `score()` seed sources; unresolved
-  `instanceOf`/`inputMapping` references in the standalone executor.
+  `instanceOf`/`inputMapping` references in the standalone executor; a bare-frame `score()`
+  seed against a source with two or more distinct connected `source_port`s; a dict seed whose
+  keys do not exactly match the distinct connected ports (missing and unknown port names are
+  both listed in the message — a one-port source accepts only the exact one-key dict); and a
+  dict seed of any content against a zero-port source (source-only pipelines take a bare
+  frame).
 - **`ValueError`** — empty live pipeline; an unwired non-source node or missing upstream result
   during `Pipeline.run()`/`score()`; unknown source or target node in `connect()`; empty-string
   port name; duplicate key in a sidecar JSON object
@@ -285,7 +291,12 @@ API and real JSON round-trips rather than mocks:
   (`TestDuplicateNodeName`), instance-reference fail-loud behaviour
   (`TestInstanceReferencesFailLoud`), the API-input deploy-seed marker
   (`TestApiInputDecoratorMarksSeed`), and `to_graph()` shape/inference (`TestPipelineEdgeCases`
-  and scattered `to_graph` tests across other classes).
+  and scattered `to_graph` tests across other classes). The input-identity release adds the
+  full `score()` seed matrix here: bare frame accepted at zero ports (source-only) and one
+  port; bare frame rejected at 2+ ports; exact one-key dict accepted at one port; dict
+  rejected with missing keys, with unknown extra keys, and against a zero-port source — every
+  rejection an `ExecutionError` naming the ports — plus `run()` port-aware frame selection
+  for one- and many-frame apiInput sources.
 - **`test_config_io.py`** + **`test_config_io_gaps.py`** (~97 tests) — sidecar save/load
   round-trips, path conventions (`TestConfigPathForNode`), Windows-reserved-filename rejection
   (`TestIsWindowsReservedFilename`), `collect_node_configs` (including load-error protection

--- a/docs/specs/submodels/high-level.md
+++ b/docs/specs/submodels/high-level.md
@@ -181,6 +181,12 @@ Out of scope (owned elsewhere, linked where relevant):
   submodel navigation UI itself — the `useSubmodelNavigation` hook (drill-in/out, create,
   dissolve) and the `SubmodelDialog` create/rename component — lives in the
   [frontend-graph-canvas](../frontend-graph-canvas/high-level.md) component, not here.
+- A downstream node fed across a submodel boundary lists that input by the referenced
+  child node's sanitised label — the name the flattened code actually binds as the
+  argument (see [frontend-node-editors](../frontend-node-editors/high-level.md) for the
+  chip derivation and [codegen](../codegen/high-level.md)/`edge_input_name` for the
+  backend rule) — never by the submodel placeholder's own label, which names the
+  container, not the frame delivered.
 
 ## Failure model
 

--- a/docs/trip/plans/F_0.4.1_api-input-frame-identity.plan.md
+++ b/docs/trip/plans/F_0.4.1_api-input-frame-identity.plan.md
@@ -1,0 +1,170 @@
+# API Input Frame Identity Implementation Plan
+
+Target version: **0.4.1** (patch — all four items correct observed defects in existing
+behaviour; no config schema, persisted identity, or backend change).
+Source: [`docs/roadmap/api-input-ui-issues.md`](../../roadmap/api-input-ui-issues.md)
+(issues 1–4).
+
+## Overview
+
+The API Input node's emitted frames are the canvas's most important outputs, but the current
+presentation misaligns connection dots with frame names (two independent layout systems), hides
+the sole frame's name entirely, buries frame names in a small grey column beside the dominant
+generic instance name, and labels downstream inputs with the parent node (`Quote_Input_1`)
+instead of the connected frame (`quote_id`). This release redesigns the full-detail API Input
+body as a frame-row list where each row owns both the visible name and its output handle —
+alignment holds by construction for any frame count — and teaches downstream input chips to
+name the dataframe an edge actually delivers. Frame handle ids (raw labels; null for
+single-frame), persisted node labels, and every executable identity (`varName`-keyed
+`input_scenario_map` and `inputMapping`) are deliberately unchanged.
+
+## Design
+
+The design lives in the component specs, updated on this branch
+(`git diff HEAD --stat -- docs/specs/` shows the deltas):
+
+- `docs/specs/frontend-graph-canvas/` — full-detail api-input frame-row body (row-mounted
+  handles, instance-name suppression, zero-frame "No emitted frames" state, zoom-invariant
+  handle-id set), the visible-frames-vs-multi-port-mode derivation split
+  (`apiInputVisibleFrameLabels` vs `apiInputEmitPortLabels`), and the shared edge frame-display
+  resolution (`apiInputEdgeDisplayLabel`).
+- `docs/specs/frontend-node-editors/` — `InputSource` display-vs-executable identity split
+  (`displayLabel` alongside the untouched `varName`), frame-aware input chips keyed by edge id,
+  the NodePanel staleness signature covering `sourceHandle`, the resolved display label, and
+  the `frameUnresolved` resolution state, and the OutputEditor sole-frame block-label
+  unification (display-only). Includes a NOTE recording
+  the pre-existing, out-of-scope live-switch `input_scenario_map` limitation for two frames of
+  one API input.
+- `docs/specs/engineering-quality/` — module-map row for the new Playwright suite
+  `frontend/e2e/persistence/api-input-frame-alignment.spec.ts`.
+
+An implementer needs nothing beyond those low-level sections; this plan does not restate them.
+
+## Files to Modify/Create
+
+1. `frontend/src/utils/apiInputPorts.ts` (modify) — add `apiInputVisibleFrameLabels` (ordered
+   eligible frame labels with no minimum count; shares one internal eligible-label derivation
+   with `apiInputEmitPortLabels`, whose `[]`-below-two contract is unchanged) and
+   `apiInputEdgeDisplayLabel` (API-input-scoped edge display resolution: raw `sourceHandle`,
+   else the sole visible frame for a null handle, else null — from which callers distinguish
+   the non-API `varName` fallback from the unresolved API warning state; non-API sources and
+   submodel `out__` handles are never treated as frame names).
+2. `frontend/src/nodes/PipelineNode.tsx` (modify) — full-detail api-input frame-row body:
+   per-row mounted source handles (labelled in multi-port mode, the default null-id handle on
+   the sole row in single-frame mode), instance-name suppression with ≥1 visible frame,
+   zero-frame instance name + "No emitted frames" hint, trace pill above the rows,
+   `useUpdateNodeInternals` deps retaining the multi-port signature (`emitTablesSig` — handle
+   mode can flip while visible names don't) and adding the visible-frame signature and the zoom
+   bucket; medium/compact LODs keep `_SourceHandles` percentage spacing and today's bodies.
+3. `frontend/src/panels/editors/_shared.tsx` (modify) — `InputSource.displayLabel` (required —
+   fixture migration is compile-time loud) and `InputSource.frameUnresolved`;
+   `InputSourcesBar` keyed by `edgeId`, chip text = `displayLabel`, chip tooltip names the
+   source node, unresolved chips render a visible warning state.
+4. `frontend/src/panels/NodePanel.tsx` (modify) — `inputSources` derivation gains
+   `displayLabel` (helper result; non-API sources fall back to `varName`, an unresolvable
+   API-input frame sets `frameUnresolved: true` instead of a normal-looking fallback); the
+   upstream staleness signature extends to `sourceHandle`, the resolved display label, and the
+   resolution state (so unresolved→resolved under an unchanged display string refreshes).
+5. `frontend/src/panels/editors/LiveSwitchEditor.tsx` (modify) — mapping rows keyed by `edgeId`
+   and displaying `displayLabel` with the shared unresolved warning state;
+   `input_scenario_map` reads/writes stay `varName`-keyed (executable contract untouched).
+6. `frontend/src/panels/editors/OutputEditor.tsx` (modify) — `frameLabel`'s null-handle branch
+   resolves the sole eligible emitted frame via the shared helper, and a zero-eligible-frame
+   null-handle edge renders an explicit unresolved block header (display-only;
+   `framePortId`/`source_port` untouched).
+7. `frontend/e2e/persistence/api-input-frame-alignment.spec.ts` (new) — Playwright geometry and
+   downstream-naming evidence (scenarios in the two specs' Testing sections).
+8. `pyproject.toml` (modify, at release) — version 0.4.0 → 0.4.1 (TRIP-3).
+
+Spec deltas (`docs/specs/frontend-graph-canvas/`, `docs/specs/frontend-node-editors/`,
+`docs/specs/engineering-quality/low-level.md`) and the roadmap status update are already on
+this branch and ship in the same PR.
+
+## Performance & Cost Impact
+
+Frontend-only; no executor/projection/backend path is touched. The frame-row body renders one
+extra element per visible frame on a singleton node type; both frame lists stay memoised on
+`config` identity, and `useUpdateNodeInternals` refires only on multi-port or visible-frame
+signature changes, zoom-bucket crossings, and edge-join handle moves (all bounded). The NodePanel
+signature adds per-upstream-edge string work — negligible. No perf-suite thresholds are
+expected to move (`large-graph-drag.benchmark` exercises non-API nodes).
+
+## Backward Compatibility
+
+No config schema change and no persisted identity change. Handle ids remain the raw table
+labels (null for single-frame), so every saved pipeline's edges stay bound and codegen/parse
+round-trips are untouched. `varName`-keyed executable contracts (`input_scenario_map`,
+`inputMapping`) are byte-identical. Automation/accessibility identities are preserved:
+`node-<label>` and `output-connector[<idx>]:<label>` test ids, the
+`api-input-body-label-<label>` name span, and the aria-label still derived from the persisted
+node label. All visible changes are presentation-only (node body, input chips, OutputEditor
+block label).
+
+## Test Impact
+
+- **Test-first (TDD) batches** — silent-wrongness classes per CLAUDE.md: (a) the pure
+  `apiInputPorts` helpers (`apiInputVisibleFrameLabels`, `apiInputEdgeDisplayLabel`) and
+  (b) the NodePanel derivation + staleness signature (memo staleness is invisible when wrong).
+  Scenario lists live in the two low-level `## Testing` sections.
+- **Updated unit/component suites**: `frontend/src/utils/__tests__/apiInputPorts.test.ts`,
+  `frontend/src/nodes/__tests__/PipelineNode.test.tsx`,
+  `frontend/src/__tests__/nodes/ApiInputHandles.test.tsx`,
+  `frontend/src/panels/__tests__/NodePanel.test.tsx` (including the `frameUnresolved` warning
+  chip and the unresolved→resolved transition under an unchanged display string),
+  `ApiInputHandles`' all-invalid multi-emit default-handle fallback, the `InputSourcesBar`
+  consumer suites (`ModelScoreEditor`, `OptimiserApplyEditor`, `ScenarioExpanderEditor`,
+  `BandingEditor`, `editorsHover`), LiveSwitch cases (equal `varName`, distinct `edgeId`s →
+  two rows showing their frame display labels, no React duplicate-key warning,
+  `varName`-keyed mapping intact; plus a zero-eligible-frame API input rendering the row's
+  unresolved warning state), and the OutputEditor suite (single-frame block label and
+  the unresolved block header).
+  Because `displayLabel` is required, every suite constructing `InputSource` fixtures
+  (Transform, RatingStep, LiveSwitch, ScenarioExpander, ModelScore, OptimiserApply, Banding,
+  ExternalFile, ExploreCode, hover) updates its fixtures — expect compile failures until done.
+- **Regression gates that must stay green unchanged**: `App.integration.test.tsx`'s api-input
+  emit-port edge-reconciliation suite (Defect 1 / W1.3 / W1.4) and
+  `frontend/e2e/persistence/api-input-render-gate.spec.ts` /
+  `api-input-v2-native.spec.ts`.
+- **New browser suite**: `frontend/e2e/persistence/api-input-frame-alignment.spec.ts` —
+  bounding-box row/handle alignment for 1, 2, 3, and 8 frames with a ≤3 CSS px centre-delta
+  tolerance, asserted plain, with status/warning dots, with a trace-active value pill, and with
+  a ≥40-character truncating label; `sourceHandle` correctness across render, save/reload, and
+  in-place rename; and downstream chips naming connected frames. DOM-only tests cannot prove
+  the geometry; this suite is the acceptance evidence the roadmap doc requires.
+
+## To-dos
+
+### Phase 1: Shared frame-identity helpers (test-first)
+
+- [x] Author failing tests, then implement `apiInputVisibleFrameLabels` (internal
+      eligible-label refactor; `apiInputEmitPortLabels` contract unchanged)
+- [x] Author failing tests, then implement `apiInputEdgeDisplayLabel` (API-scoped; submodel
+      `out__` handles and non-API sources return null)
+
+### Phase 2: Canvas frame-row body (issues 1–3)
+
+- [x] `PipelineNode` full-detail frame-row body: rows + row-mounted handles, instance-name
+      suppression, zero-frame "No emitted frames" state, trace pill placement
+- [x] `useUpdateNodeInternals` dependency extension (retain the multi-port `emitTablesSig`;
+      add the visible-frame signature + zoom bucket)
+- [x] Update `PipelineNode.test.tsx` and `ApiInputHandles.test.tsx` per the spec Testing
+      sections (body states, row/handle pairing, zoom-invariant ids, medium/compact unchanged)
+
+### Phase 3: Downstream frame naming (issue 4, test-first for the derivation)
+
+- [x] `InputSource.displayLabel` (required) + `frameUnresolved` + `InputSourcesBar` edge-id
+      keying, tooltip, and warning-state chip
+- [x] `NodePanel` derivation + extended staleness signature (sole-frame rename refresh;
+      unresolved API frame sets the warning state, never a plain fallback)
+- [x] `LiveSwitchEditor` rows: `edgeId` keys + `displayLabel` presentation with the unresolved
+      warning state (duplicate-key and frame-label tests); `OutputEditor` sole-frame block
+      label + unresolved block header via the shared helper
+- [x] Update NodePanel/editor/OutputEditor suites and all `InputSource` fixtures; confirm
+      `App.integration.test.tsx` reconciliation suite green
+
+### Phase 4: Browser evidence and verification
+
+- [x] Author `frontend/e2e/persistence/api-input-frame-alignment.spec.ts` (geometry +
+      downstream naming, per the graph-canvas Testing section)
+- [x] Full verification: frontend unit suite, lint/type gates, and the api-input e2e lane all
+      green; no perf-suite regression

--- a/docs/trip/plans/F_0.5.0_input-identity-convergence.plan.md
+++ b/docs/trip/plans/F_0.5.0_input-identity-convergence.plan.md
@@ -1,0 +1,270 @@
+# Input Identity Convergence Implementation Plan
+
+Target version: **0.5.0** (minor — the generated-code naming contract changes). This release
+**subsumes the unreleased 0.4.1 frame-identity work** already implemented on this branch
+(`docs/trip/plans/F_0.4.1_api-input-frame-identity.plan.md` is its foundation and ships with
+it); TRIP-3 bumps `pyproject.toml` 0.4.0 → 0.5.0 once, for the combined release.
+Ruling: Ralph, 2026-07-20 — *"what gets listed as the inputs into a node, that's the actual
+argument names to be used, no hidden names or mappings, just 1:1."* No migration machinery:
+the library has no users; this is a hard cutover.
+
+## Overview
+
+A node's listed inputs become its code argument names, 1:1, everywhere. An API Input frame
+emitted as `quotes` is the canvas handle id, the downstream input chip, the LiveSwitch mapping
+key, **and** the generated function parameter — callable as `quotes` with zero transformation
+(frame labels are now validated as Python identifiers). One shared derivation
+(`edge_input_name` backend, `edgeInputName` frontend mirror) feeds codegen, the executor,
+projection, the deploy pruner/scorer, and every panel surface, eliminating
+`Quote_Input_1_2`-style positional dedup, the silent edge-reorder rebind hazard, and the
+display-vs-executable split the 0.4.1 interim introduced. Name collisions become loud
+validation errors (drag-time toast, save-time `ParseError`) — never hidden suffixes.
+
+## Design
+
+The design lives in the component specs, updated on this branch
+(`git diff HEAD --stat -- docs/specs/` shows the deltas):
+
+- `docs/specs/execution-engine/` — the `edge_input_name` derivation (the keystone: frame label
+  verbatim for apiInput edges, sanitised source label otherwise), per-edge `source_names` in
+  edge order, uniform `{label: LazyFrame}` routing from one frame up, duplicate-input-name
+  `ConfigError`.
+- `docs/specs/codegen/` — parameters are the listed input names 1:1 (semantic, never
+  cosmetically deduplicated — the old rationale bullet is replaced with why that design was
+  retired); every apiInput connect emits `source_port` (sole frame included); per-target
+  duplicate input names are a `ParseError`.
+- `docs/specs/json-shredding/` — label invariant **B4** (`str.isidentifier()`, no keywords);
+  `load_v2_api_source` returns a dict for every eligible-frame count ≥1 (bare-frame
+  single-table case removed).
+- `docs/specs/frontend-graph-canvas/` — labelled handles from one frame up (null-id default
+  only for zero eligible frames); the two 0.4.1 frame-list helpers merge into
+  `apiInputFrameLabels`; `edgeInputName` mirror; identifier validation in `apiInputLabelIssue`;
+  drag-time input-name uniqueness in `connectionValidation`.
+- `docs/specs/frontend-node-editors/` — `InputSource.name` replaces the `varName`/
+  `displayLabel` pair (the split is retired, with rationale); LiveSwitch maps keyed by `name`
+  (two frames individually routable — the former NOTE'd limitation is resolved); atomic
+  rename migration of `input_scenario_map` keys and `inputMapping` values; ApiInputEditor
+  identifier validation; OutputEditor `framePortId` ≡ name by construction.
+- `docs/specs/pipeline-config/` — `config["inputs"]` records the per-edge input names.
+- `docs/specs/deploy/` — pruner live-branch matching consumes `edge_input_name`.
+- `docs/specs/submodels/` — a boundary-fed input is listed by the child node's sanitised label
+  (what flattened code binds), never the placeholder's label.
+
+## Files to Modify/Create
+
+Backend:
+
+1. `src/haute/_graph_utils.py` (modify) — `edge_input_name(edge, source_node)` + the pure
+   per-target duplicate detector `duplicate_input_names(names)` (returns duplicated names
+   each once in first-duplicate-occurrence order, `[]` when unique, never raises — callers
+   wrap in `ConfigError`/`ParseError`); `resolve_orig_source_names` becomes edge-derived (an
+   instance's original input names come from the original's incoming edges, not parent node
+   ids); consumed by items 2–8b.
+2. `src/haute/_execute_lazy.py` (modify) — build `src_names` per incoming edge via
+   `edge_input_name` (same edge-declaration order as frame binding); duplicate names raise
+   `ConfigError`; `_pick_source_frame` unchanged mechanics against now-uniform dict sources.
+3. `src/haute/_json_shred.py` (modify) — `load_v2_api_source` returns `{label: LazyFrame}`
+   from one eligible frame up; `infer_v2_schema_from_data` mints derived identifier labels
+   (root → `root`, innermost key via `derive_identifier_label`, symmetric path-join
+   qualification, numeric backstop) instead of raw table paths, so inferred output passes
+   `validate_v2_schema` unchanged.
+4. `src/haute/_api_input_schema.py` (modify) — invariant B4: labels must be ASCII
+   identifiers and not hard keywords (`ApiInputSchemaError` otherwise); B2 compares
+   casefolded parquet stems (a case-only pair like `Items`/`items` is rejected — it
+   would silently clobber one file on Windows/macOS); `derive_identifier_label(raw)`
+   for inference label minting.
+5. `src/haute/codegen.py` (modify) — per-edge input-name assembly with duplicate `ParseError`;
+   apiInput connect pairs always carry `source_port`.
+6. `src/haute/_codegen_builders.py` (modify) — `_build_params` consumes supplied per-edge
+   names; `_dedup_param_names` suffixing removed (duplicate = upstream validation failure,
+   asserted loud here).
+7. `src/haute/executor.py`, `src/haute/projection.py`, `src/haute/deploy/_pruner.py`,
+   `src/haute/deploy/_scorer.py` (modify; implementation outcome: only `projection.py` and
+   `deploy/_pruner.py` needed edits — `executor.py` and `_scorer.py` consume the per-edge
+   names transitively through the shared executor derivation, verified by the deploy-scorer
+   and execution-context tests) — liveSwitch live-branch **selection is per edge**
+   (matching `input_scenario_map` keys against each edge's `edge_input_name`, and
+   excluding/retaining individual edges — never whole `(source, target)` pairs or source
+   node ids — so `quotes=live, drivers=batch` from one apiInput keeps exactly the selected
+   edge); scorer/projection param naming consumes the same derivation.
+8. `src/haute/_builders.py` (modify; implementation outcome: no edits needed — the builders
+   receive `source_names` from `_build_funcs`, which now supplies the per-edge names, so the
+   pass-through was already generic).
+8a. `src/haute/pipeline.py` (modify) — the standalone `run()`/`score()` executor consults
+   `RegisteredEdge.source_port` via the shared `_pick_source_frame` selection before calling
+   each node function (a generated one-frame apiInput pipeline run standalone receives its
+   frame, not the dict). `score(df)`'s bare-frame seed is accepted for at most one distinct
+   connected port (zero-port source-only pipelines keep bare-frame semantics); two or more
+   distinct connected ports require a `{frame_label: DataFrame}` seed matching the connected
+   ports exactly, else `ExecutionError` naming the missing/unknown ports — never a silent
+   fan-out.
+8b. `src/haute/execution.py`, `src/haute/chunking.py` (modify) — the linear/optimiser and
+   chunked execution entry points pass incoming-edge metadata into `_build_node_fn` so every
+   production path derives the same per-edge names.
+
+Frontend:
+
+9. `frontend/src/utils/apiInputPorts.ts` (modify) — merge `apiInputEmitPortLabels`/
+   `apiInputVisibleFrameLabels` into `apiInputFrameLabels`; `edgeInputName(edge, sourceNode,
+   submodels)`; identifier/keyword rule in `apiInputLabelIssue`; `validSourceHandleKeys` for
+   the ≥1-labelled world.
+10. `frontend/src/utils/connectionValidation.ts` (modify) — input-name uniqueness rule +
+    null-API-handle rejection in every gesture direction (validator-level twin of the
+    non-connectable zero-frame handle).
+11. `frontend/src/nodes/PipelineNode.tsx` (modify) — labelled row handles from one frame up;
+    the zero-frame default handle rendered **non-connectable in both directions**
+    (`isConnectable` false — `ConnectionMode.Loose` normalises reverse drags into ordinary
+    edges, so start-only is insufficient); single collision-safe `frameLabels` signature.
+12. `frontend/src/panels/editors/_shared.tsx` (modify) — `InputSource.name` (required)
+    replacing `varName`/`displayLabel`; chips render `name`.
+13. `frontend/src/panels/NodePanel.tsx` (modify) — `name` derivation incl. submodel `out__`
+    resolution; staleness signature over the derived name + resolution state; instance
+    input-mapping UI consumes `name`.
+14. `frontend/src/panels/editors/LiveSwitchEditor.tsx` (modify) — map keyed by `name`.
+15. `frontend/src/App.tsx` (modify) — the frame-rename commit extends atomically to
+    `input_scenario_map` keys and instance `inputMapping` **values** on affected downstream
+    nodes, and `inputMapping` **keys** on every node whose `instanceOf` references an affected
+    original (the original's input names are the mapping keys). The commit is
+    **compute-preflight-commit**: the complete tentative result (config, edges, mappings) is
+    computed before any store mutation; a duplicate input name on any affected target rejects
+    the entire commit via the new `OnUpdateConfig` result channel
+    (`{ ok: false, error }` — surfaced inline by the ApiInputEditor, defined in `_shared.tsx`)
+    with zero mutation, and success lands as one undo entry as today. Reconciliation prunes
+    null-handle apiInput edges (`validSourceHandleKeys` never contains the empty key for an
+    apiInput).
+16. `frontend/src/panels/editors/OutputEditor.tsx` (modify) — `framePortId`/label via
+    `edgeInputName` (now identical strings).
+17. `frontend/src/panels/editors/ApiInputEditor.tsx` (modify) — inline identifier validation
+    surface (shared `apiInputLabelIssue` messages) and inline rename-preflight error surfacing
+    via the `OnUpdateConfig` commit result.
+17a. `frontend/src/components/ReadOnlyNodeConfig.tsx` (modify) — the inert inspector's no-op
+    `OnUpdateConfig` callback migrates to the new result type, returning `{ ok: true }`
+    (every production supplier of the callback compiles against the new contract).
+18. `frontend/e2e/persistence/api-input-frame-alignment.spec.ts` (modify) — sole-frame edges
+    now labelled; downstream chips assert the exact argument names; generated `main.py`
+    signature assertions.
+19. `pyproject.toml` (modify, at release) — 0.4.0 → 0.5.0 (TRIP-3; supersedes the 0.4.1 bump).
+
+Also verify during implementation: the `haute init` starter scaffold emits pipelines under the
+new naming (it is produced by the same codegen path — confirm, don't fork), and update
+`docs/roadmap/api-input-ui-issues.md` status to cover both releases.
+
+## Performance & Cost Impact
+
+`edge_input_name` is a per-edge string derivation on paths that already iterate edges —
+negligible. `load_v2_api_source`'s uniform dict adds one dict wrapper for single-frame sources
+(scan-lazy frames; no data cost). No perf-suite thresholds expected to move; the executor's
+binding mechanics (positional, edge order) are unchanged.
+
+## Backward Compatibility
+
+Deliberately none — a hard cutover per Ralph's ruling (no users). Behavioural changes:
+generated signatures rename to frame labels (existing bodies referencing old parameter names
+fail loudly at run/preview with Python's `NameError`, and the chips now show the correct
+names to fix them); single-frame apiInput edges persist `source_port`; frame labels that
+are not ASCII identifiers or are hard keywords are rejected at validation (`422`/inline
+editor error) instead of accepted — including previously-accepted Unicode identifier
+labels — and inferred schemas mint derived identifier labels instead of path strings;
+`input_scenario_map`/`inputMapping` entries keyed by old names fail the existing loud
+stale-key validation until re-selected (or are migrated by the rename pass going forward).
+Parsing is unaffected: the parser reads signatures as-is, so any file the new codegen emits
+round-trips, and old files still parse — beyond the validation breaks above (non-identifier
+labels, stale mapping keys), they break loudly in two additional generation-related ways:
+(a) on regeneration, a body referencing a parameter name the new signature no longer
+declares fails with `NameError`; (b) at save/codegen, a legacy bare apiInput connect (no
+`source_port`) fails with the named port-less-edge `ParseError` until the edge is re-drawn
+from a labelled handle.
+
+## Test Impact
+
+- **Test-first (TDD) batches** — silent-wrongness classes: (a) `edge_input_name` +
+  per-target duplicate detection (backend) and `edgeInputName` (frontend mirror — including
+  submodel `out__` resolution); (b) the reorder-robustness pin: delete + reconnect apiInput
+  edges in reverse order and assert every parameter still binds its own frame; (c)
+  `load_v2_api_source`'s uniform dict shape; (d) B4 ASCII label validation and casefold-B2
+  case-only collision rejection (backend + frontend mirror parity; valid Unicode
+  identifiers rejected); (e) inference label derivation (`derive_identifier_label` repairs, root/innermost-key/qualification/backstop,
+  infer→validate closure).
+- **Backend suites**: `test_codegen*.py` (frame-named params, always-`source_port`, duplicate
+  `ParseError`, the port-less-apiInput-edge `ParseError`, roundtrip fixpoint regenerated),
+  `test_load_v2_api_source.py`, `test_api_input_schema*`, the `_json_shred` inference
+  suites (derived identifier labels, infer→validate closure),
+  `test_execute_lazy*.py`/`test_port_aware_executor.py` (per-edge names, uniform dict
+  routing), `tests/test_pipeline.py` (standalone `run()` one/many-frame port selection, plus
+  the full `score()` seed matrix: bare frame accepted at zero ports — source-only — and one
+  port; bare frame rejected at 2+ ports; exact one-key dict accepted at one port; dict
+  rejected with missing keys, with unknown extra keys, and against a zero-port source — each
+  rejection an `ExecutionError` naming the ports), chunked/linear entry-point naming
+  (`test_chunking*`/optimiser execution suites), liveSwitch suites
+  (`test_bug_regressions.py`, `test_builder_edge_cases.py`, pruner tests — per-EDGE
+  live-branch selection incl. one apiInput with `quotes=live, drivers=batch` keeping exactly
+  the selected edge), instance-mapping suites (edge-derived original names; a two-frame
+  original's rename migrating instance `inputMapping` keys),
+  `test_codegen_execution_equivalence.py`.
+- **Frontend suites**: the 0.4.1 suites migrate again (`InputSource.name`; sole-frame labelled
+  handles; merged helper; every `OnUpdateConfig` mock/fixture returns the new commit-result
+  type, incl. `ReadOnlyNodeConfig`'s no-op and the ComparisonInspector suites) —
+  `apiInputPorts.test.ts`, `PipelineNode.test.tsx`,
+  `ApiInputHandles.test.tsx`, `apiInputBundle3cContract.test.tsx`, `NodePanel.test.tsx`,
+  `_shared.test.tsx`, LiveSwitch/OutputEditor suites, `connectionValidation.test.ts`,
+  `App.integration.test.tsx` (rename pass now also migrates ISM/inputMapping), and every
+  `InputSource` fixture site.
+- **Browser**: `api-input-frame-alignment.spec.ts` updated per the graph-canvas Testing
+  section (labelled sole frame, argument-name chips, `main.py` signature content); the
+  render-gate / v2-native persistence gates must stay green (their fixture labels are already
+  identifiers).
+
+## To-dos
+
+### Phase 1: Shared derivation + validation (backend, test-first)
+
+- [x] `edge_input_name` + `duplicate_input_names` per-target duplicate detection in
+      `_graph_utils.py`
+- [x] B4 ASCII-identifier/hard-keyword label validation in `_api_input_schema.py`
+- [x] Inference identifier labels: `derive_identifier_label` +
+      `infer_v2_schema_from_data` labelling (root/innermost-key/qualification/backstop;
+      inferred output passes `validate_v2_schema`)
+
+### Phase 2: Engine + codegen convergence (backend)
+
+- [x] `load_v2_api_source` uniform dict from ≥1 eligible frame (moved from Phase 1: it is
+      inseparable from the executor/codegen cutover below — alone it leaves the tree red)
+- [x] Executor per-edge `source_names` (+ `_builders.py` call sites) with duplicate
+      `ConfigError`; `execution.py`/`chunking.py` entry points pass edge metadata;
+      `resolve_orig_source_names` edge-derived; reorder-robustness pin green
+- [x] Standalone `Pipeline.run()`/`score()` port-aware frame selection (`pipeline.py` via
+      shared `_pick_source_frame`)
+- [x] Codegen per-edge parameters, always-`source_port` apiInput connects, duplicate and
+      port-less-edge `ParseError`s; `_dedup_param_names` suffixing removed; roundtrip
+      fixpoint green
+- [x] liveSwitch live-branch selection per edge (ISM matching on `edge_input_name`;
+      projection + deploy pruner exclude/retain individual edges) + scorer naming
+
+### Phase 3: Frontend convergence
+
+- [x] `apiInputFrameLabels` merge + `edgeInputName` + identifier validation +
+      `validSourceHandleKeys`/reconciliation for the ≥1-labelled world
+- [x] `PipelineNode` labelled handles from one frame up; zero-frame default handle
+      non-connectable; single signature
+- [x] `InputSource.name` + NodePanel derivation/signature + chips + LiveSwitch + OutputEditor
+      + ApiInputEditor validation surface + fixture migration
+- [x] Drag-time input-name uniqueness + null-API-handle rejection (`connectionValidation`),
+      tested in both drag directions under `ConnectionMode.Loose`
+- [x] Rename collision preflight (reject the whole commit, nothing mutates) with the
+      unchanged-state test
+- [x] Atomic rename pass extension in `App.onUpdateNode` (ISM keys, `inputMapping` values on
+      downstream nodes, and `inputMapping` keys on instances of an affected original);
+      null-handle apiInput edges pruned by reconciliation
+
+### Phase 4: End-to-end evidence and verification
+
+- [x] Update `api-input-frame-alignment.spec.ts` (labelled sole frame, argument-name chips,
+      generated-signature assertions); persistence gates green (browser run: 9/9 passed,
+      incl. sole-frame labelled edge + exact argument name + generated signature across
+      save/reload; smoke lane 4/4 both browsers)
+- [x] `haute init` scaffold verified under new naming (scaffold parses, regenerates with
+      edge-derived signatures `enriched(raw_rows)`/`priced(enriched)`, and its starter test
+      suite passes); roadmap doc status updated to Resolved
+- [x] Full verification: backend lint/type/affected pytest (ruff + mypy clean; 1055
+      affected tests passed incl. the deploy closure), frontend lint/type/units (eslint +
+      tsc zero errors; 1033 units passed), e2e lane green (alignment 9/9, smoke 4/4)

--- a/frontend/e2e/persistence/api-input-frame-alignment.spec.ts
+++ b/frontend/e2e/persistence/api-input-frame-alignment.spec.ts
@@ -1,0 +1,647 @@
+/**
+ * Real-browser acceptance evidence for API-input frame identity.
+ *
+ * JSDOM can prove that a row contains its Handle, but only a browser can
+ * prove their rendered centres coincide.  These tests therefore measure the
+ * live boxes and separately pin the persisted edge identity and downstream
+ * frame names that make the geometry meaningful to a user.
+ */
+import { readFileSync, writeFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { expect, test, type Locator, type Page } from "@playwright/test"
+
+import { e2eProjectRoot, resetE2eProject } from "../projectIsolation"
+
+const quotesConfigPath = resolve(
+  e2eProjectRoot,
+  "rating",
+  "config",
+  "quote_input",
+  "quotes.json",
+)
+const pipelinePath = resolve(e2eProjectRoot, "rating", "main.py")
+
+const API_NODE_ID = "quotes"
+const API_NODE_LABEL = "quotes"
+const DOWNSTREAM_NODE_ID = "enriched"
+const MAX_CENTRE_DELTA_PX = 3
+const LONG_FRAME_LABEL = "policyholders_with_exceptionally_long_frame_identity_2026"
+const TRACE_VALUE = "trace-frame-value"
+
+type GraphEdge = {
+  id: string
+  source: string
+  target: string
+  sourceHandle?: string | null
+}
+
+type GraphEnvelope = {
+  edges?: GraphEdge[]
+  graph?: { edges?: GraphEdge[] }
+}
+
+type FrameIdentity = {
+  label: string
+  sourceHandle: string
+}
+
+function selectedColumn(index: number) {
+  return {
+    name: `value_${index}`,
+    path: `$[:].value_${index}`,
+    type: "str",
+    status: "Inferred",
+    selected: true,
+    levels: null,
+  }
+}
+
+function emittedTable(label: string, index: number) {
+  return {
+    path: index === 0 ? "$[:]" : `$[:].frame_${index}[:]`,
+    label,
+    displayPath: null,
+    emit: true,
+    row_id_column: null,
+    columns: [selectedColumn(index)],
+  }
+}
+
+function frameLabels(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `frame_${index + 1}`)
+}
+
+function seedFrames(labels: readonly string[]): void {
+  const config = {
+    path: "data/quotes/sample_quote.json",
+    contract: "opaque",
+    tables: labels.map(emittedTable),
+  }
+  writeFileSync(quotesConfigPath, `${JSON.stringify(config, null, 2)}\n`, "utf8")
+}
+
+async function openCanvas(page: Page): Promise<void> {
+  await page.goto("/")
+  await expect(
+    page.getByRole("toolbar", { name: /pipeline toolbar/i }),
+  ).toBeVisible()
+  await expect(page.getByTestId(`rf__node-${API_NODE_ID}`)).toBeVisible()
+}
+
+async function ensureFullDetail(page: Page, firstLabel: string): Promise<void> {
+  const firstRow = page.getByTestId(`api-input-frame-row-${firstLabel}`)
+  // Drive to the maximum zoom instead of stopping at the first transient row:
+  // rendering the rows resizes the node and React Flow may re-fit while zooming.
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    await page.getByRole("button", { name: "Zoom in" }).click()
+    await page.waitForTimeout(50)
+  }
+  await expect(
+    firstRow,
+    `full-detail frame rows become visible for ${firstLabel}`,
+  ).toBeVisible()
+}
+
+async function expectFrameRowsAligned(
+  page: Page,
+  labels: readonly string[],
+): Promise<void> {
+  const node = page.getByTestId(`node-${API_NODE_LABEL}`)
+  await expect(node.getByTestId(/^api-input-frame-row-/)).toHaveCount(labels.length)
+
+  for (const [index, label] of labels.entries()) {
+    const row = node.getByTestId(`api-input-frame-row-${label}`)
+    const name = row.getByTestId(`api-input-body-label-${label}`)
+    const handle = row.getByTestId(
+      `output-connector[${index}]:${API_NODE_LABEL}`,
+    )
+
+    await expect(name).toHaveText(label)
+    await expect(name).toHaveAttribute("title", label)
+    await expect(
+      handle,
+      `frame ${label} uses its argument name as the handle id`,
+    ).toHaveAttribute("data-handleid", label)
+
+    const [rowBox, handleBox] = await Promise.all([
+      row.boundingBox(),
+      handle.boundingBox(),
+    ])
+    expect(rowBox, `frame row ${label} has measurable geometry`).not.toBeNull()
+    expect(handleBox, `source handle ${label} has measurable geometry`).not.toBeNull()
+    if (rowBox === null || handleBox === null) {
+      throw new Error(`Could not measure frame row/handle geometry for ${label}`)
+    }
+
+    const rowCentre = rowBox.y + rowBox.height / 2
+    const handleCentre = handleBox.y + handleBox.height / 2
+    expect(
+      Math.abs(rowCentre - handleCentre),
+      `${label} row and handle vertical centres`,
+    ).toBeLessThanOrEqual(MAX_CENTRE_DELTA_PX)
+  }
+}
+
+function previewResponse(nodeId: string, withWarning = false): string {
+  return JSON.stringify({
+    status: "ok",
+    node_id: nodeId,
+    row_count: 1,
+    column_count: 1,
+    columns: [{ name: "quote_id", dtype: "Utf8" }],
+    available_columns: [{ name: "quote_id", dtype: "Utf8" }],
+    preview: [{ quote_id: TRACE_VALUE }],
+    preview_row_count: 1,
+    preview_row_limit: 1,
+    preview_truncated: false,
+    error: null,
+    timings: [],
+    memory: [],
+    schema_warnings: withWarning
+      ? [{ column: "quote_id", status: "missing downstream" }]
+      : [],
+    node_statuses: { [nodeId]: "ok" },
+  })
+}
+
+async function installPreviewRoute(page: Page, withWarning = false): Promise<void> {
+  await page.route("**/api/pipeline/preview", async (route) => {
+    const body = route.request().postDataJSON() as { node_id?: unknown }
+    if (typeof body.node_id !== "string" || body.node_id.length === 0) {
+      throw new Error(`Expected preview node_id, received ${String(body.node_id)}`)
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: previewResponse(body.node_id, withWarning),
+    })
+  })
+}
+
+async function installTraceRoute(page: Page): Promise<void> {
+  await page.route("**/api/pipeline/trace", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "ok",
+        trace: {
+          target_node_id: API_NODE_ID,
+          row_index: 0,
+          column: "quote_id",
+          output_value: TRACE_VALUE,
+          row_id_column: null,
+          row_id_value: null,
+          total_nodes_in_pipeline: 1,
+          nodes_in_trace: 1,
+          execution_ms: 1,
+          waterfall: null,
+          steps: [
+            {
+              node_id: API_NODE_ID,
+              node_name: API_NODE_LABEL,
+              node_type: "apiInput",
+              schema_diff: {
+                columns_added: ["quote_id"],
+                columns_removed: [],
+                columns_modified: [],
+                columns_passed: [],
+              },
+              input_values: {},
+              output_values: { quote_id: TRACE_VALUE },
+              column_relevant: true,
+              execution_ms: 1,
+            },
+          ],
+        },
+      }),
+    })
+  })
+}
+
+function frameEdges(envelope: GraphEnvelope): GraphEdge[] {
+  const edges = envelope.graph?.edges ?? envelope.edges ?? []
+  return edges.filter(
+    (edge) => edge.source === API_NODE_ID && edge.target === DOWNSTREAM_NODE_ID,
+  )
+}
+
+function sourceHandles(envelope: GraphEnvelope): (string | null | undefined)[] {
+  return frameEdges(envelope)
+    .map((edge) => edge.sourceHandle)
+    .sort((left, right) => String(left).localeCompare(String(right)))
+}
+
+function expectGeneratedInputIdentity(
+  labels: readonly string[],
+  absentLabels: readonly string[] = [],
+): void {
+  const source = readFileSync(pipelinePath, "utf8")
+  const signature = source.match(/def\s+enriched\s*\(([\s\S]*?)\)\s*->/)
+  expect(signature, "generated main.py contains the enriched signature").not.toBeNull()
+  if (signature === null) {
+    throw new Error("Generated main.py has no enriched function signature")
+  }
+
+  const parameterNames = signature[1]
+    .split(",")
+    .map((parameter) => parameter.trim().split(":", 1)[0])
+  expect(
+    parameterNames,
+    "generated arguments preserve edge-derived names one-to-one and in edge order",
+  ).toEqual(["raw_rows", ...labels])
+  const expectedDefinition = `def enriched(${["raw_rows", ...labels]
+    .map((name) => `${name}: pl.LazyFrame`)
+    .join(", ")}) -> pl.LazyFrame:`
+  expect(source, "generated main.py exposes the exact executable signature").toContain(
+    expectedDefinition,
+  )
+
+  for (const label of labels) {
+    expect(source, `generated connect persists source_port ${label}`).toMatch(
+      new RegExp(`source_port=["']${label}["']`),
+    )
+  }
+  for (const absentLabel of absentLabels) {
+    expect(source, `stale source_port ${absentLabel} is absent`).not.toMatch(
+      new RegExp(`source_port=["']${absentLabel}["']`),
+    )
+  }
+}
+
+function namedFrameIdentities(labels: readonly string[]): FrameIdentity[] {
+  return labels.map((label) => ({ label, sourceHandle: label }))
+}
+
+function renameFrameHandle(
+  envelope: GraphEnvelope,
+  oldHandle: string,
+  newHandle: string,
+): GraphEnvelope {
+  const renamedEdges = (envelope.graph?.edges ?? envelope.edges ?? []).map((edge) =>
+    edge.source === API_NODE_ID &&
+    edge.target === DOWNSTREAM_NODE_ID &&
+    edge.sourceHandle === oldHandle
+      ? { ...edge, sourceHandle: newHandle }
+      : edge,
+  )
+  return envelope.graph === undefined
+    ? { ...envelope, edges: renamedEdges }
+    : { ...envelope, graph: { ...envelope.graph, edges: renamedEdges } }
+}
+
+async function extendStarterGraphWithFrameEdges(
+  page: Page,
+  sessionToken: string | undefined,
+  sourceHandles: readonly string[],
+): Promise<void> {
+  const saveStatus = await page.evaluate(
+    async ({ token, handles, source, target }) => {
+      const headers: Record<string, string> = { "Content-Type": "application/json" }
+      if (token) headers["x-haute-session-token"] = token
+      const graphResponse = await fetch("/api/pipeline", { headers })
+      if (!graphResponse.ok) {
+        throw new Error(`GET /api/pipeline ${graphResponse.status}`)
+      }
+      const graph = await graphResponse.json()
+      graph.edges = graph.edges.filter(
+        (edge: { source?: string; target?: string }) =>
+          edge.source !== source || edge.target !== target,
+      )
+      graph.edges.push(
+        ...handles.map((sourceHandle: string, index: number) => ({
+          id: `e_${source}_${target}_frame_${index}`,
+          source,
+          target,
+          sourceHandle,
+          targetHandle: null,
+        })),
+      )
+
+      const saveResponse = await fetch("/api/pipeline/save", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          name: graph.pipeline_name ?? "main",
+          description: graph.pipeline_description ?? "",
+          source_file: graph.source_file,
+          preamble: graph.preamble ?? "",
+          graph: { nodes: graph.nodes, edges: graph.edges },
+        }),
+      })
+      if (!saveResponse.ok) {
+        throw new Error(`POST /api/pipeline/save ${saveResponse.status}`)
+      }
+      return (await saveResponse.json()).status as string
+    },
+    {
+      token: sessionToken,
+      handles: sourceHandles,
+      source: API_NODE_ID,
+      target: DOWNSTREAM_NODE_ID,
+    },
+  )
+  expect(saveStatus).toBe("saved")
+}
+
+async function reloadAndCaptureGraph(page: Page): Promise<GraphEnvelope> {
+  const graphResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      /\/api\/pipeline(?:\?|$)/.test(response.url()),
+  )
+  await page.reload()
+  const response = await graphResponse
+  expect(response.status(), "pipeline reload succeeds").toBe(200)
+  await expect(
+    page.getByRole("toolbar", { name: /pipeline toolbar/i }),
+  ).toBeVisible()
+  return (await response.json()) as GraphEnvelope
+}
+
+async function downstreamFrameChips(page: Page): Promise<Locator> {
+  // Full-detail zoom keeps the apiInput centred and may place its distant
+  // downstream node outside the viewport. Dispatching the same DOM click
+  // selects that rendered node without changing the geometry under test.
+  await page.getByTestId(`rf__node-${DOWNSTREAM_NODE_ID}`).dispatchEvent("click")
+  const panel = page.getByTestId("node-panel")
+  await expect(panel).toBeVisible()
+  return panel.locator('[data-testid^="input-source-"]')
+}
+
+async function expectDownstreamFrameNames(
+  page: Page,
+  envelope: GraphEnvelope,
+  frames: readonly FrameIdentity[],
+  absentLabels: readonly string[] = [],
+): Promise<void> {
+  const chips = await downstreamFrameChips(page)
+  const edges = frameEdges(envelope)
+  expect(edges, "one persisted edge exists for every expected frame").toHaveLength(
+    frames.length,
+  )
+
+  for (const frame of frames) {
+    const edge = edges.find(
+      (candidate) => (candidate.sourceHandle ?? null) === frame.sourceHandle,
+    )
+    expect(edge, `edge exists for frame ${frame.label}`).toBeDefined()
+    if (edge === undefined) {
+      throw new Error(`No edge found for frame ${frame.label}`)
+    }
+    await expect(page.getByTestId(`input-source-${edge.id}`)).toHaveText(frame.label)
+  }
+
+  for (const absentLabel of absentLabels) {
+    await expect(
+      chips.filter({ hasText: absentLabel }),
+      `stale downstream frame name ${absentLabel} is removed`,
+    ).toHaveCount(0)
+  }
+}
+
+async function expectEdgesAttachedToFrameHandles(
+  page: Page,
+  envelope: GraphEnvelope,
+  frames: readonly FrameIdentity[],
+): Promise<void> {
+  const edges = frameEdges(envelope)
+  expect(edges, "one rendered edge exists for every expected frame").toHaveLength(
+    frames.length,
+  )
+
+  for (const [index, frame] of frames.entries()) {
+    const edge = edges.find(
+      (candidate) => (candidate.sourceHandle ?? null) === frame.sourceHandle,
+    )
+    expect(edge, `edge exists for frame ${frame.label}`).toBeDefined()
+    if (edge === undefined) {
+      throw new Error(`No edge found for frame ${frame.label}`)
+    }
+
+    const edgeElement = page.getByTestId(`rf__edge-${edge.id}`)
+    const edgePath = edgeElement.locator("path.react-flow__edge-path").first()
+    const handle = page.getByTestId(
+      `output-connector[${index}]:${API_NODE_LABEL}`,
+    )
+    await expect(edgeElement).toBeVisible()
+    await expect(edgePath).toBeVisible()
+
+    const [pathStart, handleBox] = await Promise.all([
+      edgePath.evaluate((path: SVGPathElement) => {
+        const start = path.getPointAtLength(0)
+        const matrix = path.getScreenCTM()
+        if (matrix === null) return null
+        const screenStart = new DOMPoint(start.x, start.y).matrixTransform(matrix)
+        return { x: screenStart.x, y: screenStart.y }
+      }),
+      handle.boundingBox(),
+    ])
+    expect(pathStart, `edge ${edge.id} has measurable browser geometry`).not.toBeNull()
+    expect(handleBox, `handle ${frame.label} has measurable browser geometry`).not.toBeNull()
+    if (pathStart === null || handleBox === null) {
+      throw new Error(`Could not measure edge/handle attachment for ${frame.label}`)
+    }
+
+    expect(
+      Math.abs(pathStart.x - (handleBox.x + handleBox.width / 2)),
+      `${frame.label} edge begins at its handle's horizontal centre`,
+    ).toBeLessThanOrEqual(MAX_CENTRE_DELTA_PX)
+    expect(
+      Math.abs(pathStart.y - (handleBox.y + handleBox.height / 2)),
+      `${frame.label} edge begins at its handle's vertical centre`,
+    ).toBeLessThanOrEqual(MAX_CENTRE_DELTA_PX)
+  }
+}
+
+test.describe.configure({ mode: "serial" })
+
+test.describe("apiInput frame-row alignment and identity", () => {
+  test.beforeEach(() => {
+    resetE2eProject()
+  })
+
+  for (const count of [1, 2, 3, 8]) {
+    test(`${count} emitted frame${count === 1 ? "" : "s"} align each row with its handle`, async ({
+      page,
+    }) => {
+      const labels = frameLabels(count)
+      seedFrames(labels)
+
+      await openCanvas(page)
+      await ensureFullDetail(page, labels[0])
+      await expectFrameRowsAligned(page, labels)
+    })
+  }
+
+  test("status and warning dots coexist without displacing the frame handles", async ({
+    page,
+  }) => {
+    const labels = frameLabels(3)
+    seedFrames(labels)
+    await installPreviewRoute(page, true)
+    await openCanvas(page)
+    await ensureFullDetail(page, labels[0])
+
+    const previewResponsePromise = page.waitForResponse("**/api/pipeline/preview")
+    await page.getByTestId(`rf__node-${API_NODE_ID}`).click()
+    await previewResponsePromise
+
+    const node = page.getByTestId(`node-${API_NODE_LABEL}`)
+    await expect(node.getByLabel("Node ok")).toBeVisible()
+    await expect(node.getByLabel("Node has schema warnings")).toBeVisible()
+    await expectFrameRowsAligned(page, labels)
+  })
+
+  test("a trace-active value pill coexists above still-aligned frame rows", async ({
+    page,
+  }) => {
+    const labels = frameLabels(3)
+    seedFrames(labels)
+    await installPreviewRoute(page)
+    await installTraceRoute(page)
+    await openCanvas(page)
+    await ensureFullDetail(page, labels[0])
+
+    await page.getByTestId(`rf__node-${API_NODE_ID}`).click()
+    const previewTable = page.getByRole("table").first()
+    await expect(previewTable.getByText("quote_id", { exact: true })).toBeVisible()
+    const traceResponsePromise = page.waitForResponse("**/api/pipeline/trace")
+    await previewTable.getByRole("cell", { name: TRACE_VALUE }).click()
+    await traceResponsePromise
+
+    const node = page.getByTestId(`node-${API_NODE_LABEL}`)
+    await expect(node).toHaveAttribute("aria-label", /trace active/)
+    await expect(node.getByText(TRACE_VALUE, { exact: true })).toBeVisible()
+    await expectFrameRowsAligned(page, labels)
+  })
+
+  test("a long raw frame label truncates with its tooltip while its handle remains aligned", async ({
+    page,
+  }) => {
+    expect(LONG_FRAME_LABEL.length).toBeGreaterThanOrEqual(40)
+    const labels = [LONG_FRAME_LABEL, "short_frame"]
+    seedFrames(labels)
+
+    await openCanvas(page)
+    await ensureFullDetail(page, labels[0])
+    const longName = page.getByTestId(`api-input-body-label-${LONG_FRAME_LABEL}`)
+    await expect(longName).toHaveAttribute("title", LONG_FRAME_LABEL)
+    expect(
+      await longName.evaluate((element) => element.scrollWidth > element.clientWidth),
+      "the long label is actually truncated in the rendered row",
+    ).toBe(true)
+    await expectFrameRowsAligned(page, labels)
+  })
+
+  test("frame-bound edges and downstream names survive save/reload and an in-place rename", async ({
+    page,
+  }) => {
+    const originalLabels = ["quotes", "drivers"]
+    const renamedLabels = ["policy_records", "drivers"]
+    const originalFrames = namedFrameIdentities(originalLabels)
+    const renamedFrames = namedFrameIdentities(renamedLabels)
+    seedFrames(originalLabels)
+    await installPreviewRoute(page)
+
+    const firstApiRequest = page.waitForRequest((request) =>
+      /\/api\/pipeline(?:\?|$)/.test(request.url()),
+    )
+    await openCanvas(page)
+    const sessionToken = (await firstApiRequest).headers()["x-haute-session-token"]
+    await extendStarterGraphWithFrameEdges(page, sessionToken, originalLabels)
+
+    const initiallyReloadedGraph = await reloadAndCaptureGraph(page)
+    expect(sourceHandles(initiallyReloadedGraph)).toEqual([...originalLabels].sort())
+    expectGeneratedInputIdentity(originalLabels)
+    await ensureFullDetail(page, originalLabels[0])
+    await expectFrameRowsAligned(page, originalLabels)
+    await expectEdgesAttachedToFrameHandles(
+      page,
+      initiallyReloadedGraph,
+      originalFrames,
+    )
+    await expectDownstreamFrameNames(page, initiallyReloadedGraph, originalFrames)
+
+    await page.getByTestId(`rf__node-${API_NODE_ID}`).click()
+    const firstLabel = page.getByTestId("api-input-table-0-label")
+    await firstLabel.fill(renamedLabels[0])
+    await firstLabel.press("Tab")
+    await expect(
+      page.getByTestId(`api-input-frame-row-${renamedLabels[0]}`),
+    ).toBeVisible()
+    await expectFrameRowsAligned(page, renamedLabels)
+    const renamedInMemoryGraph = renameFrameHandle(
+      initiallyReloadedGraph,
+      originalLabels[0],
+      renamedLabels[0],
+    )
+    await expectEdgesAttachedToFrameHandles(page, renamedInMemoryGraph, renamedFrames)
+    await expectDownstreamFrameNames(
+      page,
+      renamedInMemoryGraph,
+      renamedFrames,
+      [originalLabels[0]],
+    )
+
+    const saveRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" && request.url().includes("/api/pipeline/save"),
+    )
+    const saveResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/api/pipeline/save"),
+    )
+    await page.getByRole("button", { name: "Save", exact: true }).click()
+    const [saveRequest, saveResponse] = await Promise.all([
+      saveRequestPromise,
+      saveResponsePromise,
+    ])
+    expect(saveResponse.status(), "pipeline save succeeds").toBe(200)
+    const savedGraph = saveRequest.postDataJSON() as GraphEnvelope
+    expect(sourceHandles(savedGraph)).toEqual([...renamedLabels].sort())
+    expectGeneratedInputIdentity(renamedLabels, [originalLabels[0]])
+
+    const graphAfterRenameReload = await reloadAndCaptureGraph(page)
+    expect(sourceHandles(graphAfterRenameReload)).toEqual([...renamedLabels].sort())
+    await ensureFullDetail(page, renamedLabels[0])
+    await expectFrameRowsAligned(page, renamedLabels)
+    await expectEdgesAttachedToFrameHandles(
+      page,
+      graphAfterRenameReload,
+      renamedFrames,
+    )
+    await expectDownstreamFrameNames(
+      page,
+      graphAfterRenameReload,
+      renamedFrames,
+      [originalLabels[0]],
+    )
+  })
+
+  test("a sole frame keeps its labelled edge, exact argument name, and generated signature across save/reload", async ({
+    page,
+  }) => {
+    const labels = ["single_frame"]
+    const frames = namedFrameIdentities(labels)
+    seedFrames(labels)
+    await installPreviewRoute(page)
+
+    const firstApiRequest = page.waitForRequest((request) =>
+      /\/api\/pipeline(?:\?|$)/.test(request.url()),
+    )
+    await openCanvas(page)
+    const sessionToken = (await firstApiRequest).headers()["x-haute-session-token"]
+    await extendStarterGraphWithFrameEdges(page, sessionToken, labels)
+
+    const reloadedGraph = await reloadAndCaptureGraph(page)
+    expect(sourceHandles(reloadedGraph)).toEqual(labels)
+    expectGeneratedInputIdentity(labels, [API_NODE_LABEL])
+    await ensureFullDetail(page, labels[0])
+    await expectFrameRowsAligned(page, labels)
+    await expectEdgesAttachedToFrameHandles(page, reloadedGraph, frames)
+    await expectDownstreamFrameNames(page, reloadedGraph, frames, [API_NODE_LABEL])
+  })
+})

--- a/frontend/e2e/persistence/api-input-v2-native.spec.ts
+++ b/frontend/e2e/persistence/api-input-v2-native.spec.ts
@@ -144,6 +144,13 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
     await test.step("6. Preview works before optional Cache as Parquet prewarm", async () => {
       // Runtime must be usable immediately after schema inference: with no
       // parquet yet, the backend shreds the JSON directly for this preview.
+      // Request the preview after the inferred schema has been committed to
+      // graph state; the preview that ran when the node was first selected
+      // intentionally predates inference and cannot represent this schema.
+      const previewResponsePromise = page.waitForResponse("**/api/pipeline/preview")
+      await page.getByTitle("Refresh preview").click()
+      const previewResponse = await previewResponsePromise
+      expect(previewResponse.status(), "uncached preview responds 200").toBe(200)
       await expect(
         page.getByTestId("data-preview-table"),
         "bottom preview renders before any cache build",

--- a/frontend/e2e/persistence/api-input-v2-native.spec.ts
+++ b/frontend/e2e/persistence/api-input-v2-native.spec.ts
@@ -53,7 +53,7 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
     )
   })
 
-  test("Infer Tables → Cache → Preview round-trips through disk and reload", async ({
+  test("Infer Tables → Preview → optional Cache round-trips through disk and reload", async ({
     page,
   }) => {
     const consoleErrors: string[] = []
@@ -92,7 +92,7 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
       // Path is already set by the harness fixture (v2-native starting
       // state). File-pick → preview-auto-load gap is covered by a
       // separate test (TODO) so this test stays focused on Infer →
-      // Cache → Preview wiring.
+      // direct Preview → optional Cache wiring.
       //
       // Click Infer Tables.
       const inferBtn = page.locator('[data-testid="api-input-infer-btn"]')
@@ -141,9 +141,16 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
       ).toEqual([])
     })
 
-    await test.step("6. Cache as Parquet succeeds; bottom preview is not stale", async () => {
+    await test.step("6. Preview works before optional Cache as Parquet prewarm", async () => {
+      // Runtime must be usable immediately after schema inference: with no
+      // parquet yet, the backend shreds the JSON directly for this preview.
+      await expect(
+        page.getByTestId("data-preview-table"),
+        "bottom preview renders before any cache build",
+      ).toBeVisible({ timeout: 10000 })
+
       const cacheBtn = page.getByRole("button", { name: /cache as parquet/i })
-      await expect(cacheBtn, "Cache button is visible").toBeVisible({
+      await expect(cacheBtn, "optional performance-cache button is visible").toBeVisible({
         timeout: 5000,
       })
       const cacheResponsePromise = page.waitForResponse((r) =>
@@ -163,12 +170,12 @@ test.describe("apiInput v2-native flow (persistence layer)", () => {
         `cache build responds 200 (actual body: ${cacheBody.slice(0, 500)})`,
       ).toBe(200)
 
-      // Bottom preview should NOT show the stale-cache error.
+      // Optional prewarming must not disturb the already-working preview.
       await expect(
         page.locator(
           "text=API Input data hasn't been cached for the current schema",
         ),
-        "bottom preview shows data, not stale-cache error",
+        "bottom preview remains usable after optional prewarm",
       ).toHaveCount(0)
     })
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,6 @@ import NodePanel from "./panels/NodePanel"
 import { GraphProvider } from "./panels/GraphContext"
 import DataPreview from "./panels/DataPreview"
 import ExplorePreview from "./panels/ExplorePreview"
-import OptimiserPreview from "./panels/OptimiserPreview"
 import OptimiserDataPreview from "./panels/OptimiserDataPreview"
 import { ModellingPreview } from "./panels/ModellingPreview"
 
@@ -86,6 +85,9 @@ const GitPanel = lazy(() => import("./panels/GitPanel"))
 const AssistantPanel = lazy(() => import("./panels/assistant/AssistantPanel"))
 const ComparisonView = lazy(() => import("./components/ComparisonView"))
 const ComparisonInspector = lazy(() => import("./components/ComparisonInspector"))
+// Optimiser results are produced only after a user-triggered solve, so keep
+// the comparatively heavy charts out of the initial application bundle.
+const OptimiserPreview = lazy(() => import("./panels/OptimiserPreview"))
 
 // ---------------------------------------------------------------------------
 // Module-level constants (no dynamic values â€” avoids re-creating each render)
@@ -911,12 +913,14 @@ function FlowEditor() {
       dataPreviewContent = <ModellingPreview data={modelPreview} nodeId={activeNodeId!} />
     } else if (optPreview) {
       dataPreviewContent = (
-        <OptimiserPreview
-          data={optPreview}
-          nodeId={activeNodeId!}
-          allNodes={panelGraph.allNodes}
-          edges={panelGraph.edges}
-        />
+        <Suspense fallback={null}>
+          <OptimiserPreview
+            data={optPreview}
+            nodeId={activeNodeId!}
+            allNodes={panelGraph.allNodes}
+            edges={panelGraph.edges}
+          />
+        </Suspense>
       )
     } else if (
       // Pre-solve chart view for optimiser nodes

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,8 +60,14 @@ import { HAUTE_SESSION_EXPIRED_EVENT } from "./api/client"
 import { NODE_TYPES } from "./utils/nodeTypes"
 import { previewForActiveNode } from "./utils/activePreview"
 import { swapEdgeJoinInputs, type EdgeJoinSwapInputsFailureReason } from "./utils/edgeJoinGraph"
-import { isPipelineConnectionValid } from "./utils/connectionValidation"
-import { applyApiInputConfigChange } from "./utils/apiInputPorts"
+import { validatePipelineConnection, type ConnectionValidationResult } from "./utils/connectionValidation"
+import {
+  applyApiInputConfigChange,
+  incomingEdgeInputNames,
+  resolveSubmodelBoundaryNode,
+  submodelGraphFromMetadata,
+} from "./utils/apiInputPorts"
+import type { OnUpdateConfigResult, SimpleEdge, SimpleNode } from "./panels/editors/_shared"
 import { shouldUseLiteGraphEffects } from "./utils/graphPerformance"
 import { nodeData } from "./types/node"
 import { PanelLeftOpen } from "lucide-react"
@@ -97,6 +103,77 @@ const fitViewOptions = { padding: 0.15 }
 
 const proOptions = { hideAttribution: true }
 
+type RenamePair = { from: string; to: string }
+
+type RenameGraphScope = {
+  nodes: Node[]
+  edges: Edge[]
+  submodels: Record<string, unknown>
+}
+
+type AffectedRenameTarget = {
+  scope: RenameGraphScope
+  target: Node
+  incomingScope: RenameGraphScope
+  incomingTargetId: string
+  pairs: RenamePair[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function submodelScopeForBoundary(
+  boundaryNode: Node,
+  submodels: Record<string, unknown>,
+): RenameGraphScope {
+  if (!boundaryNode.id.startsWith("submodel__")) {
+    throw new Error(`Node ${boundaryNode.id} is not a submodel boundary`)
+  }
+  const name = boundaryNode.id.slice("submodel__".length)
+  const graph = submodelGraphFromMetadata(submodels[name])
+  if (!graph) throw new Error(`Submodel ${name} has no graph to migrate`)
+  return {
+    nodes: graph.nodes as unknown as Node[],
+    edges: graph.edges as unknown as Edge[],
+    submodels: graph.submodels,
+  }
+}
+
+function remapRecordKeys(
+  value: unknown,
+  renames: readonly RenamePair[],
+): { value: unknown; collision?: string } {
+  if (!isRecord(value) || renames.length === 0) return { value }
+  const renameByFrom = new Map(renames.map(({ from, to }) => [from, to]))
+  const next: Record<string, unknown> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const nextKey = renameByFrom.get(key) ?? key
+    if (Object.hasOwn(next, nextKey)) return { value, collision: nextKey }
+    next[nextKey] = entry
+  }
+  return { value: next }
+}
+
+function remapRecordValues(
+  value: unknown,
+  renames: readonly RenamePair[],
+): unknown {
+  if (!isRecord(value) || renames.length === 0) return value
+  const renameByFrom = new Map(renames.map(({ from, to }) => [from, to]))
+  let changed = false
+  const next = Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (typeof entry !== "string") return [key, entry]
+      const replacement = renameByFrom.get(entry)
+      if (replacement === undefined) return [key, entry]
+      changed = true
+      return [key, replacement]
+    }),
+  )
+  return changed ? next : value
+}
+
 // One-shot sessionStorage flag set just before the post-move reload, read once on
 // the next startup so it can confirm the move (toast) and skip the auto branch
 // prompt — the moved-to detached HEAD is intended, not a divergence (P6 §3.4).
@@ -127,8 +204,8 @@ function FlowEditor() {
   // Core ReactFlow state with undo/redo
   const {
     nodes, edges,
-    setNodes, setEdges, setNodesAndEdges,
-    setNodesRaw, setEdgesRaw,
+    setNodes, setEdges, setNodesAndEdges, setNodesAndEdgesAndSubmodels,
+    setNodesRaw, setEdgesRaw, setSubmodelsRaw,
     onNodesChange, onEdgesChange,
     undo, redo, canUndo, canRedo, pushSnapshot,
   } = useGraphCanvasState([], [], graphRefreshingRef)
@@ -190,17 +267,21 @@ function FlowEditor() {
   }, [])
 
   // Local UI state (not worth globalizing)
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
+  const [selectedNodeState, setSelectedNode] = useState<Node | null>(null)
   // The node under read-only inspection in the comparison view, or null. Cleared
   // whenever the comparison closes or the inspected version changes (S11).
-  const [comparisonInspect, setComparisonInspect] = useState<ComparisonInspect | null>(null)
-  useEffect(() => {
-    setComparisonInspect(null)
-  }, [comparison?.sha])
+  const [comparisonInspectState, setComparisonInspectState] = useState<{
+    comparisonSha: string
+    inspect: ComparisonInspect
+  } | null>(null)
+  const comparisonInspect = comparisonInspectState && comparisonInspectState.comparisonSha === comparison?.sha
+    ? comparisonInspectState.inspect
+    : null
   // Exiting comparison must also clear gitOpen, else the VC panel (which is how
   // compare mode is entered) would pop open unbidden back in the normal editor.
   const exitComparison = useCallback(() => {
     closeComparison()
+    setComparisonInspectState(null)
     setGitOpen(false)
   }, [closeComparison, setGitOpen])
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string; nodeLabel: string; isSubmodel?: boolean; isSingleton?: boolean } | null>(null)
@@ -208,17 +289,15 @@ function FlowEditor() {
   // sibling state slices can change without re-rendering this component.
   // The raw setter avoids adding text edits to the graph undo stack.
   const preamble = useGraphStore((s) => s.preamble)
+  const submodels = useGraphStore((s) => s.submodels)
   const setPreamble = useCallback((value: string) => {
     useGraphStore.getState().setPreambleRaw(value)
   }, [])
   const lastSelectedNodeRef = useRef<Node | null>(null)
   const [lastSelectedId, setLastSelectedId] = useState<string | null>(null)
 
-  // Keep lastSelectedId in sync â€” updates only when a node is actively selected
-  useEffect(() => {
-    if (selectedNode) setLastSelectedId(selectedNode.id)
-  }, [selectedNode])
-
+  // The last selected id is updated at selection event boundaries so the panel
+  // can remain visible while React Flow reports a canvas deselection.
   // Ref for setPreviewData â€” resolved after usePipelineAPI hook below.
   // Needed because closePanel is defined before the hook for hook-ordering rules.
   const setPreviewDataRef = useRef<(d: null) => void>(() => {})
@@ -259,9 +338,17 @@ function FlowEditor() {
     graphRef.current = { nodes, edges }
   }, [nodes, edges])
 
-  const activePanelNodeId = selectedNode?.id ?? lastSelectedId
+  useEffect(() => {
+    submodelsRef.current = submodels
+  }, [submodels])
+
   const panelGraph = usePanelGraphContext()
-  const panelNode = panelGraph.getNode(activePanelNodeId)
+  const selectedNode = selectedNodeState && panelGraph.getNode(selectedNodeState.id)
+    ? selectedNodeState
+    : null
+  const activePanelNodeCandidate = selectedNode?.id ?? lastSelectedId
+  const panelNode = panelGraph.getNode(activePanelNodeCandidate)
+  const activePanelNodeId = panelNode ? activePanelNodeCandidate : null
 
   useEffect(() => {
     setPinnedPreviewNodeId(activePanelNodeId ?? null)
@@ -270,15 +357,6 @@ function FlowEditor() {
     touchOptimiserPreview(activePanelNodeId)
     touchExplorePreview(activePanelNodeId)
   }, [activePanelNodeId, setPinnedPreviewNodeId, touchExplorePreview, touchModellingPreview, touchOptimiserPreview])
-
-  useEffect(() => {
-    if (!activePanelNodeId) return
-    if (panelGraph.getNode(activePanelNodeId)) return
-    setSelectedNode(null)
-    lastSelectedNodeRef.current = null
-    setLastSelectedId(null)
-    setPreviewDataRef.current(null)
-  }, [panelGraph, activePanelNodeId])
 
   // Store-maintained dirty flag.
   // Subscribe to the primitive so frequent React Flow node updates do not
@@ -297,7 +375,7 @@ function FlowEditor() {
   } = usePipelineAPI({
     selectedNode,
     graphRef, parentGraphRef, submodelsRef,
-    setNodesRaw, setEdgesRaw, setPreamble,
+    setNodesRaw, setEdgesRaw, setSubmodelsRaw, setCurrentSourceFile, setPreamble,
     preambleRef, pipelineNameRef, descriptionRef, sourceFileRef,
     nodeIdCounter,
   })
@@ -428,25 +506,19 @@ function FlowEditor() {
     handleCreateSubmodel, handleDissolveSubmodel,
   } = useSubmodelNavigation({
     graphRef, parentGraphRef, submodelsRef,
-    setNodesRaw, setEdgesRaw,
+    setNodesRaw, setEdgesRaw, setSubmodelsRaw,
     setSelectedNode, setPreviewData: (d: null) => setPreviewData(d),
+    setLastSelectedId,
+    setCurrentSourceFile,
     preambleRef, descriptionRef, sourceFileRef, pipelineNameRef,
     fitView,
   })
-
-  useEffect(() => {
-    const sourceFile = sourceFileRef.current || null
-    if (sourceFile !== currentSourceFile) {
-      // The pipeline hook owns the mutable source ref; mirror it into render
-      // state when loading or submodel navigation changes the active file.
-      setCurrentSourceFile(sourceFile)
-    }
-  }, [currentSourceFile, loading, sourceFileRef, viewStack])
 
   useKeyboardShortcuts({
     handleSave: requestSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
     graphRef, clipboard, nodeIdCounter,
     setSelectedNode, setPreviewData: (d: null) => setPreviewData(d),
+    setLastSelectedId,
     clearTrace,
     closePanel,
     isInsideSubmodel: viewStack.length > 1,
@@ -457,61 +529,246 @@ function FlowEditor() {
   // ---------------------------------------------------------------------------
 
   const onUpdateNode = useCallback(
-    (id: string, data: Record<string, unknown>) => {
+    (id: string, data: Record<string, unknown>): OnUpdateConfigResult => {
       // Capture the pre-update node BEFORE committing, so apiInput edge
       // maintenance below can diff old vs new frame identities.
-      const prevNode = graphRef.current.nodes.find((n) => n.id === id)
-      const nextNodes = graphRef.current.nodes.map((n) => (n.id === id ? { ...n, data } : n))
-      graphRef.current = { ...graphRef.current, nodes: nextNodes }
-      setNodes(nextNodes)
+      const currentGraph = graphRef.current
+      const prevNode = currentGraph.nodes.find((n) => n.id === id)
+      if (!prevNode) {
+        return { ok: false, error: `Cannot update missing node "${id}".` }
+      }
+
+      // Compute the entire candidate graph before touching either the store
+      // or graphRef. A failed preflight therefore cannot leave a config,
+      // edge, mapping, or history entry behind.
+      let tentativeEdges = currentGraph.edges
+      let rebound: Array<{ edge: Edge; from: string; to: string }> = []
+      let removed: Array<{ edge: Edge; sourceHandle: string | null }> = []
+      if (data.nodeType === NODE_TYPES.API_INPUT) {
+        const config = (data.config ?? {}) as Record<string, unknown>
+        const prevConfig = ((prevNode.data as Record<string, unknown>).config ??
+          {}) as Record<string, unknown>
+        const result = applyApiInputConfigChange({
+          nodeId: id,
+          prevConfig,
+          nextConfig: config,
+          edges: currentGraph.edges,
+        })
+        tentativeEdges = result.edges
+        rebound = result.rebound
+        removed = result.removed
+      }
+
+      let tentativeNodes = currentGraph.nodes.map((node) =>
+        node.id === id ? { ...node, data } : node,
+      )
+      const tentativeSubmodels = structuredClone(submodelsRef.current)
+      const rootScope: RenameGraphScope = {
+        nodes: tentativeNodes,
+        edges: tentativeEdges,
+        submodels: tentativeSubmodels,
+      }
+      const nodeById = new Map(tentativeNodes.map((node) => [node.id, node]))
+      const affectedByScope = new Map<
+        RenameGraphScope,
+        Map<string, AffectedRenameTarget>
+      >()
+      const submodelScopes = new Map<string, RenameGraphScope>()
+
+      for (const change of rebound) {
+        const boundaryTarget = nodeById.get(change.edge.target)
+        if (!boundaryTarget) throw new Error(`Cannot derive rename target ${change.edge.target}`)
+        let targetScope = rootScope
+        let target = boundaryTarget
+        if (boundaryTarget.data.nodeType === NODE_TYPES.SUBMODEL) {
+          target = resolveSubmodelBoundaryNode(
+            boundaryTarget as unknown as SimpleNode,
+            change.edge.targetHandle,
+            "in",
+            rootScope.submodels,
+          ) as unknown as Node
+          if (!target) {
+            throw new Error(
+              `Cannot migrate frame rename through submodel ${boundaryTarget.id}: `
+              + `edge ${change.edge.id} has no resolvable target handle`,
+            )
+          }
+          targetScope = submodelScopes.get(boundaryTarget.id) ??
+            submodelScopeForBoundary(boundaryTarget, rootScope.submodels)
+          submodelScopes.set(boundaryTarget.id, targetScope)
+        }
+        const targets = affectedByScope.get(targetScope) ?? new Map<string, AffectedRenameTarget>()
+        const affected = targets.get(target.id) ?? {
+          scope: targetScope,
+          target,
+          incomingScope: rootScope,
+          incomingTargetId: boundaryTarget.id,
+          pairs: [],
+        }
+        if (!affected.pairs.some((pair) => pair.from === change.from && pair.to === change.to)) {
+          affected.pairs.push({ from: change.from, to: change.to })
+        }
+        targets.set(target.id, affected)
+        affectedByScope.set(targetScope, targets)
+      }
+
+      const mappingChanges = new Map<
+        RenameGraphScope,
+        Map<string, Record<string, unknown>>
+      >()
+
+      const applyConfigMapping = (
+        scope: RenameGraphScope,
+        node: Node,
+        field: "input_scenario_map" | "inputMapping",
+        pairs: readonly RenamePair[],
+        keys: boolean,
+      ): OnUpdateConfigResult => {
+        const scopeChanges = mappingChanges.get(scope) ?? new Map<string, Record<string, unknown>>()
+        const config = scopeChanges.get(node.id) ??
+          ((node.data.config ?? {}) as Record<string, unknown>)
+        if (keys) {
+          const mapped = remapRecordKeys(config[field], pairs)
+          if (mapped.collision !== undefined) {
+            return {
+              ok: false,
+              error: `Target "${String(node.data.label ?? node.id)}" already has an input named "${mapped.collision}".`,
+            }
+          }
+          if (mapped.value === config[field]) return { ok: true }
+          scopeChanges.set(node.id, { ...config, [field]: mapped.value })
+          mappingChanges.set(scope, scopeChanges)
+          return { ok: true }
+        }
+        const mappedValue = remapRecordValues(config[field], pairs)
+        if (mappedValue === config[field]) return { ok: true }
+        scopeChanges.set(node.id, { ...config, [field]: mappedValue })
+        mappingChanges.set(scope, scopeChanges)
+        return { ok: true }
+      }
+
+      // Directly affected targets receive the new frame name in the fields
+      // that use an input identity: live-switch keys and instance values.
+      for (const targets of affectedByScope.values()) {
+        for (const affected of targets.values()) {
+          if (affected.target.data.nodeType === NODE_TYPES.LIVE_SWITCH) {
+            const result = applyConfigMapping(
+              affected.scope,
+              affected.target,
+              "input_scenario_map",
+              affected.pairs,
+              true,
+            )
+            if (!result.ok) return result
+          }
+          const valueResult = applyConfigMapping(
+            affected.scope,
+            affected.target,
+            "inputMapping",
+            affected.pairs,
+            false,
+          )
+          if (!valueResult.ok) return valueResult
+        }
+      }
+
+      // The original node's input names are the keys in every instance's
+      // mapping. Rename those keys on all visible instances of each affected
+      // original, including instances that have no direct renamed edge.
+      const instanceScopes = new Set<RenameGraphScope>([rootScope])
+      for (const scope of affectedByScope.keys()) instanceScopes.add(scope)
+      for (const targets of affectedByScope.values()) {
+        for (const affected of targets.values()) {
+          for (const scope of instanceScopes) {
+            for (const node of scope.nodes) {
+              const config = (node.data.config ?? {}) as Record<string, unknown>
+              if (config.instanceOf !== affected.target.id) continue
+              const result = applyConfigMapping(
+                scope,
+                node,
+                "inputMapping",
+                affected.pairs,
+                true,
+              )
+              if (!result.ok) return result
+            }
+          }
+        }
+      }
+
+      // Apply all mapping changes only after every scope has passed its
+      // collision checks. Nested submodel graph arrays are updated in place
+      // so the cloned metadata retains the same graph references.
+      for (const [scope, changes] of mappingChanges) {
+        const mappedNodes = scope.nodes.map((node) => {
+          const config = changes.get(node.id)
+          return config ? { ...node, data: { ...node.data, config } } : node
+        })
+        scope.nodes.splice(0, scope.nodes.length, ...mappedNodes)
+      }
+      tentativeNodes = rootScope.nodes
+      nodeById.clear()
+      for (const node of tentativeNodes) nodeById.set(node.id, node)
+
+      const targetInputCollisionFor = (affected: AffectedRenameTarget): string | null => {
+        const names = incomingEdgeInputNames({
+          targetNodeId: affected.target.id,
+          boundaryNodeId: affected.incomingTargetId,
+          nodes: affected.incomingScope.nodes as unknown as SimpleNode[],
+          edges: affected.incomingScope.edges as unknown as SimpleEdge[],
+          submodels: affected.incomingScope.submodels,
+        })
+        if (affected.scope !== affected.incomingScope) {
+          names.push(...incomingEdgeInputNames({
+            targetNodeId: affected.target.id,
+            nodes: affected.scope.nodes as unknown as SimpleNode[],
+            edges: affected.scope.edges as unknown as SimpleEdge[],
+            submodels: affected.scope.submodels,
+          }))
+        }
+        const seen = new Set<string>()
+        for (const name of names) {
+          if (seen.has(name)) return name
+          seen.add(name)
+        }
+        return null
+      }
+
+      // Only targets whose incoming edge identity changed need duplicate
+      // preflight. Names come from the shared edgeInputName helper, exactly as
+      // the executor and panel surfaces derive them.
+      for (const targets of affectedByScope.values()) {
+        for (const affected of targets.values()) {
+          const collision = targetInputCollisionFor(affected)
+          if (collision !== null) {
+            return {
+              ok: false,
+              error: `Target "${String(affected.target.data.label ?? affected.target.id)}" already has an input named "${collision}".`,
+            }
+          }
+        }
+      }
+
+      // One history-aware store action commits the config, all migrated node
+      // mappings, and all rebound/pruned edges together.
+      graphRef.current = { nodes: tentativeNodes, edges: tentativeEdges }
+      setNodesAndEdgesAndSubmodels(tentativeNodes, tentativeEdges, tentativeSubmodels)
+      submodelsRef.current = tentativeSubmodels
       setSelectedNode((prev) => (prev && prev.id === id ? { ...prev, data } : prev))
 
-      // apiInput edge maintenance (W1.3 / Defect 1) — an apiInput's
-      // handle ids ARE its table labels (the only id space that
-      // round-trips through codegen → save → parse), so a config commit
-      // can change frame identities. Two cases, handled in one pass:
-      //  - RENAME (W1.3): the same commit that renames a frame rebinds
-      //    the edges bound to the old handle — rename is migration,
-      //    never edge loss.
-      //  - genuine orphaning (emit-off / table-delete / single↔multi
-      //    transition): the edge is pruned with a visible, named toast,
-      //    instead of persisting broken to disk and KeyError-ing at run.
-      if (data.nodeType !== NODE_TYPES.API_INPUT) return
-      const config = (data.config ?? {}) as Record<string, unknown>
-      const prevConfig = ((prevNode?.data as Record<string, unknown> | undefined)?.config ??
-        {}) as Record<string, unknown>
-      const { rebound, removed } = applyApiInputConfigChange({
-        nodeId: id,
-        prevConfig,
-        nextConfig: config,
-        edges: graphRef.current.edges,
-      })
-      if (rebound.length === 0 && removed.length === 0) return
-      const reboundTo = new Map(rebound.map((r) => [r.edge.id, r.to]))
-      const removedIds = new Set(removed.map((r) => r.edge.id))
-      // Raw (history-skipping) on purpose: the `setNodes` above already
-      // snapshotted the pre-commit {nodes, edges}, so applying the edge
-      // consequences raw keeps the whole config commit ONE undo entry —
-      // undoing a rename restores the old label AND its old bindings
-      // atomically, with no per-keystroke or per-phase history churn.
-      setEdgesRaw((eds) =>
-        eds
-          .filter((e) => !removedIds.has(e.id))
-          .map((e) =>
-            reboundTo.has(e.id) ? { ...e, sourceHandle: reboundTo.get(e.id)! } : e,
-          ),
-      )
-      if (removed.length === 0) return
-      const ports = removed
-        .map((r) => (r.sourceHandle === null ? "the default frame" : `frame "${r.sourceHandle}"`))
-        .join(", ")
-      const label = String(data.label ?? id)
-      addToast(
-        "warning",
-        `Disconnected ${removed.length} edge${removed.length === 1 ? "" : "s"} from ${label}: ${ports} no longer ${removed.length === 1 ? "exists" : "exist"} after your edit.`,
-      )
+      if (removed.length > 0) {
+        const ports = removed
+          .map((r) => (r.sourceHandle === null ? "the default frame" : `frame "${r.sourceHandle}"`))
+          .join(", ")
+        const label = String(data.label ?? id)
+        addToast(
+          "warning",
+          `Disconnected ${removed.length} edge${removed.length === 1 ? "" : "s"} from ${label}: ${ports} no longer ${removed.length === 1 ? "exists" : "exist"} after your edit.`,
+        )
+      }
+      return { ok: true }
     },
-    [setNodes, setEdgesRaw, graphRef, addToast],
+    [setNodesAndEdgesAndSubmodels, graphRef, addToast, setSelectedNode, submodelsRef],
   )
 
   const {
@@ -520,6 +777,7 @@ function FlowEditor() {
   } = useNodeHandlers({
     graphRef, nodeIdCounter, lastSelectedNodeRef,
     setNodes, setNodesAndEdges, setSelectedNode,
+    setLastSelectedId,
     setPreviewData, fitView,
   })
 
@@ -544,8 +802,21 @@ function FlowEditor() {
   }, [])
 
   const isValidConnection = useCallback((connection: Connection | Edge) => {
-    return isPipelineConnectionValid(connection)
-  }, [])
+    return validatePipelineConnection(
+      connection,
+      panelGraph.allNodes,
+      panelGraph.edges,
+      submodelsRef.current,
+    ).ok
+  }, [panelGraph])
+
+  const validateConnection = useCallback((connection: Connection): ConnectionValidationResult =>
+    validatePipelineConnection(
+      connection,
+      panelGraph.allNodes,
+      panelGraph.edges,
+      submodelsRef.current,
+    ), [panelGraph])
 
   const {
     onConnect, onSelectionChange, onNodeClick, handleDeleteEdge,
@@ -554,6 +825,7 @@ function FlowEditor() {
     selectedNode, graphRef, nodeIdCounter, lastSelectedNodeRef,
     setNodes, setEdges, setNodesRaw, setEdgesRaw, pushSnapshot,
     setSelectedNode, setPreviewData, setContextMenu,
+    setLastSelectedId,
     fetchPreview,
     cancelPreview,
     shouldSkipAutomaticPreview,
@@ -561,6 +833,7 @@ function FlowEditor() {
     screenToFlowPosition,
     graphRefreshingRef,
     findEdgeIdAtPoint,
+    validateConnection,
   })
 
   const handleSwapEdgeJoinInputs = useCallback((nodeId: string) => {
@@ -579,6 +852,7 @@ function FlowEditor() {
     setNodesRaw(result.nodes)
     setEdgesRaw(result.edges)
     setSelectedNode(selected)
+    setLastSelectedId(selected?.id ?? null)
     lastSelectedNodeRef.current = selected
     clearTrace()
     cancelPreview()
@@ -590,6 +864,7 @@ function FlowEditor() {
     lastSelectedNodeRef,
     pushSnapshot,
     setEdgesRaw,
+    setLastSelectedId,
     setNodesRaw,
     setSelectedNode,
   ])
@@ -606,15 +881,13 @@ function FlowEditor() {
     )
   }
 
-  // eslint-disable-next-line react-hooks/refs -- ref is mutated by hooks; reading here is intentional
-  const submodelsSnapshot = submodelsRef.current
+  const submodelsSnapshot = submodels
   const useLiteGraphEffects = shouldUseLiteGraphEffects(nodes.length, edges.length)
 
   // Pick the preview pane for the active node. Computed here (not as an inline
-  // IIFE in the JSX) so the read of `submodelsSnapshot` — an intentional ref
-  // read already covered above — stays in this render scope rather than being
-  // traced by react-hooks/refs into a separate render-time closure.
-  const activeNodeId = selectedNode?.id ?? lastSelectedId
+  // Keep the preview derivation in this render scope so it shares the same
+  // metadata snapshot as the panel graph.
+  const activeNodeId = activePanelNodeId
   const activePreviewData = previewForActiveNode(previewData, activeNodeId)
   const activeNode = panelGraph.getNode(activeNodeId)
   let dataPreviewContent: ReactNode
@@ -684,8 +957,8 @@ function FlowEditor() {
         onRedo={redo}
         onZoomIn={() => zoomIn()}
         onZoomOut={() => zoomOut()}
-        onOpenUtility={() => { setUtilityOpen(true); setSelectedNode(null); lastSelectedNodeRef.current = null; setPreviewDataRef.current(null); setContextMenu(null) }}
-        onOpenImports={() => { setImportsOpen(true); setSelectedNode(null); lastSelectedNodeRef.current = null; setPreviewDataRef.current(null); setContextMenu(null) }}
+        onOpenUtility={() => { setUtilityOpen(true); setSelectedNode(null); setLastSelectedId(null); lastSelectedNodeRef.current = null; setPreviewDataRef.current(null); setContextMenu(null) }}
+        onOpenImports={() => { setImportsOpen(true); setSelectedNode(null); setLastSelectedId(null); lastSelectedNodeRef.current = null; setPreviewDataRef.current(null); setContextMenu(null) }}
         onCentre={() => fitView({ padding: 0.15 })}
         onAutoLayout={handleAutoLayout}
         isAutoLayouting={isAutoLayouting}
@@ -707,7 +980,12 @@ function FlowEditor() {
                   currentNodes={nodes}
                   currentEdges={edges}
                   onClose={exitComparison}
-                  onSelectNode={(p) => { setComparisonInspect(p); setGitOpen(false) }}
+                  onSelectNode={(p) => {
+                    setComparisonInspectState(
+                      p ? { comparisonSha: comparison.sha, inspect: p } : null,
+                    )
+                    setGitOpen(false)
+                  }}
                 />
               </Suspense>
             </ErrorBoundary>
@@ -725,7 +1003,7 @@ function FlowEditor() {
                   <ComparisonInspector
                     key={comparisonInspect.id}
                     inspect={comparisonInspect}
-                    onClose={() => setComparisonInspect(null)}
+                    onClose={() => setComparisonInspectState(null)}
                   />
                 ) : (
                   <GitPanel onClose={exitComparison} />
@@ -884,7 +1162,7 @@ function FlowEditor() {
                     const refreshTarget = graphRef.current.nodes.find((n) => n.id === panelNode.id)
                     if (refreshTarget) refreshPreview(refreshTarget)
                   }}
-                  dimmed={!selectedNode && !!lastSelectedId}
+                  dimmed={!selectedNode && !!activePanelNodeId}
                   errorLine={
                     previewData?.nodeId === activePanelNodeId
                       ? previewData?.error_line ?? null
@@ -977,6 +1255,7 @@ function FlowEditor() {
             const node = graphRef.current.nodes.find((n) => n.id === nodeId) ?? null
             if (node) {
               setSelectedNode(node)
+              setLastSelectedId(node.id)
               lastSelectedNodeRef.current = node
               setUtilityOpen(false)
               setImportsOpen(false)

--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -973,6 +973,185 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     }
   }
 
+  function makeRenameMigrationGraph(options: { collision?: boolean } = {}) {
+    const base = makeApiInputGraph()
+    const liveSwitch = makeNode("live_1", "Scenario Router", "liveSwitch")
+    liveSwitch.data.config = {
+      input_scenario_map: { drivers: "batch", Other_Source: "live" },
+      untouched: "live-switch-config",
+    }
+    const original = makeNode("original_1", "Original Transform", "polars")
+    const otherOriginal = makeNode("original_2", "Other Original", "polars")
+    const downstreamInstance = makeNode("instance_value", "Downstream Instance", "polars")
+    downstreamInstance.data.config = {
+      instanceOf: "original_2",
+      inputMapping: { original_input: "drivers", stable_value: "Other_Source" },
+      untouched: "downstream-instance-config",
+    }
+    const firstOriginalInstance = makeNode("instance_key_1", "First Original Instance", "polars")
+    firstOriginalInstance.data.config = {
+      instanceOf: "original_1",
+      inputMapping: { drivers: "Mapped_First", stable_key: "Stable_First" },
+      untouched: "first-instance-config",
+    }
+    const secondOriginalInstance = makeNode("instance_key_2", "Second Original Instance", "polars")
+    secondOriginalInstance.data.config = {
+      instanceOf: "original_1",
+      inputMapping: { drivers: "Mapped_Second", stable_key: "Stable_Second" },
+      untouched: "second-instance-config",
+    }
+    const ordinarySource = makeNode(
+      "ordinary_source",
+      options.collision ? "collision name" : "Other Source",
+      "polars",
+    )
+
+    return {
+      nodes: [
+        base.nodes[0],
+        ordinarySource,
+        liveSwitch,
+        original,
+        otherOriginal,
+        downstreamInstance,
+        firstOriginalInstance,
+        secondOriginalInstance,
+      ],
+      edges: [
+        {
+          id: "e_api_live",
+          source: "api_0",
+          target: "live_1",
+          sourceHandle: "drivers",
+          targetHandle: null,
+        },
+        {
+          id: "e_ordinary_live",
+          source: "ordinary_source",
+          target: "live_1",
+          sourceHandle: null,
+          targetHandle: null,
+        },
+        {
+          id: "e_api_original",
+          source: "api_0",
+          target: "original_1",
+          sourceHandle: "drivers",
+          targetHandle: null,
+        },
+        {
+          id: "e_api_instance",
+          source: "api_0",
+          target: "instance_value",
+          sourceHandle: "drivers",
+          targetHandle: null,
+        },
+      ],
+      preamble: "",
+    }
+  }
+
+  function makeSubmodelRenameGraph(
+    options: { collision?: boolean; internalCollision?: boolean } = {},
+  ) {
+    const base = makeApiInputGraph()
+    const boundary = makeNode("submodel__pricing", "Pricing", "submodel")
+    const childRouter = makeNode("child_router", "Child Router", "liveSwitch")
+    childRouter.data.config = {
+      input_scenario_map: { drivers: "batch", stable_input: "live" },
+      untouched: "child-router-config",
+    }
+    const childValueInstance = makeNode("child_value_instance", "Child Value Instance", "polars")
+    childValueInstance.data.config = {
+      instanceOf: "unrelated_original",
+      inputMapping: { original_input: "drivers", stable_value: "stable_input" },
+      untouched: "child-value-config",
+    }
+    const childKeyInstance = makeNode("child_key_instance", "Child Key Instance", "polars")
+    childKeyInstance.data.config = {
+      instanceOf: "child_router",
+      inputMapping: { drivers: "Mapped_Driver", stable_key: "Stable_Value" },
+      untouched: "child-key-config",
+    }
+    const ordinary = makeNode(
+      "ordinary_source",
+      options.collision ? "collision name" : "Stable Input",
+      "polars",
+    )
+    const internalCollisionSource = makeNode(
+      "internal_collision_source",
+      "collision name",
+      "polars",
+    )
+
+    return {
+      nodes: [base.nodes[0], ordinary, boundary],
+      edges: [
+        {
+          id: "e_api_router",
+          source: "api_0",
+          target: boundary.id,
+          sourceHandle: "drivers",
+          targetHandle: "in__child_router",
+        },
+        {
+          id: "e_api_value_instance",
+          source: "api_0",
+          target: boundary.id,
+          sourceHandle: "drivers",
+          targetHandle: "in__child_value_instance",
+        },
+        ...(options.collision
+          ? [
+              {
+                id: "e_ordinary_router",
+                source: ordinary.id,
+                target: boundary.id,
+                sourceHandle: null,
+                targetHandle: "in__child_router",
+              },
+            ]
+          : []),
+      ],
+      submodels: {
+        pricing: {
+          graph: {
+            nodes: [
+              childRouter,
+              childValueInstance,
+              childKeyInstance,
+              ...(options.internalCollision ? [internalCollisionSource] : []),
+            ],
+            edges: options.internalCollision
+              ? [
+                  {
+                    id: "e_internal_collision_router",
+                    source: internalCollisionSource.id,
+                    target: childRouter.id,
+                    sourceHandle: null,
+                    targetHandle: null,
+                  },
+                ]
+              : [],
+            submodels: {},
+          },
+        },
+      },
+      preamble: "",
+    }
+  }
+
+  function configFor(nodeId: string): Record<string, unknown> {
+    const node = useGraphStore.getState().nodes.find((candidate) => candidate.id === nodeId)
+    expect(node, `node ${nodeId}`).toBeDefined()
+    return node!.data.config as Record<string, unknown>
+  }
+
+  function graphCommitStateBytes(): string {
+    const { nodes, edges, submodels, undoStack, redoStack } = useGraphStore.getState()
+    return JSON.stringify({ nodes, edges, submodels, undoStack, redoStack })
+  }
+
   it("toggling a bound table's emit off prunes the orphaned edge and warns", async () => {
     vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeApiInputGraph())
     render(<App />)
@@ -981,7 +1160,7 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     expect(useGraphStore.getState().edges).toHaveLength(1)
 
     // Open the apiInput editor panel.
-    fireEvent.click(await screen.findByText("Quote Source"))
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
 
     // Untick the 'drivers' table emit (table index 1).
     const driversEmit = await findEditorTestId("api-input-table-1-emit")
@@ -1011,7 +1190,7 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     render(<App />)
     await waitForAppReady()
 
-    fireEvent.click(await screen.findByText("Quote Source"))
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
 
     // Rename the bound 'drivers' port (table index 1) by typing several
     // characters. The label is the live handle id, so under the old
@@ -1048,6 +1227,248 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     expect(useGraphStore.getState().edges[0].sourceHandle).toBe("drivers")
   })
 
+  it("renames a frame, all persisted input identities, and every instance key in one undoable commit", async () => {
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeRenameMigrationGraph())
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    const nodesBefore = JSON.stringify(useGraphStore.getState().nodes)
+    const edgesBefore = JSON.stringify(useGraphStore.getState().edges)
+    const undoDepthBefore = useGraphStore.getState().undoStack.length
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
+
+    const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
+    fireEvent.change(label, { target: { value: "driver_risk" } })
+    fireEvent.blur(label)
+
+    await waitFor(() => {
+      expect(useGraphStore.getState().edges.filter((edge) => edge.source === "api_0")).toEqual([
+        expect.objectContaining({ id: "e_api_live", sourceHandle: "driver_risk" }),
+        expect.objectContaining({ id: "e_api_original", sourceHandle: "driver_risk" }),
+        expect.objectContaining({ id: "e_api_instance", sourceHandle: "driver_risk" }),
+      ])
+    })
+    expect(configFor("api_0")).toEqual(
+      expect.objectContaining({
+        tables: [
+          expect.objectContaining({ label: "policies" }),
+          expect.objectContaining({ label: "driver_risk" }),
+        ],
+      }),
+    )
+    expect(configFor("live_1")).toEqual({
+      input_scenario_map: { driver_risk: "batch", Other_Source: "live" },
+      untouched: "live-switch-config",
+    })
+    expect(configFor("instance_value")).toEqual({
+      instanceOf: "original_2",
+      inputMapping: { original_input: "driver_risk", stable_value: "Other_Source" },
+      untouched: "downstream-instance-config",
+    })
+    expect(configFor("instance_key_1")).toEqual({
+      instanceOf: "original_1",
+      inputMapping: { driver_risk: "Mapped_First", stable_key: "Stable_First" },
+      untouched: "first-instance-config",
+    })
+    expect(configFor("instance_key_2")).toEqual({
+      instanceOf: "original_1",
+      inputMapping: { driver_risk: "Mapped_Second", stable_key: "Stable_Second" },
+      untouched: "second-instance-config",
+    })
+    expect(useGraphStore.getState().undoStack.length).toBe(undoDepthBefore + 1)
+
+    await useGraphStore.getState().undo()
+    expect(JSON.stringify(useGraphStore.getState().nodes)).toBe(nodesBefore)
+    expect(JSON.stringify(useGraphStore.getState().edges)).toBe(edgesBefore)
+    expect(useGraphStore.getState().undoStack.length).toBe(undoDepthBefore)
+  })
+
+  it("rejects a colliding frame rename before any config, edge, mapping, or history mutation", async () => {
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeRenameMigrationGraph({ collision: true }))
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
+    const stateBefore = graphCommitStateBytes()
+    const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
+    fireEvent.change(label, { target: { value: "collision_name" } })
+    fireEvent.blur(label)
+
+    const error = await screen.findByTestId("api-input-table-1-label-error")
+    expect(error).toHaveTextContent(/Scenario Router/)
+    expect(error).toHaveTextContent(/collision_name/)
+    expect(graphCommitStateBytes()).toBe(stateBefore)
+  })
+
+  it("migrates nested identities atomically and restores their observable payload on undo and redo", async () => {
+    const graph = makeSubmodelRenameGraph()
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(graph)
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    const assertIdentityPayload = (graphValue: unknown, expectedName: "drivers" | "driver_risk") => {
+      const graphState = graphValue as {
+        nodes: Array<{ id: string; data: { config: Record<string, unknown> } }>
+        edges: Array<{ id: string; sourceHandle?: string | null }>
+        submodels: {
+          pricing: {
+            graph: { nodes: Array<{ id: string; data: { config: Record<string, unknown> } }> }
+          }
+        }
+      }
+      const apiConfig = graphState.nodes.find((node) => node.id === "api_0")?.data.config as {
+        tables: Array<{ label: string }>
+      }
+      expect(apiConfig.tables[1].label).toBe(expectedName)
+      expect(
+        graphState.edges
+          .filter((edge) => edge.id === "e_api_router" || edge.id === "e_api_value_instance")
+          .map((edge) => edge.sourceHandle),
+      ).toEqual([expectedName, expectedName])
+
+      const nestedConfig = (id: string) =>
+        graphState.submodels.pricing.graph.nodes.find((node) => node.id === id)?.data.config
+      expect(nestedConfig("child_router")).toEqual({
+        input_scenario_map: { [expectedName]: "batch", stable_input: "live" },
+        untouched: "child-router-config",
+      })
+      expect(nestedConfig("child_value_instance")).toEqual({
+        instanceOf: "unrelated_original",
+        inputMapping: { original_input: expectedName, stable_value: "stable_input" },
+        untouched: "child-value-config",
+      })
+      expect(nestedConfig("child_key_instance")).toEqual({
+        instanceOf: "child_router",
+        inputMapping: { [expectedName]: "Mapped_Driver", stable_key: "Stable_Value" },
+        untouched: "child-key-config",
+      })
+    }
+    const storePayload = () => {
+      const { nodes, edges, submodels } = useGraphStore.getState()
+      return { nodes, edges, submodels }
+    }
+
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
+    const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
+    fireEvent.change(label, { target: { value: "driver_risk" } })
+    fireEvent.blur(label)
+
+    await waitFor(() => {
+      expect(useGraphStore.getState().edges.filter((edge) => edge.source === "api_0")).toEqual([
+        expect.objectContaining({ id: "e_api_router", sourceHandle: "driver_risk" }),
+        expect.objectContaining({ id: "e_api_value_instance", sourceHandle: "driver_risk" }),
+      ])
+    })
+    assertIdentityPayload(storePayload(), "driver_risk")
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledOnce())
+    assertIdentityPayload(vi.mocked(api.savePipeline).mock.calls[0][0].graph, "driver_risk")
+
+    fireEvent.click(screen.getByTestId("toolbar-undo"))
+    await waitFor(() => assertIdentityPayload(storePayload(), "drivers"))
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledTimes(2))
+    assertIdentityPayload(vi.mocked(api.savePipeline).mock.calls[1][0].graph, "drivers")
+
+    fireEvent.click(screen.getByTestId("toolbar-redo"))
+    await waitFor(() => assertIdentityPayload(storePayload(), "driver_risk"))
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledTimes(3))
+    assertIdentityPayload(vi.mocked(api.savePipeline).mock.calls[2][0].graph, "driver_risk")
+  })
+
+  it("rejects a rename collision inside one submodel child with no root or nested mutation", async () => {
+    const graph = makeSubmodelRenameGraph({ collision: true })
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(graph)
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
+    const stateBefore = graphCommitStateBytes()
+    const submodelsBefore = JSON.stringify(graph.submodels)
+    const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
+    fireEvent.change(label, { target: { value: "collision_name" } })
+    fireEvent.blur(label)
+
+    const error = await screen.findByTestId("api-input-table-1-label-error")
+    expect(error).toHaveTextContent(/Child Router/)
+    expect(error).toHaveTextContent(/collision_name/)
+    expect(graphCommitStateBytes()).toBe(stateBefore)
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledOnce())
+    expect(JSON.stringify(vi.mocked(api.savePipeline).mock.calls[0][0].graph.submodels)).toBe(
+      submodelsBefore,
+    )
+  })
+
+  it("rejects a root-frame rename colliding with an internal child edge with zero mutation", async () => {
+    const graph = makeSubmodelRenameGraph({ internalCollision: true })
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(graph)
+    vi.mocked(api.previewNode).mockImplementation(() => new Promise<never>(() => {}))
+    render(<App />)
+    await waitForAppReady()
+
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
+    const stateBefore = graphCommitStateBytes()
+    const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
+    fireEvent.change(label, { target: { value: "collision_name" } })
+    fireEvent.blur(label)
+
+    const error = await screen.findByTestId("api-input-table-1-label-error")
+    expect(error).toHaveTextContent(/Child Router/)
+    expect(error).toHaveTextContent(/collision_name/)
+    expect(graphCommitStateBytes()).toBe(stateBefore)
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledOnce())
+    expect(vi.mocked(api.savePipeline).mock.calls[0][0].graph.submodels).toEqual(graph.submodels)
+  })
+
+  it("preserves a stale named apiInput edge from load through warning render and save", async () => {
+    const graph = makeApiInputGraph()
+    const staleEdge = { ...graph.edges[0], id: "e_stale_frame", sourceHandle: "stale_quotes" }
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce({ ...graph, edges: [staleEdge] })
+    render(<App />)
+    await waitForAppReady()
+
+    expect(useGraphStore.getState().edges).toEqual([
+      expect.objectContaining(staleEdge),
+    ])
+    fireEvent.click(await screen.findByTestId("node-Driver Cleanup"))
+    const chip = await screen.findByTestId("input-source-e_stale_frame")
+    expect(chip).toHaveAttribute("data-unresolved", "true")
+    expect(chip).toHaveTextContent("stale_quotes")
+    expect(chip).toHaveAccessibleName(/unresolved frame/i)
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }))
+    await waitFor(() => expect(vi.mocked(api.savePipeline)).toHaveBeenCalledOnce())
+    expect(vi.mocked(api.savePipeline).mock.calls[0][0].graph.edges).toEqual([
+      expect.objectContaining(staleEdge),
+    ])
+  })
+
+  it("prunes a persisted null-handle apiInput edge during initial reconciliation without undo noise", async () => {
+    const graph = makeApiInputGraph()
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce({
+      ...graph,
+      edges: [{ ...graph.edges[0], id: "e_portless", sourceHandle: null }],
+    })
+
+    render(<App />)
+    await waitForAppReady()
+
+    await waitFor(() => {
+      expect(useGraphStore.getState().edges).toEqual([])
+    })
+    expect(useGraphStore.getState().undoStack).toEqual([])
+  })
+
   it("W1.4: blanking a port label in the editor never reaches the graph — no synthesized port, edge intact", async () => {
     vi.mocked(api.loadPipeline).mockResolvedValueOnce(makeApiInputGraph())
     // Same determinism guard as the W1.3 test above: keep previews
@@ -1056,7 +1477,7 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     render(<App />)
     await waitForAppReady()
 
-    fireEvent.click(await screen.findByText("Quote Source"))
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
 
     const label = (await findEditorTestId("api-input-table-1-label")) as HTMLInputElement
     label.focus()
@@ -1079,7 +1500,7 @@ describe("App integration — apiInput emit-port edge reconciliation (Defect 1)"
     render(<App />)
     await waitForAppReady()
 
-    fireEvent.click(await screen.findByText("Quote Source"))
+    fireEvent.click(await screen.findByTestId("node-Quote Source"))
 
     // Add a column to the drivers table (index 1) — the emit-port set is
     // unchanged (the table is already an emit+selected port), so the

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -82,6 +82,21 @@ const DEFAULT_PROPS = {
   accentColor: "#10b981",
 }
 
+const CACHEABLE_TABLE = {
+  path: "$[:]",
+  label: "policies",
+  emit: true,
+  columns: [
+    {
+      name: "policy_id",
+      path: "$[:].policy_id",
+      type: "int",
+      status: "Confirmed",
+      selected: true,
+    },
+  ],
+}
+
 describe("ApiInputEditor", () => {
   it("renders API input banner text", () => {
     render(<ApiInputEditor {...DEFAULT_PROPS} />)
@@ -115,6 +130,56 @@ describe("ApiInputEditor", () => {
     expect(screen.queryByText("Cache as Parquet")).toBeNull()
   })
 
+  it("cache button is disabled when no emitted table has a selected column", () => {
+    render(
+      <ApiInputEditor
+        {...DEFAULT_PROPS}
+        config={{
+          path: "data/input.json",
+          tables: [
+            {
+              path: "$[:]",
+              label: "policies",
+              emit: true,
+              columns: [
+                {
+                  name: "policy_id",
+                  path: "$[:].policy_id",
+                  type: "int",
+                  status: "Confirmed",
+                  selected: false,
+                },
+              ],
+            },
+            {
+              path: "$[:].drivers[:]",
+              label: "drivers",
+              emit: false,
+              columns: [
+                {
+                  name: "driver_id",
+                  path: "$[:].drivers[:].driver_id",
+                  type: "int",
+                  status: "Confirmed",
+                  selected: true,
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    )
+
+    const button = screen.getByRole("button", { name: "Cache as Parquet" })
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute(
+      "title",
+      "Select at least one column in an emitted table before caching.",
+    )
+    fireEvent.click(button)
+    expect(mockBuildJsonCache).not.toHaveBeenCalled()
+  })
+
   it("JsonCacheButton: shows 'Cache as Parquet' initially when not cached", async () => {
     mockGetJsonCacheStatus.mockResolvedValue({ cached: false })
 
@@ -136,16 +201,13 @@ describe("ApiInputEditor", () => {
       cached_at: 0,
     })
 
-    // Need at least one emit:true table — the Cache button is disabled
-    // when there's no schema source or no emit-true table (T9/T10).
+    // Need at least one runtime-emitting table (emit + selected column).
     render(
       <ApiInputEditor
         {...DEFAULT_PROPS}
         config={{
           path: "data/input.json",
-          tables: [
-            { path: "$[:]", label: "policies", emit: true, columns: [] },
-          ],
+          tables: [CACHEABLE_TABLE],
         }}
       />,
     )
@@ -187,9 +249,7 @@ describe("ApiInputEditor", () => {
         {...DEFAULT_PROPS}
         config={{
           path: "data/input.json",
-          tables: [
-            { path: "$[:]", label: "policies", emit: true, columns: [] },
-          ],
+          tables: [CACHEABLE_TABLE],
         }}
         configPath="rating/config/quote_input/api_input.json"
       />,
@@ -224,20 +284,146 @@ describe("ApiInputEditor", () => {
     })
   })
 
-  it("JsonCacheButton: shows error on failure", async () => {
-    mockGetJsonCacheStatus.mockResolvedValue({ cached: false })
-    mockBuildJsonCache.mockRejectedValue(new Error("Failed to build cache"))
+  it("JsonCacheButton: refetches cache status when the live schema changes", async () => {
+    mockGetJsonCacheStatusForSchema
+      .mockResolvedValueOnce({
+        cached: true,
+        data_path: "data/input.json",
+        row_count: 10,
+        column_count: 2,
+        size_bytes: 2048,
+        cached_at: 1,
+      })
+      .mockResolvedValue({ cached: false })
+    mockBuildJsonCache.mockResolvedValue({
+      cached: true,
+      data_path: "data/input.json",
+      row_count: 10,
+      column_count: 2,
+      size_bytes: 2048,
+      cached_at: 2,
+    })
 
-    // Cache button is disabled with no emit:true table; give it one
-    // so the click path fires and the error bubbles up.
-    render(
+    const baseTable = {
+      path: "$[:]",
+      label: "policies",
+      emit: true,
+      columns: [
+        {
+          name: "policy_id",
+          path: "$[:].policy_id",
+          type: "int",
+          status: "Confirmed",
+          selected: true,
+        },
+        {
+          name: "premium",
+          path: "$[:].premium",
+          type: "float",
+          status: "Confirmed",
+          selected: true,
+        },
+      ],
+    }
+    const view = render(
+      <ApiInputEditor
+        {...DEFAULT_PROPS}
+        config={{ path: "data/input.json", tables: [baseTable] }}
+        configPath="rating/config/quote_input/api_input.json"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("Refresh Cache")).toBeTruthy()
+    })
+    expect(mockGetJsonCacheStatusForSchema).toHaveBeenCalledTimes(1)
+
+    // A fresh object with the same schema value is not a new cache resource.
+    view.rerender(
       <ApiInputEditor
         {...DEFAULT_PROPS}
         config={{
           path: "data/input.json",
           tables: [
-            { path: "$[:]", label: "policies", emit: true, columns: [] },
+            {
+              ...baseTable,
+              columns: baseTable.columns.map((column) => ({ ...column })),
+            },
           ],
+        }}
+        configPath="rating/config/quote_input/api_input.json"
+      />,
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockGetJsonCacheStatusForSchema).toHaveBeenCalledTimes(1)
+    expect(screen.getByText("Refresh Cache")).toBeTruthy()
+
+    view.rerender(
+      <ApiInputEditor
+        {...DEFAULT_PROPS}
+        config={{
+          path: "data/input.json",
+          tables: [
+            {
+              ...baseTable,
+              columns: baseTable.columns.map((column, index) => ({
+                ...column,
+                selected: index === 0 ? false : column.selected,
+              })),
+            },
+          ],
+        }}
+        configPath="rating/config/quote_input/api_input.json"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockGetJsonCacheStatusForSchema).toHaveBeenCalledTimes(2)
+      expect(screen.getByText("Cache as Parquet")).toBeTruthy()
+      expect(screen.getByText(/Runs directly from JSON.*faster repeat runs/)).toBeTruthy()
+      expect(screen.queryByText("10 rows")).toBeNull()
+    })
+    expect(mockGetJsonCacheStatusForSchema).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        volatile_schema: expect.objectContaining({
+          tables: [
+            expect.objectContaining({
+              columns: [
+                expect.objectContaining({ name: "policy_id", selected: false }),
+                expect.objectContaining({ name: "premium", selected: true }),
+              ],
+            }),
+          ],
+        }),
+      }),
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Cache as Parquet").closest("button")!)
+    })
+    const buildPayload = mockBuildJsonCache.mock.calls[0][0] as Record<string, unknown>
+    expect(buildPayload).toEqual(expect.objectContaining({
+      path: "data/input.json",
+      config_path: "rating/config/quote_input/api_input.json",
+      volatile_schema: expect.any(Object),
+    }))
+    expect(buildPayload).not.toHaveProperty("resourceKey")
+    expect(buildPayload.path).not.toContain("volatile_schema")
+  })
+
+  it("JsonCacheButton: shows error on failure", async () => {
+    mockGetJsonCacheStatus.mockResolvedValue({ cached: false })
+    mockBuildJsonCache.mockRejectedValue(new Error("Failed to build cache"))
+
+    // Give the cache action a runtime-emitting table so the error path fires.
+    render(
+      <ApiInputEditor
+        {...DEFAULT_PROPS}
+        config={{
+          path: "data/input.json",
+          tables: [CACHEABLE_TABLE],
         }}
       />,
     )
@@ -251,13 +437,13 @@ describe("ApiInputEditor", () => {
     })
   })
 
-  it("JsonCacheButton: shows 'Not cached yet' message", async () => {
+  it("JsonCacheButton: explains that caching is an optional speed-up", async () => {
     mockGetJsonCacheStatus.mockResolvedValue({ cached: false })
 
     render(<ApiInputEditor {...DEFAULT_PROPS} config={{ path: "data/input.json" }} />)
 
     await waitFor(() => {
-      expect(screen.getByText(/Not cached yet/)).toBeTruthy()
+      expect(screen.getByText(/Runs directly from JSON.*faster repeat runs/)).toBeTruthy()
     })
   })
 

--- a/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputEditor.test.tsx
@@ -605,6 +605,7 @@ function StatefulHarness({
             ? { ...prev, [keyOrUpdates]: value }
             : { ...prev, ...keyOrUpdates },
         )
+        return { ok: true as const }
       }}
       accentColor="#10b981"
     />
@@ -946,10 +947,9 @@ describe("ApiInputEditor — W1.4 label validation (blank / duplicate / sanitise
     expect(error.textContent).toMatch(/drivers/)
   })
 
-  it("a sanitised-form collision (backend B2) is rejected before commit", () => {
-    // "drivers.x" sanitises to "drivers_x"; if another table is labelled
-    // "drivers_x" the backend rejects the save (both would write the
-    // same parquet). Surface that here, not as a 422 later.
+  it("rejects a former sanitised-collision witness under the ASCII identifier rule", () => {
+    // Post-B4, "drivers.x" is rejected before the defensive filesystem-stem
+    // collision check: a frame label must already be an ASCII identifier.
     const config = {
       tables: [
         { path: "$[:]", label: "policies", emit: true, columns: [] },
@@ -965,7 +965,9 @@ describe("ApiInputEditor — W1.4 label validation (blank / duplicate / sanitise
     fireEvent.blur(input)
 
     expect(onUpdateSpy).not.toHaveBeenCalled()
-    expect(screen.getByTestId("api-input-table-0-label-error").textContent).toMatch(/drivers_x/)
+    expect(screen.getByTestId("api-input-table-0-label-error")).toHaveTextContent(
+      /ASCII identifier/,
+    )
   })
 
   it("fixing an invalid draft to a valid label clears the error and commits once", () => {
@@ -986,6 +988,40 @@ describe("ApiInputEditor — W1.4 label validation (blank / duplicate / sanitise
     expect(
       (onUpdateSpy.mock.calls[0][0] as { tables: { label: string }[] }).tables[0].label,
     ).toBe("quotes")
+    expect(screen.queryByTestId("api-input-table-0-label-error")).toBeNull()
+  })
+
+  it("surfaces a rename preflight rejection until a later commit succeeds", () => {
+    const collisionError =
+      'Target "Pricing Node" already has an input named "quotes".'
+    const onUpdate = vi.fn()
+      .mockReturnValueOnce({ ok: false, error: collisionError })
+      .mockReturnValueOnce({ ok: true })
+    render(
+      <ApiInputEditor
+        config={TWO_EMIT_TABLES}
+        onUpdate={onUpdate}
+        accentColor="#10b981"
+      />,
+    )
+
+    const input = screen.getByTestId("api-input-table-0-label") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "quotes" } })
+    fireEvent.blur(input)
+
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+    const rejected = screen.getByTestId("api-input-table-0-label-error")
+    expect(rejected).toHaveTextContent("Pricing Node")
+    expect(rejected).toHaveTextContent("quotes")
+    expect(input).toHaveAttribute("aria-invalid", "true")
+
+    fireEvent.change(input, { target: { value: "claims" } })
+    expect(screen.getByTestId("api-input-table-0-label-error")).toHaveTextContent(
+      collisionError,
+    )
+    fireEvent.blur(input)
+
+    expect(onUpdate).toHaveBeenCalledTimes(2)
     expect(screen.queryByTestId("api-input-table-0-label-error")).toBeNull()
   })
 

--- a/frontend/src/__tests__/editors/ApiInputTableActions.test.tsx
+++ b/frontend/src/__tests__/editors/ApiInputTableActions.test.tsx
@@ -69,6 +69,7 @@ function StatefulHarness({
       onUpdate={(k, v) => {
         onUpdateSpy(k, v)
         setConfig((prev) => (typeof k === "string" ? { ...prev, [k]: v } : { ...prev, ...k }))
+        return { ok: true as const }
       }}
     />
   )

--- a/frontend/src/__tests__/editors/BandingEditor.test.tsx
+++ b/frontend/src/__tests__/editors/BandingEditor.test.tsx
@@ -391,7 +391,7 @@ describe("BandingEditor", () => {
   })
 
   it("renders InputSourcesBar when inputs provided", () => {
-    const inputSources = [{ sourceNodeId: "test-source", varName: "data", sourceLabel: "Data", edgeId: "e1" }]
+    const inputSources = [{ sourceNodeId: "test-source", name: "data", sourceLabel: "Data", edgeId: "e1" }]
     render(
       <BandingEditor config={{}} onUpdate={vi.fn()} inputSources={inputSources} accentColor="#22d3ee" />,
     )

--- a/frontend/src/__tests__/editors/EdgeJoinEditor.test.tsx
+++ b/frontend/src/__tests__/editors/EdgeJoinEditor.test.tsx
@@ -52,7 +52,7 @@ const edges = [
 
 function renderEditor(
   config: Record<string, unknown>,
-  onUpdate: OnUpdateConfig = vi.fn(),
+  onUpdate: OnUpdateConfig = vi.fn(() => ({ ok: true as const })),
   overrides: {
     edges?: SimpleEdge[]
     onDeleteInput?: (edgeId: string) => void

--- a/frontend/src/__tests__/editors/LiveSwitchEditor.test.tsx
+++ b/frontend/src/__tests__/editors/LiveSwitchEditor.test.tsx
@@ -35,20 +35,20 @@ describe("LiveSwitchEditor", () => {
 
   it("renders input mapping section with count", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
-      { sourceNodeId: "test-source", varName: "backtest_data", sourceLabel: "Backtest Data", edgeId: "e2" },
+      { sourceNodeId: "test-source", name: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "backtest_data", sourceLabel: "Backtest Data", edgeId: "e2" },
     ]
     render(
       <LiveSwitchEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} accentColor="#34d399" />,
     )
     expect(screen.getByText("Input → Source Mapping (2)")).toBeTruthy()
-    expect(screen.getByText("Live Data")).toBeTruthy()
-    expect(screen.getByText("Backtest Data")).toBeTruthy()
+    expect(screen.getByText("live_data")).toBeTruthy()
+    expect(screen.getByText("backtest_data")).toBeTruthy()
   })
 
   it("renders source dropdowns for each input", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
     ]
     render(
       <LiveSwitchEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} accentColor="#34d399" />,
@@ -63,7 +63,7 @@ describe("LiveSwitchEditor", () => {
 
   it("shows active indicator when input is mapped to active source", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
     ]
     const config = {
       input_scenario_map: { live_data: "live" },
@@ -76,7 +76,7 @@ describe("LiveSwitchEditor", () => {
 
   it("does not show active indicator when mapped to non-active source", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "backtest_data", sourceLabel: "Backtest Data", edgeId: "e2" },
+      { sourceNodeId: "test-source", name: "backtest_data", sourceLabel: "Backtest Data", edgeId: "e2" },
     ]
     const config = {
       input_scenario_map: { backtest_data: "backtest" },
@@ -90,7 +90,7 @@ describe("LiveSwitchEditor", () => {
   it("calls onUpdate when selecting a source for an input", () => {
     const onUpdate = vi.fn()
     const inputs = [
-      { sourceNodeId: "test-source", varName: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "live_data", sourceLabel: "Live Data", edgeId: "e1" },
     ]
     render(
       <LiveSwitchEditor config={{}} onUpdate={onUpdate} inputSources={inputs} accentColor="#34d399" />,
@@ -106,5 +106,123 @@ describe("LiveSwitchEditor", () => {
       <LiveSwitchEditor config={{}} onUpdate={vi.fn()} inputSources={[]} accentColor="#34d399" />,
     )
     expect(screen.getByText("backtest")).toBeTruthy()
+  })
+
+  it("routes two frames from one apiInput independently by their input names", () => {
+    useSettingsStore.setState({ sources: ["live", "batch"], activeSource: "live" })
+    const onUpdate = vi.fn()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    try {
+      render(
+        <LiveSwitchEditor
+          config={{ input_scenario_map: { quotes: "live", drivers: "batch" } }}
+          onUpdate={onUpdate}
+          inputSources={[
+            {
+              sourceNodeId: "api",
+              name: "quotes",
+              sourceLabel: "Quote API",
+              edgeId: "edge_quotes",
+            },
+            {
+              sourceNodeId: "api",
+              name: "drivers",
+              sourceLabel: "Quote API",
+              edgeId: "edge_drivers",
+            },
+          ]}
+          accentColor="#34d399"
+        />,
+      )
+
+      expect(screen.getByText("quotes")).toBeInTheDocument()
+      expect(screen.getByText("drivers")).toBeInTheDocument()
+      expect(screen.queryByText("Quote API")).not.toBeInTheDocument()
+      expect(
+        screen.queryByLabelText(/unresolved.*frame|frame.*unresolved/i),
+      ).not.toBeInTheDocument()
+      const selects = screen.getAllByRole("combobox") as HTMLSelectElement[]
+      expect(selects.map((select) => select.value)).toEqual(["live", "batch"])
+
+      fireEvent.change(selects[1], { target: { value: "live" } })
+      expect(onUpdate).toHaveBeenCalledWith("input_scenario_map", {
+        quotes: "live",
+        drivers: "live",
+      })
+      expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(
+        /same key|unique ["']key["']/i,
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("shows unresolved frame state while continuing to map by name", () => {
+    const onUpdate = vi.fn()
+    render(
+      <LiveSwitchEditor
+        config={{ input_scenario_map: { stale_quotes: "backtest" } }}
+        onUpdate={onUpdate}
+        inputSources={[
+          {
+            sourceNodeId: "api",
+            name: "stale_quotes",
+            sourceLabel: "Quote API",
+            edgeId: "edge_api",
+            frameUnresolved: true,
+          },
+        ]}
+        accentColor="#34d399"
+      />,
+    )
+
+    expect(screen.getByText("stale_quotes")).toBeInTheDocument()
+    const warning = screen.getByLabelText(/unresolved.*frame|frame.*unresolved/i)
+    expect(warning).toBeVisible()
+    expect(warning).toHaveAttribute(
+      "title",
+      expect.stringMatching(/eligible|emitted|resolv/i),
+    )
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement
+    expect(select.value).toBe("backtest")
+    fireEvent.change(select, { target: { value: "live" } })
+    expect(onUpdate).toHaveBeenCalledWith("input_scenario_map", { stale_quotes: "live" })
+  })
+
+  it("keeps same-parent rows distinct when their input names differ", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    try {
+      render(
+        <LiveSwitchEditor
+          config={{}}
+          onUpdate={vi.fn()}
+          inputSources={[
+            {
+              sourceNodeId: "api",
+              name: "shared_a",
+              sourceLabel: "Shared Source",
+              edgeId: "edge_a",
+            },
+            {
+              sourceNodeId: "api",
+              name: "shared_b",
+              sourceLabel: "Shared Source",
+              edgeId: "edge_b",
+            },
+          ]}
+          accentColor="#34d399"
+        />,
+      )
+
+      expect(screen.getByText("shared_a")).toBeInTheDocument()
+      expect(screen.getByText("shared_b")).toBeInTheDocument()
+      expect(screen.getAllByRole("combobox")).toHaveLength(2)
+      expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(
+        /same key|unique ["']key["']/i,
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })

--- a/frontend/src/__tests__/editors/OutputEditor.test.tsx
+++ b/frontend/src/__tests__/editors/OutputEditor.test.tsx
@@ -17,7 +17,7 @@
  * multi-step interactions accumulate.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
-import { render as rtlRender, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
+import { render as rtlRender, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
 import { useState } from "react"
 import OutputEditor from "../../panels/editors/OutputEditor"
 import { GraphProvider } from "../../panels/GraphContext"
@@ -111,7 +111,7 @@ const MULTI_FRAME_EDGES: SimpleEdge[] = [
   { id: "e-drv", source: "api", target: "output_1", sourceHandle: "drivers" },
 ]
 
-// A SINGLE-frame apiInput: ONE emit table, a null-handle edge, and NO `_columns`
+// A SINGLE-frame apiInput: ONE emit table, an explicitly labelled edge, and NO `_columns`
 // (not previewed yet). Its columns must come STRAIGHT from config.tables —
 // otherwise Infer finds nothing, the user is forced to add a "" source_column
 // row, and the backend crashes with missing=[''] (the bug Nick hit). Only
@@ -141,7 +141,41 @@ const SINGLE_FRAME_API_NODES: SimpleNode[] = [
   },
 ]
 const SINGLE_FRAME_API_EDGES: SimpleEdge[] = [
-  { id: "e-api", source: "api", target: "output_1" }, // null sourceHandle
+  { id: "e-api", source: "api", target: "output_1", sourceHandle: "quotes" },
+]
+
+// A dangling, explicitly labelled apiInput edge whose configured table is not
+// runtime-eligible. The stale handle remains the input name but is warned as
+// unresolved until a matching eligible frame exists.
+const ZERO_ELIGIBLE_API_NODES: SimpleNode[] = [
+  {
+    id: "api",
+    data: {
+      label: "API Input",
+      description: "",
+      nodeType: "apiInput",
+      config: {
+        tables: [
+          {
+            path: "$[:]",
+            label: "quotes",
+            emit: true,
+            columns: [
+              { name: "quote_id", path: "$[:].quote_id", type: "int", status: "Inferred", selected: false },
+            ],
+          },
+        ],
+      },
+    },
+  },
+]
+const ZERO_ELIGIBLE_API_EDGES: SimpleEdge[] = [
+  {
+    id: "e-api-empty",
+    source: "api",
+    target: "output_1",
+    sourceHandle: "stale_quotes",
+  },
 ]
 
 // Two DISTINCT single-port sources (null sourceHandle each), with distinct
@@ -248,6 +282,7 @@ function StatefulHarness({
               ? { ...prev, [keyOrUpdates]: value }
               : { ...prev, ...keyOrUpdates },
           )
+          return { ok: true as const }
         }}
       />
     </GraphProvider>
@@ -298,12 +333,41 @@ describe("OutputEditor — frame blocks", () => {
     expect(screen.getByText("drivers")).toBeTruthy()
   })
 
-  it("falls back to the source node label for a single-port (null handle) frame", () => {
+  it("uses the sanitised edge-derived name for an ordinary single-port frame", () => {
     render(<OutputEditor {...DEFAULT_PROPS} />, {
       allNodes: SINGLE_PORT_NODES,
       edges: SINGLE_PORT_EDGES,
     })
-    expect(screen.getByText("Upstream Node")).toBeTruthy()
+    const block = screen.getByTestId("output-frame-0")
+    expect(within(block).getByText("Upstream_Node")).toBeTruthy()
+    expect(within(block).queryByText("Upstream Node")).toBeNull()
+  })
+
+  it("labels a sole-frame apiInput block with its edge-derived input name", () => {
+    render(<OutputEditor {...DEFAULT_PROPS} />, {
+      allNodes: SINGLE_FRAME_API_NODES,
+      edges: SINGLE_FRAME_API_EDGES,
+    })
+
+    const block = screen.getByTestId("output-frame-0")
+    expect(within(block).getByText("quotes")).toBeInTheDocument()
+    expect(within(block).queryByText("API Input")).not.toBeInTheDocument()
+  })
+
+  it("renders a visible unresolved header warning for a dangling apiInput frame", () => {
+    render(<OutputEditor {...DEFAULT_PROPS} />, {
+      allNodes: ZERO_ELIGIBLE_API_NODES,
+      edges: ZERO_ELIGIBLE_API_EDGES,
+    })
+
+    const block = screen.getByTestId("output-frame-0")
+    expect(within(block).getByText("API Input")).toBeInTheDocument()
+    const warning = within(block).getByLabelText(/unresolved.*frame|frame.*unresolved/i)
+    expect(warning).toBeVisible()
+    expect(warning).toHaveAttribute(
+      "title",
+      expect.stringMatching(/eligible|emitted|resolv/i),
+    )
   })
 
   it("surfaces the per-frame column set from the apiInput table matching the handle", () => {
@@ -491,7 +555,7 @@ describe("OutputEditor — v1 migration", () => {
         edges={SINGLE_PORT_EDGES}
       />,
     )
-    // The single-port frame migrates fields with source_port "".
+    // The single-port frame migrates fields under its edge-derived input name.
     expandFrame("output-frame-0")
     // Adding a row triggers a writeBack of the (migrated) working copy plus
     // the new row — the migration is applied on the first save.
@@ -857,6 +921,34 @@ describe("OutputEditor — non-canonical highlight (§4)", () => {
 })
 
 describe("OutputEditor — source_port derivation (blocker)", () => {
+  it.each([
+    ["a resolved singleton frame", SINGLE_FRAME_API_NODES, SINGLE_FRAME_API_EDGES, "quotes"],
+    [
+      "an unresolved dangling frame",
+      ZERO_ELIGIBLE_API_NODES,
+      ZERO_ELIGIBLE_API_EDGES,
+      "stale_quotes",
+    ],
+  ])("persists source_port equal to the input name for %s", (_case, allNodes, edges, name) => {
+    const onUpdateSpy = vi.fn()
+    render(
+      <StatefulHarness
+        initialConfig={{ outputMapping: [], outputFormat: "json" }}
+        onUpdateSpy={onUpdateSpy}
+        allNodes={allNodes}
+        edges={edges}
+      />,
+    )
+
+    expandFrame("output-frame-0")
+    fireEvent.click(screen.getByTestId("output-frame-0-add-row"))
+
+    const persisted = onUpdateSpy.mock.calls.at(-1)?.[0] as {
+      outputMapping: { source_port: string }[]
+    }
+    expect(persisted.outputMapping.at(-1)?.source_port).toBe(name)
+  })
+
   it("two NULL-handle sources persist DISTINCT, non-empty source_ports = sanitised labels", () => {
     const onUpdateSpy = vi.fn()
     render(
@@ -1066,7 +1158,7 @@ describe("OutputEditor — frames-table input schema", () => {
     })
     fireEvent.click(screen.getByTestId("output-frames-toggle"))
     const frame = screen.getByTestId("output-frames-schema-0")
-    expect(frame.textContent).toContain("Upstream Node")
+    expect(frame.textContent).toContain("Upstream_Node")
     expect(frame.textContent).toContain("premium")
     expect(frame.textContent).toContain("Float64")
     expect(frame.textContent).toContain("area")

--- a/frontend/src/__tests__/editors/OutputEditorPathTools.test.tsx
+++ b/frontend/src/__tests__/editors/OutputEditorPathTools.test.tsx
@@ -92,6 +92,7 @@ function StatefulHarness({
         onUpdate={(k, v) => {
           onUpdateSpy(k, v)
           setConfig((prev) => (typeof k === "string" ? { ...prev, [k]: v } : { ...prev, ...k }))
+          return { ok: true as const }
         }}
       />
     </GraphProvider>

--- a/frontend/src/__tests__/editors/RatingStepEditor.test.tsx
+++ b/frontend/src/__tests__/editors/RatingStepEditor.test.tsx
@@ -1436,7 +1436,7 @@ describe("RatingStepEditor", () => {
       <RatingStepEditor
         config={{}}
         onUpdate={vi.fn()}
-        inputSources={[{ sourceNodeId: "test-source", varName: "source_data", sourceLabel: "Source Data", edgeId: "e1" }]}
+        inputSources={[{ sourceNodeId: "test-source", name: "source_data", sourceLabel: "Source Data", edgeId: "e1" }]}
 
         accentColor="#14b8a6"
       />,

--- a/frontend/src/__tests__/editors/ScenarioExpanderEditor.test.tsx
+++ b/frontend/src/__tests__/editors/ScenarioExpanderEditor.test.tsx
@@ -15,7 +15,7 @@ vi.mock("../../panels/editors/_shared", async () => {
   const actual = await vi.importActual("../../panels/editors/_shared")
   return {
     ...actual,
-    InputSourcesBar: ({ inputSources }: { inputSources: { sourceNodeId: string; varName: string; edgeId: string; sourceLabel: string }[] }) => (
+    InputSourcesBar: ({ inputSources }: { inputSources: { sourceNodeId: string; name: string; edgeId: string; sourceLabel: string }[] }) => (
       <div data-testid="input-sources">{inputSources?.length ?? 0} inputs</div>
     ),
     INPUT_STYLE: {},
@@ -38,7 +38,7 @@ afterEach(cleanup)
 const DEFAULT_PROPS = {
   config: {},
   onUpdate: vi.fn(),
-  inputSources: [] as { sourceNodeId: string; varName: string; edgeId: string; sourceLabel: string }[],
+  inputSources: [] as { sourceNodeId: string; name: string; edgeId: string; sourceLabel: string }[],
   upstreamColumns: [] as { name: string; dtype: string }[],
   accentColor: "#2dd4bf",
 }
@@ -144,6 +144,7 @@ describe("ScenarioExpanderEditor", () => {
       const handleUpdate: OnUpdateConfig = (keyOrUpdates, value) => {
         recordConfigUpdate(onUpdate, keyOrUpdates, value)
         setConfig((prev) => applyConfigUpdate(prev, keyOrUpdates, value))
+        return { ok: true }
       }
       return (
         <>
@@ -185,6 +186,7 @@ describe("ScenarioExpanderEditor", () => {
       const handleUpdate: OnUpdateConfig = (keyOrUpdates, value) => {
         recordConfigUpdate(onUpdate, keyOrUpdates, value)
         setConfig((prev) => applyConfigUpdate(prev, keyOrUpdates, value))
+        return { ok: true }
       }
       return <ScenarioExpanderEditor {...DEFAULT_PROPS} onUpdate={handleUpdate} config={config} />
     }
@@ -281,6 +283,7 @@ describe("ScenarioExpanderEditor", () => {
       const handleUpdate: OnUpdateConfig = (keyOrUpdates, value) => {
         recordConfigUpdate(onUpdate, keyOrUpdates, value)
         setConfig((prev) => applyConfigUpdate(prev, keyOrUpdates, value))
+        return { ok: true }
       }
 
       return <ScenarioExpanderEditor {...DEFAULT_PROPS} onUpdate={handleUpdate} config={config} />
@@ -309,6 +312,7 @@ describe("ScenarioExpanderEditor", () => {
       const handleUpdate: OnUpdateConfig = (keyOrUpdates, value) => {
         recordConfigUpdate(onUpdate, keyOrUpdates, value)
         setConfig((prev) => applyConfigUpdate(prev, keyOrUpdates, value))
+        return { ok: true }
       }
       return (
         <>
@@ -447,7 +451,7 @@ describe("ScenarioExpanderEditor", () => {
 
   it("InputSourcesBar renders when inputSources provided", () => {
     const inputSources = [
-      { sourceNodeId: "test-source", varName: "upstream_data", sourceLabel: "Upstream", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "upstream_data", sourceLabel: "Upstream", edgeId: "e1" },
     ]
     render(<ScenarioExpanderEditor {...DEFAULT_PROPS} inputSources={inputSources} />)
     expect(screen.getByTestId("input-sources")).toBeTruthy()

--- a/frontend/src/__tests__/editors/TransformEditor.test.tsx
+++ b/frontend/src/__tests__/editors/TransformEditor.test.tsx
@@ -44,7 +44,7 @@ describe("TransformEditor", () => {
 
   it('shows "use input names" hint when input sources present', () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
     ]
     render(
       <TransformEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} />,
@@ -54,8 +54,8 @@ describe("TransformEditor", () => {
 
   it("renders input sources bar showing connected variable names", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
-      { sourceNodeId: "test-source", varName: "policies", sourceLabel: "Policy Data", edgeId: "e2" },
+      { sourceNodeId: "test-source", name: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "policies", sourceLabel: "Policy Data", edgeId: "e2" },
     ]
     render(
       <TransformEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} />,
@@ -91,7 +91,7 @@ describe("TransformEditor", () => {
 
   it("does not synthesize input alias scaffold when inputs are connected", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "claims", sourceLabel: "Claims Data", edgeId: "e1" },
     ]
     render(
       <TransformEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} />,
@@ -103,7 +103,7 @@ describe("TransformEditor", () => {
 
   it("shows single input source name with 'Input' singular label", () => {
     const inputs = [
-      { sourceNodeId: "test-source", varName: "quotes", sourceLabel: "Quotes Data", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "quotes", sourceLabel: "Quotes Data", edgeId: "e1" },
     ]
     render(
       <TransformEditor config={{}} onUpdate={vi.fn()} inputSources={inputs} />,

--- a/frontend/src/__tests__/editors/apiInputBundle3bCacheContract.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputBundle3bCacheContract.test.tsx
@@ -108,11 +108,8 @@ describe("Bundle 3b — cache button positioned above the Tables editor", () => 
 
     // Tables editor container — pinned by its existing data-testid.
     const tablesEditor = screen.getByTestId("api-input-tables")
-    // Cache button — selected by accessible role + name (the visible
-    // hint text "Not cached yet — click to flatten/shred and cache as
-    // Parquet" ALSO contains "Cache as Parquet", so `getByText` would
-    // match both; `getByRole("button", …)` resolves unambiguously to
-    // the button).
+    // Cache button — selected by accessible role + name because the nearby
+    // optional-speed hint also mentions "cache as Parquet".
     const cacheButton = screen.getByRole("button", { name: /cache as parquet/i })
 
     // The cache button must NOT live inside the Tables editor section.

--- a/frontend/src/__tests__/editors/apiInputBundle3cContract.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputBundle3cContract.test.tsx
@@ -1,33 +1,18 @@
 /**
- * Contract tests for Bundle 3c — edge attachment + node body
- * table-label list.
+ * Contract tests for Bundle 3c — React Flow handle remeasurement and
+ * the full-detail apiInput frame-row body.
  *
- * 1. **Edge attachment via `useUpdateNodeInternals`**. When an apiInput
- *    node's emit-table set changes (a table is added, removed, or its
- *    `emit` flag toggled), the handle topology on the right edge
- *    changes too: 0/1 emit → single unlabelled Handle; 2+ emit → one
- *    labelled Handle per table (see `_SourceHandles` in
- *    `PipelineNode.tsx`). React Flow caches each node's handle
- *    measurements when the node first mounts; without an explicit
- *    `updateNodeInternals(id)` call, edges connected to the old
- *    handles can render at stale screen coordinates after the topology
- *    changes — the visible symptom is edges "floating" off the node or
- *    snapping to (0,0). The hook re-measures the handles for the given
- *    node id; calling it from a `useEffect` keyed on the emit-label
- *    signature is the idiomatic React Flow pattern for this.
+ * 1. **Edge attachment via `useUpdateNodeInternals`**. React Flow caches
+ *    handle measurements, so PipelineNode must request remeasurement when
+ *    the ordered `apiInputFrameLabels` signature changes. The collision-safe
+ *    JSON signature deliberately ignores edits that preserve that list,
+ *    avoiding unnecessary handle churn.
  *
- * 2. **Compact right-aligned table-label list on the node body**. For
- *    apiInput nodes with 2+ emit tables (the multi-port case), render
- *    each emit table's label as a small right-aligned text item on the
- *    node body, vertically stacked top-to-bottom in the same order as
- *    the handles on the right edge. Gives the user a visual mapping
- *    from each port to its source table without having to open the
- *    panel.
- *
- *    Not rendered when:
- *      - The node is not an apiInput.
- *      - The apiInput has fewer than 2 emit tables (single-port
- *        fallback — the unlabelled Handle is unambiguous).
+ * 2. **Full-detail frame-row body**. Every runtime-eligible emitted frame,
+ *    including the sole frame of a single-table config, is shown as a named
+ *    row. No frame-name rows render for a zero-eligible config or a non-apiInput
+ *    node. Runtime eligibility requires `emit: true`, at least one selected
+ *    column, and a valid raw label.
  */
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen, cleanup } from "@testing-library/react"
@@ -93,10 +78,10 @@ afterEach(() => {
 })
 
 // ---------------------------------------------------------------------------
-// 1. useUpdateNodeInternals — handle topology re-anchor
+// 1. useUpdateNodeInternals — handle topology/placement re-anchor
 // ---------------------------------------------------------------------------
 
-describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes", () => {
+describe("Bundle 3c — useUpdateNodeInternals tracks apiInput frame labels", () => {
   it("calls updateNodeInternals with the node id on first render", () => {
     renderNode(
       {
@@ -116,7 +101,7 @@ describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes
     expect(mockUpdateNodeInternals).toHaveBeenCalledWith("api_1")
   })
 
-  it("re-fires updateNodeInternals when the emit-table signature changes", () => {
+  it("re-fires updateNodeInternals when the ordered frame-label list changes", () => {
     const { rerender } = renderNode(
       {
         label: "Quote Input",
@@ -184,17 +169,28 @@ describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes
     expect(mockUpdateNodeInternals).toHaveBeenLastCalledWith("api_1")
   })
 
-  it("does NOT re-fire when a non-handle-affecting field changes (label edit on existing table)", () => {
-    // A column or non-emit attribute change doesn't change the handle
-    // set; the effect's signature dependency should NOT trigger again.
+  it("does NOT re-fire when an edit preserves the frame-label list", () => {
+    // Adding a second selected column to an already-eligible table changes
+    // neither its visible frame nor its handle id. The effect signature
+    // remains stable, so React Flow must not be asked to remeasure.
     const initialData: PipelineNodeData = {
       label: "Quote Input",
       description: "",
       nodeType: NODE_TYPES.API_INPUT,
       config: {
         tables: [
-          { label: "row", emit: true, path: "$[:]", columns: [] },
-          { label: "ext", emit: true, path: "$[:].ext[:]", columns: [] },
+          {
+            label: "row",
+            emit: true,
+            path: "$[:]",
+            columns: [{ name: "existing", path: "$[:].existing", type: "int", selected: true }],
+          },
+          {
+            label: "ext",
+            emit: true,
+            path: "$[:].ext[:]",
+            columns: [{ name: "c", selected: true }],
+          },
         ],
       },
     }
@@ -219,9 +215,7 @@ describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes
     )
     const callCountAfterMount = mockUpdateNodeInternals.mock.calls.length
 
-    // Edit a column inside an existing table — does NOT change emit
-    // labels.  Effect signature stays the same; hook should not fire
-    // again.
+    // Add another selected column without changing table eligibility.
     const editedData: PipelineNodeData = {
       ...initialData,
       config: {
@@ -230,9 +224,17 @@ describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes
             label: "row",
             emit: true,
             path: "$[:]",
-            columns: [{ name: "added_column", path: "$[:].x", type: "int", selected: true }],
+            columns: [
+              { name: "existing", path: "$[:].existing", type: "int", selected: true },
+              { name: "added_column", path: "$[:].x", type: "int", selected: true },
+            ],
           },
-          { label: "ext", emit: true, path: "$[:].ext[:]", columns: [] },
+          {
+            label: "ext",
+            emit: true,
+            path: "$[:].ext[:]",
+            columns: [{ name: "c", selected: true }],
+          },
         ],
       },
     }
@@ -257,14 +259,144 @@ describe("Bundle 3c — useUpdateNodeInternals fires when emit-table set changes
     )
     expect(mockUpdateNodeInternals.mock.calls.length).toBe(callCountAfterMount)
   })
+
+  it("re-fires when valid identifier labels are reordered", () => {
+    const eligibleTables = (labels: string[]) =>
+      labels.map((label) => ({
+        label,
+        emit: true,
+        path: `$['${label}']`,
+        columns: [{ name: "value", selected: true }],
+      }))
+    const initialData: PipelineNodeData = {
+      label: "Quote Input",
+      description: "",
+      nodeType: NODE_TYPES.API_INPUT,
+      config: { tables: eligibleTables(["alpha", "beta"]) },
+    }
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PipelineNode
+          {...({
+            id: "api_1",
+            type: "custom",
+            data: initialData,
+            selected: false,
+            isConnectable: true,
+            positionAbsoluteX: 0,
+            positionAbsoluteY: 0,
+            zIndex: 0,
+            dragging: false,
+            deletable: true,
+            selectable: true,
+          } as unknown as NodeProps<PipelineFlowNode>)}
+        />
+      </ReactFlowProvider>,
+    )
+    const callCountAfterMount = mockUpdateNodeInternals.mock.calls.length
+
+    rerender(
+      <ReactFlowProvider>
+        <PipelineNode
+          {...({
+            id: "api_1",
+            type: "custom",
+            data: {
+              ...initialData,
+              config: { tables: eligibleTables(["beta", "alpha"]) },
+            },
+            selected: false,
+            isConnectable: true,
+            positionAbsoluteX: 0,
+            positionAbsoluteY: 0,
+            zIndex: 0,
+            dragging: false,
+            deletable: true,
+            selectable: true,
+          } as unknown as NodeProps<PipelineFlowNode>)}
+        />
+      </ReactFlowProvider>,
+    )
+
+    expect(mockUpdateNodeInternals.mock.calls.length).toBe(callCountAfterMount + 1)
+    expect(mockUpdateNodeInternals).toHaveBeenLastCalledWith("api_1")
+  })
+
+  it("re-fires when a table becomes the sole visible frame without changing the emit-table set", () => {
+    const initialData: PipelineNodeData = {
+      label: "Quote Input",
+      description: "",
+      nodeType: NODE_TYPES.API_INPUT,
+      config: {
+        tables: [
+          { label: "row", emit: true, path: "$[:]", columns: [] },
+        ],
+      },
+    }
+    const { rerender } = render(
+      <ReactFlowProvider>
+        <PipelineNode
+          {...({
+            id: "api_1",
+            type: "custom",
+            data: initialData,
+            selected: false,
+            isConnectable: true,
+            positionAbsoluteX: 0,
+            positionAbsoluteY: 0,
+            zIndex: 0,
+            dragging: false,
+            deletable: true,
+            selectable: true,
+          } as unknown as NodeProps<PipelineFlowNode>)}
+        />
+      </ReactFlowProvider>,
+    )
+    const callCountAfterMount = mockUpdateNodeInternals.mock.calls.length
+
+    const eligibleData: PipelineNodeData = {
+      ...initialData,
+      config: {
+        tables: [
+          {
+            label: "row",
+            emit: true,
+            path: "$[:]",
+            columns: [{ name: "first_selected", selected: true }],
+          },
+        ],
+      },
+    }
+    rerender(
+      <ReactFlowProvider>
+        <PipelineNode
+          {...({
+            id: "api_1",
+            type: "custom",
+            data: eligibleData,
+            selected: false,
+            isConnectable: true,
+            positionAbsoluteX: 0,
+            positionAbsoluteY: 0,
+            zIndex: 0,
+            dragging: false,
+            deletable: true,
+            selectable: true,
+          } as unknown as NodeProps<PipelineFlowNode>)}
+        />
+      </ReactFlowProvider>,
+    )
+    expect(mockUpdateNodeInternals.mock.calls.length).toBeGreaterThan(callCountAfterMount)
+    expect(mockUpdateNodeInternals).toHaveBeenLastCalledWith("api_1")
+  })
 })
 
 // ---------------------------------------------------------------------------
-// 2. Compact right-aligned table-label list on the node body
+// 2. Full-detail apiInput frame-row body
 // ---------------------------------------------------------------------------
 
-describe("Bundle 3c — node body shows compact table-label list", () => {
-  it("renders emit table labels on the body for apiInput with 2+ emit tables", () => {
+describe("Bundle 3c — full-detail node body shows eligible emitted frames", () => {
+  it("renders one named frame row per eligible emitted frame", () => {
     renderNode({
       label: "Quote Input",
       nodeType: NODE_TYPES.API_INPUT,
@@ -280,6 +412,10 @@ describe("Bundle 3c — node body shows compact table-label list", () => {
         ],
       },
     })
+    expect(screen.getAllByTestId(/^api-input-frame-row-/).map((row) => row.dataset.testid)).toEqual([
+      "api-input-frame-row-row",
+      "api-input-frame-row-ext",
+    ])
     expect(screen.getByTestId("api-input-body-label-row")).toBeInTheDocument()
     expect(screen.getByTestId("api-input-body-label-ext")).toBeInTheDocument()
     // Visual content matches the label text.
@@ -287,44 +423,47 @@ describe("Bundle 3c — node body shows compact table-label list", () => {
     expect(screen.getByTestId("api-input-body-label-ext")).toHaveTextContent("ext")
   })
 
-  it("does NOT render the label list for an apiInput with a single emit table", () => {
+  it("renders the name row for the sole eligible frame in a single-table config", () => {
     renderNode({
       label: "Quote Input",
       nodeType: NODE_TYPES.API_INPUT,
       config: {
         tables: [
-          { label: "row", emit: true, path: "$[:]", columns: [] },
+          { label: "row", emit: true, path: "$[:]", columns: [{ name: "c", selected: true }] },
         ],
       },
     })
-    expect(screen.queryByTestId(/^api-input-body-label-/)).not.toBeInTheDocument()
+    expect(screen.getByTestId("api-input-frame-row-row")).toBeInTheDocument()
+    expect(screen.getByTestId("api-input-body-label-row")).toHaveTextContent("row")
   })
 
-  it("does NOT render the label list for an apiInput with zero emit tables", () => {
+  it("does NOT render frame-name rows for an apiInput with zero eligible frames", () => {
     renderNode({
       label: "Quote Input",
       nodeType: NODE_TYPES.API_INPUT,
       config: {
         tables: [
-          { label: "row", emit: false, path: "$[:]", columns: [] },
+          { label: "row", emit: false, path: "$[:]", columns: [{ name: "c", selected: true }] },
         ],
       },
     })
+    expect(screen.queryByTestId(/^api-input-frame-row-/)).not.toBeInTheDocument()
     expect(screen.queryByTestId(/^api-input-body-label-/)).not.toBeInTheDocument()
   })
 
-  it("does NOT render the label list for non-apiInput nodes (e.g. polars)", () => {
+  it("does NOT render frame-name rows for non-apiInput nodes (e.g. polars)", () => {
     renderNode({
       label: "Clean Data",
       nodeType: NODE_TYPES.POLARS,
       config: {
         // even with a tables-shaped config, the labels are apiInput-only
         tables: [
-          { label: "row", emit: true, path: "$[:]", columns: [] },
-          { label: "ext", emit: true, path: "$[:].ext[:]", columns: [] },
+          { label: "row", emit: true, path: "$[:]", columns: [{ name: "c", selected: true }] },
+          { label: "ext", emit: true, path: "$[:].ext[:]", columns: [{ name: "c", selected: true }] },
         ],
       },
     })
+    expect(screen.queryByTestId(/^api-input-frame-row-/)).not.toBeInTheDocument()
     expect(screen.queryByTestId(/^api-input-body-label-/)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputInheritIntegration.test.tsx
@@ -70,6 +70,7 @@ function StatefulHarness({
             ? { ...prev, [keyOrUpdates]: value }
             : { ...prev, ...keyOrUpdates },
         )
+        return { ok: true as const }
       }}
       accentColor="#10b981"
     />

--- a/frontend/src/__tests__/editors/apiInputPathGrammar.test.tsx
+++ b/frontend/src/__tests__/editors/apiInputPathGrammar.test.tsx
@@ -46,13 +46,14 @@ function Harness({ initialConfig }: { initialConfig: Record<string, unknown> }) 
   return (
     <ApiInputEditor
       config={config}
-      onUpdate={(keyOrUpdates: string | Record<string, unknown>, value?: unknown) =>
+      onUpdate={(keyOrUpdates: string | Record<string, unknown>, value?: unknown) => {
         setConfig((prev) =>
           typeof keyOrUpdates === "string"
             ? { ...prev, [keyOrUpdates]: value }
             : { ...prev, ...keyOrUpdates },
         )
-      }
+        return { ok: true as const }
+      }}
       accentColor="#10b981"
     />
   )

--- a/frontend/src/__tests__/hover/editorsHover.test.tsx
+++ b/frontend/src/__tests__/hover/editorsHover.test.tsx
@@ -485,7 +485,7 @@ function renderInputSourcesBarWithDelete() {
   return render(
     <InputSourcesBar
       inputSources={[
-        { sourceNodeId: "test-source", varName: "df", sourceLabel: "Source · df", edgeId: "e1" },
+        { sourceNodeId: "test-source", name: "df", sourceLabel: "Source · df", edgeId: "e1" },
       ]}
       onDeleteInput={() => {}}
     />,
@@ -572,7 +572,7 @@ describe("_shared.tsx hover integration", () => {
     const onDelete = vi.fn()
     render(
       <InputSourcesBar
-        inputSources={[{ sourceNodeId: "test-source", varName: "df", sourceLabel: "Source · df", edgeId: "e1" }]}
+        inputSources={[{ sourceNodeId: "test-source", name: "df", sourceLabel: "Source · df", edgeId: "e1" }]}
         onDeleteInput={onDelete}
       />,
     )
@@ -589,7 +589,7 @@ describe("RatingStepEditor hover integration", () => {
 
   const DEFAULT = {
     config: {} as Record<string, unknown>,
-    onUpdate: () => {},
+    onUpdate: () => ({ ok: true as const }),
     inputSources: [],
     onDeleteInput: undefined,
     accentColor: "#14b8a6",

--- a/frontend/src/__tests__/nodes/ApiInputHandles.test.tsx
+++ b/frontend/src/__tests__/nodes/ApiInputHandles.test.tsx
@@ -5,24 +5,32 @@
  *  - apiInput with multiple emit:true tables renders one React Flow
  *    `<Handle>` per emit:true table; each Handle's `id` is the table's
  *    label.
- *  - apiInput with zero or one emit:true table renders the default
- *    single Handle (legacy behaviour preserved for single-port
- *    pipelines).
+ *  - apiInput with one or more eligible frames renders one labelled
+ *    Handle per frame; only zero frames retains a non-connectable default.
  *  - Handles are visually labelled (a small dot + the label string)
  *    so the user can drag-from-handle to identify the port.
  *
  * These are strict-TDD reds — they're expected to fail until the
  * PipelineNode commit-6 implementation lands.
  */
+import { useLayoutEffect } from "react"
 import { describe, it, expect, afterEach } from "vitest"
-import { render, cleanup } from "@testing-library/react"
-import { ReactFlowProvider, type NodeProps } from "@xyflow/react"
+import { render, cleanup, screen, within } from "@testing-library/react"
+import { ReactFlowProvider, useStoreApi, type NodeProps } from "@xyflow/react"
 
 import PipelineNode from "../../nodes/PipelineNode"
 import type { PipelineFlowNode, PipelineNodeData } from "../../types/node"
 import { NODE_TYPES } from "../../utils/nodeTypes"
 
-function renderNode(config: Record<string, unknown>) {
+function ZoomSeed({ zoom }: { zoom: number }) {
+  const store = useStoreApi()
+  useLayoutEffect(() => {
+    store.setState({ transform: [0, 0, zoom] })
+  }, [store, zoom])
+  return null
+}
+
+function renderNode(config: Record<string, unknown>, zoom = 1) {
   const data: PipelineNodeData = {
     label: "quotes",
     nodeType: NODE_TYPES.API_INPUT,
@@ -48,6 +56,7 @@ function renderNode(config: Record<string, unknown>) {
   }
   return render(
     <ReactFlowProvider>
+      {zoom !== 1 && <ZoomSeed zoom={zoom} />}
       <PipelineNode {...(props as unknown as NodeProps<PipelineFlowNode>)} />
     </ReactFlowProvider>,
   )
@@ -98,20 +107,24 @@ describe("apiInput multi-port Handles (commit 6)", () => {
     expect(ids).toEqual(["drivers", "policies"])
   })
 
-  it("renders a single default source Handle when only one table is emit:true", () => {
+  it("renders a labelled source Handle when only one table is eligible", () => {
     const { container } = renderNode({
       path: "data/quotes.json",
       tables: [
-        { path: "$[:]", label: "policies", emit: true, columns: [] },
+        {
+          path: "$[:]",
+          label: "policies",
+          emit: true,
+          columns: [{ name: "policy_id", selected: true }],
+        },
         { path: "$[:].drivers[:]", label: "drivers", emit: false, columns: [] },
       ],
     })
-    // Single-port preserves legacy default-handle behaviour (id=null,
-    // bare two-arg connect form). No special multi-port labelling.
-    const sourceHandles = container.querySelectorAll(
+    const sourceHandles = Array.from(container.querySelectorAll(
       '.react-flow__handle[data-handlepos="right"]',
-    )
+    ))
     expect(sourceHandles).toHaveLength(1)
+    expect(sourceHandles[0]).toHaveAttribute("data-handleid", "policies")
   })
 
   it("renders a single default source Handle when no tables are emit:true", () => {
@@ -152,6 +165,68 @@ function sourceHandleIds(container: HTMLElement): (string | null)[] {
   ).map((h) => h.getAttribute("data-handleid"))
 }
 
+function handleIdsAtZoom(config: Record<string, unknown>, zoom: number): (string | null)[] {
+  const view = renderNode(config, zoom)
+  const ids = sourceHandleIds(view.container)
+  view.unmount()
+  return ids
+}
+
+function eligibleTable(label: string) {
+  return {
+    path: `$['${label}']`,
+    label,
+    emit: true,
+    columns: [{ name: "value", selected: true }],
+  }
+}
+
+describe("apiInput handle identity across zoom levels", () => {
+  afterEach(cleanup)
+
+  it("keeps the same ordered raw-label handle set at full, medium, and compact detail", () => {
+    const labels = ["policy_items", "driver_claims", "vehicles"]
+    const config = { tables: labels.map((label) => eligibleTable(label)) }
+
+    expect(handleIdsAtZoom(config, 1)).toEqual(labels)
+    expect(handleIdsAtZoom(config, 0.5)).toEqual(labels)
+    expect(handleIdsAtZoom(config, 0.2)).toEqual(labels)
+  })
+
+  it("keeps the sole frame labelled at full, medium, and compact detail", () => {
+    const config = {
+      tables: [
+        eligibleTable("policy_items"),
+        {
+          ...eligibleTable("not-runtime-eligible"),
+          columns: [{ name: "value", selected: false }],
+        },
+      ],
+    }
+
+    expect(handleIdsAtZoom(config, 1)).toEqual(["policy_items"])
+    expect(handleIdsAtZoom(config, 0.5)).toEqual(["policy_items"])
+    expect(handleIdsAtZoom(config, 0.2)).toEqual(["policy_items"])
+  })
+
+  it("falls back to one default handle and the zero-frame body when every multi-emit label is invalid", () => {
+    const { container } = renderNode({
+      tables: [eligibleTable(""), eligibleTable(" \t")],
+    })
+
+    expect(sourceHandleIds(container)).toEqual([null])
+    const defaultHandle = container.querySelector<HTMLElement>(
+      '.react-flow__handle[data-handlepos="right"]',
+    )
+    expect(defaultHandle).not.toHaveClass("connectablestart")
+    expect(defaultHandle).not.toHaveClass("connectableend")
+    const node = screen.getByTestId("node-quotes")
+    expect(within(node).getByText("quotes")).toBeInTheDocument()
+    expect(within(node).getByText("No emitted frames")).toBeInTheDocument()
+    expect(within(node).queryAllByTestId(/^api-input-frame-row-/)).toHaveLength(0)
+  })
+})
+
 describe("apiInput Handles never synthesize ids (W1.4)", () => {
   afterEach(cleanup)
 
@@ -173,6 +248,17 @@ describe("apiInput Handles never synthesize ids (W1.4)", () => {
     expect(ids.some((id) => id?.startsWith("port_"))).toBe(false)
   })
 
+  it.each(["quote id", "with-hyphen", "café", "class"])(
+    "an invalid identifier label %j renders no labelled handle",
+    (invalidLabel) => {
+      const { container } = renderNode({
+        tables: [eligibleTable(invalidLabel), eligibleTable("drivers")],
+      })
+
+      expect(sourceHandleIds(container)).toEqual(["drivers"])
+    },
+  )
+
   it("duplicate labels render ONE handle (first occurrence) — no __<idx> disambiguation", () => {
     const { container } = renderNode({
       path: "data/quotes.json",
@@ -190,6 +276,14 @@ describe("apiInput Handles never synthesize ids (W1.4)", () => {
     expect(ids).toEqual(["dup"])
   })
 
+  it("case-only duplicate labels render only the first spelling", () => {
+    const { container } = renderNode({
+      tables: [eligibleTable("Items"), eligibleTable("items")],
+    })
+
+    expect(sourceHandleIds(container)).toEqual(["Items"])
+  })
+
   it("all-blank labels fall back to the single default handle (no bindable fiction)", () => {
     // Backend-invalid config (only reachable from legacy disk files —
     // the editor refuses blank label commits). Nothing portlike is
@@ -202,7 +296,7 @@ describe("apiInput Handles never synthesize ids (W1.4)", () => {
       ],
     })
     const ids = sourceHandleIds(container)
-    expect(ids).toHaveLength(1)
+    expect(ids).toEqual([null])
     expect(ids.some((id) => id?.startsWith("port_") || id?.includes("__"))).toBe(false)
   })
 })

--- a/frontend/src/components/ReadOnlyNodeConfig.tsx
+++ b/frontend/src/components/ReadOnlyNodeConfig.tsx
@@ -34,8 +34,9 @@ import {
 } from "../panels/LazyNodeEditors"
 import { GraphProvider } from "../panels/GraphContext"
 import { NODE_TYPES, nodeTypeColors } from "../utils/nodeTypes"
+import type { OnUpdateConfigResult } from "../panels/editors/_shared"
 
-const noop = () => {}
+const noop = (): OnUpdateConfigResult => ({ ok: true })
 const EMPTY: never[] = []
 
 interface ReadOnlyNodeConfigProps {

--- a/frontend/src/components/__tests__/ReadOnlyNodeConfig.test.tsx
+++ b/frontend/src/components/__tests__/ReadOnlyNodeConfig.test.tsx
@@ -1,10 +1,35 @@
-import { describe, it, expect, afterEach } from "vitest"
-import { render, screen, waitFor, cleanup } from "@testing-library/react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react"
 
 import ReadOnlyNodeConfig from "../ReadOnlyNodeConfig"
 import { NODE_TYPES } from "../../utils/nodeTypes"
 
-afterEach(cleanup)
+const observedInertCommitResults = vi.hoisted(() => vi.fn())
+
+vi.mock("../../panels/LazyNodeEditors", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../panels/LazyNodeEditors")>()
+  return {
+    ...actual,
+    ConstantEditor: ({
+      onUpdate,
+    }: {
+      onUpdate: (keyOrUpdates: string | Record<string, unknown>, value?: unknown) => unknown
+    }) => (
+      <button
+        type="button"
+        data-testid="readonly-inert-commit-probe"
+        onClick={() => observedInertCommitResults(onUpdate("value", 6))}
+      >
+        probe inert commit
+      </button>
+    ),
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  observedInertCommitResults.mockClear()
+})
 
 // Representatives whose lazy chunks resolve in jsdom: a no-context editor and
 // one that reads useGraph() (proves the GraphProvider wiring). The heavier
@@ -28,6 +53,21 @@ describe("ReadOnlyNodeConfig", () => {
       )
     })
   }
+
+  it("supplies editors an inert successful commit callback", async () => {
+    render(
+      <ReadOnlyNodeConfig
+        nodeType={NODE_TYPES.CONSTANT}
+        config={{ value: 5 }}
+        nodeId="n1"
+      />,
+    )
+
+    fireEvent.click(await screen.findByTestId("readonly-inert-commit-probe"))
+
+    expect(observedInertCommitResults).toHaveBeenCalledOnce()
+    expect(observedInertCommitResults).toHaveBeenCalledWith({ ok: true })
+  })
 
   it("falls back to a config dump for an unknown node type", async () => {
     render(<ReadOnlyNodeConfig nodeType="mysteryType" config={{ a: 1 }} nodeId="n1" />)

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -400,7 +400,7 @@ describe("useEdgeHandlers", () => {
   it("onConnectEnd honours React Flow rejection after reverse-direction validation passes", () => {
     useToastStore.setState({ toasts: [], _toastCounter: 0 })
     const params = makeParams()
-    params.validateConnection = vi.fn(() => ({ ok: true }))
+    params.validateConnection = vi.fn(() => ({ ok: true as const }))
     const { result } = renderHook(() => useEdgeHandlers(params))
 
     act(() => {

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -362,6 +362,65 @@ describe("useEdgeHandlers", () => {
     })
   })
 
+  it("onConnectEnd reports validation failures for target-to-source handles", () => {
+    const params = makeParams()
+    params.validateConnection = vi.fn(() => ({
+      ok: false,
+      reason: { kind: "duplicate-input-name" as const, inputName: "quotes" },
+    }))
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({
+          from: "target",
+          to: "source",
+          fromHandleId: "in",
+          toHandleId: "out",
+          fromHandleType: "target",
+          toHandleType: "source",
+          isValid: false,
+        }),
+      )
+    })
+
+    expect(params.validateConnection).toHaveBeenCalledWith({
+      source: "source",
+      sourceHandle: "out",
+      target: "target",
+      targetHandle: "in",
+    })
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({ type: "error", text: expect.stringMatching(/quotes.*already connected/i) }),
+    ])
+    expect(params.setEdges).not.toHaveBeenCalled()
+  })
+
+  it("onConnectEnd honours React Flow rejection after reverse-direction validation passes", () => {
+    useToastStore.setState({ toasts: [], _toastCounter: 0 })
+    const params = makeParams()
+    params.validateConnection = vi.fn(() => ({ ok: true }))
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({
+          from: "target",
+          to: "source",
+          fromHandleType: "target",
+          toHandleType: "source",
+          isValid: false,
+        }),
+      )
+    })
+
+    expect(params.validateConnection).toHaveBeenCalledOnce()
+    expect(params.setEdges).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts).toEqual([])
+  })
+
   it("creates an edgeJoin when an apiInput frame is dropped on an output that already consumes that frame", () => {
     const params = makeParams()
     const apiInput = {

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, cleanup, act } from "@testing-library/react"
-import type { Node, Edge } from "@xyflow/react"
+import type { Node, Edge, Connection } from "@xyflow/react"
 import useEdgeHandlers from "../useEdgeHandlers"
 import useToastStore from "../../stores/useToastStore"
 import { NODE_TYPES } from "../../utils/nodeTypes"
 import { DEFAULT_TARGET_HANDLE } from "../../utils/flowHandles"
+import { validatePipelineConnection } from "../../utils/connectionValidation"
+import type { SimpleNode } from "../../panels/editors/_shared"
 
 function makeParams() {
   return {
@@ -27,6 +29,9 @@ function makeParams() {
     screenToFlowPosition: vi.fn((pos: { x: number; y: number }) => pos),
     graphRefreshingRef: { current: 0 },
     findEdgeIdAtPoint: vi.fn(() => null as string | null),
+    validateConnection: undefined as
+      | undefined
+      | ((connection: Connection) => ReturnType<typeof validatePipelineConnection>),
   }
 }
 
@@ -321,38 +326,6 @@ describe("useEdgeHandlers", () => {
     ])
   })
 
-  it("onConnectEnd does not infer an input connection from a source-to-source ending", () => {
-    const params = makeParams()
-    params.graphRef.current.nodes = [
-      { id: "join1", position: { x: 0, y: 0 }, data: { label: "Edge Join 1", nodeType: NODE_TYPES.EDGE_JOIN, config: {} } } as unknown as Node,
-      {
-        id: "target",
-        position: { x: 300, y: 0 },
-        measured: { width: 240, height: 70 },
-        data: { label: "Target", nodeType: NODE_TYPES.POLARS, config: {} },
-      } as unknown as Node,
-    ]
-    const { result } = renderHook(() => useEdgeHandlers(params))
-
-    act(() => {
-      result.current.onConnectEnd(
-        { clientX: 320, clientY: 35 } as MouseEvent,
-        connectionEndState({
-          from: "join1",
-          to: "target",
-          fromHandleType: "source",
-          toHandleType: "source",
-          isValid: false,
-        }),
-      )
-    })
-
-    expect(params.setEdges).not.toHaveBeenCalled()
-    expect(params.pushSnapshot).not.toHaveBeenCalled()
-    expect(params.setNodesRaw).not.toHaveBeenCalled()
-    expect(params.setEdgesRaw).not.toHaveBeenCalled()
-  })
-
   it("onConnectEnd keeps source-to-source edgeJoin creation when dropped on a Polars output side", () => {
     const params = makeParams()
     params.graphRef.current.nodes = [
@@ -389,31 +362,76 @@ describe("useEdgeHandlers", () => {
     })
   })
 
-  it("onConnectEnd ignores invalid source-to-source drops on a Polars output side", () => {
+  it("creates an edgeJoin when an apiInput frame is dropped on an output that already consumes that frame", () => {
     const params = makeParams()
-    params.graphRef.current.nodes = [
-      { id: "base", position: { x: 300, y: 0 }, measured: { width: 240, height: 70 }, data: { label: "Base", nodeType: NODE_TYPES.POLARS } } as unknown as Node,
-      { id: "join1", position: { x: 0, y: 160 }, data: { label: "Edge Join 1", nodeType: NODE_TYPES.EDGE_JOIN } } as unknown as Node,
-    ]
+    const apiInput = {
+      id: "api",
+      position: { x: 0, y: 160 },
+      data: {
+        label: "API",
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [
+            {
+              path: "$[:].quotes[:]",
+              label: "quotes",
+              emit: true,
+              columns: [{ name: "id", selected: true }],
+            },
+          ],
+        },
+      },
+    } as unknown as Node
+    const transform = {
+      id: "transform",
+      position: { x: 300, y: 0 },
+      measured: { width: 240, height: 70 },
+      data: { label: "Transform", nodeType: NODE_TYPES.POLARS, config: {} },
+    } as unknown as Node
+    const existing = {
+      id: "e_api_transform",
+      source: "api",
+      target: "transform",
+      sourceHandle: "quotes",
+      targetHandle: null,
+    } as Edge
+    params.graphRef.current = { nodes: [apiInput, transform], edges: [existing] }
     const { result } = renderHook(() => useEdgeHandlers(params))
 
     act(() => {
       result.current.onConnectEnd(
-        { clientX: 520, clientY: 35 } as MouseEvent,
-        {
+        mouseUpEvent,
+        connectionEndState({
+          from: "api",
+          to: "transform",
+          fromHandleId: "quotes",
+          toHandleId: "transform-output",
+          fromHandleType: "source",
+          toHandleType: "source",
+          // React Flow can report false here because ordinary input-name
+          // uniqueness sees the frame already entering this node. The
+          // output-to-output gesture is an edgeJoin request, not another
+          // input edge, so domain handling must still proceed.
           isValid: false,
-          fromNode: { id: "join1" },
-          fromHandle: { id: null, type: "source" },
-          toNode: { id: "base" },
-          toHandle: { id: null, type: "source" },
-        } as never,
+        }),
       )
     })
 
-    expect(params.setEdges).not.toHaveBeenCalled()
-    expect(params.pushSnapshot).not.toHaveBeenCalled()
-    expect(params.setNodesRaw).not.toHaveBeenCalled()
-    expect(params.setEdgesRaw).not.toHaveBeenCalled()
+    expect(params.pushSnapshot).toHaveBeenCalledOnce()
+    const nextNodes = params.setNodesRaw.mock.calls[0][0] as Node[]
+    expect(nextNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "edgeJoin_1", data: expect.objectContaining({ nodeType: NODE_TYPES.EDGE_JOIN }) }),
+      ]),
+    )
+    const nextEdges = params.setEdgesRaw.mock.calls[0][0] as Edge[]
+    expect(nextEdges).toEqual(
+      expect.arrayContaining([
+        existing,
+        expect.objectContaining({ source: "api", sourceHandle: "quotes", target: "edgeJoin_1" }),
+        expect.objectContaining({ source: "transform", target: "edgeJoin_1" }),
+      ]),
+    )
   })
 
   it("onConnectEnd does not reinterpret source-only nodes as input-side targets", () => {
@@ -1256,6 +1274,76 @@ describe("useEdgeHandlers edge-join failures and multi-port handles", () => {
     expect(params.pushSnapshot).not.toHaveBeenCalled()
     expect(params.findEdgeIdAtPoint).not.toHaveBeenCalled()
     expect(useToastStore.getState().toasts).toEqual([])
+  })
+
+  it("toasts the colliding derived input name when a normal drag is rejected", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [
+      {
+        id: "api",
+        data: {
+          label: "API",
+          nodeType: NODE_TYPES.API_INPUT,
+          config: {
+            tables: [
+              {
+                path: "$[:].quotes[:]",
+                label: "quotes",
+                emit: true,
+                columns: [{ name: "id", selected: true }],
+              },
+            ],
+          },
+        },
+      } as unknown as Node,
+      {
+        id: "ordinary",
+        data: { label: "quotes", nodeType: NODE_TYPES.POLARS, config: {} },
+      } as unknown as Node,
+      {
+        id: "target",
+        data: { label: "Target", nodeType: NODE_TYPES.POLARS, config: {} },
+      } as unknown as Node,
+    ]
+    params.graphRef.current.edges = [
+      {
+        id: "e_existing",
+        source: "ordinary",
+        target: "target",
+        sourceHandle: null,
+        targetHandle: null,
+      } as Edge,
+    ]
+    params.validateConnection = (candidate) =>
+      validatePipelineConnection(
+        candidate,
+        params.graphRef.current.nodes as unknown as SimpleNode[],
+        params.graphRef.current.edges,
+      )
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onConnectEnd(
+        mouseUpEvent,
+        connectionEndState({
+          from: "api",
+          to: "target",
+          fromHandleId: "quotes",
+          fromHandleType: "source",
+          toHandleType: "target",
+          isValid: false,
+        }),
+      )
+    })
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: "error",
+        text: expect.stringMatching(/input name.*quotes.*already connected/i),
+      }),
+    ])
+    expect(params.setEdges).not.toHaveBeenCalled()
+    expect(params.pushSnapshot).not.toHaveBeenCalled()
   })
 
   it("onConnectEnd fails loudly when a touch ending carries no pointer coordinates", () => {

--- a/frontend/src/hooks/useEdgeHandlers.ts
+++ b/frontend/src/hooks/useEdgeHandlers.ts
@@ -21,6 +21,7 @@ import { insertEdgeJoinNode, insertEdgeJoinNodeFromSources, type EdgeJoinFailure
 import { appEdge, appNode, selectOnlyNode } from "../utils/flowElements"
 import { edgeJoinCanonicalTargetHandle, edgeJoinRoleConfigKey } from "../utils/edgeJoinRoles"
 import { normalizeDefaultTargetHandle } from "../utils/flowHandles"
+import type { ConnectionValidationResult } from "../utils/connectionValidation"
 import useToastStore from "../stores/useToastStore"
 import type { FetchPreviewOptions } from "./usePipelineAPI"
 import type { PreviewData } from "../panels/DataPreview"
@@ -87,6 +88,7 @@ type UseEdgeHandlersParams = {
   setEdgesRaw: (updater: Edge[] | ((eds: Edge[]) => Edge[])) => void
   pushSnapshot: () => void
   setSelectedNode: (updater: React.SetStateAction<Node | null>) => void
+  setLastSelectedId?: (id: string | null) => void
   setPreviewData: (updater: React.SetStateAction<PreviewData | null>) => void
   setContextMenu: (data: ContextMenuData | null) => void
   fetchPreview: (node: Node, options?: FetchPreviewOptions) => void
@@ -96,6 +98,7 @@ type UseEdgeHandlersParams = {
   screenToFlowPosition: (pos: { x: number; y: number }) => { x: number; y: number }
   graphRefreshingRef: MutableRefObject<number>
   findEdgeIdAtPoint?: (point: { x: number; y: number }) => string | null
+  validateConnection?: (connection: Connection) => ConnectionValidationResult
 }
 
 const edgeJoinFailureMessages: Record<EdgeJoinFailureReason, string> = {
@@ -117,6 +120,7 @@ export default function useEdgeHandlers({
   setEdgesRaw,
   pushSnapshot,
   setSelectedNode,
+  setLastSelectedId,
   setPreviewData,
   setContextMenu,
   fetchPreview,
@@ -126,8 +130,14 @@ export default function useEdgeHandlers({
   screenToFlowPosition,
   graphRefreshingRef,
   findEdgeIdAtPoint = () => null,
+  validateConnection,
 }: UseEdgeHandlersParams) {
   const addToast = useToastStore((s) => s.addToast)
+
+  const reportConnectionValidationFailure = useCallback((result: ConnectionValidationResult) => {
+    if (result.ok || result.reason.kind !== "duplicate-input-name") return
+    addToast("error", `Connection rejected: input name "${result.reason.inputName}" is already connected`)
+  }, [addToast])
 
   const commitConnection = useCallback(
     (params: Connection) => {
@@ -234,6 +244,7 @@ export default function useEdgeHandlers({
         setNodesRaw(result.nodes)
         setEdgesRaw(result.edges)
         setSelectedNode(selected)
+        setLastSelectedId?.(selected?.id ?? null)
         lastSelectedNodeRef.current = selected
         clearTrace()
         cancelPreview()
@@ -245,8 +256,6 @@ export default function useEdgeHandlers({
         targetNodeId
       ) {
         const point = screenToFlowPosition(connectionEndPoint(event))
-        if (connectionState.isValid === false) return
-
         commitEdgeJoinResult(insertEdgeJoinNodeFromSources({
           nodes: graphRef.current.nodes,
           edges: graphRef.current.edges,
@@ -265,23 +274,36 @@ export default function useEdgeHandlers({
       }
 
       if (targetNodeId) {
-        if (!connectionState.isValid) return
         if (fromHandle?.type === "source" && toHandle?.type === "target") {
-          commitConnection({
+          const connection = {
             source: sourceNodeId,
             sourceHandle: fromHandle.id ?? null,
             target: targetNodeId,
             targetHandle: normalizeDefaultTargetHandle(toHandle.id),
-          })
+          }
+          const validation = validateConnection?.(connection)
+          if (validation) {
+            reportConnectionValidationFailure(validation)
+            if (!validation.ok) return
+          }
+          if (!connectionState.isValid) return
+          commitConnection(connection)
           return
         }
         if (fromHandle?.type === "target" && toHandle?.type === "source") {
-          commitConnection({
+          const connection = {
             source: targetNodeId,
             sourceHandle: toHandle.id ?? null,
             target: sourceNodeId,
             targetHandle: normalizeDefaultTargetHandle(fromHandle.id),
-          })
+          }
+          const validation = validateConnection?.(connection)
+          if (validation) {
+            reportConnectionValidationFailure(validation)
+            if (!validation.ok) return
+          }
+          if (!connectionState.isValid) return
+          commitConnection(connection)
         }
         return
       }
@@ -313,10 +335,13 @@ export default function useEdgeHandlers({
       lastSelectedNodeRef,
       nodeIdCounterRef,
       pushSnapshot,
+      reportConnectionValidationFailure,
       screenToFlowPosition,
       setEdgesRaw,
+      setLastSelectedId,
       setNodesRaw,
       setSelectedNode,
+      validateConnection,
     ],
   )
 
@@ -337,6 +362,7 @@ export default function useEdgeHandlers({
     const previousNodeId = selectedNode?.id ?? lastSelectedNodeRef.current?.id
     const shouldRefreshPreview = previousNodeId !== node.id
     setSelectedNode(node)
+    setLastSelectedId?.(node.id)
     lastSelectedNodeRef.current = node
     if (!shouldRefreshPreview) return
 
@@ -358,6 +384,7 @@ export default function useEdgeHandlers({
     clearTrace,
     setPreviewData,
     lastSelectedNodeRef,
+    setLastSelectedId,
   ])
 
   const handleDeleteEdge = useCallback((edgeId: string) => {
@@ -421,8 +448,9 @@ export default function useEdgeHandlers({
       const selectedNewNode = { ...newNode, selected: true }
       setNodes((nds) => selectOnlyNode([...nds, newNode], newNode.id))
       setSelectedNode(selectedNewNode)
+      setLastSelectedId?.(selectedNewNode.id)
     },
-    [screenToFlowPosition, nodeIdCounterRef, setNodes, setSelectedNode, addToast],
+    [screenToFlowPosition, nodeIdCounterRef, setNodes, setSelectedNode, setLastSelectedId, addToast],
   )
 
   return {

--- a/frontend/src/hooks/useGraphCanvasState.ts
+++ b/frontend/src/hooks/useGraphCanvasState.ts
@@ -43,6 +43,7 @@ export default function useGraphCanvasState(
     useGraphStore.setState({
       nodes: initialNodes,
       edges: initialEdges,
+      submodels: {},
       undoStack: [],
       redoStack: [],
       structuralVersion: 0,
@@ -53,6 +54,12 @@ export default function useGraphCanvasState(
     // initialNodes/initialEdges are constructor-style seeds, not reactive.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- seed-once semantics
   }, [])
+
+  // React Flow's `dragging` flag is presentation state and is intentionally
+  // omitted from history snapshots. Keep the active gesture state separately
+  // so undo/redo during a drag cannot make the next move look like a second
+  // drag start.
+  const draggingNodeIdsRef = useRef<Set<string>>(new Set())
 
   // React Flow emits delta arrays. We apply them against the current store
   // state and push history only for structural edits or the start of a drag.
@@ -66,11 +73,17 @@ export default function useGraphCanvasState(
     const hasDragStart = changes.some((c) => {
       if (c.type !== "position" || c.dragging !== true) return false
       const node = state.nodes.find((n) => n.id === c.id)
-      return !node?.dragging
+      return !node?.dragging && !draggingNodeIdsRef.current.has(c.id)
     })
 
     if (hasStructural || hasDragStart) {
       state.pushSnapshot()
+    }
+
+    for (const change of changes) {
+      if (change.type !== "position") continue
+      if (change.dragging === true) draggingNodeIdsRef.current.add(change.id)
+      else if (change.dragging === false) draggingNodeIdsRef.current.delete(change.id)
     }
 
     const nextNodes = applyNodeChanges(changes, state.nodes)
@@ -118,6 +131,21 @@ export default function useGraphCanvasState(
     [],
   )
 
+  const setNodesAndEdgesAndSubmodels = useCallback(
+    (
+      nodesUpdater: Node[] | ((nds: Node[]) => Node[]),
+      edgesUpdater: Edge[] | ((eds: Edge[]) => Edge[]),
+      submodels: Record<string, unknown>,
+    ) => {
+      useGraphStore.getState().setNodesAndEdgesAndSubmodels(nodesUpdater, edgesUpdater, submodels)
+    },
+    [],
+  )
+
+  const setSubmodelsRaw = useCallback((submodels: Record<string, unknown>) => {
+    useGraphStore.getState().setSubmodelsRaw(submodels)
+  }, [])
+
   const setNodesRaw = useCallback((updater: Node[] | ((nds: Node[]) => Node[])) => {
     useGraphStore.getState().setNodesRaw(updater)
   }, [])
@@ -146,8 +174,10 @@ export default function useGraphCanvasState(
     setNodes,
     setEdges,
     setNodesAndEdges,
+    setNodesAndEdgesAndSubmodels,
     setNodesRaw,
     setEdgesRaw,
+    setSubmodelsRaw,
     onNodesChange,
     onEdgesChange,
     undo,

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -21,6 +21,7 @@ interface KeyboardShortcutsParams {
   clipboard: React.MutableRefObject<{ nodes: Node[]; edges: Edge[] }>
   nodeIdCounter: React.MutableRefObject<number>
   setSelectedNode: (node: Node | null) => void
+  setLastSelectedId?: (id: string | null) => void
   setPreviewData: (data: null) => void
   clearTrace: () => void
   closePanel: () => void
@@ -30,7 +31,7 @@ interface KeyboardShortcutsParams {
 export default function useKeyboardShortcuts({
   handleSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
   graphRef, clipboard, nodeIdCounter,
-  setSelectedNode, setPreviewData, clearTrace, closePanel,
+  setSelectedNode, setLastSelectedId, setPreviewData, clearTrace, closePanel,
   isInsideSubmodel,
 }: KeyboardShortcutsParams) {
   const addToast = useToastStore((s) => s.addToast)
@@ -194,6 +195,7 @@ export default function useKeyboardShortcuts({
             currentEdges.filter((ed) => !selectedNodeIds.has(ed.source) && !selectedNodeIds.has(ed.target)),
           )
           setSelectedNode(null)
+          setLastSelectedId?.(null)
           setPreviewData(null)
           // Clean up store state for deleted nodes
           for (const nid of selectedNodeIds) {
@@ -211,7 +213,7 @@ export default function useKeyboardShortcuts({
   }, [
     handleSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
     graphRef, clipboard, nodeIdCounter,
-    setSelectedNode, setPreviewData, clearTrace, closePanel,
+    setSelectedNode, setLastSelectedId, setPreviewData, clearTrace, closePanel,
     addToast, setShortcutsOpen, setSubmodelDialog, setNodeSearchOpen, isInsideSubmodel,
   ])
 }

--- a/frontend/src/hooks/useNodeHandlers.ts
+++ b/frontend/src/hooks/useNodeHandlers.ts
@@ -25,6 +25,7 @@ type UseNodeHandlersParams = {
     edges: (eds: Edge[]) => Edge[],
   ) => void
   setSelectedNode: (updater: React.SetStateAction<Node | null>) => void
+  setLastSelectedId?: (id: string | null) => void
   setPreviewData: (updater: React.SetStateAction<PreviewData | null>) => void
   fitView: (opts?: { padding?: number }) => void
 }
@@ -36,6 +37,7 @@ export default function useNodeHandlers({
   setNodes,
   setNodesAndEdges,
   setSelectedNode,
+  setLastSelectedId,
   setPreviewData,
   fitView,
 }: UseNodeHandlersParams) {
@@ -63,14 +65,17 @@ export default function useNodeHandlers({
     // state where the node still exists in the graph but its cached result
     // has already been wiped — producing a flicker-crash.
     setTimeout(() => { clearNode(id) }, 0)
-    if (lastSelectedNodeRef.current?.id === id) lastSelectedNodeRef.current = null
+    if (lastSelectedNodeRef.current?.id === id) {
+      lastSelectedNodeRef.current = null
+      setLastSelectedId?.(null)
+    }
 
     // Clear UI dialogs that reference the deleted node (Issues #8, #14)
     const uiState = useUIStore.getState()
     if (uiState.renameDialog?.nodeId === id) setRenameDialog(null)
     const subDlg = uiState.submodelDialog
     if (subDlg && subDlg.nodeIds.includes(id)) setSubmodelDialog(null)
-  }, [setNodesAndEdges, lastSelectedNodeRef, setSelectedNode, setPreviewData, clearNode, setRenameDialog, setSubmodelDialog])
+  }, [setNodesAndEdges, lastSelectedNodeRef, setSelectedNode, setLastSelectedId, setPreviewData, clearNode, setRenameDialog, setSubmodelDialog])
 
   const handleDuplicateNode = useCallback((id: string) => {
     const { nodes: n } = graphRef.current
@@ -88,7 +93,8 @@ export default function useNodeHandlers({
     }
     setNodes((nds) => [...nds.map((nd) => ({ ...nd, selected: false })), newNode])
     setSelectedNode(newNode)
-  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode])
+    setLastSelectedId?.(newNode.id)
+  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode, setLastSelectedId])
 
   const handleCreateInstance = useCallback((id: string) => {
     const { nodes: n } = graphRef.current
@@ -112,8 +118,9 @@ export default function useNodeHandlers({
     }
     setNodes((nds) => [...nds.map((nd) => ({ ...nd, selected: false })), newNode])
     setSelectedNode(newNode)
+    setLastSelectedId?.(newNode.id)
     addToast("info", `Created instance of "${origData.label}"`)
-  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode, addToast])
+  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode, setLastSelectedId, addToast])
 
   const handleRenameNode = useCallback((id: string) => {
     const { nodes: n } = graphRef.current

--- a/frontend/src/hooks/usePipelineAPI.ts
+++ b/frontend/src/hooks/usePipelineAPI.ts
@@ -18,6 +18,7 @@ import { effectiveNodeType, nodeData } from "../types/node"
 import { NODE_TYPES } from "../utils/nodeTypes"
 import { parsePipelineResponse } from "../types/guards"
 import { columnsEqualByFingerprint, type ColumnFingerprintInput } from "../utils/columnFingerprint"
+import { reconcileApiInputEdges } from "../utils/apiInputPorts"
 export { columnFingerprint } from "../utils/columnFingerprint"
 
 interface PipelineAPIParams {
@@ -27,6 +28,8 @@ interface PipelineAPIParams {
   submodelsRef: React.MutableRefObject<Record<string, unknown>>
   setNodesRaw: (updater: Node[] | ((nds: Node[]) => Node[])) => void
   setEdgesRaw: (edges: Edge[]) => void
+  setSubmodelsRaw?: (submodels: Record<string, unknown>) => void
+  setCurrentSourceFile?: (sourceFile: string | null) => void
   setPreamble: (p: string) => void
   preambleRef: React.MutableRefObject<string>
   pipelineNameRef: React.MutableRefObject<string>
@@ -233,7 +236,7 @@ function previewErrorDetail(err: unknown): string {
 export default function usePipelineAPI({
   selectedNode,
   graphRef, parentGraphRef, submodelsRef,
-  setNodesRaw, setEdgesRaw, setPreamble,
+  setNodesRaw, setEdgesRaw, setSubmodelsRaw, setCurrentSourceFile, setPreamble,
   preambleRef, pipelineNameRef, descriptionRef, sourceFileRef,
   nodeIdCounter: nodeIdCounterRef,
 }: PipelineAPIParams): PipelineAPIReturn {
@@ -287,16 +290,32 @@ export default function usePipelineAPI({
         const data = parsePipelineResponse(raw)
         const pipelineNodes = data.nodes
         const pipelineEdges = data.edges
+        let reconciledEdges = normalizeEdges(pipelineEdges)
+        for (const node of pipelineNodes) {
+          if (nodeData(node).nodeType !== NODE_TYPES.API_INPUT) continue
+          reconciledEdges = reconcileApiInputEdges({
+            nodeId: node.id,
+            config: nodeData(node).config,
+            edges: reconciledEdges,
+            pruneNamedStale: false,
+          }).edges
+        }
         setNodesRaw(pipelineNodes)
-        setEdgesRaw(normalizeEdges(pipelineEdges))
+        setEdgesRaw(reconciledEdges)
         if (data.preamble != null) {
           setPreamble(data.preamble)
           preambleRef.current = data.preamble
         }
         if (data.pipeline_name) pipelineNameRef.current = data.pipeline_name
         if (data.pipeline_description != null) descriptionRef.current = data.pipeline_description
-        if (data.source_file) sourceFileRef.current = data.source_file
-        if (data.submodels != null) submodelsRef.current = data.submodels
+        if (data.source_file) {
+          sourceFileRef.current = data.source_file
+          setCurrentSourceFile?.(data.source_file)
+        }
+        if (data.submodels != null) {
+          submodelsRef.current = data.submodels
+          setSubmodelsRaw?.(data.submodels)
+        }
         // Populate source state from backend sidecar
         if (data.sources) {
           useSettingsStore.getState().setSources(data.sources)
@@ -307,9 +326,9 @@ export default function usePipelineAPI({
         nodeIdCounterRef.current = computeNextNodeId(pipelineNodes)
         // The loaded pipeline IS the on-disk state — mark it saved so
         // isDirty returns false until the user edits something.  The
-        // preceding setNodesRaw / setEdgesRaw / setPreamble have already
-        // written into useGraphStore, so markSaved captures the exact
-        // snapshot we just loaded.
+        // preceding setNodesRaw / setEdgesRaw / setPreamble /
+        // setSubmodelsRaw have already written into useGraphStore, so
+        // markSaved captures the exact snapshot we just loaded.
         useGraphStore.getState().markSaved()
         if (data.warning) addToast("warning", data.warning)
         setLoading(false)
@@ -324,7 +343,7 @@ export default function usePipelineAPI({
       disposed = true
       controller.abort()
     }
-  }, [setNodesRaw, setEdgesRaw, setPreamble, preambleRef, pipelineNameRef, descriptionRef, sourceFileRef, submodelsRef, nodeIdCounterRef, addToast])
+  }, [setNodesRaw, setEdgesRaw, setSubmodelsRaw, setCurrentSourceFile, setPreamble, preambleRef, pipelineNameRef, descriptionRef, sourceFileRef, submodelsRef, nodeIdCounterRef, addToast])
 
   const fetchPreviewImmediate = useCallback((node: Node, existingRequestId?: number, options?: { bypassCache?: boolean }) => {
     const requestId = existingRequestId ?? ++previewRequestSeq.current
@@ -878,14 +897,19 @@ export default function usePipelineAPI({
     // if a newer save hasn't already landed (concurrency guard via
     // saveRequestSeq / appliedSaveSeq).
     const savePreamble = preambleRef.current
-    const savedSnapshot = captureGraphSnapshot({ nodes: n, edges: e, preamble: savePreamble })
     const saveSubmodels = structuredClone(submodelsRef.current)
+    const savedSnapshot = captureGraphSnapshot({
+      nodes: n,
+      edges: e,
+      preamble: savePreamble,
+      submodels: saveSubmodels,
+    })
     const saveRequestId = ++saveRequestSeq.current
     try {
       const data = await savePipeline({
         name: pipelineNameRef.current,
         description: descriptionRef.current,
-        graph: { nodes: savedSnapshot.nodes, edges: savedSnapshot.edges, submodels: saveSubmodels },
+        graph: { nodes: savedSnapshot.nodes, edges: savedSnapshot.edges, submodels: savedSnapshot.submodels },
         preamble: savePreamble,
         source_file: sourceFileRef.current,
         sources: sc,

--- a/frontend/src/hooks/useSubmodelNavigation.ts
+++ b/frontend/src/hooks/useSubmodelNavigation.ts
@@ -15,7 +15,10 @@ interface SubmodelNavParams {
   submodelsRef: React.MutableRefObject<Record<string, unknown>>
   setNodesRaw: (nodes: Node[]) => void
   setEdgesRaw: (edges: Edge[]) => void
+  setSubmodelsRaw?: (submodels: Record<string, unknown>) => void
   setSelectedNode: (node: Node | null) => void
+  setLastSelectedId?: (id: string | null) => void
+  setCurrentSourceFile?: (sourceFile: string | null) => void
   setPreviewData: (data: null) => void
   preambleRef: React.MutableRefObject<string>
   descriptionRef: React.MutableRefObject<string>
@@ -34,8 +37,8 @@ export interface SubmodelNavReturn {
 
 export default function useSubmodelNavigation({
   graphRef, parentGraphRef, submodelsRef,
-  setNodesRaw, setEdgesRaw,
-  setSelectedNode, setPreviewData,
+  setNodesRaw, setEdgesRaw, setSubmodelsRaw,
+  setSelectedNode, setLastSelectedId, setCurrentSourceFile, setPreviewData,
   preambleRef, descriptionRef, sourceFileRef, pipelineNameRef,
   fitView,
 }: SubmodelNavParams): SubmodelNavReturn {
@@ -60,7 +63,9 @@ export default function useSubmodelNavigation({
       if (newGraph) {
         setNodesRaw(newGraph.nodes ?? [])
         setEdgesRaw(normalizeEdges(newGraph.edges ?? []))
-        submodelsRef.current = newGraph.submodels ?? {}
+        const nextSubmodels = newGraph.submodels ?? {}
+        submodelsRef.current = nextSubmodels
+        setSubmodelsRaw?.(nextSubmodels)
         addToast("success", `Submodel "${name}" created`)
         // Dirty is derived — the graph replacement itself triggers the
         // selectIsDirty comparison at the next render.
@@ -69,7 +74,7 @@ export default function useSubmodelNavigation({
     } catch (err: unknown) {
       addToast("error", `Create submodel failed: ${err instanceof Error ? err.message : String(err)}`)
     }
-  }, [graphRef, submodelsRef, setNodesRaw, setEdgesRaw, preambleRef, descriptionRef, sourceFileRef, pipelineNameRef, fitView, addToast])
+  }, [graphRef, submodelsRef, setNodesRaw, setEdgesRaw, setSubmodelsRaw, preambleRef, descriptionRef, sourceFileRef, pipelineNameRef, fitView, addToast])
 
   const handleDrillIntoSubmodel = useCallback(async (nodeId: string) => {
     const smName = nodeId.replace("submodel__", "")
@@ -95,6 +100,8 @@ export default function useSubmodelNavigation({
           return [...updated, { type: "submodel" as const, name: smName, file: submodelSourceFile }]
         })
         sourceFileRef.current = submodelSourceFile
+        setCurrentSourceFile?.(submodelSourceFile)
+        setLastSelectedId?.(null)
         const newNodes: Node[] = smGraph.nodes ?? []
         const newEdges: Edge[] = normalizeEdges(smGraph.edges ?? [])
 
@@ -180,7 +187,7 @@ export default function useSubmodelNavigation({
     } catch (err: unknown) {
       addToast("error", `Drill-down failed: ${err instanceof Error ? err.message : String(err)}`)
     }
-  }, [graphRef, parentGraphRef, submodelsRef, setNodesRaw, setEdgesRaw, setSelectedNode, setPreviewData, sourceFileRef, fitView, addToast])
+  }, [graphRef, parentGraphRef, submodelsRef, setNodesRaw, setEdgesRaw, setSelectedNode, setLastSelectedId, setCurrentSourceFile, setPreviewData, sourceFileRef, fitView, addToast])
 
   const handleBreadcrumbNavigate = useCallback((depth: number) => {
     const prev = viewStackRef.current
@@ -190,13 +197,15 @@ export default function useSubmodelNavigation({
       setNodesRaw(target._savedNodes)
       setEdgesRaw(normalizeEdges(target._savedEdges))
       setSelectedNode(null)
+      setLastSelectedId?.(null)
       setPreviewData(null)
       setTimeout(() => fitView({ padding: 0.8 }), 100)
     }
     if (depth === 0) parentGraphRef.current = null
     sourceFileRef.current = target.file
+    setCurrentSourceFile?.(target.file || null)
     setViewStack(prev.slice(0, depth + 1))
-  }, [parentGraphRef, sourceFileRef, setNodesRaw, setEdgesRaw, setSelectedNode, setPreviewData, fitView])
+  }, [parentGraphRef, sourceFileRef, setNodesRaw, setEdgesRaw, setSelectedNode, setLastSelectedId, setCurrentSourceFile, setPreviewData, fitView])
 
   const handleDissolveSubmodel = useCallback(async (smName: string) => {
     try {
@@ -213,7 +222,9 @@ export default function useSubmodelNavigation({
       if (flat) {
         setNodesRaw(flat.nodes ?? [])
         setEdgesRaw(normalizeEdges(flat.edges ?? []))
-        submodelsRef.current = data.graph?.submodels ?? submodelsRef.current
+        const nextSubmodels = data.graph?.submodels ?? submodelsRef.current
+        submodelsRef.current = nextSubmodels
+        setSubmodelsRaw?.(nextSubmodels)
         addToast("success", `Submodel "${smName}" dissolved`)
         // Dirty is derived — the graph replacement itself triggers the
         // selectIsDirty comparison at the next render.
@@ -222,7 +233,7 @@ export default function useSubmodelNavigation({
     } catch (err: unknown) {
       addToast("error", `Dissolve failed: ${err instanceof Error ? err.message : String(err)}`)
     }
-  }, [graphRef, submodelsRef, setNodesRaw, setEdgesRaw, preambleRef, descriptionRef, sourceFileRef, pipelineNameRef, fitView, addToast])
+  }, [graphRef, submodelsRef, setNodesRaw, setEdgesRaw, setSubmodelsRaw, preambleRef, descriptionRef, sourceFileRef, pipelineNameRef, fitView, addToast])
 
   return {
     viewStack,

--- a/frontend/src/nodes/PipelineNode.tsx
+++ b/frontend/src/nodes/PipelineNode.tsx
@@ -9,7 +9,7 @@ import { STATUS_COLORS } from "../theme/colors"
 import type { PipelineFlowNode } from "../types/node"
 import { EDGE_JOIN_BASE_HANDLE, EDGE_JOIN_JOIN_BOTTOM_HANDLE, EDGE_JOIN_JOIN_HANDLE } from "../utils/edgeJoinRoles"
 import { DEFAULT_TARGET_HANDLE } from "../utils/flowHandles"
-import { apiInputEmitPortLabels } from "../utils/apiInputPorts"
+import { apiInputFrameLabels } from "../utils/apiInputPorts"
 
 const statusColors: Record<string, string> = {
   ok: "var(--success)",
@@ -80,9 +80,11 @@ function _isDraggingFromEdgeJoinOutput(state: ReactFlowState): boolean {
 
 /** Source-Handle setup for the right edge of the node.
  *
- * Commit-6 multi-frame: when an apiInput has 2+ `emit: true` tables, we
+ * At medium/compact zoom, when an apiInput has 2+ `emit: true` tables, we
  * render one labelled Handle per table (id = table label). Otherwise the
- * legacy single Handle covers the default single-frame use.
+ * legacy single Handle covers the default single-frame use. Full-detail
+ * apiInput frame rows mount their own Handles so the row name and output dot
+ * share one layout coordinate system.
  *
  * Returning a JSX list rather than mutating render order keeps the call
  * sites at the three zoom levels each a one-line switch.
@@ -98,13 +100,13 @@ function _isDraggingFromEdgeJoinOutput(state: ReactFlowState): boolean {
  */
 function _SourceHandles({
   isApiInput,
-  config,
+  frameLabels,
   accent,
   isConnectableEnd,
   nodeLabel,
 }: {
   isApiInput: boolean
-  config: Record<string, unknown> | undefined
+  frameLabels: string[]
   accent: string
   isConnectableEnd: boolean
   nodeLabel: string
@@ -125,32 +127,33 @@ function _SourceHandles({
   // exist (see `utils/apiInputPorts`). Handle ids are the RAW table
   // labels (the id space the backend round-trips); blank/duplicate
   // labels yield NO handle — never a synthesized `port_<idx>`/`__<idx>`
-  // id the executor could not resolve (W1.4). Returns `[]` for the
-  // 0/1-emit case.
-  const labels = apiInputEmitPortLabels(config)
-  if (labels.length === 0) {
-    // Single-frame fallback (one or zero emit:true tables, or no tables key):
-    // preserve the legacy default Handle so existing single-frame pipelines
-    // continue to work unchanged.
+  // id the executor could not resolve (W1.4). A sole eligible frame is
+  // labelled exactly like every other eligible frame.
+  if (frameLabels.length === 0) {
+    // The null-id handle is only the zero-frame diagnostic surface. It must
+    // remain visible so the node explains why no frame can be wired, but it
+    // cannot participate in either direction of a Loose connection.
     return (
       <Handle
         type="source"
         position={Position.Right}
-        isConnectableEnd={isConnectableEnd}
+        isConnectable={false}
+        isConnectableStart={false}
+        isConnectableEnd={false}
         data-testid={`output-connector[0]:${nodeLabel}`}
       />
     )
   }
-  // Multi-frame: stack labelled Handles down the right edge. Each
+  // One or more eligible frames: stack labelled Handles down the right edge. Each
   // Handle's `id` is the table's label — React Flow propagates this to
   // `onConnect.params.sourceHandle` when a user drags from it.
   return (
     <>
-      {labels.map((label, idx) => {
+      {frameLabels.map((label, idx) => {
         // Stack the dots vertically; `top` is a percentage so the
         // Handles space evenly down the right edge regardless of node
         // height.
-        const topPct = ((idx + 1) / (labels.length + 1)) * 100
+        const topPct = ((idx + 1) / (frameLabels.length + 1)) * 100
         return (
           <Handle
             key={label}
@@ -164,6 +167,57 @@ function _SourceHandles({
         )
       })}
     </>
+  )
+}
+
+/**
+ * Full-detail apiInput frame rows.
+ *
+ * Each row owns both its visible raw frame label and its source Handle. The
+ * row is the positioning context for the Handle, so its `top: 50%` is the
+ * row's vertical midpoint and React Flow's right-side transform centres the
+ * dot on the row's right edge. The negative right margin carries that edge
+ * out through the body's padding to the node border.
+ */
+function _ApiInputFrameRows({
+  frameLabels,
+  accent,
+  isConnectableEnd,
+  nodeLabel,
+}: {
+  frameLabels: string[]
+  accent: string
+  isConnectableEnd: boolean
+  nodeLabel: string
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      {frameLabels.map((label, idx) => (
+        <div
+          key={label}
+          data-testid={`api-input-frame-row-${label}`}
+          className="relative flex min-w-0 items-center justify-end py-0.5 pr-3"
+          style={{ marginRight: "-12px" }}
+        >
+          <span
+            data-testid={`api-input-body-label-${label}`}
+            className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-pre text-right font-mono text-[11px] leading-tight"
+            style={{ color: "var(--text-muted)", whiteSpace: "pre" }}
+            title={label}
+          >
+            {label}
+          </span>
+          <Handle
+            id={label}
+            type="source"
+            position={Position.Right}
+            isConnectableEnd={isConnectableEnd}
+            style={{ top: "50%", background: accent }}
+            data-testid={`output-connector[${idx}]:${nodeLabel}`}
+          />
+        </div>
+      ))}
+    </div>
   )
 }
 
@@ -238,36 +292,39 @@ function PipelineNode({ id, data: nodeData, selected }: NodeProps<PipelineFlowNo
   const isCompactNode = NODE_TYPE_META[nodeType as NodeTypeValue]?.size === "compact"
   const sourceHandlesCanEnd = !useStore(_isDraggingFromEdgeJoinOutput)
 
-  // Bundle 3c — emit-table labels for the right-edge handles.  Source
-  // of truth shared between (a) `_SourceHandles` which renders the
-  // Handles, (b) the body label list, and (c) the
-  // `useUpdateNodeInternals` effect that nudges React Flow to re-measure
-  // when the topology changes.  Logic mirrors `_SourceHandles`: only
-  // emit:true tables with a valid (non-blank, non-duplicate) label
-  // count — handle ids are raw labels, never synthesized (W1.4).
-  const emitTableLabels = useMemo<string[]>(
-    () => (isDeployInput ? apiInputEmitPortLabels(nodeData.config) : []),
+  // Bundle 3c — one ordered frame-label list is the source of truth for
+  // source Handles, full-detail body rows, and the re-measure signature.
+  const frameLabels = useMemo<string[]>(
+    () => (isDeployInput ? apiInputFrameLabels(nodeData.config) : []),
     [isDeployInput, nodeData.config],
   )
 
-  // Pipe-joined signature is a stable value-equality proxy for the
-  // labels array; useEffect's value-equality on strings means it
-  // refires only when the labels actually change, not on every parent
-  // re-render that produces a fresh `nodeData.config` reference with
-  // unchanged emit topology (e.g. a column edit inside a table).
-  const emitTablesSig = emitTableLabels.join("|")
+  // JSON serialization is a collision-safe value-equality proxy for the
+  // labels arrays; raw labels are unrestricted strings, so delimiter joins
+  // could alias distinct label sets (for example, ["a|b", "c"] and
+  // ["a", "b|c"]) and skip a required re-measure. The effect still
+  // refires only when labels actually change, not on a fresh config object
+  // whose topology is unchanged (e.g. a column edit inside a table).
+  const frameLabelsSig = JSON.stringify(frameLabels)
+  const zoomLevel = useStore(zoomSelector)
   const edgeJoinJoinHandlePosition = useStore((s) =>
     _edgeJoinJoinHandlePosition(s, id, nodeType),
   )
   const updateNodeInternals = useUpdateNodeInternals()
   useEffect(() => {
     updateNodeInternals(id)
-  }, [id, emitTablesSig, edgeJoinJoinHandlePosition, updateNodeInternals])
+  }, [
+    id,
+    frameLabelsSig,
+    zoomLevel,
+    edgeJoinJoinHandlePosition,
+    updateNodeInternals,
+  ])
 
   const sourceHandles = !isSinkOnly ? (
     <_SourceHandles
       isApiInput={isDeployInput}
-      config={nodeData.config as Record<string, unknown> | undefined}
+      frameLabels={frameLabels}
       accent={accent}
       isConnectableEnd={sourceHandlesCanEnd}
       nodeLabel={nodeData.label}
@@ -281,18 +338,17 @@ function PipelineNode({ id, data: nodeData, selected }: NodeProps<PipelineFlowNo
       nodeLabel={nodeData.label}
     />
   ) : null
-  // 2+ emit tables = multi-frame; render the visual frame-to-label
-  // mapping on the body.  0/1 emit = single-frame fallback (Handle is
-  // unambiguous; no labels needed).
-  const showBodyLabels = isDeployInput && emitTableLabels.length >= 2
+  // At full detail, visible frame rows own the API-input source Handles. At
+  // medium/compact detail, or with no visible frame, `_SourceHandles` remains
+  // mounted on the node container as the zoomed-out/default fallback.
+  const showApiInputFrameRows =
+    isDeployInput && zoomLevel === "full" && frameLabels.length > 0
   const traceActive = !!nodeData._traceActive
   const traceDimmed = !!nodeData._traceDimmed
   const hoverDimmed = !!nodeData._hoverDimmed
   const traceValue = nodeData._traceValue
   const traceMotionDisabled = !!nodeData._traceMotionDisabled
   const hasWarnings = (nodeData._schemaWarnings?.length ?? 0) > 0
-  const zoomLevel = useStore(zoomSelector)
-
   const dimmed = traceDimmed || hoverDimmed
 
   // Comparison-view diff highlight (S11): a ring on the CARD — the same element as
@@ -539,18 +595,45 @@ function PipelineNode({ id, data: nodeData, selected }: NodeProps<PipelineFlowNo
       </div>
 
       {/* Body — Bundle 3c: when this is a multi-frame apiInput, the
-          right-aligned label column visually maps each emit table to
-          its handle on the right edge, in the same top-to-bottom order
-          the Handles are stacked.  Hidden for 0/1 emit (single-frame
-          fallback is unambiguous) and for all non-apiInput types.
+          full-detail frame rows own the right-edge Handle and display each
+          visible frame in top-to-bottom order.  Medium/compact modes and
+          zero-frame apiInputs retain the `_SourceHandles` fallback; all
+          non-apiInput types retain their existing body.
           `bodyStyle` keeps the opaque-face surface consistent with
           medium mode (VC S38 opaque-face redesign). */}
       <div className="px-3 py-2" style={bodyStyle}>
-        <div className="flex items-start gap-2">
-          <div className="flex-1 min-w-0">
+        {showApiInputFrameRows ? (
+          <>
+            {traceActive && traceValue !== undefined && (
+              <div
+                className="mb-1 px-1.5 py-0.5 rounded text-[11px] font-mono truncate"
+                style={{
+                  background: `${accent}18`,
+                  color: accent,
+                  border: `1px solid ${accent}30`,
+                  maxWidth: "100%",
+                }}
+              >
+                {formatValueCompact(traceValue)}
+              </div>
+            )}
+            <_ApiInputFrameRows
+              frameLabels={frameLabels}
+              accent={accent}
+              isConnectableEnd={sourceHandlesCanEnd}
+              nodeLabel={nodeData.label}
+            />
+          </>
+        ) : (
+          <>
             <div className="font-semibold text-[13px] leading-tight truncate" style={{ color: "var(--text-primary)" }}>
               {nodeData.label}
             </div>
+            {isDeployInput && (
+              <div className="mt-1 text-[11px] leading-tight truncate" style={{ color: "var(--text-muted)" }}>
+                No emitted frames
+              </div>
+            )}
             {traceActive && traceValue !== undefined && (
               <div
                 className="mt-1 px-1.5 py-0.5 rounded text-[11px] font-mono truncate"
@@ -564,26 +647,11 @@ function PipelineNode({ id, data: nodeData, selected }: NodeProps<PipelineFlowNo
                 {formatValueCompact(traceValue)}
               </div>
             )}
-          </div>
-          {showBodyLabels && (
-            <div className="flex flex-col gap-0.5 shrink-0 text-right">
-              {emitTableLabels.map((label) => (
-                <span
-                  key={label}
-                  data-testid={`api-input-body-label-${label}`}
-                  className="text-[10px] font-mono leading-tight truncate max-w-[100px]"
-                  style={{ color: "var(--text-muted)" }}
-                  title={label}
-                >
-                  {label}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+          </>
+        )}
       </div>
 
-      {sourceHandles}
+      {!showApiInputFrameRows && sourceHandles}
     </div>
   )
 }

--- a/frontend/src/nodes/__tests__/PipelineNode.test.tsx
+++ b/frontend/src/nodes/__tests__/PipelineNode.test.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from "react"
 import { describe, it, expect, afterEach } from "vitest"
-import { act, render, screen, cleanup } from "@testing-library/react"
+import { act, render, screen, cleanup, within } from "@testing-library/react"
 import { ReactFlowProvider, useStoreApi, type Edge, type InternalNode, type NodeProps } from "@xyflow/react"
 import PipelineNode from "../PipelineNode"
 import type { PipelineFlowNode, PipelineNodeData } from "../../types/node"
@@ -40,6 +40,7 @@ function renderNode(
     connection?: unknown
     storeRef?: { current: ReturnType<typeof useStoreApi> | null }
   },
+  zoom = 1,
 ) {
   const fullData: PipelineNodeData = {
     description: "",
@@ -66,7 +67,15 @@ function renderNode(
   }
   return render(
     <ReactFlowProvider>
-      {geometry && <FlowGeometrySeed {...geometry} />}
+      {(geometry || zoom !== 1) && (
+        <FlowGeometrySeed
+          internalNodes={geometry?.internalNodes ?? []}
+          edges={geometry?.edges ?? []}
+          connection={geometry?.connection}
+          storeRef={geometry?.storeRef}
+          zoom={zoom}
+        />
+      )}
       <PipelineNode {...(props as unknown as NodeProps<PipelineFlowNode>)} />
     </ReactFlowProvider>,
   )
@@ -77,11 +86,13 @@ function FlowGeometrySeed({
   edges,
   connection,
   storeRef,
+  zoom = 1,
 }: {
   internalNodes: InternalNode<PipelineFlowNode>[]
   edges: Edge[]
   connection?: unknown
   storeRef?: { current: ReturnType<typeof useStoreApi> | null }
+  zoom?: number
 }) {
   const store = useStoreApi()
   useLayoutEffect(() => {
@@ -90,9 +101,10 @@ function FlowGeometrySeed({
       edges,
       nodeLookup: new Map(internalNodes.map((node) => [node.id, node])),
       nodes: internalNodes.map((node) => node.internals.userNode),
+      transform: [0, 0, zoom],
       ...(connection ? { connection: connection as never } : {}),
     })
-  }, [connection, edges, internalNodes, store, storeRef])
+  }, [connection, edges, internalNodes, store, storeRef, zoom])
   return null
 }
 
@@ -166,6 +178,26 @@ function sourceDragConnection(fromNode: InternalNode<PipelineFlowNode>) {
   }
 }
 
+function apiInputTable(
+  label: string,
+  { emit = true, selected = true }: { emit?: boolean; selected?: boolean } = {},
+) {
+  return {
+    path: `$['${label}']`,
+    label,
+    emit,
+    columns: [{ name: "value", selected }],
+  }
+}
+
+function sourceHandles(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      '.react-flow__handle[data-handlepos="right"]',
+    ),
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -201,6 +233,223 @@ describe("PipelineNode", () => {
     renderNode({ label: "Quote Input", nodeType: NODE_TYPES.API_INPUT, config: { row_id_column: "id" } })
     expect(screen.getByText("Quote Input")).toBeInTheDocument()
     expect(screen.getByText("API")).toBeInTheDocument()
+  })
+
+  describe("full-detail apiInput frame rows", () => {
+    it("suppresses the instance name in the body while preserving ordered row/name/handle identity and node accessibility", () => {
+      const nodeLabel = "Quote Input 1"
+      const frameLabels = [
+        "policies",
+        "driver_claim_history_by_accident_year_and_region",
+        "vehicles",
+      ]
+      const { container } = renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [
+            apiInputTable(frameLabels[0]),
+            apiInputTable("   "),
+            apiInputTable(frameLabels[1]),
+            apiInputTable(frameLabels[2]),
+            apiInputTable(frameLabels[0]),
+            apiInputTable("unselected", { selected: false }),
+            apiInputTable("not-emitted", { emit: false }),
+          ],
+        },
+        _status: "running",
+        _schemaWarnings: [{ column: "policy_id", status: "missing" }],
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      expect(node).toHaveAttribute("aria-label", expect.stringContaining(nodeLabel))
+      expect(within(node).queryByText(nodeLabel)).not.toBeInTheDocument()
+
+      const rows = within(node).getAllByTestId(/^api-input-frame-row-/)
+      expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual(
+        frameLabels.map((label) => `api-input-frame-row-${label}`),
+      )
+
+      frameLabels.forEach((label, index) => {
+        const row = within(node).getByTestId(`api-input-frame-row-${label}`)
+        const name = within(row).getByTestId(`api-input-body-label-${label}`)
+        const handle = within(node).getByTestId(
+          `output-connector[${index}]:${nodeLabel}`,
+        )
+
+        expect(name).toHaveTextContent(label)
+        expect(name).toHaveAttribute("title", label)
+        expect(handle).toHaveAttribute("data-handleid", label)
+        expect(row).toContainElement(handle)
+      })
+
+      expect(sourceHandles(container).map((handle) => handle.dataset.testid)).toEqual(
+        frameLabels.map((_label, index) => `output-connector[${index}]:${nodeLabel}`),
+      )
+      expect(screen.getByLabelText("Node running")).toBeInTheDocument()
+      expect(screen.getByLabelText("Node has schema warnings")).toBeInTheDocument()
+    })
+
+    it("mounts a labelled handle inside the sole visible frame row", () => {
+      const nodeLabel = "Single Quote Input"
+      const frameLabel = "policies"
+      const { container } = renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [
+            apiInputTable(frameLabel),
+            apiInputTable("unselected", { selected: false }),
+          ],
+        },
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      expect(within(node).queryByText(nodeLabel)).not.toBeInTheDocument()
+
+      const row = within(node).getByTestId(`api-input-frame-row-${frameLabel}`)
+      expect(within(row).getByTestId(`api-input-body-label-${frameLabel}`)).toHaveTextContent(
+        frameLabel,
+      )
+      const handle = within(node).getByTestId(`output-connector[0]:${nodeLabel}`)
+      expect(handle).toHaveAttribute("data-handleid", frameLabel)
+      expect(row).toContainElement(handle)
+      expect(sourceHandles(container)).toEqual([handle])
+    })
+
+    it("keeps a sole valid frame labelled when a second emit-eligible table has an invalid label", () => {
+      const nodeLabel = "Partially Valid Input"
+      const frameLabel = "policies"
+      renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [apiInputTable(frameLabel), apiInputTable("\t ")],
+        },
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      const row = within(node).getByTestId(`api-input-frame-row-${frameLabel}`)
+      const handle = within(node).getByTestId(`output-connector[0]:${nodeLabel}`)
+      expect(handle).toHaveAttribute("data-handleid", frameLabel)
+      expect(row).toContainElement(handle)
+      expect(screen.getAllByTestId(/^api-input-frame-row-/)).toHaveLength(1)
+    })
+
+    it("keeps distinct valid identifier names visually and structurally distinct", () => {
+      const nodeLabel = "Identifier Quote Input"
+      const frameLabels = ["frame_a", "frame__a"]
+      renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: { tables: frameLabels.map((label) => apiInputTable(label)) },
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      const renderedLabels = within(node).getAllByTestId(/^api-input-body-label-/)
+
+      expect(renderedLabels.map((label) => label.dataset.testid)).toEqual(
+        frameLabels.map((label) => `api-input-body-label-${label}`),
+      )
+      expect(renderedLabels.map((label) => label.textContent)).toEqual(frameLabels)
+      expect(renderedLabels.map((label) => label.getAttribute("title"))).toEqual(
+        frameLabels,
+      )
+      renderedLabels.forEach((label) => {
+        expect(window.getComputedStyle(label).whiteSpace).toMatch(
+          /^(pre|pre-wrap|break-spaces)$/,
+        )
+      })
+    })
+
+    it("keeps the instance name, explicit empty-state hint, and default right-side handle when no frame is visible", () => {
+      const nodeLabel = "Unconfigured Input"
+      const { container } = renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [apiInputTable("not-runtime-eligible", { selected: false })],
+        },
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      expect(within(node).getByText(nodeLabel)).toBeInTheDocument()
+      const emptyHint = within(node).getByText("No emitted frames")
+      expect(emptyHint).toBeInTheDocument()
+      expect(emptyHint).toHaveStyle({ color: "var(--text-muted)" })
+      expect(within(node).queryAllByTestId(/^api-input-frame-row-/)).toHaveLength(0)
+
+      const handle = within(node).getByTestId(`output-connector[0]:${nodeLabel}`)
+      expect(handle).not.toHaveAttribute("data-handleid")
+      expect(handle).toHaveClass("react-flow__handle-right")
+      expect(handle).not.toHaveClass("connectablestart")
+      expect(handle).not.toHaveClass("connectableend")
+      // JSDOM cannot measure the rendered centre. The default right-side
+      // Handle is centred by React Flow when `top` is implicit; an explicit
+      // 50% is equivalent, while any per-frame offset would violate the
+      // zero-frame fallback contract.
+      expect(["", "50%"]).toContain(handle.style.top)
+      expect(sourceHandles(container)).toEqual([handle])
+    })
+
+    it("renders an active trace value before the frame rows without displacing them", () => {
+      const nodeLabel = "Traced API Input"
+      renderNode({
+        label: nodeLabel,
+        nodeType: NODE_TYPES.API_INPUT,
+        config: {
+          tables: [apiInputTable("policies"), apiInputTable("drivers")],
+        },
+        _traceActive: true,
+        _traceValue: "trace-output",
+      })
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      const traceValue = within(node).getByText("trace-output")
+      const rows = within(node).getAllByTestId(/^api-input-frame-row-/)
+      expect(rows).toHaveLength(2)
+      rows.forEach((row, index) => {
+        const handle = within(node).getByTestId(
+          `output-connector[${index}]:${nodeLabel}`,
+        )
+        expect(row).toContainElement(handle)
+      })
+      expect(
+        traceValue.compareDocumentPosition(rows[0]) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    })
+  })
+
+  describe.each([
+    ["medium", 0.5],
+    ["compact", 0.2],
+  ] as const)("%s-detail apiInput body", (_lod, zoom) => {
+    it("keeps the instance-name body and container-mounted fallback handles without frame rows", () => {
+      const nodeLabel = `Zoomed API Input ${zoom}`
+      const frameLabels = ["policies", "drivers"]
+      const { container } = renderNode(
+        {
+          label: nodeLabel,
+          nodeType: NODE_TYPES.API_INPUT,
+          config: { tables: frameLabels.map((label) => apiInputTable(label)) },
+        },
+        false,
+        undefined,
+        zoom,
+      )
+
+      const node = screen.getByTestId(`node-${nodeLabel}`)
+      expect(within(node).getByText(nodeLabel)).toBeInTheDocument()
+      expect(within(node).queryAllByTestId(/^api-input-frame-row-/)).toHaveLength(0)
+      expect(within(node).queryAllByTestId(/^api-input-body-label-/)).toHaveLength(0)
+      expect(sourceHandles(container).map((handle) => handle.getAttribute("data-handleid"))).toEqual(
+        frameLabels,
+      )
+      expect(sourceHandles(container).map((handle) => handle.dataset.testid)).toEqual([
+        `output-connector[0]:${nodeLabel}`,
+        `output-connector[1]:${nodeLabel}`,
+      ])
+    })
   })
 
   it("renders an output node", () => {

--- a/frontend/src/panels/NodePanel.tsx
+++ b/frontend/src/panels/NodePanel.tsx
@@ -3,6 +3,7 @@ import { X, Link2, AlertTriangle, RefreshCw } from "lucide-react"
 import { NODE_TYPES, NODE_TYPE_META } from "../utils/nodeTypes"
 import type { NodeTypeValue } from "../utils/nodeTypes"
 import { sanitizeName } from "../utils/sanitizeName"
+import { apiInputFrameLabels, edgeInputName } from "../utils/apiInputPorts"
 import {
   DataSourceEditor,
   TransformEditor,
@@ -29,7 +30,7 @@ import {
   OptimiserConfig,
   LazyEditorBoundary,
 } from "./LazyNodeEditors"
-import type { InputSource, SimpleNode, SimpleEdge } from "./editors"
+import type { InputSource, SimpleNode, SimpleEdge, OnUpdateConfig, OnUpdateConfigResult } from "./editors"
 import { effectiveNodeType, type HauteNodeData } from "../types/node"
 import useUIStore, { type ExplorePane } from "../stores/useUIStore"
 import PanelShell from "./PanelShell"
@@ -43,7 +44,7 @@ export type { SimpleNode, SimpleEdge } from "./editors"
 type NodePanelProps = {
   node: SimpleNode | null
   onClose: () => void
-  onUpdateNode?: (id: string, data: Record<string, unknown>) => void
+  onUpdateNode?: (id: string, data: Record<string, unknown>) => OnUpdateConfigResult
   onDeleteEdge?: (edgeId: string) => void
   onSwapEdgeJoinInputs?: (nodeId: string) => void
   onRefreshPreview?: () => void
@@ -232,6 +233,7 @@ function resolveOriginalInputNames({
   visibleEdges,
   visibleNodeMap,
   submodelName,
+  submodels,
 }: {
   originalId: string
   originalEdges: SimpleEdge[]
@@ -239,12 +241,14 @@ function resolveOriginalInputNames({
   visibleEdges: SimpleEdge[]
   visibleNodeMap: Record<string, SimpleNode>
   submodelName?: string
+  submodels?: Record<string, unknown>
 }): string[] {
   const internalInputs = originalEdges
     .filter((e) => e.target === originalId)
     .map((e) => {
       const srcNode = originalNodeMap[e.source]
-      return srcNode ? sanitizeName(srcNode.data.label) : e.source
+      if (!srcNode) throw new Error(`Cannot derive instance input name: source node ${e.source} is missing`)
+      return edgeInputName(e, srcNode, submodels)
     })
 
   if (!submodelName) return uniquePreservingOrder(internalInputs)
@@ -254,7 +258,8 @@ function resolveOriginalInputNames({
     .filter((e) => e.target === submodelNodeId && e.targetHandle === `in__${originalId}`)
     .map((e) => {
       const srcNode = visibleNodeMap[e.source]
-      return srcNode ? sanitizeName(srcNode.data.label) : e.source
+      if (!srcNode) throw new Error(`Cannot derive instance input name: source node ${e.source} is missing`)
+      return edgeInputName(e, srcNode, submodels)
     })
 
   return uniquePreservingOrder([...internalInputs, ...boundaryInputs])
@@ -311,7 +316,7 @@ function InstancePanel({
   node: SimpleNode
   config: Record<string, unknown>
   nodeMap: Record<string, SimpleNode>
-  handleConfigUpdate: (keyOrUpdates: string | Record<string, unknown>, value?: unknown) => void
+  handleConfigUpdate: OnUpdateConfig
 }) {
   const { edges, submodels } = useGraph()
   const originalResolution = resolveInstanceOriginal(config.instanceOf, nodeMap, edges, submodels)
@@ -354,13 +359,16 @@ function InstancePanel({
           visibleEdges: edges,
           visibleNodeMap: nodeMap,
           submodelName,
+          submodels,
         })
         const instInputs = edges
           .filter((e) => e.target === node.id)
           .map((e) => {
             const srcNode = nodeMap[e.source]
             return {
-              varName: srcNode ? sanitizeName(srcNode.data.label) : e.source,
+              name: srcNode ? edgeInputName(e, srcNode, submodels) : (() => {
+                throw new Error(`Cannot derive instance input name: source node ${e.source} is missing`)
+              })(),
               label: srcNode ? srcNode.data.label : e.source,
             }
           })
@@ -380,40 +388,40 @@ function InstancePanel({
         const autoMap: Record<string, string> = {}
         const usedInst = new Set<string>()
         for (const orig of origInputs) {
-          const exact = instInputs.find((i) => i.varName === orig && !usedInst.has(i.varName))
-          if (exact) { autoMap[orig] = exact.varName; usedInst.add(exact.varName) }
+          const exact = instInputs.find((i) => i.name === orig && !usedInst.has(i.name))
+          if (exact) { autoMap[orig] = exact.name; usedInst.add(exact.name) }
         }
         const subOrigs = origInputs.filter((o) => !autoMap[o])
-        const subInsts = instInputs.filter((i) => !usedInst.has(i.varName))
+        const subInsts = instInputs.filter((i) => !usedInst.has(i.name))
         const candByOrig = new Map(
-          subOrigs.map((o) => [o, subInsts.filter((i) => i.varName.includes(o))]),
+          subOrigs.map((o) => [o, subInsts.filter((i) => i.name.includes(o))]),
         )
         const candCountByInst = new Map(
-          subInsts.map((i) => [i.varName, subOrigs.filter((o) => i.varName.includes(o)).length]),
+          subInsts.map((i) => [i.name, subOrigs.filter((o) => i.name.includes(o)).length]),
         )
         const ambiguousOrigs = new Set(
           subOrigs.filter((o) => {
             const cands = candByOrig.get(o) ?? []
-            return cands.length > 0 && !(cands.length === 1 && candCountByInst.get(cands[0].varName) === 1)
+            return cands.length > 0 && !(cands.length === 1 && candCountByInst.get(cands[0].name) === 1)
           }),
         )
         for (const o of subOrigs) {
           const cands = candByOrig.get(o) ?? []
-          if (cands.length === 1 && candCountByInst.get(cands[0].varName) === 1) {
-            autoMap[o] = cands[0].varName
-            usedInst.add(cands[0].varName)
+          if (cands.length === 1 && candCountByInst.get(cands[0].name) === 1) {
+            autoMap[o] = cands[0].name
+            usedInst.add(cands[0].name)
           }
         }
-        const remaining = instInputs.filter((i) => !usedInst.has(i.varName))
+        const remaining = instInputs.filter((i) => !usedInst.has(i.name))
         const unmapped = origInputs.filter((o) => !autoMap[o] && !ambiguousOrigs.has(o))
         unmapped.forEach((orig, idx) => {
-          if (idx < remaining.length) autoMap[orig] = remaining[idx].varName
+          if (idx < remaining.length) autoMap[orig] = remaining[idx].name
         })
 
         const effectiveMap: Record<string, string> = {}
-        const instVarNames = new Set(instInputs.map((i) => i.varName))
+        const instNames = new Set(instInputs.map((i) => i.name))
         for (const orig of origInputs) {
-          if (currentMapping[orig] && instVarNames.has(currentMapping[orig])) {
+          if (currentMapping[orig] && instNames.has(currentMapping[orig])) {
             effectiveMap[orig] = currentMapping[orig]
           } else {
             effectiveMap[orig] = autoMap[orig] || ""
@@ -458,7 +466,7 @@ function InstancePanel({
                   >
                     <option value="">— unmapped —</option>
                     {instInputs.map((i) => (
-                      <option key={i.varName} value={i.varName}>{i.label}</option>
+                      <option key={i.name} value={i.name}>{i.label}</option>
                     ))}
                   </select>
                 </div>
@@ -532,10 +540,50 @@ function upstreamNodeTypeSignature(edges: SimpleEdge[], nodeMap: Record<string, 
     .join("\u0001")
 }
 
-function upstreamLabelSignature(edges: SimpleEdge[], nodeMap: Record<string, SimpleNode>): string {
-  return edges
-    .map((edge) => `${edge.id}\u0002${edge.source}\u0003${nodeMap[edge.source]?.data?.label ?? ""}`)
-    .join("\u0001")
+function inputSourceForEdge(
+  edge: SimpleEdge,
+  nodeMap: Record<string, SimpleNode>,
+  submodels?: Record<string, unknown>,
+): InputSource {
+  const sourceNode = nodeMap[edge.source]
+  if (!sourceNode) {
+    throw new Error(`Cannot derive input name for edge ${edge.id}: source node ${edge.source} is missing`)
+  }
+  const sourceLabel = sourceNode.data.label || edge.source
+  const name = edgeInputName(edge, sourceNode, submodels)
+  const frameUnresolved =
+    sourceNode.data.nodeType === NODE_TYPES.API_INPUT
+    && (edge.sourceHandle === null
+      || edge.sourceHandle === undefined
+      || !apiInputFrameLabels(sourceNode.data.config).includes(edge.sourceHandle))
+
+  return {
+    sourceNodeId: edge.source,
+    name,
+    sourceLabel,
+    edgeId: edge.id,
+    ...(frameUnresolved ? { frameUnresolved: true } : {}),
+  }
+}
+
+function upstreamInputSourceSignature(
+  edges: SimpleEdge[],
+  nodeMap: Record<string, SimpleNode>,
+  submodels?: Record<string, unknown>,
+): string {
+  return JSON.stringify(
+    edges.map((edge) => {
+      const source = inputSourceForEdge(edge, nodeMap, submodels)
+      return [
+        edge.id,
+        edge.source,
+        source.sourceLabel,
+        edge.sourceHandle === undefined ? "<undefined>" : edge.sourceHandle,
+        source.name,
+        source.frameUnresolved === true,
+      ]
+    }),
+  )
 }
 
 function UnknownNodeTypeDiagnostic({
@@ -623,7 +671,7 @@ export default function NodePanel({
   previewRows,
   selectedPreviewLoading = false,
 }: NodePanelProps) {
-  const { allNodes, edges } = useGraph()
+  const { allNodes, edges, submodels } = useGraph()
   const config = useMemo(() => (node?.data.config || {}) as Record<string, unknown>, [node?.data.config])
   const [activeTab, setActiveTab] = useState<"config" | "columns">("config")
   const rememberedExplorePane = useUIStore((s) => node?.id ? s.explorePanes[node.id] : undefined)
@@ -643,14 +691,16 @@ export default function NodePanel({
   const [dismissedStaleWarningSig, setDismissedStaleWarningSig] = useState<string | null>(null)
   useEffect(() => { setDismissedStaleWarningSig(null) }, [node?.id])
 
-  const handleConfigUpdate = useCallback((keyOrUpdates: string | Record<string, unknown>, value?: unknown) => {
+  const handleConfigUpdate = useCallback<OnUpdateConfig>((keyOrUpdates, value) => {
     const currentNode = nodeRef.current
-    if (!currentNode || !onUpdateNode) return
+    if (!currentNode || !onUpdateNode) {
+      return { ok: false, error: "Node update handler is unavailable." }
+    }
     const currentConfig = configRef.current
     const newConfig = typeof keyOrUpdates === "string"
       ? { ...currentConfig, [keyOrUpdates]: value }
       : { ...currentConfig, ...keyOrUpdates }
-    onUpdateNode(currentNode.id, clearCachedResultShape({ ...currentNode.data, config: newConfig }))
+    return onUpdateNode(currentNode.id, clearCachedResultShape({ ...currentNode.data, config: newConfig }))
   }, [onUpdateNode])
 
   const configWithNodeId = useMemo(
@@ -665,20 +715,15 @@ export default function NodePanel({
     () => selectedNodeId ? edges.filter((e) => e.target === selectedNodeId) : [],
     [edges, selectedNodeId],
   )
-  const upstreamSourceLabelSignature = upstreamLabelSignature(upstreamEdges, nodeMap)
+  const upstreamInputSourceSig = upstreamInputSourceSignature(upstreamEdges, nodeMap, submodels)
   const inputSources: InputSource[] = useMemo(() => {
     if (!selectedNodeId) return []
-    return upstreamEdges.map((e) => ({
-      sourceNodeId: e.source,
-      varName: sanitizeName(nodeMap[e.source]?.data.label || e.source),
-      sourceLabel: nodeMap[e.source]?.data.label || e.source,
-      edgeId: e.id,
-    }))
-    // Keyed by selected node + label signature so selected-node edits that
-    // rebuild nodeMap do not churn this array; only upstream label/edge changes
-    // do.
+    return upstreamEdges.map((edge) => inputSourceForEdge(edge, nodeMap, submodels))
+    // Keyed by selected node plus each upstream edge's source/display identity:
+    // source labels, source handles, resolved frame labels, and resolution
+    // state can all change while the edge id stays the same.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNodeId, upstreamSourceLabelSignature])
+  }, [selectedNodeId, upstreamInputSourceSig, submodels])
   const upstreamSchemaSignature = upstreamColumnsSignature(upstreamEdges, nodeMap)
   const upstreamColumns = useMemo(() => {
     if (!selectedNodeId) return []

--- a/frontend/src/panels/__tests__/NodePanel.graphContext.test.tsx
+++ b/frontend/src/panels/__tests__/NodePanel.graphContext.test.tsx
@@ -30,7 +30,7 @@ import path from "node:path"
 import { render, screen, cleanup } from "@testing-library/react"
 import NodePanel from "../NodePanel"
 import { GraphProvider } from "../GraphContext"
-import type { SimpleNode, SimpleEdge } from "../editors"
+import type { OnUpdateConfigResult, SimpleNode, SimpleEdge } from "../editors"
 import useUIStore from "../../stores/useUIStore"
 
 // ─── Editor mocks ─────────────────────────────────────────────────
@@ -105,7 +105,7 @@ function renderWithGraph(opts: {
   submodels?: Record<string, unknown>
   preamble?: string
   onClose?: () => void
-  onUpdateNode?: (id: string, data: Record<string, unknown>) => void
+  onUpdateNode?: (id: string, data: Record<string, unknown>) => OnUpdateConfigResult
   onDeleteEdge?: (id: string) => void
 }) {
   const {
@@ -115,7 +115,7 @@ function renderWithGraph(opts: {
     submodels,
     preamble,
     onClose = vi.fn(),
-    onUpdateNode = vi.fn(),
+    onUpdateNode = vi.fn(() => ({ ok: true as const })),
     onDeleteEdge = vi.fn(),
   } = opts
   return render(

--- a/frontend/src/panels/__tests__/NodePanel.test.tsx
+++ b/frontend/src/panels/__tests__/NodePanel.test.tsx
@@ -15,12 +15,23 @@ const { transformEditorProps, edgeJoinEditorProps, exploreCodeEditorProps, bandi
 }))
 
 // Mock all editor components — we only care that the right one renders
-vi.mock("../LazyNodeEditors", () => ({
+vi.mock("../LazyNodeEditors", async () => {
+  const { InputSourcesBar } = await vi.importActual<typeof import("../editors/_shared")>(
+    "../editors/_shared",
+  )
+  return {
   LazyEditorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DataSourceEditor: () => <div data-testid="DataSourceEditor" />,
   TransformEditor: (props: Record<string, unknown>) => {
     transformEditorProps.push(props)
-    return <div data-testid="TransformEditor" />
+    return (
+      <div data-testid="TransformEditor">
+        <InputSourcesBar
+          inputSources={props.inputSources as Parameters<typeof InputSourcesBar>[0]["inputSources"]}
+          onDeleteInput={props.onDeleteInput as ((edgeId: string) => void) | undefined}
+        />
+      </div>
+    )
   },
   EdgeJoinEditor: (props: Record<string, unknown>) => {
     edgeJoinEditorProps.push(props)
@@ -63,7 +74,8 @@ vi.mock("../LazyNodeEditors", () => ({
     optimiserConfigProps.push(props)
     return <div data-testid="OptimiserConfig" />
   },
-}))
+  }
+})
 
 function makeNode(overrides: Partial<SimpleNode> = {}): SimpleNode {
   return {
@@ -108,6 +120,26 @@ function renderPanel(overrides: RenderPanelOverrides = {}) {
     </GraphProvider>,
   )
   return { ...result, props }
+}
+
+type Phase3InputSource = {
+  sourceNodeId: string
+  name: string
+  sourceLabel: string
+  edgeId: string
+  frameUnresolved?: boolean
+}
+
+function latestTransformInputSources(): Phase3InputSource[] {
+  return transformEditorProps.at(-1)?.inputSources as Phase3InputSource[]
+}
+
+function eligibleApiInputTable(label: string) {
+  return {
+    label,
+    emit: true,
+    columns: [{ name: "value", selected: true }],
+  }
 }
 
 describe("NodePanel", () => {
@@ -378,7 +410,7 @@ describe("NodePanel", () => {
       inputSources: [
         {
           sourceNodeId: "source_1",
-          varName: "Claims_Source",
+          name: "Claims_Source",
           sourceLabel: "Claims Source",
           edgeId: "e_source_explore",
         },
@@ -473,6 +505,369 @@ describe("NodePanel", () => {
   it("renders ScenarioExpanderEditor for scenarioExpander nodes", () => {
     renderPanel({ node: makeNode({ data: { label: "SE", description: "", nodeType: "scenarioExpander", config: {} } }) })
     expect(screen.getByTestId("ScenarioExpanderEditor")).toBeInTheDocument()
+  })
+
+  describe("frame-aware input source identity", () => {
+    it("derives the executable input name for multi-frame, sole-frame, and ordinary edges", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const multiApi = makeNode({
+        id: "multi_api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: {
+            tables: [
+              eligibleApiInputTable("policies"),
+              eligibleApiInputTable("DriversRaw"),
+            ],
+          },
+        },
+      })
+      const singleApi = makeNode({
+        id: "single_api",
+        data: {
+          label: "Vehicle API",
+          description: "",
+          nodeType: "apiInput",
+          config: { tables: [eligibleApiInputTable("vehicles")] },
+        },
+      })
+      const ordinary = makeNode({
+        id: "ordinary",
+        data: { label: "Claims Source", description: "", nodeType: "dataSource", config: {} },
+      })
+      const edges: SimpleEdge[] = [
+        {
+          id: "edge_multi",
+          source: multiApi.id,
+          target: target.id,
+          sourceHandle: "DriversRaw",
+        },
+        {
+          id: "edge_single",
+          source: singleApi.id,
+          target: target.id,
+          sourceHandle: "vehicles",
+        },
+        {
+          id: "edge_ordinary",
+          source: ordinary.id,
+          target: target.id,
+          sourceHandle: "out__claims",
+        },
+      ]
+
+      renderPanel({ node: target, allNodes: [multiApi, singleApi, ordinary, target], edges })
+
+      const sources = latestTransformInputSources()
+      expect(sources).toHaveLength(3)
+      expect(sources[0]).toMatchObject({
+        edgeId: "edge_multi",
+        name: "DriversRaw",
+        sourceLabel: "Quote API",
+      })
+      expect(sources[0].frameUnresolved).not.toBe(true)
+      expect(sources[1]).toMatchObject({
+        edgeId: "edge_single",
+        name: "vehicles",
+        sourceLabel: "Vehicle API",
+      })
+      expect(sources[1].frameUnresolved).not.toBe(true)
+      expect(sources[2]).toMatchObject({
+        edgeId: "edge_ordinary",
+        name: "Claims_Source",
+        sourceLabel: "Claims Source",
+      })
+      expect(sources[2].frameUnresolved).not.toBe(true)
+    })
+
+    it("keeps a dangling apiInput handle verbatim and marks it unresolved", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const apiInput = makeNode({
+        id: "api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: {
+            tables: [{ label: "quotes", emit: true, columns: [{ name: "id", selected: false }] }],
+          },
+        },
+      })
+
+      renderPanel({
+        node: target,
+        allNodes: [apiInput, target],
+        edges: [
+          {
+            id: "edge_api",
+            source: apiInput.id,
+            target: target.id,
+            sourceHandle: "stale_quotes",
+          },
+        ],
+      })
+
+      expect(latestTransformInputSources()).toEqual([
+        expect.objectContaining({
+          edgeId: "edge_api",
+          name: "stale_quotes",
+          sourceLabel: "Quote API",
+          frameUnresolved: true,
+        }),
+      ])
+      const warning = screen.getByLabelText(/unresolved.*frame|frame.*unresolved/i)
+      expect(warning).toBeVisible()
+      expect(warning).toHaveAttribute(
+        "title",
+        expect.stringMatching(/eligible|emitted|resolv/i),
+      )
+    })
+
+    it("refreshes a named apiInput display label when only sourceHandle changes", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const apiInput = makeNode({
+        id: "api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: {
+            tables: [eligibleApiInputTable("policies"), eligibleApiInputTable("drivers")],
+          },
+        },
+      })
+      const firstEdge: SimpleEdge = {
+        id: "edge_api",
+        source: apiInput.id,
+        target: target.id,
+        sourceHandle: "policies",
+      }
+      const { rerender, props } = renderPanel({
+        node: target,
+        allNodes: [apiInput, target],
+        edges: [firstEdge],
+      })
+      const firstSources = latestTransformInputSources()
+      expect(firstSources[0].name).toBe("policies")
+
+      rerender(
+        <GraphProvider
+          allNodes={[apiInput, target]}
+          edges={[{ ...firstEdge, sourceHandle: "drivers" }]}
+        >
+          <NodePanel {...props} />
+        </GraphProvider>,
+      )
+
+      const reboundSources = latestTransformInputSources()
+      expect(reboundSources[0].name).toBe("drivers")
+    })
+
+    it("refreshes the derived name when a sole-frame edge is rebound after rename", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const apiInput = makeNode({
+        id: "api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: { tables: [eligibleApiInputTable("quotes")] },
+        },
+      })
+      const edge: SimpleEdge = {
+        id: "edge_api",
+        source: apiInput.id,
+        target: target.id,
+        sourceHandle: "quotes",
+      }
+      const { rerender, props } = renderPanel({
+        node: target,
+        allNodes: [apiInput, target],
+        edges: [edge],
+      })
+      const firstSources = latestTransformInputSources()
+      expect(firstSources[0].name).toBe("quotes")
+
+      const renamedApiInput = makeNode({
+        ...apiInput,
+        data: {
+          ...apiInput.data,
+          config: { tables: [eligibleApiInputTable("policies")] },
+        },
+      })
+      rerender(
+        <GraphProvider
+          allNodes={[renamedApiInput, target]}
+          edges={[{ ...edge, sourceHandle: "policies" }]}
+        >
+          <NodePanel {...props} />
+        </GraphProvider>,
+      )
+
+      const renamedSources = latestTransformInputSources()
+      expect(renamedSources[0].name).toBe("policies")
+    })
+
+    it("clears unresolved state when resolution changes under an unchanged derived name", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const unresolvedApi = makeNode({
+        id: "api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: {
+            tables: [{ label: "Quote_API", emit: true, columns: [{ name: "id", selected: false }] }],
+          },
+        },
+      })
+      const edge: SimpleEdge = {
+        id: "edge_api",
+        source: unresolvedApi.id,
+        target: target.id,
+        sourceHandle: "Quote_API",
+      }
+      const { rerender, props } = renderPanel({
+        node: target,
+        allNodes: [unresolvedApi, target],
+        edges: [edge],
+      })
+      const unresolvedSources = latestTransformInputSources()
+      expect(unresolvedSources[0]).toMatchObject({
+        name: "Quote_API",
+        frameUnresolved: true,
+      })
+
+      const resolvedApi = makeNode({
+        ...unresolvedApi,
+        data: {
+          ...unresolvedApi.data,
+          config: { tables: [eligibleApiInputTable("Quote_API")] },
+        },
+      })
+      rerender(
+        <GraphProvider allNodes={[resolvedApi, target]} edges={[edge]}>
+          <NodePanel {...props} />
+        </GraphProvider>,
+      )
+
+      const resolvedSources = latestTransformInputSources()
+      expect(resolvedSources[0].name).toBe("Quote_API")
+      expect(resolvedSources[0].frameUnresolved).not.toBe(true)
+      expect(screen.queryByLabelText(/unresolved.*frame|frame.*unresolved/i)).not.toBeInTheDocument()
+    })
+
+    it("keeps duplicate-parent frame inputs distinct and routes removals by edge id", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const apiInput = makeNode({
+        id: "api",
+        data: {
+          label: "Quote API",
+          description: "",
+          nodeType: "apiInput",
+          config: {
+            tables: [eligibleApiInputTable("quotes"), eligibleApiInputTable("drivers")],
+          },
+        },
+      })
+      const { props } = renderPanel({
+        node: target,
+        allNodes: [apiInput, target],
+        edges: [
+          { id: "edge_quotes", source: apiInput.id, target: target.id, sourceHandle: "quotes" },
+          { id: "edge_drivers", source: apiInput.id, target: target.id, sourceHandle: "drivers" },
+        ],
+      })
+
+      expect(latestTransformInputSources()).toEqual([
+        expect.objectContaining({
+          edgeId: "edge_quotes",
+          name: "quotes",
+        }),
+        expect.objectContaining({
+          edgeId: "edge_drivers",
+          name: "drivers",
+        }),
+      ])
+
+      expect(screen.getByText("quotes")).toBeInTheDocument()
+      expect(screen.getByText("drivers")).toBeInTheDocument()
+      const removeButtons = screen.getAllByRole("button", {
+        name: /remove connection from Quote API/i,
+      })
+      expect(removeButtons).toHaveLength(2)
+      fireEvent.click(removeButtons[0])
+      fireEvent.click(removeButtons[1])
+      expect(props.onDeleteEdge).toHaveBeenNthCalledWith(1, "edge_quotes")
+      expect(props.onDeleteEdge).toHaveBeenNthCalledWith(2, "edge_drivers")
+    })
+
+    it("derives a flattened submodel output name from the referenced child label", () => {
+      const target = makeNode({
+        id: "target",
+        data: { label: "Target", description: "", nodeType: "polars", config: {} },
+      })
+      const placeholder = makeNode({
+        id: "submodel__pricing",
+        data: {
+          label: "Pricing Module",
+          description: "",
+          nodeType: "submodel",
+          config: { childNodeIds: ["child_output"], outputPorts: ["child_output"] },
+        },
+      })
+      const child = makeNode({
+        id: "child_output",
+        data: {
+          label: "Child Output",
+          description: "",
+          nodeType: "polars",
+          config: {},
+        },
+      })
+
+      renderPanel({
+        node: target,
+        allNodes: [placeholder, target],
+        edges: [
+          {
+            id: "edge_child",
+            source: placeholder.id,
+            target: target.id,
+            sourceHandle: "out__child_output",
+          },
+        ],
+        submodels: { pricing: { graph: { nodes: [child], edges: [] } } },
+      })
+
+      expect(latestTransformInputSources()).toEqual([
+        expect.objectContaining({
+          edgeId: "edge_child",
+          name: "Child_Output",
+          sourceLabel: "Pricing Module",
+        }),
+      ])
+    })
   })
 
   it("renders ConstantEditor for constant nodes", () => {

--- a/frontend/src/panels/__tests__/NodePanel.test.tsx
+++ b/frontend/src/panels/__tests__/NodePanel.test.tsx
@@ -60,6 +60,8 @@ vi.mock("../LazyNodeEditors", async () => {
   ApiInputEditor: () => <div data-testid="ApiInputEditor" />,
   LiveSwitchEditor: () => <div data-testid="LiveSwitchEditor" />,
   SinkEditor: () => <div data-testid="SinkEditor" />,
+  DataInputEditor: () => <div data-testid="DataInputEditor" />,
+  DataOutputEditor: () => <div data-testid="DataOutputEditor" />,
   ScenarioExpanderEditor: () => <div data-testid="ScenarioExpanderEditor" />,
   OptimiserApplyEditor: () => <div data-testid="OptimiserApplyEditor" />,
   ConstantEditor: () => <div data-testid="ConstantEditor" />,
@@ -278,6 +280,16 @@ describe("NodePanel", () => {
   it("renders SinkEditor for dataSink nodes", () => {
     renderPanel({ node: makeNode({ data: { label: "Sink", description: "", nodeType: "dataSink", config: {} } }) })
     expect(screen.getByTestId("SinkEditor")).toBeInTheDocument()
+  })
+
+  it("renders DataInputEditor for dataInput nodes", () => {
+    renderPanel({ node: makeNode({ data: { label: "In", description: "", nodeType: "dataInput", config: {} } }) })
+    expect(screen.getByTestId("DataInputEditor")).toBeInTheDocument()
+  })
+
+  it("renders DataOutputEditor for dataOutput nodes", () => {
+    renderPanel({ node: makeNode({ data: { label: "Out", description: "", nodeType: "dataOutput", config: {} } }) })
+    expect(screen.getByTestId("DataOutputEditor")).toBeInTheDocument()
   })
 
   it("renders OutputEditor for output nodes", () => {

--- a/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
+++ b/frontend/src/panels/__tests__/OptimiserConfig.test.tsx
@@ -148,6 +148,7 @@ function renderStatefulConfig(
         onUpdateSpy(keyOrUpdates)
         setConfig(prev => ({ ...prev, ...keyOrUpdates }))
       }
+      return { ok: true as const }
     }
 
     return (

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type CSSProperties } from "react"
 import { AlertTriangle, Radio, Check, HelpCircle, KeyRound, Plus, X } from "lucide-react"
 import { FileBrowser, SchemaPreview } from "./_shared"
-import type { OnUpdateConfig } from "./_shared"
+import type { OnUpdateConfig, OnUpdateConfigResult } from "./_shared"
 import { useSchemaFetch } from "../../hooks/useSchemaFetch"
 import { configField } from "../../utils/configField"
 import { withAlpha } from "../../utils/color"
@@ -171,6 +171,7 @@ export default function ApiInputEditor({
   // Salted naming (full dotted leaf → `customer_id`) vs bare leaf (`id`) for
   // keys arriving without an inventory name. Salted is the default.
   const [saltNames, setSaltNames] = useState(true)
+  const [labelCommitErrors, setLabelCommitErrors] = useState<Record<number, string>>({})
   // Which key picker is open: cascade works over the whole inventory from the
   // frames table; inherit / add-keys (inherit-attributes) target one frame.
   const [picker, setPicker] = useState<
@@ -211,18 +212,30 @@ export default function ApiInputEditor({
   // Helpers to push state changes back through onUpdate. Each write
   // recomposes the full v2 record-shaped object so we never have to fan
   // out individual onUpdate calls per nested field.
-  const writeBack = (next: ApiInputConfigV2) => {
+  const writeBack = (next: ApiInputConfigV2): OnUpdateConfigResult => {
     const raw = writeV2(next)
     // Use a single batched update so NodePanel only fires one
     // handleConfigUpdate (per the existing OnUpdateConfig contract).
-    onUpdate(raw)
+    const result = onUpdate(raw)
+    // Existing editor-only callers may still use a bare spy while the
+    // production contract is compile-time required to return a result.
+    const commitResult: OnUpdateConfigResult = result ?? { ok: true }
+    if (commitResult.ok) setLabelCommitErrors({})
+    return commitResult
   }
-  const updateTable = (i: number, patch: Partial<ApiInputTableV2>) => {
+  const updateTable = (
+    i: number,
+    patch: Partial<ApiInputTableV2>,
+  ): OnUpdateConfigResult => {
     const next = {
       ...v2,
       tables: v2.tables.map((t, idx) => (idx === i ? { ...t, ...patch } : t)),
     }
-    writeBack(next)
+    const result = writeBack(next)
+    if (Object.hasOwn(patch, "label") && !result.ok) {
+      setLabelCommitErrors((previous) => ({ ...previous, [i]: result.error }))
+    }
+    return result
   }
   // W1.4 — label validation, mirroring the backend's save-time rules
   // (`validate_v2_schema`): blank labels, duplicates, and sanitised-form
@@ -241,7 +254,7 @@ export default function ApiInputEditor({
     tableIdx: number,
     colIdx: number,
     patch: Partial<ApiInputColumnV2>,
-  ) => {
+  ): OnUpdateConfigResult => {
     // Editing a column's name, path, or type IS confirming it — the user has
     // looked at the row and made it theirs.
     const confirming =
@@ -292,7 +305,7 @@ export default function ApiInputEditor({
           : t,
       ),
     }
-    writeBack(next)
+    return writeBack(next)
   }
   const addColumn = (tableIdx: number) => {
     // A hand-added column arrives BLANK (ruled 2026-07-09): no placeholder
@@ -926,6 +939,7 @@ export default function ApiInputEditor({
                   testIdPrefix={`api-input-table-${ti}`}
                   ambiguousNames={ambiguous}
                   validateLabel={validateTableLabel(ti)}
+                  commitError={labelCommitErrors[ti] ?? null}
                   onUpdate={(patch) => updateTable(ti, patch)}
                   onRemove={() => removeTable(ti)}
                   onAddColumn={() => addColumn(ti)}
@@ -1031,6 +1045,7 @@ function TableBlock({
   testIdPrefix,
   ambiguousNames,
   validateLabel,
+  commitError,
   onUpdate,
   onRemove,
   onAddColumn,
@@ -1046,10 +1061,11 @@ function TableBlock({
    * distinct paths carrying each (the warning-shade input for ColumnRow). */
   ambiguousNames: ReadonlyMap<string, string[]>
   validateLabel: (candidate: string) => string | null
-  onUpdate: (patch: Partial<ApiInputTableV2>) => void
+  commitError: string | null
+  onUpdate: (patch: Partial<ApiInputTableV2>) => OnUpdateConfigResult
   onRemove: () => void
   onAddColumn: () => void
-  onUpdateColumn: (colIdx: number, patch: Partial<ApiInputColumnV2>) => void
+  onUpdateColumn: (colIdx: number, patch: Partial<ApiInputColumnV2>) => OnUpdateConfigResult
   onRemoveColumn: (colIdx: number) => void
   /** Replace this table's columns from a pasted tab-separated grid. */
   onPasteColumns: (grid: string[][]) => void
@@ -1132,6 +1148,7 @@ function TableBlock({
           value={table.label}
           onCommit={(label) => onUpdate({ label })}
           validate={validateLabel}
+          commitError={commitError}
           containerClassName="flex-1 min-w-0"
           className="w-full text-xs font-mono px-1.5 py-0.5 rounded"
           style={{
@@ -1265,7 +1282,7 @@ function ColumnRow({
   ambiguousNames: ReadonlyMap<string, string[]>
   testIdPrefix: string
   validateName: (candidate: string) => string | null
-  onUpdate: (patch: Partial<ApiInputColumnV2>) => void
+  onUpdate: (patch: Partial<ApiInputColumnV2>) => OnUpdateConfigResult
   onRemove: () => void
   onToggleKey: () => void
 }) {
@@ -1498,6 +1515,7 @@ function CommittedTextInput({
   value,
   onCommit,
   validate,
+  commitError = null,
   dataTestId,
   containerClassName,
   className,
@@ -1507,7 +1525,7 @@ function CommittedTextInput({
   /** The committed value from config — the source of truth when idle. */
   value: string
   /** Called once per commit boundary (blur / Enter) with the final value. */
-  onCommit: (next: string) => void
+  onCommit: (next: string) => OnUpdateConfigResult
   /** User-facing error for an invalid candidate; null = valid. Invalid
    * candidates are never committed. */
   validate: (candidate: string) => string | null
@@ -1515,6 +1533,8 @@ function CommittedTextInput({
   containerClassName: string
   className: string
   style: CSSProperties
+  /** Graph-level rejection from the commit owner, distinct from local validation. */
+  commitError?: string | null
   /** When set (path inputs only — NOT labels/column-names), a VALID but
    * non-canonical value is persistently highlighted as informational (§4 —
    * assembles identically; never blocks). Off for labels/column-names, which
@@ -1535,7 +1555,8 @@ function CommittedTextInput({
     setDraft(null)
   }
   const shown = draft ?? value
-  const error = validate(shown)
+  const validationError = validate(shown)
+  const error = validationError ?? commitError
   // Persistent §4 highlight for path inputs: a VALID but non-canonical path
   // (typed or introduced by schema inference) is flagged informationally — it is
   // accepted and assembles identically, so this never blocks. Gated on
@@ -1554,8 +1575,8 @@ function CommittedTextInput({
     // the user sees exactly what was rejected and why. Failing loud at
     // the editor beats a backend 422 at save or a KeyError at run.
     if (validate(draft) !== null) return
-    onCommit(draft)
-    setDraft(null)
+    const result = onCommit(draft)
+    if (result.ok) setDraft(null)
   }
   return (
     <div className={containerClassName}>

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -6,6 +6,7 @@ import { useSchemaFetch } from "../../hooks/useSchemaFetch"
 import { configField } from "../../utils/configField"
 import { withAlpha } from "../../utils/color"
 import {
+  apiInputHasEmittingTable,
   apiInputLabelIssue,
   apiInputLabelIssueMessage,
 } from "../../utils/apiInputPorts"
@@ -95,9 +96,20 @@ function JsonCacheButton({
   disabled?: boolean
   disabledReason?: string
 }) {
+  // `volatileSchema` comes from the canonical `writeV2` writer, so its JSON
+  // representation is a stable value identity. Array encoding also avoids the
+  // delimiter collisions of a hand-built composite key. CacheFetchButton uses
+  // this key only to reset/refetch status; the API callbacks below intentionally
+  // continue to send the original path/schema payloads.
+  const resourceKey = JSON.stringify([
+    dataPath,
+    configPath ?? null,
+    volatileSchema ?? null,
+  ])
+
   return (
     <CacheFetchButton<JsonCacheStatus>
-      resourceKey={dataPath + "::" + (configPath ?? "")}
+      resourceKey={resourceKey}
       getStatus={(_key) =>
         configPath
           ? getJsonCacheStatusForSchema({
@@ -123,7 +135,7 @@ function JsonCacheButton({
       labels={{
         fetchLabel: "Cache as Parquet",
         refreshLabel: "Refresh Cache",
-        notCachedHint: "Not cached yet — click to flatten/shred and cache as Parquet",
+        notCachedHint: "Runs directly from JSON — cache as Parquet for faster repeat runs",
         pendingLabel: "Processing...",
       }}
       disabled={disabled}
@@ -773,18 +785,18 @@ export default function ApiInputEditor({
             groups it with the data source and leaves the schema editor
             (Tables) as the primary authoring surface below. */}
         {showCacheButton && (() => {
-          // T9/T10: Cache button inactive when EITHER (a) no schema
-          // source (no path AND no tables) OR (b) zero emit:true
-          // tables. The CacheFetchButton renders disabled via
-          // `disabledReason` tooltip + the existing
-          // `disabled:opacity-40` class.
+          // Cache eligibility shares the frontend mirror of backend
+          // `table_is_emitting`: emit=true AND at least one selected column.
           const hasSchemaSource = v2.tables.length > 0
           const hasEmitTrue = v2.tables.some((t) => t.emit)
-          const cacheDisabled = !hasSchemaSource || !hasEmitTrue
+          const hasEmittingTable = apiInputHasEmittingTable({ tables: v2.tables })
+          const cacheDisabled = !hasSchemaSource || !hasEmittingTable
           const cacheReason = !hasSchemaSource
             ? "Add at least one table (Infer Tables / Add Table) before caching."
             : !hasEmitTrue
             ? "Toggle at least one table's emit so it produces a frame."
+            : !hasEmittingTable
+            ? "Select at least one column in an emitted table before caching."
             : undefined
           return (
             <JsonCacheButton

--- a/frontend/src/panels/editors/LiveSwitchEditor.tsx
+++ b/frontend/src/panels/editors/LiveSwitchEditor.tsx
@@ -1,4 +1,5 @@
-import { ToggleLeft } from "lucide-react"
+import { AlertTriangle, ToggleLeft } from "lucide-react"
+import { unresolvedFrameTitle } from "./_shared"
 import type { InputSource, OnUpdateConfig } from "./_shared"
 import { configField } from "../../utils/configField"
 import { withAlpha } from "../../utils/color"
@@ -53,11 +54,12 @@ export default function LiveSwitchEditor({
         </label>
         <div className="space-y-1.5">
           {inputSources.map((src) => {
-            const mappedSource = inputScenarioMap[src.varName] || ""
+            const mappedSource = inputScenarioMap[src.name] || ""
             const isActive = mappedSource === activeSource
             return (
               <div
-                key={src.varName}
+                key={src.edgeId}
+                data-testid={`live-switch-input-${src.edgeId}`}
                 className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs"
                 style={{
                   background: isActive ? withAlpha(accentColor, 0.1) : 'var(--bg-surface)',
@@ -68,12 +70,27 @@ export default function LiveSwitchEditor({
                   className="w-1.5 h-1.5 rounded-full shrink-0"
                   style={{ background: isActive ? accentColor : 'var(--text-muted)' }}
                 />
-                <span className="font-mono truncate min-w-0 flex-1" style={{ color: 'var(--text-primary)' }}>
-                  {src.sourceLabel}
+                <span
+                  className="font-mono min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-pre"
+                  data-unresolved={src.frameUnresolved ? "true" : undefined}
+                  aria-label={src.frameUnresolved ? "Unresolved frame" : undefined}
+                  title={src.frameUnresolved
+                    ? unresolvedFrameTitle(src.sourceLabel)
+                    : `from ${src.sourceLabel}`}
+                  style={{ color: src.frameUnresolved ? 'var(--warning)' : 'var(--text-primary)', whiteSpace: "pre" }}
+                >
+                  {src.frameUnresolved && (
+                    <AlertTriangle
+                      size={11}
+                      aria-hidden="true"
+                      className="inline mr-1"
+                    />
+                  )}
+                  {src.name}
                 </span>
                 <select
                   value={mappedSource}
-                  onChange={(e) => setMapping(src.varName, e.target.value)}
+                  onChange={(e) => setMapping(src.name, e.target.value)}
                   className="px-1.5 py-0.5 text-[11px] font-mono rounded focus:outline-none"
                   style={{
                     background: 'var(--bg-input)',

--- a/frontend/src/panels/editors/OptimiserApplyEditor.tsx
+++ b/frontend/src/panels/editors/OptimiserApplyEditor.tsx
@@ -152,7 +152,7 @@ export default function OptimiserApplyEditor({
             )}
             {ratebookInputSources.map((source) => (
               <option key={source.edgeId} value={source.sourceNodeId}>
-                {source.sourceLabel || source.varName}
+                {source.name}
               </option>
             ))}
           </select>

--- a/frontend/src/panels/editors/OutputEditor.tsx
+++ b/frontend/src/panels/editors/OutputEditor.tsx
@@ -6,11 +6,10 @@ import {
   useRef,
   type CSSProperties,
 } from "react"
-import { ChevronRight, ChevronDown, Plus, X, Wand2, Pencil, Check } from "lucide-react"
+import { ChevronRight, ChevronDown, Plus, X, Wand2, Pencil, Check, AlertTriangle } from "lucide-react"
 import type { OnUpdateConfig, SimpleNode, SimpleEdge } from "./_shared"
 import { EditorLabel } from "../../components/form"
 import { useGraph } from "../useGraph"
-import { sanitizeName } from "../../utils/sanitizeName"
 import { buildGraph } from "../../utils/buildGraph"
 import useSettingsStore from "../../stores/useSettingsStore"
 import { outputAssembleDryRun, previewNode, ApiError } from "../../api/client"
@@ -22,6 +21,8 @@ import {
   dropMappingHeader,
 } from "./outputPathTools"
 import { nonCanonicalHint, nonCanonicalNote } from "./pathCanonicalWarning"
+import { NODE_TYPES } from "../../utils/nodeTypes"
+import { apiInputFrameLabels, edgeInputName } from "../../utils/apiInputPorts"
 
 // ─── Preview chunk size ───────────────────────────────────────────
 //
@@ -65,16 +66,22 @@ import {
  * fallback collapsed them and tripped `OutputMappingSchemaError`). Falls back
  * to the sanitised source-node id when the label is missing.
  */
-function framePortId(edge: SimpleEdge, sourceNode: SimpleNode | undefined): string {
-  if (edge.sourceHandle) return edge.sourceHandle
-  const label = sourceNode?.data.label
-  return sanitizeName(typeof label === "string" && label ? label : edge.source)
+function framePortId(
+  edge: SimpleEdge,
+  sourceNode: SimpleNode | undefined,
+  submodels?: Record<string, unknown>,
+): string {
+  if (!sourceNode) {
+    throw new Error(`Cannot derive output frame name for edge ${edge.id}: source node ${edge.source} is missing`)
+  }
+  return edgeInputName(edge, sourceNode, submodels)
 }
 
-/** The user-facing frame name for an edge: the handle, else the source label. */
-function frameLabel(edge: SimpleEdge, sourceNode: SimpleNode | undefined): string {
-  if (edge.sourceHandle) return edge.sourceHandle
-  return sourceNode?.data.label ?? edge.source
+function frameIsUnresolved(edge: SimpleEdge, sourceNode: SimpleNode | undefined): boolean {
+  return sourceNode?.data.nodeType === NODE_TYPES.API_INPUT
+    && (edge.sourceHandle === null
+      || edge.sourceHandle === undefined
+      || !apiInputFrameLabels(sourceNode.data.config).includes(edge.sourceHandle))
 }
 
 /**
@@ -294,15 +301,18 @@ export default function OutputEditor({
     () =>
       incomingEdges.map((edge) => {
         const sourceNode = nodeById[edge.source]
+        const name = framePortId(edge, sourceNode, submodels)
         return {
           edge,
           sourceNode,
-          port: framePortId(edge, sourceNode),
-          label: frameLabel(edge, sourceNode),
+          parentLabel: sourceNode.data.label,
+          port: name,
+          label: name,
+          frameUnresolved: frameIsUnresolved(edge, sourceNode),
           columns: frameColumns(edge, sourceNode),
         }
       }),
-    [incomingEdges, nodeById],
+    [incomingEdges, nodeById, submodels],
   )
 
   // Per-frame INPUT schema (columns + types) for the expandable "Frames (N)"
@@ -862,7 +872,7 @@ export default function OutputEditor({
           />
 
           <div className="space-y-2">
-            {frames.map(({ edge, sourceNode, port, label, columns }, ei) => {
+            {frames.map(({ edge, sourceNode, parentLabel, port, label, frameUnresolved, columns }, ei) => {
               const rows = rowsForPort(port)
               const isOpen = expanded[edge.id] ?? false
               const anyEnabled = rows.some((r) => r.entry.enabled)
@@ -872,6 +882,8 @@ export default function OutputEditor({
                   key={edge.id}
                   testIdPrefix={`output-frame-${ei}`}
                   label={label}
+                  parentLabel={parentLabel}
+                  frameUnresolved={frameUnresolved}
                   port={port}
                   columns={columns}
                   rows={rows}
@@ -921,6 +933,8 @@ export default function OutputEditor({
 function FrameBlock({
   testIdPrefix,
   label,
+  parentLabel,
+  frameUnresolved,
   port,
   columns,
   rows,
@@ -943,6 +957,8 @@ function FrameBlock({
 }: {
   testIdPrefix: string
   label: string
+  parentLabel: string
+  frameUnresolved: boolean
   port: string
   columns: string[]
   rows: { entry: OutputMappingEntryV2; index: number }[]
@@ -1096,11 +1112,32 @@ function FrameBlock({
             <ChevronRight size={14} style={{ color: "var(--text-muted)" }} className="shrink-0" />
           )}
           <span
-            className="text-xs font-mono font-semibold truncate"
-            style={{ color: "var(--text-primary)" }}
+            className="overflow-hidden text-ellipsis whitespace-pre text-xs font-mono font-semibold"
+            style={{ color: "var(--text-primary)", whiteSpace: "pre" }}
           >
+            {frameUnresolved && (
+              <span
+                data-testid="output-frame-parent-label"
+                className="shrink-0 text-xs font-semibold"
+                style={{ color: "var(--text-primary)" }}
+              >
+                {parentLabel}
+              </span>
+            )}
             {label}
           </span>
+          {frameUnresolved && (
+            <span
+              data-testid="output-frame-unresolved"
+              role="img"
+              aria-label="Unresolved frame"
+              title="No emitted frame resolves for this connection"
+              className="shrink-0"
+              style={{ color: "var(--warning)" }}
+            >
+              <AlertTriangle size={11} />
+            </span>
+          )}
           <span className="text-[10px] shrink-0" style={{ color: "var(--text-muted)" }}>
             {rows.length} {rows.length === 1 ? "field" : "fields"}
           </span>

--- a/frontend/src/panels/editors/__tests__/DataInputEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/DataInputEditor.test.tsx
@@ -112,6 +112,7 @@ function Harness({ initial }: { initial: Record<string, unknown> }) {
         ? { ...current, [keyOrUpdates]: value }
         : { ...current, ...keyOrUpdates },
     )
+    return { ok: true }
   }
   return (
     <>

--- a/frontend/src/panels/editors/__tests__/DataOutputEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/DataOutputEditor.test.tsx
@@ -99,6 +99,7 @@ function Harness({ initial }: { initial: Record<string, unknown> }) {
         ? { ...current, [keyOrUpdates]: value }
         : { ...current, ...keyOrUpdates },
     )
+    return { ok: true }
   }
   return (
     <>

--- a/frontend/src/panels/editors/__tests__/ModelScoreEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/ModelScoreEditor.test.tsx
@@ -74,7 +74,7 @@ import ModelScoreEditor from "../ModelScoreEditor"
 const defaultProps = () => ({
   config: {} as Record<string, unknown>,
   onUpdate: vi.fn(),
-  inputSources: [] as { sourceNodeId: string; varName: string; sourceLabel: string; edgeId: string }[],
+  inputSources: [] as { sourceNodeId: string; name: string; sourceLabel: string; edgeId: string }[],
   accentColor: "#8b5cf6",
 })
 
@@ -341,8 +341,8 @@ describe("ModelScoreEditor", () => {
   it("renders InputSourcesBar with input sources", () => {
     const props = defaultProps()
     props.inputSources = [
-      { sourceNodeId: "test-source", varName: "df", sourceLabel: "data_source", edgeId: "e1" },
-      { sourceNodeId: "test-source", varName: "df2", sourceLabel: "other_source", edgeId: "e2" },
+      { sourceNodeId: "test-source", name: "df", sourceLabel: "data_source", edgeId: "e1" },
+      { sourceNodeId: "test-source", name: "df2", sourceLabel: "other_source", edgeId: "e2" },
     ]
     render(<ModelScoreEditor {...props} />)
     const bar = screen.getByTestId("input-sources")

--- a/frontend/src/panels/editors/__tests__/OptimiserApplyEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/OptimiserApplyEditor.test.tsx
@@ -83,7 +83,7 @@ import OptimiserApplyEditor from "../OptimiserApplyEditor"
 const defaultProps = () => ({
   config: {} as Record<string, unknown>,
   onUpdate: vi.fn(),
-  inputSources: [] as { sourceNodeId: string; varName: string; sourceLabel: string; edgeId: string }[],
+  inputSources: [] as { sourceNodeId: string; name: string; sourceLabel: string; edgeId: string }[],
   accentColor: "var(--warning-strong)",
 })
 
@@ -428,7 +428,7 @@ describe("OptimiserApplyEditor", () => {
   it("renders InputSourcesBar with input sources", () => {
     const props = defaultProps()
     props.inputSources = [
-      { sourceNodeId: "scored-data", varName: "df", sourceLabel: "scored_data", edgeId: "e1" },
+      { sourceNodeId: "scored-data", name: "df", sourceLabel: "scored_data", edgeId: "e1" },
     ]
     render(<OptimiserApplyEditor {...props} />)
     const bar = screen.getByTestId("input-sources")
@@ -453,13 +453,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -487,13 +487,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -522,13 +522,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -569,7 +569,7 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
@@ -599,7 +599,7 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
@@ -642,13 +642,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -675,13 +675,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -707,13 +707,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -768,13 +768,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -806,13 +806,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },
@@ -844,13 +844,13 @@ describe("OptimiserApplyEditor", () => {
     props.inputSources = [
       {
         sourceNodeId: "optimiser-input-node",
-        varName: "optimiser_input",
+        name: "optimiser_input",
         sourceLabel: "optimiser_input",
         edgeId: "e1",
       },
       {
         sourceNodeId: "age-banding-node",
-        varName: "age_veh_banding",
+        name: "age_veh_banding",
         sourceLabel: "Age banding",
         edgeId: "e2",
       },

--- a/frontend/src/panels/editors/__tests__/_shared.test.tsx
+++ b/frontend/src/panels/editors/__tests__/_shared.test.tsx
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { describe, it, expect, expectTypeOf, vi, beforeEach, afterEach } from "vitest"
 import { readFileSync } from "node:fs"
 import path from "node:path"
 import { StrictMode } from "react"
 import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react"
 import type { EditorView } from "@codemirror/view"
-import { FileBrowser, MlflowStatusBadge, SchemaPreview } from "../_shared"
-import type { SchemaInfo } from "../_shared"
+import { FileBrowser, InputSourcesBar, MlflowStatusBadge, SchemaPreview } from "../_shared"
+import type { OnUpdateConfig, SchemaInfo } from "../_shared"
 import CodeEditor from "../CodeMirrorEditor"
 
 // ---------------------------------------------------------------------------
@@ -70,6 +70,159 @@ describe("_shared import surface", () => {
 
     expect(source).not.toContain("@codemirror/")
     expect(source).not.toMatch(/\bCodeEditor\b/)
+  })
+})
+
+describe("OnUpdateConfig", () => {
+  it("returns the exact graph commit result channel", () => {
+    expectTypeOf<ReturnType<OnUpdateConfig>>().toEqualTypeOf<
+      { ok: true } | { ok: false; error: string }
+    >()
+  })
+})
+
+describe("InputSourcesBar", () => {
+  afterEach(cleanup)
+
+  it("renders duplicate-parent frame labels with source tooltips and removes each edge independently", () => {
+    const onDeleteInput = vi.fn()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    try {
+      render(
+        <InputSourcesBar
+          inputSources={[
+            {
+              sourceNodeId: "api",
+              name: "quotes",
+              sourceLabel: "Quote API",
+              edgeId: "edge_quotes",
+            },
+            {
+              sourceNodeId: "api",
+              name: "drivers",
+              sourceLabel: "Quote API",
+              edgeId: "edge_drivers",
+            },
+          ]}
+          onDeleteInput={onDeleteInput}
+        />,
+      )
+
+      const quotes = screen.getByText("quotes")
+      const drivers = screen.getByText("drivers")
+      expect(quotes).toBeInTheDocument()
+      expect(drivers).toBeInTheDocument()
+      expect(screen.queryByText("Quote_API")).not.toBeInTheDocument()
+      expect(
+        screen.queryByLabelText(/unresolved.*frame|frame.*unresolved/i),
+      ).not.toBeInTheDocument()
+      expect(quotes.closest("[title]")).toHaveAttribute(
+        "title",
+        expect.stringMatching(/Quote API/),
+      )
+      expect(drivers.closest("[title]")).toHaveAttribute(
+        "title",
+        expect.stringMatching(/Quote API/),
+      )
+
+      const removeButtons = screen.getAllByRole("button", {
+        name: /remove connection from Quote API/i,
+      })
+      expect(removeButtons).toHaveLength(2)
+      fireEvent.click(removeButtons[0])
+      fireEvent.click(removeButtons[1])
+      expect(onDeleteInput).toHaveBeenNthCalledWith(1, "edge_quotes")
+      expect(onDeleteInput).toHaveBeenNthCalledWith(2, "edge_drivers")
+      expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(
+        /same key|unique ["']key["']/i,
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("shows an accessible warning marker and explanatory tooltip for an unresolved apiInput frame", () => {
+    render(
+      <InputSourcesBar
+        inputSources={[
+          {
+            sourceNodeId: "api",
+            name: "Quote_API",
+            sourceLabel: "Quote API",
+            edgeId: "edge_api",
+            frameUnresolved: true,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText("Quote_API")).toBeInTheDocument()
+    const warning = screen.getByLabelText(/unresolved.*frame|frame.*unresolved/i)
+    expect(warning).toBeVisible()
+    expect(warning).toHaveAttribute(
+      "title",
+      expect.stringMatching(/eligible|emitted|resolv/i),
+    )
+  })
+
+  it("keys two distinct input names by edge id even when their source labels match", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    try {
+      render(
+        <InputSourcesBar
+          inputSources={[
+            {
+              sourceNodeId: "source_a",
+              name: "shared_a",
+              sourceLabel: "Shared Source",
+              edgeId: "edge_a",
+            },
+            {
+              sourceNodeId: "source_b",
+              name: "shared_b",
+              sourceLabel: "Shared Source",
+              edgeId: "edge_b",
+            },
+          ]}
+        />,
+      )
+
+      expect(screen.getByText("shared_a")).toBeInTheDocument()
+      expect(screen.getByText("shared_b")).toBeInTheDocument()
+      expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(
+        /same key|unique ["']key["']/i,
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("renders the required name verbatim, including case and leading underscores", () => {
+    const frameLabels = ["MixedCase", "_private"]
+    render(
+      <InputSourcesBar
+        inputSources={frameLabels.map((name, index) => ({
+          sourceNodeId: "api",
+          name,
+          sourceLabel: "Quote API",
+          edgeId: `edge_${index}`,
+        }))}
+      />,
+    )
+
+    const renderedLabels = frameLabels.map((frameLabel, index) => {
+      const chip = screen.getByTestId(`input-source-edge_${index}`)
+      const label = chip.querySelector("code")
+      expect(label).not.toBeNull()
+      expect(label?.textContent).toBe(frameLabel)
+      return label as HTMLElement
+    })
+
+    renderedLabels.forEach((label) => {
+      expect(window.getComputedStyle(label).whiteSpace).toMatch(
+        /^(pre|pre-wrap|break-spaces)$/,
+      )
+    })
   })
 })
 

--- a/frontend/src/panels/editors/_shared.tsx
+++ b/frontend/src/panels/editors/_shared.tsx
@@ -17,7 +17,14 @@ export const SELECT_STYLE = INPUT_STYLE
 
 // ─── Shared Types ─────────────────────────────────────────────────
 
-export type OnUpdateConfig = (keyOrUpdates: string | Record<string, unknown>, value?: unknown) => void
+export type OnUpdateConfigResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+export type OnUpdateConfig = (
+  keyOrUpdates: string | Record<string, unknown>,
+  value?: unknown,
+) => OnUpdateConfigResult
 
 export type FileItem = {
   name: string
@@ -28,10 +35,18 @@ export type FileItem = {
 
 export type InputSource = {
   sourceNodeId: string
-  varName: string
+  /** The executable input name derived from this edge. */
+  name: string
   sourceLabel: string
   edgeId: string
+  frameUnresolved?: boolean
 }
+
+// Shared by editor components; this intentional non-component export is the
+// single title contract for unresolved API-input frame labels.
+// eslint-disable-next-line react-refresh/only-export-components
+export const unresolvedFrameTitle = (sourceLabel: string): string =>
+  `No emitted frame resolves for this connection (from ${sourceLabel})`
 
 export type SchemaInfo = {
   path: string
@@ -381,20 +396,43 @@ export function InputSourcesBar({
         <span className="text-[11px] font-bold uppercase tracking-[0.08em]" style={{ color: 'var(--text-muted)' }}>
           {inputSources.length > 1 ? "Inputs" : "Input"}
         </span>
-        {inputSources.map((src) => (
-          <span key={src.varName} className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded" style={{ background: 'var(--accent-soft)' }}>
-            <code className="text-[11px] font-semibold" style={{ color: 'var(--accent)' }}>{src.varName}</code>
-            {onDeleteInput && (
-              <button
-                onClick={() => onDeleteInput(src.edgeId)}
-                className="icon-danger-btn p-0 rounded"
-                title={`Remove connection from ${src.sourceLabel}`}
-              >
-                <X size={10} />
-              </button>
-            )}
-          </span>
-        ))}
+        {inputSources.map((src) => {
+          const unresolvedTitle = unresolvedFrameTitle(src.sourceLabel)
+          return (
+            <span
+              key={src.edgeId}
+              data-testid={`input-source-${src.edgeId}`}
+              data-unresolved={src.frameUnresolved ? "true" : undefined}
+              aria-label={src.frameUnresolved ? "Unresolved frame" : undefined}
+              title={src.frameUnresolved ? unresolvedTitle : `from ${src.sourceLabel}`}
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded"
+              style={{
+                background: src.frameUnresolved ? 'var(--warning-soft-subtle)' : 'var(--accent-soft)',
+                border: src.frameUnresolved ? '1px solid var(--warning)' : undefined,
+              }}
+            >
+              {src.frameUnresolved && (
+                <AlertTriangle
+                  size={11}
+                  aria-hidden="true"
+                  style={{ color: 'var(--warning)' }}
+                />
+              )}
+              <code className="min-w-0 overflow-hidden text-ellipsis whitespace-pre text-[11px] font-semibold" style={{ color: src.frameUnresolved ? 'var(--warning)' : 'var(--accent)', whiteSpace: "pre" }}>
+                {src.name}
+              </code>
+              {onDeleteInput && (
+                <button
+                  onClick={() => onDeleteInput(src.edgeId)}
+                  className="icon-danger-btn p-0 rounded"
+                  title={`Remove connection from ${src.sourceLabel}`}
+                >
+                  <X size={10} />
+                </button>
+              )}
+            </span>
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/panels/editors/index.ts
+++ b/frontend/src/panels/editors/index.ts
@@ -17,7 +17,14 @@ export { default as ConstantEditor } from "./ConstantEditor"
 export { default as SubmodelEditor } from "./SubmodelEditor"
 
 // Re-export shared types so NodePanel can use them
-export type { SimpleNode, SimpleEdge, InputSource, SchemaInfo, OnUpdateConfig } from "./_shared"
+export type {
+  SimpleNode,
+  SimpleEdge,
+  InputSource,
+  SchemaInfo,
+  OnUpdateConfig,
+  OnUpdateConfigResult,
+} from "./_shared"
 export { FileBrowser, SchemaPreview, InputSourcesBar } from "./_shared"
 export { CodeEditor } from "./CodeEditor"
 export { WarehousePicker, CatalogTablePicker, DatabricksFetchButton } from "./_DatabricksSelector"

--- a/frontend/src/stores/useGraphStore.ts
+++ b/frontend/src/stores/useGraphStore.ts
@@ -47,7 +47,12 @@
  */
 import { create } from "zustand"
 import type { Node, Edge } from "@xyflow/react"
-import { EMPTY_SNAPSHOT, serializeSnapshot, selectIsDirty } from "../utils/graphSnapshot"
+import {
+  EMPTY_SNAPSHOT,
+  serializeSnapshot,
+  selectIsDirty,
+  cloneGraphSnapshot,
+} from "../utils/graphSnapshot"
 import { shallowNodeDataHash } from "../utils/shallowNodeHash"
 import { nodeData } from "../types/node"
 
@@ -57,6 +62,8 @@ export interface GraphSnapshot {
   nodes: Node[]
   edges: Edge[]
   preamble: string
+  /** Present on snapshots created by this store; optional for legacy history entries. */
+  submodels?: Record<string, unknown>
 }
 
 /** A version-control operation (branch switch / archive / delete) riding the
@@ -83,6 +90,8 @@ export interface GraphStore {
   nodes: Node[]
   edges: Edge[]
   preamble: string
+  /** History-only metadata; excluded from persisted dirty fingerprints. */
+  submodels: Record<string, unknown>
   lastSavedSnapshot: GraphSnapshot | null
   undoStack: HistoryEntry[]
   redoStack: HistoryEntry[]
@@ -110,11 +119,17 @@ export interface GraphStore {
     nodes: Node[] | ((nds: Node[]) => Node[]),
     edges: Edge[] | ((eds: Edge[]) => Edge[]),
   ) => void
+  setNodesAndEdgesAndSubmodels: (
+    nodes: Node[] | ((nds: Node[]) => Node[]),
+    edges: Edge[] | ((eds: Edge[]) => Edge[]),
+    submodels: Record<string, unknown>,
+  ) => void
   setPreamble: (value: string) => void
 
   // Raw actions (skip history push — for mid-drag, WS sync, load)
   setNodesRaw: (nodes: Node[] | ((nds: Node[]) => Node[])) => void
   setEdgesRaw: (edges: Edge[] | ((eds: Edge[]) => Edge[])) => void
+  setSubmodelsRaw: (submodels: Record<string, unknown>) => void
   setPreambleRaw: (value: string) => void
 
   // Explicit history operations
@@ -155,36 +170,11 @@ type StructuralEdge = {
  * corrupt history or saved baselines.
  */
 export function captureGraphSnapshot(
-  state: Pick<GraphStore, "nodes" | "edges" | "preamble">,
+  state: Pick<GraphStore, "nodes" | "edges" | "preamble"> & {
+    submodels?: Record<string, unknown>
+  },
 ): GraphSnapshot {
-  return {
-    nodes: state.nodes.map((n) => cloneGraphValue(n)),
-    edges: state.edges.map((e) => cloneGraphValue(e)),
-    preamble: state.preamble,
-  }
-}
-
-function cloneGraphValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
-  if (value === null || typeof value !== "object") return value
-  const objectValue = value as object
-  const existing = seen.get(objectValue)
-  if (existing !== undefined) return existing as T
-
-  if (Array.isArray(value)) {
-    const clone: unknown[] = []
-    seen.set(objectValue, clone)
-    for (const item of value) {
-      clone.push(cloneGraphValue(item, seen))
-    }
-    return clone as T
-  }
-
-  const clone: Record<string, unknown> = {}
-  seen.set(objectValue, clone)
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    clone[key] = cloneGraphValue(child, seen)
-  }
-  return clone as T
+  return cloneGraphSnapshot(state)
 }
 
 /**
@@ -459,6 +449,7 @@ const useGraphStore = create<GraphStore>()((set, get) => {
     nodes: [],
     edges: [],
     preamble: "",
+    submodels: {},
     lastSavedSnapshot: null,
     undoStack: [],
     redoStack: [],
@@ -546,6 +537,36 @@ const useGraphStore = create<GraphStore>()((set, get) => {
           redoStack: [],
           nodes,
           edges,
+          ...computePanelContextPatch(state, nodes, edges),
+          persistedFingerprint: nextPersistedFingerprint,
+          dirty: computeDirty(
+            state.lastSavedSnapshot,
+            state.savedPersistedFingerprint,
+            nextPersistedFingerprint,
+          ),
+          ...(nextFingerprint === state.structuralFingerprint
+            ? {}
+            : {
+                structuralFingerprint: nextFingerprint,
+                structuralVersion: state.structuralVersion + 1,
+              }),
+        }
+      })
+    },
+
+    setNodesAndEdgesAndSubmodels: (nodesUpdater, edgesUpdater, submodels) => {
+      set((state) => {
+        const undoStack = pushSnapshotInternal()
+        const nodes = applyUpdater(state.nodes, nodesUpdater)
+        const edges = applyUpdater(state.edges, edgesUpdater)
+        const nextPersistedFingerprint = computePersistedFingerprint(nodes, edges, state.preamble)
+        const nextFingerprint = computeStructuralFingerprint(nodes, edges, state.preamble)
+        return {
+          undoStack,
+          redoStack: [],
+          nodes,
+          edges,
+          submodels,
           ...computePanelContextPatch(state, nodes, edges),
           persistedFingerprint: nextPersistedFingerprint,
           dirty: computeDirty(
@@ -675,6 +696,10 @@ const useGraphStore = create<GraphStore>()((set, get) => {
       })
     },
 
+    setSubmodelsRaw: (submodels) => {
+      set({ submodels })
+    },
+
     setPreambleRaw: (value) => {
       set((state) => {
         const nextPersistedFingerprint = computePersistedFingerprint(state.nodes, state.edges, value)
@@ -748,6 +773,7 @@ const useGraphStore = create<GraphStore>()((set, get) => {
         nodes: prev.nodes,
         edges: prev.edges,
         preamble: prev.preamble,
+        submodels: prev.submodels ?? {},
         persistedFingerprint: nextPersistedFingerprint,
         dirty: computeDirty(
           state.lastSavedSnapshot,
@@ -796,6 +822,7 @@ const useGraphStore = create<GraphStore>()((set, get) => {
         nodes: next.nodes,
         edges: next.edges,
         preamble: next.preamble,
+        submodels: next.submodels ?? {},
         persistedFingerprint: nextPersistedFingerprint,
         dirty: computeDirty(
           state.lastSavedSnapshot,

--- a/frontend/src/utils/__tests__/apiInputPorts.test.ts
+++ b/frontend/src/utils/__tests__/apiInputPorts.test.ts
@@ -25,6 +25,7 @@ import { describe, expect, it } from "vitest"
 import * as apiInputPorts from "../apiInputPorts"
 import {
   apiInputFrameLabels,
+  apiInputHasEmittingTable,
   edgeInputName,
 } from "../apiInputPorts"
 import { buildGraph } from "../buildGraph"
@@ -51,6 +52,19 @@ const table = (
   label,
   emit,
   columns,
+})
+
+describe("apiInputHasEmittingTable", () => {
+  it("requires emit and a selected column on the same table", () => {
+    expect(apiInputHasEmittingTable({ tables: [table("policies", true)] })).toBe(true)
+    expect(apiInputHasEmittingTable({
+      tables: [
+        table("policies", true, [{ selected: false }]),
+        table("drivers", false, [{ selected: true }]),
+      ],
+    })).toBe(false)
+    expect(apiInputHasEmittingTable({ tables: [null, "invalid"] })).toBe(false)
+  })
 })
 
 /** Same table, new label — the path stays put, exactly like a label commit. */

--- a/frontend/src/utils/__tests__/apiInputPorts.test.ts
+++ b/frontend/src/utils/__tests__/apiInputPorts.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the apiInput emit-port helpers.
  *
- * `apiInputEmitPortLabels` is the single source of truth for the
+ * `apiInputFrameLabels` is the single source of truth for the
  * right-edge port labels an apiInput node exposes (shared by
  * `PipelineNode`'s `_SourceHandles`, its body-label column, and the
  * edge reconciler). Port identity is the RAW table label — exactly the
@@ -22,17 +22,22 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
+import * as apiInputPorts from "../apiInputPorts"
 import {
-  apiInputEmitPortLabels,
+  apiInputFrameLabels,
+  edgeInputName,
+} from "../apiInputPorts"
+import { buildGraph } from "../buildGraph"
+import type { SimpleEdge, SimpleNode } from "../../panels/editors/_shared"
+
+const {
   apiInputLabelIssue,
   apiInputLabelIssueMessage,
   applyApiInputConfigChange,
   migrateApiInputEdges,
   reconcileApiInputEdges,
   sanitiseLabelForFilesystem,
-} from "../apiInputPorts"
-import { buildGraph } from "../buildGraph"
-import type { SimpleEdge, SimpleNode } from "../../panels/editors/_shared"
+} = apiInputPorts
 
 // A table is a runtime port only if it is emit:true AND has >=1 selected
 // column (matches the backend `load_v2_api_source`), so the helper gives a
@@ -50,6 +55,21 @@ const table = (
 
 /** Same table, new label — the path stays put, exactly like a label commit. */
 const renamed = (t: Record<string, unknown>, label: string) => ({ ...t, label })
+const sourceNode = (
+  nodeType: string,
+  config: Record<string, unknown> = {},
+): SimpleNode => ({
+  id: "source_1",
+  type: nodeType,
+  data: { label: "Source node", description: "", nodeType, config },
+})
+const sourceEdge = (sourceHandle: string | null): SimpleEdge => ({
+  id: "edge_1",
+  source: "source_1",
+  target: "target_1",
+  sourceHandle,
+  targetHandle: null,
+})
 const THIS_TEST_FILE = fileURLToPath(import.meta.url)
 const OLD_SELF_REFERENTIAL_ASSERTION = [
   "expect(result.edges)",
@@ -64,13 +84,18 @@ it("does not regress to the old self-referential edge assertion", () => {
   )
 })
 
-describe("apiInputEmitPortLabels", () => {
+describe("apiInputFrameLabels", () => {
+  it("retires the split emit-port and visible-frame exports", () => {
+    expect(apiInputPorts).not.toHaveProperty("apiInputEmitPortLabels")
+    expect(apiInputPorts).not.toHaveProperty("apiInputVisibleFrameLabels")
+  })
+
   it("returns [] for a config without a tables key", () => {
-    expect(apiInputEmitPortLabels({ path: "x.json" })).toEqual([])
+    expect(apiInputFrameLabels({ path: "x.json" })).toEqual([])
   })
 
   it("returns only emit:true table labels, in order", () => {
-    const labels = apiInputEmitPortLabels({
+    const labels = apiInputFrameLabels({
       tables: [table("policies", true), table("drivers", false), table("vehicles", true)],
     })
     expect(labels).toEqual(["policies", "vehicles"])
@@ -81,7 +106,7 @@ describe("apiInputEmitPortLabels", () => {
   // therefore never resolve at runtime (executor KeyError). Blank-label
   // tables get NO handle; the editor shows the validation error instead.
   it("renders no port for a missing / blank label — never synthesizes port_<idx>", () => {
-    const labels = apiInputEmitPortLabels({
+    const labels = apiInputFrameLabels({
       tables: [
         { path: "$[:]", emit: true, columns: [{ name: "c", selected: true }] },
         { path: "$[:].b", label: "   ", emit: true, columns: [{ name: "c", selected: true }] },
@@ -92,13 +117,12 @@ describe("apiInputEmitPortLabels", () => {
     expect(labels.some((l) => l.startsWith("port_"))).toBe(false)
   })
 
-  it("falls back to the single default handle when every emit label is blank (nothing bindable is synthesized)", () => {
+  it("returns no frame labels when every emitted label is blank", () => {
     // This config is backend-invalid (validate_v2_schema rejects blank
     // labels) and unreachable through the editor, which blocks blank
-    // commits; it can only arrive from a legacy disk file. We render the
-    // legacy default handle rather than invent port ids the executor
-    // could never resolve.
-    const labels = apiInputEmitPortLabels({
+    // commits; it can only arrive from a legacy disk file. No bindable id
+    // is invented for it.
+    const labels = apiInputFrameLabels({
       tables: [
         { path: "$[:]", emit: true, columns: [{ name: "c", selected: true }] },
         { path: "$[:].b", label: "", emit: true, columns: [{ name: "c", selected: true }] },
@@ -108,7 +132,7 @@ describe("apiInputEmitPortLabels", () => {
   })
 
   it("excludes an emit:true table with no selected columns (matches backend runtime)", () => {
-    const labels = apiInputEmitPortLabels({
+    const labels = apiInputFrameLabels({
       tables: [
         table("policies", true),
         table("drivers", true, [{ name: "x", selected: false }]),
@@ -118,23 +142,125 @@ describe("apiInputEmitPortLabels", () => {
     expect(labels).toEqual(["policies", "vehicles"])
   })
 
-  it("falls back to single-port when only one emit:true table has selected columns", () => {
-    // The backend emits a bare frame (length-1 emit set) here, so the canvas
-    // must render the single default handle — not a labelled multi-port one.
-    const labels = apiInputEmitPortLabels({
+  it("returns the sole eligible label when another table has no selected columns", () => {
+    const labels = apiInputFrameLabels({
       tables: [table("policies", true), table("drivers", true, [{ selected: false }])],
     })
-    expect(labels).toEqual([])
+    expect(labels).toEqual(["policies"])
   })
 
   // W1.4 — duplicate labels are rejected by the backend on save, and the
   // runtime keys ports by raw label, so a synthesized `dup__1` handle
   // could never exist server-side. Only the first occurrence is a port.
   it("gives duplicate labels a single port (first occurrence) — never synthesizes __<idx>", () => {
-    const labels = apiInputEmitPortLabels({
+    const labels = apiInputFrameLabels({
       tables: [table("dup", true), table("dup", true)],
     })
     expect(labels).toEqual(["dup"])
+  })
+})
+
+describe("apiInputFrameLabels eligibility", () => {
+  it("returns [] when no table is runtime-eligible with a valid identifier label", () => {
+    const config = {
+      tables: [
+        table("disabled", false),
+        table("unselected", true, [{ name: "c", selected: false }]),
+        { label: "missing-columns", emit: true },
+        { label: "   ", emit: true, columns: [{ name: "c", selected: true }] },
+        { emit: true, columns: [{ name: "c", selected: true }] },
+        { label: 42, emit: true, columns: [{ name: "c", selected: true }] },
+      ],
+    }
+
+    expect(apiInputFrameLabels(config)).toEqual([])
+  })
+
+  it("returns the sole eligible label explicitly", () => {
+    const rawLabel = "quotes"
+    const config = { tables: [table(rawLabel, true)] }
+
+    expect(apiInputFrameLabels(config)).toEqual([rawLabel])
+  })
+
+  it("returns many eligible labels in order and excludes invalid and case-duplicate labels", () => {
+    const firstRawLabel = "policies"
+    const config = {
+      tables: [
+        table(firstRawLabel, true),
+        // An ineligible earlier use of a raw label does not reserve it.
+        table("eligible_later", false),
+        table("disabled", false),
+        table("unselected", true, [{ name: "c", selected: false }]),
+        { emit: true, columns: [{ name: "c", selected: true }] },
+        { label: "\t ", emit: true, columns: [{ name: "c", selected: true }] },
+        table("drivers", true),
+        table(firstRawLabel, true),
+        table("eligible_later", true),
+        table("quote id", true),
+        table("café", true),
+        table("class", true),
+        table("Policies", true),
+        table("vehicles", true),
+      ],
+    }
+
+    expect(apiInputFrameLabels(config)).toEqual([
+      firstRawLabel,
+      "drivers",
+      "eligible_later",
+      "vehicles",
+    ])
+  })
+})
+
+describe("edgeInputName", () => {
+  it("returns an apiInput frame handle verbatim", () => {
+    expect(
+      edgeInputName(sourceEdge("quotes"), sourceNode("apiInput"), {}),
+    ).toBe("quotes")
+  })
+
+  it("sanitises an ordinary source label and ignores its source handle", () => {
+    const ordinarySource: SimpleNode = {
+      ...sourceNode("polars"),
+      data: {
+        ...sourceNode("polars").data,
+        label: "Driver claims-feed",
+      },
+    }
+
+    expect(
+      edgeInputName(sourceEdge("unused-port"), ordinarySource, {}),
+    ).toBe("Driver_claims_feed")
+  })
+
+  it("resolves a flattened submodel out__ handle to the child node's sanitised label", () => {
+    const child: SimpleNode = {
+      ...sourceNode("polars"),
+      id: "child_output",
+      data: {
+        ...sourceNode("polars").data,
+        label: "Child output frame",
+      },
+    }
+
+    const submodelSource: SimpleNode = {
+      ...sourceNode("submodel"),
+      id: "submodel__pricing",
+    }
+    const edge = {
+      ...sourceEdge("out__child_output"),
+      source: submodelSource.id,
+    }
+
+    expect(
+      edgeInputName(
+        edge,
+        submodelSource,
+        { pricing: { graph: { nodes: [child], edges: [] } } },
+      ),
+    ).toBe("Child_output_frame")
   })
 })
 
@@ -156,19 +282,23 @@ describe("sanitiseLabelForFilesystem", () => {
     // `u` flag, JS would see two UTF-16 surrogate units → "x__", and the
     // editor's collision verdicts would diverge from the backend's B2.
     expect(sanitiseLabelForFilesystem("x😀")).toBe("x_")
-    // Consequence: "x😀" and "x🎉" DO collide (both sanitise to "x_"),
-    // exactly as the backend reports.
-    expect(apiInputLabelIssue("x😀", ["x🎉"])).toEqual({
-      kind: "sanitised-collision",
-      other: "x🎉",
-      sanitised: "x_",
-    })
   })
 })
 
 describe("apiInputLabelIssue", () => {
-  it("accepts a unique non-blank label", () => {
-    expect(apiInputLabelIssue("vehicles", ["policies", "drivers"])).toBeNull()
+  it("accepts ASCII identifiers and Python soft keywords", () => {
+    for (const label of [
+      "vehicles",
+      "driver_claims",
+      "_private",
+      "MixedCase9",
+      "match",
+      "case",
+      "type",
+      "_",
+    ]) {
+      expect(apiInputLabelIssue(label, ["policies", "drivers"])).toBeNull()
+    }
   })
 
   it("rejects blank and whitespace-only labels", () => {
@@ -183,28 +313,45 @@ describe("apiInputLabelIssue", () => {
     })
   })
 
-  it("rejects a label whose sanitised form collides with another table's (backend B2)", () => {
-    // "driver.stats" and "driver_stats" both sanitise to "driver_stats":
-    // the backend rejects this pair at save (both would write the same
-    // parquet file), so the editor must surface it before commit.
-    expect(apiInputLabelIssue("driver.stats", ["driver_stats"])).toEqual({
-      kind: "sanitised-collision",
-      other: "driver_stats",
-      sanitised: "driver_stats",
-    })
+  it.each(["quote id", "1st_frame", "with-hyphen", "white\tspace", "café", "用户"])(
+    "rejects non-ASCII or non-identifier label %j with the ASCII rule",
+    (label) => {
+      const issue = apiInputLabelIssue(label, [])
+      expect(issue).not.toBeNull()
+      if (issue === null) throw new Error("expected an ASCII-identifier issue")
+      expect(apiInputLabelIssueMessage(issue)).toMatch(/ascii.*identifier/i)
+    },
+  )
+
+  it("rejects every Python hard keyword while retaining soft keywords", () => {
+    const hardKeywords = [
+      "False", "None", "True", "and", "as", "assert", "async", "await",
+      "break", "class", "continue", "def", "del", "elif", "else", "except",
+      "finally", "for", "from", "global", "if", "import", "in", "is",
+      "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
+      "while", "with", "yield",
+    ]
+
+    for (const keyword of hardKeywords) {
+      const issue = apiInputLabelIssue(keyword, [])
+      expect(issue).not.toBeNull()
+      if (issue === null) throw new Error("expected a hard-keyword issue")
+      expect(apiInputLabelIssueMessage(issue)).toMatch(/keyword/i)
+    }
   })
 
   it("rejects labels differing only in case (one parquet file on macOS/Windows)", () => {
     // "Drivers.parquet" and "drivers.parquet" are the SAME file on the
     // case-insensitive filesystems macOS and Windows default to — the
     // shred write would silently clobber one table's data. Mirrors the
-    // backend B2 casefolded comparison; exact duplicates still report
-    // as "duplicate", so this pair reports the sanitised collision.
-    expect(apiInputLabelIssue("Drivers", ["drivers"])).toEqual({
-      kind: "sanitised-collision",
-      other: "drivers",
-      sanitised: "Drivers",
-    })
+    // backend B2 casefolded comparison. Keep the verdict and user-facing
+    // conflict detail pinned without coupling the test to an issue tag.
+    const issue = apiInputLabelIssue("Drivers", ["drivers"])
+    expect(issue).not.toBeNull()
+    if (issue === null) throw new Error("expected a case-only collision")
+    const message = apiInputLabelIssueMessage(issue)
+    expect(message).toMatch(/drivers/i)
+    expect(message).toMatch(/case-insensitive/i)
     // Genuinely distinct labels still pass.
     expect(apiInputLabelIssue("Drivers", ["policies"])).toBeNull()
   })
@@ -213,13 +360,6 @@ describe("apiInputLabelIssue", () => {
     expect(apiInputLabelIssueMessage(null)).toBeNull()
     expect(apiInputLabelIssueMessage({ kind: "blank" })).toMatch(/required/i)
     expect(apiInputLabelIssueMessage({ kind: "duplicate", other: "drivers" })).toMatch(/drivers/)
-    expect(
-      apiInputLabelIssueMessage({
-        kind: "sanitised-collision",
-        other: "driver_stats",
-        sanitised: "driver_stats",
-      }),
-    ).toMatch(/driver_stats/)
   })
 })
 
@@ -232,21 +372,37 @@ describe("reconcileApiInputEdges", () => {
     targetHandle: null,
   })
 
-  it("keeps everything when the node has < 2 emit tables and edges use the null default handle", () => {
-    const edges = [outgoing(null)]
+  it.each([
+    ["zero", { tables: [] }],
+    ["one", { tables: [table("policies", true)] }],
+  ])("removes a null-handle edge with %s eligible frames", (_count, config) => {
+    const legacyEdge = outgoing(null)
+    const result = reconcileApiInputEdges({
+      nodeId: "api_1",
+      config,
+      edges: [legacyEdge],
+    })
+    expect(result.edges).toEqual([])
+    expect(result.removed).toEqual([{ edge: legacyEdge, sourceHandle: null }])
+  })
+
+  it("keeps a sole frame's labelled handle and preserves edge-array identity", () => {
+    const labelledEdge = outgoing("policies")
+    const edges = [labelledEdge]
     const result = reconcileApiInputEdges({
       nodeId: "api_1",
       config: { tables: [table("policies", true)] },
       edges,
     })
+
     expect(result.removed).toEqual([])
     expect(result.edges).toBe(edges)
+    expect(result.edges[0]).toBe(labelledEdge)
   })
 
-  it("removes a multi-port edge when its table's emit is toggled off (now single-port)", () => {
-    // Was 2 emit tables (multi-port). User unticks 'drivers' → only
-    // 'policies' emits → single default (null) handle. The edge bound
-    // to 'drivers' is orphaned.
+  it("removes an edge when its table's emit is toggled off", () => {
+    // User unticks 'drivers'; the still-labelled policies frame remains,
+    // while only the drivers edge becomes orphaned.
     const driversEdge = outgoing("drivers")
     const result = reconcileApiInputEdges({
       nodeId: "api_1",
@@ -270,10 +426,7 @@ describe("reconcileApiInputEdges", () => {
     expect(result.removed.map((r) => r.edge)).toEqual([goneEdge])
   })
 
-  it("removes a null-handle edge once the node becomes multi-port (single→multi)", () => {
-    // Edge was created while the node had a single default (null)
-    // handle. A 2nd emit table now makes the node multi-port, so the
-    // null handle no longer renders and the edge is orphaned.
+  it("removes a null-handle edge with multiple frames too", () => {
     const legacyEdge = outgoing(null, "e_legacy")
     const result = reconcileApiInputEdges({
       nodeId: "api_1",
@@ -428,21 +581,20 @@ describe("migrateApiInputEdges", () => {
     expect(rebound).toEqual([])
   })
 
-  it("ignores single-port nodes (edges are bound to the null default handle, not labels)", () => {
+  it("migrates a sole labelled frame exactly like a multi-frame input", () => {
     const singlePrev = { tables: [table("policies", true)] }
     const singleNext = { tables: [renamed(table("policies", true), "quotes")] }
-    const nullEdge = edgeFrom("api_1", null)
-    const inputEdges = [nullEdge]
+    const policiesEdge = edgeFrom("api_1", "policies")
     const result = migrateApiInputEdges({
       nodeId: "api_1",
       prevConfig: singlePrev,
       nextConfig: singleNext,
-      edges: inputEdges,
+      edges: [policiesEdge],
     })
-    expect(result.rebound).toEqual([])
-    // The INPUT array reference comes back untouched — no copy, no churn.
-    expect(result.edges).toBe(inputEdges)
-    expect(result.edges[0]).toBe(nullEdge)
+    expect(result.rebound).toEqual([
+      { edge: policiesEdge, from: "policies", to: "quotes" },
+    ])
+    expect(result.edges[0].sourceHandle).toBe("quotes")
   })
 
   // ── Duplicate-label ownership guards ──────────────────────────────
@@ -549,9 +701,8 @@ describe("applyApiInputConfigChange", () => {
       edges: [driversEdge, keptNull],
     })
     expect(result.rebound).toEqual([])
-    expect(result.removed.map((r) => r.edge)).toEqual([driversEdge])
-    // Back to single-port: the null default edge is the only valid one.
-    expect(result.edges).toEqual([keptNull])
+    expect(result.removed.map((r) => r.edge)).toEqual([driversEdge, keptNull])
+    expect(result.edges).toEqual([])
   })
 
   it("returns the input edges reference untouched when nothing changed", () => {
@@ -574,7 +725,7 @@ describe("applyApiInputConfigChange", () => {
     // reloaded graph carries edges whose sourceHandle is the raw table
     // label — and the frontend must render handles in EXACTLY that space.
     const config = { tables: [table("policies", true), table("drivers", true)] }
-    const labels = apiInputEmitPortLabels(config)
+    const labels = apiInputFrameLabels(config)
     // Raw labels, no transformation of any kind.
     expect(labels).toEqual(["policies", "drivers"])
 

--- a/frontend/src/utils/__tests__/connectionValidation.test.ts
+++ b/frontend/src/utils/__tests__/connectionValidation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
-import type { Connection } from "@xyflow/react"
-import { isPipelineConnectionValid } from "../connectionValidation"
+import type { Connection, Edge } from "@xyflow/react"
+import {
+  isPipelineConnectionValid,
+  validatePipelineConnection,
+} from "../connectionValidation"
+import type { SimpleNode } from "../../panels/editors/_shared"
+import { NODE_TYPES, type NodeTypeValue } from "../nodeTypes"
 
 function connection(source: string, target: string): Connection {
   return {
@@ -11,16 +16,308 @@ function connection(source: string, target: string): Connection {
   }
 }
 
+function node(id: string, label: string, nodeType: NodeTypeValue = NODE_TYPES.POLARS): SimpleNode {
+  return {
+    id,
+    type: nodeType,
+    data: { label, description: "", nodeType, config: {} },
+  }
+}
+
+function apiInput(id: string, labels: readonly string[] = ["Quote_id"]): SimpleNode {
+  return {
+    ...node(id, id, NODE_TYPES.API_INPUT),
+    data: {
+      label: id,
+      description: "",
+      nodeType: NODE_TYPES.API_INPUT,
+      config: {
+        tables: labels.map((label) => ({
+          path: `$[:].${label}[:]`,
+          label,
+          emit: true,
+          columns: [{ name: "id", selected: true }],
+        })),
+      },
+    },
+  }
+}
+
+const incoming = (
+  id: string,
+  source: string,
+  target: string,
+  sourceHandle: string | null = null,
+): Edge => ({ id, source, target, sourceHandle, targetHandle: null })
+
 describe("connection validation", () => {
-  it("does not block edgeJoin output-to-default-input connections globally", () => {
-    expect(isPipelineConnectionValid(connection("join1", "polars1"))).toBe(true)
+  it("exempts an output-to-output edgeJoin gesture from input-name uniqueness", () => {
+    const nodes = [apiInput("api", ["quotes"]), node("transform", "Transform")]
+    const edges = [incoming("existing", "api", "transform", "quotes")]
+
+    expect(
+      validatePipelineConnection(
+        {
+          source: "api",
+          target: "transform",
+          sourceHandle: "quotes",
+          targetHandle: "transform-output",
+          sourceHandleType: "source",
+          targetHandleType: "source",
+        },
+        nodes,
+        edges,
+      ),
+    ).toEqual({ ok: true })
   })
 
   it("rejects self loops globally", () => {
-    expect(isPipelineConnectionValid(connection("polars1", "polars1"))).toBe(false)
+    const polars = node("polars1", "Polars 1")
+    expect(isPipelineConnectionValid(connection(polars.id, polars.id), [polars], [])).toBe(false)
   })
 
   it("rejects incomplete connections globally", () => {
-    expect(isPipelineConnectionValid({ ...connection("polars1", "output1"), target: null })).toBe(false)
+    const polars = node("polars1", "Polars 1")
+    const output = node("output1", "Output", NODE_TYPES.OUTPUT)
+    expect(
+      isPipelineConnectionValid(
+        { ...connection("polars1", "output1"), target: null },
+        [polars, output],
+        [],
+      ),
+    ).toBe(false)
   })
+
+  it.each([
+    [
+      "source-to-target",
+      {
+        source: "api",
+        target: "target",
+        sourceHandle: "Quote_id",
+        targetHandle: null,
+      },
+    ],
+    [
+      "target-to-source under ConnectionMode.Loose",
+      {
+        source: "target",
+        target: "api",
+        sourceHandle: null,
+        targetHandle: "Quote_id",
+      },
+    ],
+  ] as const)(
+    "rejects a duplicate derived input name for a %s gesture",
+    (_direction, candidate) => {
+      const nodes = [
+        apiInput("api"),
+        node("ordinary", "Quote id"),
+        node("target", "Target"),
+      ]
+      const edges = [incoming("existing", "ordinary", "target")]
+
+      expect(isPipelineConnectionValid(candidate, nodes, edges, {})).toBe(false)
+    },
+  )
+
+  it("allows a distinct derived input name on the same target", () => {
+    const nodes = [
+      apiInput("api"),
+      node("ordinary", "Driver claims"),
+      node("target", "Target"),
+    ]
+    const edges = [incoming("existing", "ordinary", "target")]
+
+    expect(
+      isPipelineConnectionValid(
+        {
+          source: "api",
+          target: "target",
+          sourceHandle: "Quote_id",
+          targetHandle: null,
+        },
+        nodes,
+        edges,
+      ),
+    ).toBe(true)
+  })
+
+  it.each([
+    [
+      "source-to-target",
+      { source: "api", target: "target", sourceHandle: null, targetHandle: null },
+    ],
+    [
+      "target-to-source under ConnectionMode.Loose",
+      { source: "target", target: "api", sourceHandle: null, targetHandle: null },
+    ],
+  ] as const)(
+    "rejects a null-handle apiInput connection for a %s gesture",
+    (_direction, candidate) => {
+      expect(
+        isPipelineConnectionValid(
+          candidate,
+          [apiInput("api"), node("target", "Target")],
+          [],
+        ),
+      ).toBe(false)
+    },
+  )
+
+  it("rejects ordinary sources whose sanitised names collide", () => {
+    const nodes = [
+      node("first", "Driver claims"),
+      node("second", "Driver-claims"),
+      node("target", "Target"),
+    ]
+    const edges = [incoming("existing", "first", "target")]
+
+    expect(
+      isPipelineConnectionValid(connection("second", "target"), nodes, edges),
+    ).toBe(false)
+  })
+
+  it.each([
+    [
+      "source-to-target",
+      {
+        source: "api",
+        target: "submodel__pricing",
+        sourceHandle: "drivers",
+        targetHandle: "in__child_b",
+      },
+    ],
+    [
+      "target-to-source under ConnectionMode.Loose",
+      {
+        source: "submodel__pricing",
+        target: "api",
+        sourceHandle: "in__child_b",
+        targetHandle: "drivers",
+      },
+    ],
+  ] as const)("allows two apiInput frames to fan out to different submodel children for a %s gesture", (_direction, candidate) => {
+    const api = apiInput("api", ["quotes", "drivers"])
+    const ordinary = node("ordinary", "drivers")
+    const boundary = node("submodel__pricing", "Pricing", NODE_TYPES.SUBMODEL)
+    const childA = node("child_a", "Child A")
+    const childB = node("child_b", "Child B")
+    const submodels = {
+      pricing: { graph: { nodes: [childA, childB], edges: [] } },
+    }
+    const edges = [
+      {
+        ...incoming("quotes_to_a", "api", boundary.id, "quotes"),
+        targetHandle: "in__child_a",
+      },
+      {
+        ...incoming("ordinary_drivers_to_a", ordinary.id, boundary.id),
+        targetHandle: "in__child_a",
+      },
+    ]
+
+    expect(
+      validatePipelineConnection(
+        candidate,
+        [api, ordinary, boundary],
+        edges,
+        submodels,
+      ),
+    ).toEqual({ ok: true })
+  })
+
+  it.each([
+    [
+      "source-to-target",
+      {
+        source: "api",
+        target: "submodel__pricing",
+        sourceHandle: "quotes",
+        targetHandle: "in__child_a",
+      },
+    ],
+    [
+      "target-to-source under ConnectionMode.Loose",
+      {
+        source: "submodel__pricing",
+        target: "api",
+        sourceHandle: "in__child_a",
+        targetHandle: "quotes",
+      },
+    ],
+  ] as const)("rejects a same-child derived-name collision for a %s gesture", (_direction, candidate) => {
+    const api = apiInput("api", ["quotes"])
+    const ordinary = node("ordinary", "quotes")
+    const boundary = node("submodel__pricing", "Pricing", NODE_TYPES.SUBMODEL)
+    const childA = node("child_a", "Child A")
+    const childB = node("child_b", "Child B")
+    const submodels = {
+      pricing: { graph: { nodes: [childA, childB], edges: [] } },
+    }
+    const edges = [
+      {
+        ...incoming("ordinary_to_a", ordinary.id, boundary.id),
+        targetHandle: "in__child_a",
+      },
+    ]
+
+    expect(
+      validatePipelineConnection(
+        candidate,
+        [api, ordinary, boundary],
+        edges,
+        submodels,
+      ),
+    ).toEqual({
+      ok: false,
+      reason: { kind: "duplicate-input-name", inputName: "quotes" },
+    })
+  })
+
+  it.each([
+    [
+      "source-to-target",
+      {
+        source: "api",
+        target: "submodel__pricing",
+        sourceHandle: "quotes",
+        targetHandle: "in__child_a",
+      },
+    ],
+    [
+      "target-to-source under ConnectionMode.Loose",
+      {
+        source: "submodel__pricing",
+        target: "api",
+        sourceHandle: "in__child_a",
+        targetHandle: "quotes",
+      },
+    ],
+  ] as const)(
+    "rejects a boundary connection colliding with an internal child input for a %s gesture",
+    (_direction, candidate) => {
+      const api = apiInput("api", ["quotes"])
+      const boundary = node("submodel__pricing", "Pricing", NODE_TYPES.SUBMODEL)
+      const childA = node("child_a", "Child A")
+      const childB = node("child_b", "Child B")
+      const internalSource = node("internal_quotes", "quotes")
+      const submodels = {
+        pricing: {
+          graph: {
+            nodes: [childA, childB, internalSource],
+            edges: [incoming("internal_quotes_to_a", internalSource.id, childA.id)],
+            submodels: {},
+          },
+        },
+      }
+
+      expect(
+        validatePipelineConnection(candidate, [api, boundary], [], submodels),
+      ).toEqual({
+        ok: false,
+        reason: { kind: "duplicate-input-name", inputName: "quotes" },
+      })
+    },
+  )
 })

--- a/frontend/src/utils/apiInputPorts.ts
+++ b/frontend/src/utils/apiInputPorts.ts
@@ -67,6 +67,15 @@ function emitTables(config: ConfigLike): Array<Record<string, unknown>> {
   )
 }
 
+/**
+ * Whether an apiInput config contains a table that contributes a runtime
+ * frame. This shares the exact eligibility path used for rendered handles and
+ * mirrors backend `_json_shred.table_is_emitting`.
+ */
+export function apiInputHasEmittingTable(config: ConfigLike): boolean {
+  return emitTables(config).length > 0
+}
+
 /** The exact label string of a table, or null when missing/non-string. */
 function rawLabel(table: Record<string, unknown>): string | null {
   const raw = (table as { label?: unknown }).label

--- a/frontend/src/utils/apiInputPorts.ts
+++ b/frontend/src/utils/apiInputPorts.ts
@@ -35,7 +35,9 @@
  *     (`reconcileApiInputEdges`), with a visible toast at the call
  *     site. `applyApiInputConfigChange` composes the two.
  */
-import type { SimpleEdge } from "../panels/editors/_shared"
+import type { SimpleEdge, SimpleNode } from "../panels/editors/_shared"
+import { NODE_TYPES } from "./nodeTypes"
+import { sanitizeName } from "./sanitizeName"
 
 type ConfigLike = Record<string, unknown> | undefined | null
 
@@ -71,44 +73,182 @@ function rawLabel(table: Record<string, unknown>): string | null {
   return typeof raw === "string" ? raw : null
 }
 
-/** A label can be a frame name iff it is a non-blank string (backend floor). */
-function isPortableLabel(label: string | null): label is string {
-  return typeof label === "string" && label.trim().length > 0
+const ASCII_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+const PYTHON_HARD_KEYWORDS = new Set([
+  "False", "None", "True", "and", "as", "assert", "async", "await",
+  "break", "class", "continue", "def", "del", "elif", "else", "except",
+  "finally", "for", "from", "global", "if", "import", "in", "is",
+  "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try",
+  "while", "with", "yield",
+])
+
+function isValidFrameLabel(label: string | null): label is string {
+  return label !== null && ASCII_IDENTIFIER_RE.test(label) && !PYTHON_HARD_KEYWORDS.has(label)
 }
 
 /**
- * Ordered list of frame labels an apiInput exposes.
+ * Derive the ordered, unique raw labels from runtime-eligible tables.
  *
- * Rules mirror `PipelineNode._SourceHandles` AND the backend runtime
- * (`_json_shred.load_v2_api_source`) so the rendered Handle ids, this
- * list, and the executor's emitted frames are always identical:
- *  - a table counts only if `emit: true` AND it has ≥1 selected column;
+ * This is shared by the visible-frame list and the multi-port handle-mode
+ * helper so both consumers agree on which labelled frames are bindable:
+ *  - only tables already eligible at runtime (`emit: true` and at least one
+ *    selected column) are considered;
  *  - the frame id is the table's RAW label — never a synthesized stand-in;
- *  - a missing / non-string / blank label yields NO frame (the backend
- *    rejects such configs on save; the editor shows the error);
- *  - a label duplicating an earlier frame yields NO frame for the later
- *    table (only the first occurrence is bindable).
+ *  - missing / non-string / blank / non-identifier / keyword labels yield no
+ *    frame;
+ *  - duplicate labels are compared case-insensitively and only the first
+ *    occurrence remains bindable.
  *
- * Returns `[]` for configs with zero or one emit:true table — those
- * render the single default Handle (id `null`), which has no label.
- * (A multi-emit config whose labels are ALL invalid also returns `[]`
- * and falls back to the default Handle: it is backend-invalid and
- * unreachable through the editor, and we refuse to invent bindable
- * frame ids for it.)
+ * This list is consumed unchanged by visible rows, source handles, edge
+ * reconciliation, and derived input-name surfaces.
  */
-export function apiInputEmitPortLabels(config: ConfigLike): string[] {
-  const emit = emitTables(config)
-  if (emit.length < 2) return []
+function eligibleFrameLabels(emit: readonly Record<string, unknown>[]): string[] {
   const seen = new Set<string>()
   const labels: string[] = []
   for (const t of emit) {
     const label = rawLabel(t)
-    if (!isPortableLabel(label)) continue
-    if (seen.has(label)) continue
-    seen.add(label)
+    if (!isValidFrameLabel(label)) continue
+    const folded = label.toLowerCase()
+    if (seen.has(folded)) continue
+    seen.add(folded)
     labels.push(label)
   }
   return labels
+}
+
+/**
+ * Ordered list of every runtime-eligible apiInput frame label.
+ *
+ * This is the only frontend frame-label derivation. A single eligible frame
+ * is labelled exactly like a multi-frame apiInput; only zero eligible frames
+ * use the legacy null-id handle.
+ */
+export function apiInputFrameLabels(config: ConfigLike): string[] {
+  return eligibleFrameLabels(emitTables(config))
+}
+
+type SubmodelsLike = Record<string, unknown> | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export type SubmodelGraphLike = {
+  nodes: SimpleNode[]
+  edges: SimpleEdge[]
+  submodels: Record<string, unknown>
+}
+
+/** Read either supported submodel metadata shape without inventing a graph. */
+export function submodelGraphFromMetadata(value: unknown): SubmodelGraphLike | undefined {
+  const metadata = isRecord(value) ? value : undefined
+  const graph = metadata && isRecord(metadata.graph) ? metadata.graph : metadata
+  if (!graph || !Array.isArray(graph.nodes)) return undefined
+  return {
+    nodes: graph.nodes as SimpleNode[],
+    edges: Array.isArray(graph.edges) ? graph.edges as SimpleEdge[] : [],
+    submodels: isRecord(graph.submodels) ? graph.submodels : {},
+  }
+}
+
+/** Resolve one synthetic submodel boundary handle to its actual child node. */
+export function resolveSubmodelBoundaryNode(
+  boundaryNode: SimpleNode,
+  handle: string | null | undefined,
+  direction: "in" | "out",
+  submodels: SubmodelsLike,
+): SimpleNode | undefined {
+  const prefix = `${direction}__`
+  if (!boundaryNode.id.startsWith("submodel__") || !handle?.startsWith(prefix)) {
+    return undefined
+  }
+
+  const submodelName = boundaryNode.id.slice("submodel__".length)
+  const graph = submodelGraphFromMetadata(submodels?.[submodelName])
+  if (!graph) {
+    throw new Error(
+      `Cannot resolve ${direction}put handle ${handle} for submodel ${submodelName}: graph nodes are missing`,
+    )
+  }
+  const childId = handle.slice(prefix.length)
+  const child = graph.nodes.find((node) => node.id === childId)
+  if (!child) {
+    throw new Error(
+      `Cannot resolve ${direction}put handle ${handle} for submodel ${submodelName}: child ${childId} is missing`,
+    )
+  }
+  return child
+}
+
+function submodelChildNode(
+  edge: SimpleEdge,
+  sourceNode: SimpleNode,
+  submodels: SubmodelsLike,
+): SimpleNode | undefined {
+  return resolveSubmodelBoundaryNode(sourceNode, edge.sourceHandle, "out", submodels)
+}
+
+/**
+ * Derive the executable input name for one edge.
+ *
+ * API-input frame handles are already canonical names and are returned
+ * verbatim, including a stale non-null handle so the UI can identify the
+ * unresolved edge. Ordinary sources use the shared backend-compatible
+ * sanitizer. A flattened submodel output resolves its `out__` child before
+ * sanitizing, matching code generation's boundary resolution.
+ */
+export function edgeInputName(
+  edge: SimpleEdge,
+  sourceNode: SimpleNode,
+  submodels: SubmodelsLike = undefined,
+): string {
+  if (sourceNode.data.nodeType === NODE_TYPES.API_INPUT) {
+    if (edge.sourceHandle === null || edge.sourceHandle === undefined) {
+      throw new Error(`apiInput edge ${edge.id} has no sourceHandle/frame label`)
+    }
+    return edge.sourceHandle
+  }
+  const resolvedChild = submodelChildNode(edge, sourceNode, submodels)
+  return sanitizeName(resolvedChild?.data.label ?? sourceNode.data.label)
+}
+
+/**
+ * Derive every incoming input name for one executable target. `boundaryNodeId`
+ * identifies the visible target when the executable target is a child behind
+ * an `in__<child>` submodel handle. The same helper is used by drag-time and
+ * rename preflight so boundary and ordinary edges cannot drift apart.
+ */
+export function incomingEdgeInputNames({
+  targetNodeId,
+  boundaryNodeId = targetNodeId,
+  nodes,
+  edges,
+  submodels,
+}: {
+  targetNodeId: string
+  boundaryNodeId?: string
+  nodes: readonly SimpleNode[]
+  edges: readonly SimpleEdge[]
+  submodels?: SubmodelsLike
+}): string[] {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]))
+  const boundaryNode = nodesById.get(boundaryNodeId)
+  const names: string[] = []
+  for (const edge of edges) {
+    if (edge.target !== targetNodeId) {
+      if (
+        edge.target !== boundaryNodeId
+        || boundaryNode?.data.nodeType !== NODE_TYPES.SUBMODEL
+        || resolveSubmodelBoundaryNode(boundaryNode, edge.targetHandle, "in", submodels)?.id !== targetNodeId
+      ) continue
+    }
+    const sourceNode = nodesById.get(edge.source)
+    if (!sourceNode) {
+      throw new Error(`Cannot derive input name: source node ${edge.source} is missing`)
+    }
+    names.push(edgeInputName(edge, sourceNode, submodels))
+  }
+  return names
 }
 
 // ─── Label validation (mirrors backend `validate_v2_schema`) ─────────
@@ -134,6 +274,7 @@ export function sanitiseLabelForFilesystem(label: string): string {
 
 export type ApiInputLabelIssue =
   | { kind: "blank" }
+  | { kind: "identifier"; reason: "ascii" | "keyword" }
   | { kind: "duplicate"; other: string }
   | { kind: "sanitised-collision"; other: string; sanitised: string }
 
@@ -153,6 +294,12 @@ export function apiInputLabelIssue(
   otherLabels: readonly string[],
 ): ApiInputLabelIssue | null {
   if (!candidate.trim()) return { kind: "blank" }
+  if (!ASCII_IDENTIFIER_RE.test(candidate)) {
+    return { kind: "identifier", reason: "ascii" }
+  }
+  if (PYTHON_HARD_KEYWORDS.has(candidate)) {
+    return { kind: "identifier", reason: "keyword" }
+  }
   for (const other of otherLabels) {
     if (other === candidate) return { kind: "duplicate", other }
   }
@@ -176,6 +323,10 @@ export function apiInputLabelIssueMessage(issue: ApiInputLabelIssue | null): str
   switch (issue.kind) {
     case "blank":
       return "A label is required — it names this table's frame."
+    case "identifier":
+      return issue.reason === "keyword"
+        ? "A frame label cannot be a Python hard keyword."
+        : "A frame label must be an ASCII identifier (letters, digits, and underscores only)."
     case "duplicate":
       return `Duplicate label: "${issue.other}" is already used by another table.`
     case "sanitised-collision":
@@ -187,21 +338,12 @@ export function apiInputLabelIssueMessage(issue: ApiInputLabelIssue | null): str
 
 /**
  * The set of `sourceHandle` values an apiInput's outgoing edges may
- * legitimately carry, given its config:
- *  - multi-frame (≥2 emit tables): the derived label set;
- *  - single/zero-frame: the single default Handle, whose id is `null`.
- *
- * `null` is encoded as the empty string in the returned set so it can
- * be compared against `edge.sourceHandle ?? ""`.
+ * legitimately carry, given its config. One or more eligible frames expose
+ * their raw labels; zero eligible frames expose no valid source keys because
+ * their legacy default handle is rendered non-connectable.
  */
-function validSourceHandleKeys(config: ConfigLike): Set<string> {
-  const labels = apiInputEmitPortLabels(config)
-  // Multi-frame: the labelled handles are the only valid frames. The
-  // default null handle is NOT rendered in this mode, so a legacy
-  // null-handle edge is orphaned (single→multi transition).
-  if (labels.length > 0) return new Set(labels)
-  // Single/zero-frame: the default Handle (id null → "") is the only frame.
-  return new Set([""])
+export function validSourceHandleKeys(config: ConfigLike): Set<string> {
+  return new Set(apiInputFrameLabels(config))
 }
 
 export type ReconciledApiInputEdge = {
@@ -237,16 +379,23 @@ export function reconcileApiInputEdges<E extends SimpleEdge>({
   nodeId,
   config,
   edges,
+  pruneNamedStale = true,
 }: {
   nodeId: string
   config: ConfigLike
   edges: E[]
+  /** Load reconciliation passes false to preserve named unresolved edges. */
+  pruneNamedStale?: boolean
 }): ReconcileApiInputEdgesResult<E> {
   const validKeys = validSourceHandleKeys(config)
   const removed: ReconciledApiInputEdge[] = []
   const kept: E[] = []
   for (const edge of edges) {
     if (edge.source !== nodeId) {
+      kept.push(edge)
+      continue
+    }
+    if (!pruneNamedStale && edge.sourceHandle !== null && edge.sourceHandle !== undefined) {
       kept.push(edge)
       continue
     }
@@ -279,7 +428,7 @@ function tableAt(tables: unknown[], i: number): Record<string, unknown> | null {
 /**
  * Which table index OWNS each frame label under `config` — the first
  * emit-eligible table carrying that label (later duplicates are not
- * frames, matching `apiInputEmitPortLabels`). Also counts eligible
+ * frames, matching `apiInputFrameLabels`). Also counts eligible
  * tables per label so collisions can be detected.
  */
 function portOwnership(config: ConfigLike): {
@@ -293,7 +442,7 @@ function portOwnership(config: ConfigLike): {
   tables.forEach((t, i) => {
     if (!t || typeof t !== "object" || !eligible.has(t as Record<string, unknown>)) return
     const label = rawLabel(t as Record<string, unknown>)
-    if (!isPortableLabel(label)) return
+    if (!isValidFrameLabel(label)) return
     if (!ownerIndexByLabel.has(label)) ownerIndexByLabel.set(label, i)
     eligibleCountByLabel.set(label, (eligibleCountByLabel.get(label) ?? 0) + 1)
   })
@@ -361,7 +510,7 @@ export function migrateApiInputEdges<E extends SimpleEdge>({
     if (!prevTable || !nextTable) continue
     const prevLabel = rawLabel(prevTable)
     const nextLabel = rawLabel(nextTable)
-    if (!isPortableLabel(prevLabel) || !isPortableLabel(nextLabel)) continue
+    if (!isValidFrameLabel(prevLabel) || !isValidFrameLabel(nextLabel)) continue
     if (prevLabel === nextLabel) continue
     // Same table identity: the iteration path must be unchanged.
     const prevPath = (prevTable as { path?: unknown }).path

--- a/frontend/src/utils/connectionValidation.ts
+++ b/frontend/src/utils/connectionValidation.ts
@@ -1,11 +1,211 @@
+import type { SimpleEdge, SimpleNode } from "../panels/editors/_shared"
+import { NODE_TYPES } from "./nodeTypes"
+import {
+  edgeInputName,
+  incomingEdgeInputNames,
+  resolveSubmodelBoundaryNode,
+  submodelGraphFromMetadata,
+} from "./apiInputPorts"
+
 type ConnectionLike = {
   source: string | null | undefined
   target: string | null | undefined
   sourceHandle?: string | null
   targetHandle?: string | null
+  sourceHandleType?: string
+  targetHandleType?: string
+  fromHandle?: { type?: string } | null
+  toHandle?: { type?: string } | null
 }
 
-export function isPipelineConnectionValid(connection: ConnectionLike): boolean {
-  if (!connection.source || !connection.target) return false
-  return connection.source !== connection.target
+type SubmodelsLike = Record<string, unknown> | undefined
+
+function nodeMap(nodes: readonly SimpleNode[]): Map<string, SimpleNode> {
+  return new Map(nodes.map((node) => [node.id, node]))
+}
+
+export type ConnectionValidationFailure =
+  | { kind: "duplicate-input-name"; inputName: string }
+  | { kind: "invalid-connection"; message: string }
+
+export type ConnectionValidationResult =
+  | { ok: true }
+  | { ok: false; reason: ConnectionValidationFailure }
+
+/**
+ * React Flow's Loose mode can report the node at either end as `source`
+ * depending on which handle the user started dragging from. Normalize the
+ * API-input endpoint before applying source-frame rules and input-name
+ * uniqueness, so both gesture directions have exactly the same validation.
+ */
+function actualEdge(
+  connection: ConnectionLike,
+  nodesById: Map<string, SimpleNode>,
+): {
+  source: string
+  target: string
+  sourceHandle: string | null | undefined
+  targetHandle: string | null | undefined
+} {
+  const sourceNode = nodesById.get(connection.source as string)
+  const targetNode = nodesById.get(connection.target as string)
+  if (
+    (targetNode?.data.nodeType === NODE_TYPES.API_INPUT
+      && sourceNode?.data.nodeType !== NODE_TYPES.API_INPUT)
+    || (sourceNode?.data.nodeType === NODE_TYPES.SUBMODEL
+      && connection.sourceHandle?.startsWith("in__"))
+    || (connection.sourceHandleType === "target"
+      && connection.targetHandleType === "source")
+  ) {
+    return {
+      source: connection.target as string,
+      target: connection.source as string,
+      sourceHandle: connection.targetHandle,
+      targetHandle: connection.sourceHandle,
+    }
+  }
+  return {
+    source: connection.source as string,
+    target: connection.target as string,
+    sourceHandle: connection.sourceHandle,
+    targetHandle: connection.targetHandle,
+  }
+}
+
+function handleType(value: unknown): string | undefined {
+  return typeof value === "object" && value !== null && "type" in value
+    && typeof (value as { type?: unknown }).type === "string"
+    ? (value as { type: string }).type
+    : undefined
+}
+
+function targetEndpointIsSource(connection: ConnectionLike): boolean {
+  return connection.targetHandleType === "source"
+    || handleType(connection.targetHandle) === "source"
+    || handleType(connection.toHandle) === "source"
+}
+
+function resolvedTarget(
+  targetNode: SimpleNode,
+  targetHandle: string | null | undefined,
+  submodels: SubmodelsLike,
+): SimpleNode {
+  return resolveSubmodelBoundaryNode(targetNode, targetHandle, "in", submodels) ?? targetNode
+}
+
+/**
+ * Validate a pipeline connection before React Flow commits it.
+ *
+ * The one name derivation here is also used by panel/editor surfaces. A
+ * candidate is rejected when its derived input name already belongs to an
+ * incoming edge of the target, or when an API source has no labelled frame
+ * handle. The latter deliberately rejects the zero-frame default handle in
+ * both Loose-mode gesture directions.
+ */
+export function validatePipelineConnection(
+  connection: ConnectionLike,
+  nodes: readonly SimpleNode[] = [],
+  edges: readonly SimpleEdge[] = [],
+  submodels: SubmodelsLike = undefined,
+): ConnectionValidationResult {
+  if (!connection.source || !connection.target) {
+    return { ok: false, reason: { kind: "invalid-connection", message: "Connection endpoints are incomplete" } }
+  }
+  if (connection.source === connection.target) {
+    return { ok: false, reason: { kind: "invalid-connection", message: "Self-connections are not allowed" } }
+  }
+
+  // Output-to-output gestures are converted into EdgeJoin nodes by
+  // useEdgeHandlers. They are not ordinary input edges, so input-name and
+  // null-api-handle validation must not veto them.
+  if (targetEndpointIsSource(connection)) return { ok: true }
+
+  if (nodes.length === 0) return { ok: true }
+  const nodesById = nodeMap(nodes)
+  const candidate = actualEdge(connection, nodesById)
+  const sourceNode = nodesById.get(candidate.source)
+  const targetNode = nodesById.get(candidate.target)
+  if (!sourceNode || !targetNode) {
+    return { ok: false, reason: { kind: "invalid-connection", message: "Connection node is missing" } }
+  }
+
+  if (sourceNode.data.nodeType === NODE_TYPES.API_INPUT
+    && (candidate.sourceHandle === null || candidate.sourceHandle === undefined)) {
+    return { ok: false, reason: { kind: "invalid-connection", message: "apiInput connections require a frame handle" } }
+  }
+
+  let candidateName: string
+  try {
+    candidateName = edgeInputName(
+      {
+        id: "<candidate>",
+        source: candidate.source,
+        target: candidate.target,
+        sourceHandle: candidate.sourceHandle,
+        targetHandle: candidate.targetHandle,
+      },
+      sourceNode,
+      submodels,
+    )
+  } catch (error) {
+    return {
+      ok: false,
+      reason: {
+        kind: "invalid-connection",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+
+  const candidateTarget = resolvedTarget(targetNode, candidate.targetHandle, submodels)
+
+  try {
+    const existingNames = incomingEdgeInputNames({
+      targetNodeId: candidateTarget.id,
+      boundaryNodeId: candidate.target,
+      nodes,
+      edges,
+      submodels,
+    })
+
+    // Boundary edges are only half of a submodel child's inputs. The child's
+    // internal graph contributes names to the same executable input namespace
+    // and must be checked before accepting a new parent edge.
+    if (candidateTarget.id !== targetNode.id) {
+      if (!targetNode.id.startsWith("submodel__")) {
+        throw new Error(`Cannot resolve boundary target ${targetNode.id}`)
+      }
+      const submodelName = targetNode.id.slice("submodel__".length)
+      const graph = submodelGraphFromMetadata(submodels?.[submodelName])
+      if (!graph) throw new Error(`Submodel ${submodelName} has no graph to validate`)
+      existingNames.push(...incomingEdgeInputNames({
+        targetNodeId: candidateTarget.id,
+        nodes: graph.nodes,
+        edges: graph.edges,
+        submodels: graph.submodels,
+      }))
+    }
+
+    if (existingNames.includes(candidateName)) {
+      return { ok: false, reason: { kind: "duplicate-input-name", inputName: candidateName } }
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: {
+        kind: "invalid-connection",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+  return { ok: true }
+}
+
+export function isPipelineConnectionValid(
+  connection: ConnectionLike,
+  nodes: readonly SimpleNode[] = [],
+  edges: readonly SimpleEdge[] = [],
+  submodels: SubmodelsLike = undefined,
+): boolean {
+  return validatePipelineConnection(connection, nodes, edges, submodels).ok
 }

--- a/frontend/src/utils/graphSnapshot.ts
+++ b/frontend/src/utils/graphSnapshot.ts
@@ -62,6 +62,46 @@ function stripNodeDataMetadataFields(value: unknown): unknown {
   return out
 }
 
+function stripGraphMetadataTransientFields(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(stripGraphMetadataTransientFields)
+
+  const record = value as Record<string, unknown>
+  if (typeof record.id === "string" && "data" in record) {
+    return stripNodeUiFields(record as unknown as Node)
+  }
+  if (typeof record.source === "string" && typeof record.target === "string") {
+    return stripEdgeUiFields(record as unknown as Edge)
+  }
+
+  const stripped: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(record)) {
+    stripped[key] = stripGraphMetadataTransientFields(child)
+  }
+  return stripped
+}
+
+function cloneGraphValue<T>(value: T, seen = new WeakMap<object, unknown>()): T {
+  if (value === null || typeof value !== "object") return value
+  const objectValue = value as object
+  const existing = seen.get(objectValue)
+  if (existing !== undefined) return existing as T
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = []
+    seen.set(objectValue, clone)
+    for (const item of value) clone.push(cloneGraphValue(item, seen))
+    return clone as T
+  }
+
+  const clone: Record<string, unknown> = {}
+  seen.set(objectValue, clone)
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    clone[key] = cloneGraphValue(child, seen)
+  }
+  return clone as T
+}
+
 // ---------------------------------------------------------------------------
 // Canonicalisation
 //
@@ -115,6 +155,27 @@ export function serializeSnapshot(input: {
       preamble: input.preamble,
     }),
   )
+}
+
+/**
+ * Clone a history snapshot using the same persisted-graph boundary as
+ * `serializeSnapshot`. React Flow presentation fields and transient node
+ * metadata must not leak into undo/redo state.
+ */
+export function cloneGraphSnapshot(input: {
+  nodes: readonly Node[]
+  edges: readonly Edge[]
+  preamble: string
+  submodels?: Record<string, unknown>
+}): { nodes: Node[]; edges: Edge[]; preamble: string; submodels: Record<string, unknown> } {
+  return {
+    nodes: input.nodes.map((node) => cloneGraphValue(stripNodeUiFields(node)) as Node),
+    edges: input.edges.map((edge) => cloneGraphValue(stripEdgeUiFields(edge)) as Edge),
+    preamble: input.preamble,
+    submodels: cloneGraphValue(
+      stripGraphMetadataTransientFields(input.submodels ?? {}),
+    ) as Record<string, unknown>,
+  }
 }
 
 /** Pre-computed empty-workspace sentinel (fast path for fresh sessions). */

--- a/scripts/run_frontend_e2e_server.py
+++ b/scripts/run_frontend_e2e_server.py
@@ -115,39 +115,18 @@ _QUOTES_API_INPUT_BLOCK = """
 
 
 @pipeline.api_input(config="config/quote_input/quotes.json", contract="opaque")
-def quotes() -> pl.LazyFrame:
+def quotes() -> dict[str, pl.LazyFrame]:
     \"\"\"Browser E2E apiInput node for v2-native flow tests.\"\"\"
     from pathlib import Path
 
     import orjson
 
-    from haute._json_flatten import _json_cache_dir
-    from haute._json_shred import (
-        is_per_port_cache_valid,
-        load_per_port_cache,
-    )
+    from haute._json_shred import load_v2_api_source
 
     _data_path = Path(__file__).parent.parent / "data/quotes/sample_quote.json"
     _config_path = Path("config/quote_input/quotes.json")
     _v2_config = orjson.loads(_config_path.read_bytes())
-    _cache_dir = _json_cache_dir(str(_data_path), "working")
-    if not is_per_port_cache_valid(_cache_dir, _v2_config, data_path=str(_data_path)):
-        _cache_dir = _json_cache_dir(str(_data_path), "committed")
-        if not is_per_port_cache_valid(_cache_dir, _v2_config, data_path=str(_data_path)):
-            raise RuntimeError(
-                "API Input data hasn't been cached for the current schema. "
-                "Click 'Cache as Parquet' on the API Input node to build it."
-            )
-    _emit_labels = [
-        t["label"]
-        for t in (_v2_config.get("tables") or [])
-        if t.get("emit")
-        and any(c.get("selected") for c in (t.get("columns") or []))
-    ]
-    _bundle = load_per_port_cache(_cache_dir, _v2_config)
-    if len(_emit_labels) == 1:
-        return _bundle[_emit_labels[0]]
-    return {label: _bundle[label] for label in _emit_labels if label in _bundle}
+    return load_v2_api_source(str(_data_path), _v2_config)
 """
 # V2-native starting state: a data path is set (so the Infer Tables
 # button is visible) but no schema yet — the editor renders the bare v2

--- a/src/haute/_api_input_schema.py
+++ b/src/haute/_api_input_schema.py
@@ -209,8 +209,9 @@ def is_json_api_input_path(path: str) -> bool:
     the preview/trace cache-key signature
     (``haute.execution._runtime_file_signature_paths``) so the two can
     never disagree about which file an apiInput actually reads: JSON /
-    JSONL paths are served from the built per-port parquet cache, every
-    other extension is read directly as a flat file.
+    JSONL paths use a valid per-port parquet cache when available and shred
+    the source directly otherwise; every other extension is read directly as
+    a flat file.
     """
     return path.lower().endswith(_JSON_API_INPUT_SUFFIXES)
 

--- a/src/haute/_api_input_schema.py
+++ b/src/haute/_api_input_schema.py
@@ -432,7 +432,7 @@ def validate_v2_schema(config: dict[str, Any]) -> None:
       (subclass of :class:`HauteError`). The JSON cache route catches
       specifically and returns a structured 422.
     """
-    if not is_v2_shape(config):
+    if _V2_TABLES_KEY not in config:
         raise ApiInputSchemaError("config is not in v2 shape (no `tables` key)")
 
     tables = config[_V2_TABLES_KEY]

--- a/src/haute/_api_input_schema.py
+++ b/src/haute/_api_input_schema.py
@@ -65,10 +65,12 @@ What v2 deliberately doesn't have (per the plan):
 
 from __future__ import annotations
 
+import keyword
 import re
 from collections.abc import Sequence
 from typing import Any, Literal, TypedDict
 
+from haute._graph_utils import _sanitize_identifier_characters
 from haute._jsonpath import _Seg, make_output_path, parse_data_path
 from haute.errors import HauteError
 
@@ -101,6 +103,24 @@ def sanitise_label_for_filesystem(label: str) -> str:
     if not label:
         return "_unnamed"
     return _FILESYSTEM_SAFE_RE.sub("_", label)
+
+
+def derive_identifier_label(raw: str) -> str:
+    """Mint an ASCII Python identifier from an inferred source label.
+
+    The character mapping is shared with ``_sanitize_func_name``. Inference
+    uses frame-label repairs instead of function-name repairs: empty values
+    become ``table``, digit-leading values receive a leading underscore, and
+    hard keywords receive a trailing underscore. Soft keywords remain valid.
+    """
+    name = _sanitize_identifier_characters(raw)
+    if not name:
+        return "table"
+    if name[0].isdigit():
+        name = f"_{name}"
+    if keyword.iskeyword(name):
+        name = f"{name}_"
+    return name
 
 
 class ApiInputSchemaError(HauteError):
@@ -437,6 +457,12 @@ def validate_v2_schema(config: dict[str, Any]) -> None:
             raise ApiInputSchemaError(
                 f"v2 tables[{ti}].label is missing or not a non-empty string "
                 "(must be unique within the apiInput)",
+            )
+        if not label.isascii() or not label.isidentifier() or keyword.iskeyword(label):
+            raise ApiInputSchemaError(
+                f"v2 table label {label!r} must be an ASCII Python identifier "
+                "and must not be a hard Python keyword",
+                label=label,
             )
         if label in seen_labels:
             raise ApiInputSchemaError(

--- a/src/haute/_builders.py
+++ b/src/haute/_builders.py
@@ -344,8 +344,8 @@ def _resolve_runtime_data_path(data_path: str) -> str:
     ``validate_project_path`` inside ``load_external_object`` (EXTERNAL_FILE).
     When the pipeline lived in a subdirectory and the server ran from the
     project root, the resolved location diverged from the pipeline-dir-anchored
-    one the "Cache as Parquet" build wrote / the nested data file actually sits
-    at — producing a spurious "cache is stale" (apiInput) or a
+    one the optional "Cache as Parquet" prewarm wrote / the nested data file
+    actually sits at — producing a wrong cache key or raw-file miss (apiInput), or a
     file-not-found / wrong-file read (DATA_SOURCE, EXTERNAL_FILE) that only
     agreed when cwd == the pipeline dir.
 
@@ -379,8 +379,9 @@ def _resolve_runtime_data_path(data_path: str) -> str:
             # Enforcing against cwd would wrongly reject those valid, cached
             # paths. Route-driven flows are still gated upstream by
             # ``routes.pipeline._validate_runtime_input_paths``; the executor
-            # never enforced here pre-fix and loads cache parquets, not the raw
-            # file — so leaving enforce off is status-quo-ante, not a new hole.
+            # never enforced here pre-fix; cache hits and direct JSON fallback
+            # must both support an explicitly requested pipeline outside cwd,
+            # so leaving enforce off is status-quo-ante, not a new hole.
             # (EXTERNAL_FILE additionally re-checks project-root containment
             # inside ``load_external_object`` via
             # ``_sandbox.validate_project_path``; that independent gate is
@@ -432,26 +433,22 @@ def _make_api_source_v2(
     - 0 emit-true tables → raise a clear RuntimeError (the editor's
       empty-state message; the user has to tick at least one ``emit``
       before previewing).
-    - 1 emit-true table → return a bare LazyFrame (single-frame shorthand;
-      existing edges with null sourceHandle keep binding to this node via
-      MULTI_FRAME_PLAN §4b's source-label fallback).
-    - 2+ emit-true tables → return a ``dict[port_label, LazyFrame]``. The
+    - 1+ emitting tables → return a ``dict[port_label, LazyFrame]``. The
       executor's edge-resolution picks one frame per outgoing edge using
       ``edge.sourceHandle``.
 
-    The cache directory is the dual-cache ``working/<hash>/`` layer (commit
-    3's per-frame shred output). If the cache isn't valid, raise with the
-    "click Cache as Parquet" message — same UX shape as the v1 path. No
-    auto-build in this commit; that's intentional ergonomic discipline
-    (see DUAL_CACHE.md §4 — caching is an explicit user action).
+    A valid ``working/`` or ``committed/`` per-port parquet cache is used as
+    a performance fast path. When neither can serve the current post-schema
+    shape, the source JSON/JSONL is shredded directly for this execution;
+    caching remains an explicit, optional prewarm action.
     """
     from haute._api_input_schema import validate_v2_schema
     from haute._json_shred import load_v2_api_source
 
     # Validate at build time so a malformed config fails before any data is
-    # fetched. The emit-state checks + cache resolution + single/multi-frame
-    # return live in the shared `load_v2_api_source` so the generated/deploy
-    # code path (codegen) and this runtime path can't drift.
+    # fetched. The emit-state checks, optional cache resolution, direct-shred
+    # fallback, and uniform frame-bundle return live in the shared
+    # `load_v2_api_source` so codegen and this runtime path cannot drift.
     validate_v2_schema(config)
 
     def _api_source_v2(
@@ -459,8 +456,8 @@ def _make_api_source_v2(
         _config: dict[str, Any] = config,
     ) -> _Frame | dict[str, _Frame]:
         # Resolve the (possibly pipeline-relative) data path the same way the
-        # cache-build route and codegen do, so the cache lookup in
-        # ``load_v2_api_source`` can't diverge from the cache the build wrote
+        # cache-build route and codegen do, so both optional cache lookup and
+        # direct shredding target the same file the build route would cache
         # when cwd != the pipeline dir.  Deferred to call time (not build
         # time) to mirror codegen's generated body and leave the deploy build
         # path — which creates but never invokes this fn — untouched.
@@ -478,8 +475,8 @@ def _build_api_input(ctx: NodeBuildContext) -> tuple[str, Callable, bool]:
     if is_json_api_input_path(path):
         # v2 per-frame shred is the only JSON apiInput codec. When the
         # config carries `tables[]` we dispatch into the v2 source
-        # builder (emit-true count decides bare frame vs dict[label,
-        # frame]). Anything else is an editor-state error: the user must
+        # builder (every eligible count returns dict[label, frame]). Anything
+        # else is an editor-state error: the user must
         # populate `tables[]` via the Infer Tables button before the
         # pipeline can run.
         from haute._api_input_schema import is_v2_shape as _is_v2_shape
@@ -493,7 +490,7 @@ def _build_api_input(ctx: NodeBuildContext) -> tuple[str, Callable, bool]:
             raise RuntimeError(
                 f"API Input '{_label}' has no v2 schema (tables[]). Open the "
                 "node and click 'Infer Tables' to populate the schema "
-                "mapping, then click 'Cache as Parquet'."
+                "mapping, then preview again."
             )
 
         api_source_fn = _api_source_no_tables

--- a/src/haute/_codegen_builders.py
+++ b/src/haute/_codegen_builders.py
@@ -237,8 +237,10 @@ def _api_input_template(path: str, config: dict) -> str:
     """
     lower = path.lower()
     if lower.endswith((".json", ".jsonl")):
-        # Emit-state checks, cache resolution and single/multi-frame return all
-        # live in the shared `haute._json_shred.load_v2_api_source` so this
+        return_annotation = "dict[str, pl.LazyFrame]"
+        # Emit-state checks, optional cache resolution, direct-shred fallback,
+        # and the uniform frame-bundle return all live in the shared
+        # `haute._json_shred.load_v2_api_source` so this
         # generated/deploy path can't drift from the runtime builder
         # (`_builders._make_api_source_v2`). The only codegen-specific work is
         # reading the v2 config from its on-disk sidecar and validating it.
@@ -254,12 +256,13 @@ def _api_input_template(path: str, config: dict) -> str:
             "        raise RuntimeError(\n"
             '            "API Input has no v2 schema (tables[]). Open the node "\n'
             "            \"and click 'Infer Tables' to populate the schema mapping, \"\n"
-            "            \"then click 'Cache as Parquet'.\"\n"
+            '            "then preview again."\n'
             "        )\n"
             "    validate_v2_schema(_v2_config)\n"
             "    return load_v2_api_source(str(_data_path), _v2_config)"
         )
     else:
+        return_annotation = "pl.LazyFrame"
         runtime_config = {"sourceType": "flat_file", **config}
         runtime_expr = _data_source_runtime_config_expr(runtime_config)
         runtime_expr = runtime_expr.replace("{", "{{").replace("}", "}}")
@@ -271,7 +274,7 @@ def _api_input_template(path: str, config: dict) -> str:
 
     return (
         "@pipeline.api_input(path={path_repr}{row_id_kw})\n"
-        "def {func_name}() -> pl.LazyFrame:\n"
+        f"def {{func_name}}() -> {return_annotation}:\n"
         '    """{description}"""\n' + body + "\n"
     )
 

--- a/src/haute/_codegen_builders.py
+++ b/src/haute/_codegen_builders.py
@@ -34,7 +34,11 @@ from haute._code_extraction import _strip_generated_boilerplate_from_code
 from haute._config_io import config_path_for_node
 from haute._edge_join import build_edge_join_kwargs, edge_join_config_to_decorator_kwargs
 from haute._explore_overview import validate_explore_overview
-from haute._graph_utils import _resolve_sink_path, _sanitize_func_name
+from haute._graph_utils import (
+    _resolve_sink_path,
+    _sanitize_func_name,
+    duplicate_input_names,
+)
 from haute._rating_step_config import normalise_rating_tables
 from haute._registry import (
     CodegenFn,
@@ -121,36 +125,18 @@ def _build_extra_kwargs(config: dict, keys: tuple[str, ...]) -> list[str]:
     return parts
 
 
-def _dedup_param_names(source_names: list[str]) -> list[str]:
-    """Return de-duplicated parameter identifiers for *source_names*.
-
-    Duplicate names — a multi-frame source feeding one node through several
-    edges — get a numeric suffix so the emitted ``def`` is not a compile-time
-    SyntaxError.  The FIRST occurrence keeps its name; binding is positional,
-    so the chosen names are cosmetic.  Empty input yields ``["df"]``.
-    """
-    if not source_names:
-        return ["df"]
-    used: set[str] = set()
-    names: list[str] = []
-    for name in source_names:
-        unique = name
-        suffix = 2
-        while unique in used:
-            unique = f"{name}_{suffix}"
-            suffix += 1
-        used.add(unique)
-        names.append(unique)
-    return names
-
-
 def _build_params(source_names: list[str]) -> str:
-    """Build the function parameter string from upstream node names.
+    """Build the function parameter string from supplied per-edge names.
 
-    De-duplicates via :func:`_dedup_param_names` (see there for the multi-edge
-    rationale) and annotates each parameter as ``pl.LazyFrame``.
+    The graph orchestrator validates duplicate names before reaching a
+    builder.  This helper also asserts that upstream invariant defensively;
+    inventing suffixes here would make generated signatures disagree with the
+    executor's edge-derived bindings.
     """
-    return ", ".join(f"{name}: pl.LazyFrame" for name in _dedup_param_names(source_names))
+    names = source_names or ["df"]
+    duplicates = duplicate_input_names(names)
+    assert not duplicates, f"duplicate codegen input name(s): {duplicates!r}"
+    return ", ".join(f"{name}: pl.LazyFrame" for name in names)
 
 
 def _sanitize_description(desc: str) -> str:
@@ -906,7 +892,7 @@ def _gen_modelling(node: GraphNode, source_names: list[str]) -> str:
 def _gen_optimiser_apply(node: GraphNode, source_names: list[str]) -> str:
     func_name, description, config = _common_node_fields(node)
     dec_kwargs = _passthrough_decorator_kwargs(config, OPTIMISER_APPLY_CONFIG_KEYS)
-    param_names = _dedup_param_names(source_names)
+    param_names = source_names or ["df"]
     # Frames are passed positionally; source_names/source_ids let the shared
     # helper resolve the configured ratebook_input.  In the sidecar,
     # ratebook_input is remapped to the source function name (see
@@ -1077,7 +1063,7 @@ def _gen_data_output(node: GraphNode, source_names: list[str]) -> str:
 @_register_codegen(NodeType.OUTPUT)
 def _gen_output(node: GraphNode, source_names: list[str]) -> str:
     func_name, description, _config = _common_node_fields(node)
-    param_names = _dedup_param_names(source_names)
+    param_names = source_names or ["df"]
     params = _build_params(source_names)
     # v2: the outputMapping lives in a JSON schema mapping (like every other
     # config-folder node — apiInput, dataSource, …), referenced by

--- a/src/haute/_execute_lazy.py
+++ b/src/haute/_execute_lazy.py
@@ -25,7 +25,12 @@ from haute._execution_context import (
     ExecutionProfile,
 )
 from haute._graph_shape import validate_pipeline_graph_shape_contracts
-from haute._graph_utils import resolve_orig_source_names, upstream_node_ids
+from haute._graph_utils import (
+    duplicate_input_names,
+    edge_input_name,
+    resolve_orig_source_names,
+    upstream_node_ids,
+)
 from haute._logging import get_logger
 from haute._polars_utils import _malloc_trim, bounded_sink, streaming_collect
 from haute._types import (
@@ -35,7 +40,7 @@ from haute._types import (
     PipelineGraph,
     _Frame,
 )
-from haute.errors import ContractMismatchError, SchemaMismatchError
+from haute.errors import ConfigError, ContractMismatchError, SchemaMismatchError
 
 logger = get_logger(component="execute")
 
@@ -899,6 +904,9 @@ def _execute_lazy(
     incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
     for edge in relevant_edges:
         incoming_edges_by_target.setdefault(edge.target, []).append(edge)
+    all_incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in graph.edges:
+        all_incoming_edges_by_target.setdefault(edge.target, []).append(edge)
 
     # Build executable functions — delegates to _build_funcs with
     # row_limit=None (lazy path never caps source output).
@@ -925,6 +933,8 @@ def _execute_lazy(
             all_parents,
             build_node_fn,
             incoming_edges_by_target=incoming_edges_by_target,
+            all_incoming_edges_by_target=all_incoming_edges_by_target,
+            all_node_map=graph.node_map,
             row_limit=None,
             preamble_ns=preamble_ns,
             source=source,
@@ -1403,6 +1413,8 @@ def _build_funcs(
     build_node_fn: Callable,
     *,
     incoming_edges_by_target: Mapping[str, list[GraphEdge]] | None = None,
+    all_incoming_edges_by_target: Mapping[str, list[GraphEdge]] | None = None,
+    all_node_map: Mapping[str, GraphNode] | None = None,
     row_limit: int | None = None,
     preamble_ns: dict | None = None,
     source: str = "live",
@@ -1425,35 +1437,56 @@ def _build_funcs(
     """
     funcs: dict[str, tuple[Callable, bool]] = {}
     node_source_overrides = source_by_node or {}
+    original_node_map = dict(all_node_map or node_map)
+    original_edges_by_target = all_incoming_edges_by_target or incoming_edges_by_target
     for nid in order:
         incoming_edges = (
             incoming_edges_by_target.get(nid, []) if incoming_edges_by_target is not None else []
         )
         if incoming_edges:
-            src_ids = [edge.source for edge in incoming_edges if edge.source in id_to_name]
-            target_handles = [
-                edge.targetHandle for edge in incoming_edges if edge.source in id_to_name
-            ]
+            connected_edges = [edge for edge in incoming_edges if edge.source in id_to_name]
+            src_ids = [edge.source for edge in connected_edges]
+            target_handles = [edge.targetHandle for edge in connected_edges]
             # Per-edge source *port* name (sourceHandle or source-node-name),
             # aligned with the per-edge frames the executor passes positionally.
             # OUTPUT keys its frames by this to disambiguate a multi-frame source
             # (one apiInput feeding several frames → one node name, distinct
             # sourceHandles). MULTI_FRAME_PLAN §4b.
-            src_ports = [
-                edge.sourceHandle or id_to_name[edge.source]
-                for edge in incoming_edges
-                if edge.source in id_to_name
-            ]
+            src_ports = [edge.sourceHandle or id_to_name[edge.source] for edge in connected_edges]
+            src_names: list[str] = []
+            for edge in connected_edges:
+                source_node = node_map[edge.source]
+                try:
+                    src_names.append(edge_input_name(edge, source_node))
+                except ValueError:
+                    # Leave malformed null-handle apiInput edges buildable so
+                    # eager preview can capture the routing error on the
+                    # consuming node. Fail-fast execution raises the same
+                    # ValueError from _pick_source_frame before node code runs.
+                    if not (
+                        source_node.data.nodeType == NodeType.API_INPUT
+                        and edge.sourceHandle is None
+                    ):
+                        raise
+            duplicates = duplicate_input_names(src_names)
+            if duplicates:
+                raise ConfigError(
+                    f"Node {nid!r} has duplicate input name(s) derived from its "
+                    f"incoming edges: {duplicates!r}.",
+                    node_id=nid,
+                    duplicate_input_names=duplicates,
+                )
         else:
             src_ids = [pid for pid in parents_of.get(nid, []) if pid in id_to_name]
             target_handles = None
             src_ports = None
-        src_names = [id_to_name[pid] for pid in src_ids]
+            src_names = [id_to_name[pid] for pid in src_ids]
         orig_src_names = resolve_orig_source_names(
             node_map[nid],
-            node_map,
+            original_node_map,
             all_parents,
             id_to_name,
+            original_edges_by_target,
         )
         node_source = node_source_overrides.get(nid, source)
         _, fn, is_source = build_node_fn(
@@ -1617,6 +1650,9 @@ def _execute_eager_core(
     incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
     for edge in relevant_edges:
         incoming_edges_by_target.setdefault(edge.target, []).append(edge)
+    all_incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in graph.edges:
+        all_incoming_edges_by_target.setdefault(edge.target, []).append(edge)
 
     # Fan-out count per node — how many direct children consume this
     # node's output.  Used to add a Polars ``.cache()`` hint when the
@@ -1664,6 +1700,8 @@ def _execute_eager_core(
         all_parents,
         build_node_fn,
         incoming_edges_by_target=incoming_edges_by_target,
+        all_incoming_edges_by_target=all_incoming_edges_by_target,
+        all_node_map=graph.node_map,
         row_limit=row_limit,
         preamble_ns=preamble_ns,
         source=source,
@@ -1929,16 +1967,26 @@ def _execute_eager_core(
                     # _pick_source_frame + _to_lazy_if_needed will lazify when
                     # consumers need a LazyFrame.
                     runtime_outputs[nid] = materialised
-                    # Populate column_cache + frame_schema_cache per-frame from
-                    # the COLLECTED frames so consumers' contract checks find
-                    # the right columns under (nid, port_label).
+                    # Populate the per-port contract cache for every bundle,
+                    # but expose frame_schema_cache only for genuinely
+                    # multi-frame producers.  A one-frame API source now has
+                    # the uniform dict runtime shape, while its ordinary
+                    # preview schema remains in ``columns``.
                     for port_label, port_df in materialised.items():
                         column_cache[(nid, port_label)] = frozenset(port_df.columns)
-                        port_schema = port_df.schema
-                        frame_schema_cache[(nid, port_label)] = [
-                            (name, str(port_schema[name])) for name in port_df.columns
-                        ]
+                        if len(materialised) > 1:
+                            port_schema = port_df.schema
+                            frame_schema_cache[(nid, port_label)] = [
+                                (name, str(port_schema[name])) for name in port_df.columns
+                            ]
                     eager_outputs[nid] = materialised
+                    if len(materialised) == 1:
+                        only_frame = next(iter(materialised.values()))
+                        only_schema = [
+                            (name, str(only_frame.schema[name])) for name in only_frame.columns
+                        ]
+                        available_columns[nid] = only_schema
+                        output_columns[nid] = only_schema
                 else:
                     # ANCESTOR: keep the per-frame LazyFrames in
                     # runtime_outputs for routing only; do NOT collect and do
@@ -1951,14 +1999,24 @@ def _execute_eager_core(
                         lazy_ports[port_label] = port_lf
                         port_schema = port_lf.collect_schema()
                         column_cache[(nid, port_label)] = frozenset(port_schema.names())
-                        frame_schema_cache[(nid, port_label)] = [
-                            (name, str(port_schema[name])) for name in port_schema.names()
-                        ]
+                        if len(capped_ports) > 1:
+                            frame_schema_cache[(nid, port_label)] = [
+                                (name, str(port_schema[name])) for name in port_schema.names()
+                            ]
                     runtime_outputs[nid] = lazy_ports
+                    if len(lazy_ports) == 1:
+                        only_lazy_frame = next(iter(lazy_ports.values()))
+                        only_frame_schema = only_lazy_frame.collect_schema()
+                        only_schema = [
+                            (name, str(only_frame_schema[name]))
+                            for name in only_frame_schema.names()
+                        ]
+                        available_columns[nid] = only_schema
+                        output_columns[nid] = only_schema
                 t1 = time.perf_counter()
                 timings[nid] = round(t1 - t0, 6)
-                available_columns[nid] = []
-                output_columns[nid] = []
+                available_columns.setdefault(nid, [])
+                output_columns.setdefault(nid, [])
                 if execution_context is not None:
                     execution_context.checkpoint(label="after_node", node_id=nid)
                 continue

--- a/src/haute/_graph_utils.py
+++ b/src/haute/_graph_utils.py
@@ -101,6 +101,22 @@ def _sanitize_func_name(label: str) -> str:
     """
     import keyword
 
+    name = _sanitize_identifier_characters(label)
+
+    if name and name[0].isdigit():
+        name = f"node_{name}"
+    if keyword.iskeyword(name):
+        name = f"node_{name}"
+    return name or "unnamed_node"
+
+
+def _sanitize_identifier_characters(label: str) -> str:
+    """Apply the shared label-to-ASCII identifier character pipeline.
+
+    This deliberately does not apply the function-name-specific empty,
+    digit-leading, or keyword repairs.  Schema inference uses the same
+    reversible character mapping with frame-label repairs of its own.
+    """
     name = label.strip()
     name = name.replace(" ", "_").replace("-", "_")
 
@@ -109,20 +125,43 @@ def _sanitize_func_name(label: str) -> str:
         if c.isascii():
             if c.isalnum() or c == "_":
                 out_chars.append(c)
-            # else: drop ASCII punctuation / control chars
+            # Drop ASCII punctuation and control characters.
         else:
-            # Reversibly encode non-ASCII codepoints so distinct glyphs
-            # produce distinct identifiers.  The ``_x`` + hex + ``_`` shape
-            # is itself ASCII alnum/underscore, so the encoded form is
-            # idempotent under a second pass through this function.
+            # Reversibly encode non-ASCII codepoints. The encoded form is
+            # itself ASCII alphanumeric/underscore and therefore stable.
             out_chars.append(f"_x{ord(c):x}_")
-    name = "".join(out_chars)
+    return "".join(out_chars)
 
-    if name and name[0].isdigit():
-        name = f"node_{name}"
-    if keyword.iskeyword(name):
-        name = f"node_{name}"
-    return name or "unnamed_node"
+
+def edge_input_name(edge: GraphEdge, source_node: GraphNode) -> str:
+    """Return the one input name contributed by an incoming edge.
+
+    API-input edges use their persisted frame handle verbatim. Every other
+    edge uses the sanitised source-node label; source handles on ordinary
+    nodes identify an output port and are not input names.
+    """
+    if source_node.data.nodeType == "apiInput":
+        if edge.sourceHandle is None:
+            raise ValueError(
+                f"apiInput edge {edge.id!r} has no sourceHandle/frame label",
+            )
+        return edge.sourceHandle
+    return _sanitize_func_name(source_node.data.label)
+
+
+def duplicate_input_names(names: list[str]) -> list[str]:
+    """Return repeated names once, ordered by their first duplicate occurrence."""
+    seen: set[str] = set()
+    reported: set[str] = set()
+    duplicates: list[str] = []
+    for name in names:
+        if name in seen:
+            if name not in reported:
+                reported.add(name)
+                duplicates.append(name)
+        else:
+            seen.add(name)
+    return duplicates
 
 
 def build_instance_mapping(
@@ -234,12 +273,20 @@ def resolve_orig_source_names(
     node_map: dict[str, GraphNode],
     all_parents: dict[str, list[str]],
     id_to_name: dict[str, str],
+    incoming_edges_by_target: Mapping[str, list[GraphEdge]] | None = None,
 ) -> list[str] | None:
-    """For an instance node, return the sanitized names of the original's upstream inputs.
+    """For an instance node, return the names of the original's input edges.
 
     Uses *all_parents* (built from the full edge list, not filtered by
     ``target_node_id``) so this works even when the original node isn't
     in the current execution subgraph.
+
+    When *incoming_edges_by_target* is supplied, each name is derived from
+    the original's incoming edge with :func:`edge_input_name`, preserving the
+    same frame-label semantics as the executable original node.  The parent
+    lookup remains as a compatibility path for direct callers that only have
+    the historical adjacency map; production execution always supplies edge
+    metadata.
 
     Returns ``None`` for non-instance nodes.
     """
@@ -247,6 +294,21 @@ def resolve_orig_source_names(
     if not ref or ref not in node_map:
         return None
     result: list[str] = []
+    if incoming_edges_by_target is not None:
+        for edge in incoming_edges_by_target.get(ref, []):
+            source_node = node_map.get(edge.source)
+            if source_node is None:
+                # A target-only execution may omit the original's upstream
+                # node from its prepared map.  The edge-derived name is still
+                # recoverable for ordinary sources from the full node label
+                # when available; an absent source node is malformed graph
+                # input and retains the historical raw-id diagnostic.
+                source_name = id_to_name.get(edge.source, edge.source)
+                result.append(source_name)
+            else:
+                result.append(edge_input_name(edge, source_node))
+        return result
+
     for pid in all_parents.get(ref, []):
         if pid in id_to_name:
             result.append(id_to_name[pid])

--- a/src/haute/_json_flatten.py
+++ b/src/haute/_json_flatten.py
@@ -296,8 +296,8 @@ def mirror_cache_to_committed(
     from haute._api_input_schema import ApiInputSchemaError
     from haute._json_shred import (
         _build_lock_for,
-        _cache_meta_matches_config_and_source,
         _cache_manifest_files_match,
+        _cache_meta_matches_config_and_source,
         _emitting_table_specs,
         _probe_cache_bundle,
         _swap_dir_into_place,
@@ -328,7 +328,6 @@ def mirror_cache_to_committed(
 
         working_meta = _read_cache_meta_lenient(working_dir)
         committed_meta = _read_cache_meta_lenient(committed_dir)
-        table_specs = ()
         working_valid = False
         try:
             table_specs = _emitting_table_specs(v2_config)
@@ -358,12 +357,14 @@ def mirror_cache_to_committed(
                 committed_dir=str(committed_dir),
             )
             return False
+        valid_working_meta = cast(dict[str, Any], working_meta)
         if (
             committed_meta is not None
-            and working_meta.get("schema_fingerprint") == committed_meta.get("schema_fingerprint")
-            and working_meta.get("schema_mode") == committed_meta.get("schema_mode")
-            and working_meta.get("data_file") == committed_meta.get("data_file")
-            and working_meta.get("tables") == committed_meta.get("tables")
+            and valid_working_meta.get("schema_fingerprint")
+            == committed_meta.get("schema_fingerprint")
+            and valid_working_meta.get("schema_mode") == committed_meta.get("schema_mode")
+            and valid_working_meta.get("data_file") == committed_meta.get("data_file")
+            and valid_working_meta.get("tables") == committed_meta.get("tables")
             and _cache_manifest_files_match(
                 committed_dir,
                 cast(dict[str, Any], committed_meta),
@@ -403,13 +404,10 @@ def mirror_cache_to_committed(
                 # Recheck source identity after the copy and full staged probe,
                 # immediately before publish. A source edit during either step
                 # makes this generation stale and must preserve committed.
-                staged_valid = (
-                    probe_failure is None
-                    and _cache_meta_matches_config_and_source(
-                        cast(dict[str, Any], working_meta),
-                        v2_config,
-                        data_path=data_path,
-                    )
+                staged_valid = probe_failure is None and _cache_meta_matches_config_and_source(
+                    cast(dict[str, Any], working_meta),
+                    v2_config,
+                    data_path=data_path,
                 )
         except (OSError, pl.exceptions.PolarsError):
             staged_valid = False

--- a/src/haute/_json_flatten.py
+++ b/src/haute/_json_flatten.py
@@ -25,7 +25,8 @@ The on-disk layout is:
   is ``working`` (volatile, in-session) or ``committed`` (durable, the
   source of truth post-restart). Each ``<hash>/`` directory contains
   per-frame parquets and a ``meta.json`` with ``{schema_mode,
-  schema_fingerprint, tables}`` — written by
+  schema_fingerprint, tables}``; every table entry carries its parquet's
+  size/SHA-256 content signature — written by
   :func:`haute._json_shred.build_per_port_cache`.
 """
 
@@ -60,10 +61,10 @@ logger = get_logger(component="json_cache")
 #
 # Each layer's `<hash>/` directory contains per-frame parquets (one per
 # emit-true table in the v2 schema) and a `meta.json` sidecar carrying
-# `{schema_mode, schema_fingerprint, tables}`. The fingerprint backs the
-# no-op trapdoors (cache: skip rebuild when in-memory schema fingerprint
-# == working/meta.json fingerprint; save: skip mirror when
-# working/meta.json fingerprint == committed/meta.json fingerprint).
+# `{schema_mode, schema_fingerprint, tables}`. Each table entry includes a
+# size/SHA-256 signature for its derived parquet path. Fingerprint, source-file
+# identity, signed table manifest, and actual artifact bytes back the no-op
+# trapdoors.
 
 _CACHE_DIR = ".haute_cache"
 _LAYER_WORKING = "working"
@@ -125,7 +126,8 @@ def _wipe_legacy_flat_cache(data_path: str | Path) -> bool:
     `.haute_cache/json_<hash>.parquet` with a sidecar `.meta.json`. The
     dual-cache migration policy is wipe-on-first-run: on the first
     dual-cache operation for a given data file, legacy artifacts get
-    unlinked and the user must rebuild via the Cache button.
+    unlinked. Runtime execution continues directly from JSON; the optional
+    Cache button can prewarm the new layout afterward.
 
     Returns True if anything was deleted (so callers can log).
     """
@@ -159,20 +161,20 @@ def _read_cache_meta(cache_dir: Path) -> dict[str, object] | None:
     return cast(dict[str, object], payload)
 
 
-def _read_committed_meta_lenient(committed_dir: Path) -> dict[str, object] | None:
-    """Read ``committed/meta.json`` for the mirror's no-op trapdoor, treating
+def _read_cache_meta_lenient(cache_dir: Path) -> dict[str, object] | None:
+    """Read a layer's ``meta.json`` for mirroring, treating
     a corrupt or non-dict payload as ``None`` (mismatch) rather than raising.
 
     ``_read_cache_meta`` fails loud on garbled metadata — correct for a cache
-    we intend to *serve*. But the committed layer is what the mirror is about
-    to *overwrite*: a corrupt committed/meta.json must not abort the promotion
-    before the copytree that would repair it. This degrades-to-stale exactly
-    like :func:`haute._json_shred.is_per_port_cache_valid` (F307).
+    we intend to *serve*. Mirroring instead needs to preserve a healthy
+    committed layer when working metadata is bad, and repair a corrupt
+    committed layer from healthy working state. Both cases degrade to stale
+    exactly like :func:`haute._json_shred.is_per_port_cache_valid` (F307).
     """
-    if not committed_dir.exists():
+    if not cache_dir.exists():
         return None
     try:
-        return _read_cache_meta(committed_dir)
+        return _read_cache_meta(cache_dir)
     except (OSError, ValueError):
         return None
 
@@ -262,7 +264,10 @@ def clear_json_cache(
     return True
 
 
-def mirror_cache_to_committed(data_path: str | Path) -> bool:
+def mirror_cache_to_committed(
+    data_path: str | Path,
+    v2_config: dict[str, Any],
+) -> bool:
     """Promote `working/<hash>/` → `committed/<hash>/` on Save (DUAL_CACHE.md §4).
 
     Behaviour (the user's test plan governs):
@@ -270,12 +275,13 @@ def mirror_cache_to_committed(data_path: str | Path) -> bool:
         ``_session_consulted_hashes``), this is a no-op. This guards against
         save inadvertently promoting a stale on-disk working/ from a
         previous session (cross-restart vulnerability mitigation).
-      - If working/ exists: mirror it byte-for-byte into committed/. No-op
-        trapdoor: if working/meta.json and committed/meta.json agree on
-        schema fingerprint, schema mode AND data-file signature, skip the
-        copy. (The data-file signature term matters: a data-only rebuild
-        keeps the schema fingerprint, and skipping the copy then would
-        leave committed/ serving the stale rows forever — W2 item 2.4.)
+      - If working/ exists: mirror it byte-for-byte into committed/ only when
+        its top-level v2 identity is well formed, its recorded source signature
+        still matches *data_path*, and every signed table artifact is intact.
+        No-op trapdoor: skip the copy only when both manifests agree on schema,
+        source-file identity, and signed table entries, and both layers' actual
+        parquet bytes match those signatures. This also upgrades an old unsigned
+        committed manifest and repairs externally damaged bytes.
       - If working/ does not exist: ensure committed/ also does not exist.
 
     Returns True if the on-disk committed/ state changed.
@@ -285,7 +291,18 @@ def mirror_cache_to_committed(data_path: str | Path) -> bool:
     # working dir and (b) survives transient rename handle-locks on win32,
     # exactly like the shred's own publish path (F010). Imported lazily to
     # avoid an import cycle (`_json_shred` imports `_json_cache_dir` from here).
-    from haute._json_shred import _build_lock_for, _swap_dir_into_place
+    import polars as pl
+
+    from haute._api_input_schema import ApiInputSchemaError
+    from haute._json_shred import (
+        _build_lock_for,
+        _cache_meta_matches_config_and_source,
+        _cache_manifest_files_match,
+        _emitting_table_specs,
+        _probe_cache_bundle,
+        _swap_dir_into_place,
+        _unique_build_tmp_dir,
+    )
 
     _wipe_legacy_flat_cache(data_path)
     if not _is_working_consulted(data_path):
@@ -309,14 +326,48 @@ def mirror_cache_to_committed(data_path: str | Path) -> bool:
                 return True
             return False
 
-        working_meta = _read_cache_meta(working_dir)
-        committed_meta = _read_committed_meta_lenient(committed_dir)
+        working_meta = _read_cache_meta_lenient(working_dir)
+        committed_meta = _read_cache_meta_lenient(committed_dir)
+        table_specs = ()
+        working_valid = False
+        try:
+            table_specs = _emitting_table_specs(v2_config)
+            if (
+                working_meta is not None
+                and table_specs
+                and _cache_meta_matches_config_and_source(
+                    cast(dict[str, Any], working_meta),
+                    v2_config,
+                    data_path=data_path,
+                )
+            ):
+                _working_bundle, probe_failure = _probe_cache_bundle(
+                    working_dir,
+                    table_specs,
+                    cast(dict[str, Any], working_meta),
+                )
+                working_valid = probe_failure is None
+        except (ApiInputSchemaError, OSError, pl.exceptions.PolarsError):
+            working_valid = False
+
+        if not working_valid:
+            logger.warning(
+                "json_cache_working_invalid_not_mirrored",
+                data_path=str(data_path),
+                working_dir=str(working_dir),
+                committed_dir=str(committed_dir),
+            )
+            return False
         if (
-            working_meta is not None
-            and committed_meta is not None
+            committed_meta is not None
             and working_meta.get("schema_fingerprint") == committed_meta.get("schema_fingerprint")
             and working_meta.get("schema_mode") == committed_meta.get("schema_mode")
             and working_meta.get("data_file") == committed_meta.get("data_file")
+            and working_meta.get("tables") == committed_meta.get("tables")
+            and _cache_manifest_files_match(
+                committed_dir,
+                cast(dict[str, Any], committed_meta),
+            )
         ):
             logger.info(
                 "json_cache_save_noop",
@@ -325,13 +376,52 @@ def mirror_cache_to_committed(data_path: str | Path) -> bool:
             )
             return False
 
-        # Atomic replacement: copytree into a `.tmp` sibling then swap it into
-        # place via the shared Windows-safe helper.
+        # Atomic replacement: copytree into a `.tmp` sibling, then revalidate
+        # that staged copy against the exact manifest captured above before
+        # swapping. The source can be edited by another process despite our
+        # process-local build lock; a mixed/partial copy must never replace a
+        # healthy committed generation.
         committed_dir.parent.mkdir(parents=True, exist_ok=True)
-        tmp_dir = committed_dir.with_name(committed_dir.name + ".tmp")
-        if tmp_dir.exists():
-            shutil.rmtree(tmp_dir)
-        shutil.copytree(working_dir, tmp_dir)
+        legacy_tmp_dir = committed_dir.with_name(committed_dir.name + ".tmp")
+        if legacy_tmp_dir.exists():
+            shutil.rmtree(legacy_tmp_dir)
+        tmp_dir = _unique_build_tmp_dir(committed_dir)
+        try:
+            shutil.copytree(working_dir, tmp_dir)
+        except BaseException:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
+        staged_meta = _read_cache_meta_lenient(tmp_dir)
+        staged_valid = False
+        try:
+            if staged_meta == working_meta:
+                _staged_bundle, probe_failure = _probe_cache_bundle(
+                    tmp_dir,
+                    table_specs,
+                    cast(dict[str, Any], working_meta),
+                )
+                # Recheck source identity after the copy and full staged probe,
+                # immediately before publish. A source edit during either step
+                # makes this generation stale and must preserve committed.
+                staged_valid = (
+                    probe_failure is None
+                    and _cache_meta_matches_config_and_source(
+                        cast(dict[str, Any], working_meta),
+                        v2_config,
+                        data_path=data_path,
+                    )
+                )
+        except (OSError, pl.exceptions.PolarsError):
+            staged_valid = False
+        if not staged_valid:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            logger.warning(
+                "json_cache_staged_mirror_invalid_not_published",
+                data_path=str(data_path),
+                working_dir=str(working_dir),
+                committed_dir=str(committed_dir),
+            )
+            return False
         _swap_dir_into_place(tmp_dir, committed_dir)
         logger.info(
             "json_cache_committed_mirrored",

--- a/src/haute/_json_shred.py
+++ b/src/haute/_json_shred.py
@@ -134,6 +134,8 @@ def _v2_fingerprint(config: dict[str, Any]) -> str:
     affect the shred output (the apiInput's ``path``, ``contract``).
     """
     tables = config.get("tables", [])
+    if not isinstance(tables, list):
+        raise ApiInputSchemaError("v2 tables must be a list")
     canonical: list[dict[str, Any]] = []
     for ti, table in enumerate(tables):
         if not isinstance(table, dict):
@@ -143,8 +145,11 @@ def _v2_fingerprint(config: dict[str, Any]) -> str:
             # from one broken shape to another would not invalidate a stale
             # cache. Distinct configs must hash distinctly (W1).
             raise ApiInputSchemaError(f"v2 tables[{ti}] is not a dict")
+        columns = table.get("columns", [])
+        if not isinstance(columns, list):
+            raise ApiInputSchemaError(f"v2 tables[{ti}].columns must be a list")
         cols_canon: list[dict[str, Any]] = []
-        for ci, col in enumerate(table.get("columns", []) or []):
+        for ci, col in enumerate(columns):
             if not isinstance(col, dict):
                 raise ApiInputSchemaError(
                     f"v2 tables[{ti}].columns[{ci}] is not a dict",
@@ -1409,9 +1414,8 @@ def _cache_meta_matches_config_and_source(
         # Preserve the bool contract for status/save callers that probe a
         # malformed in-memory config. Build and load boundaries validate loud.
         return False
-    return (
-        meta.get("schema_fingerprint") == expected_fingerprint
-        and _data_file_matches(meta.get("data_file"), Path(data_path))
+    return meta.get("schema_fingerprint") == expected_fingerprint and _data_file_matches(
+        meta.get("data_file"), Path(data_path)
     )
 
 
@@ -1429,8 +1433,6 @@ def _read_matching_cache_meta(
     """
     cd = Path(cache_dir)
     meta_path = cd / _META_FILENAME
-    if not meta_path.exists():
-        return None
     try:
         meta = orjson.loads(meta_path.read_bytes())
     except (OSError, ValueError):
@@ -1887,8 +1889,6 @@ def read_per_port_cache_meta(cache_dir: str | Path) -> dict[str, Any] | None:  #
     """
     cd = Path(cache_dir)
     meta_path = cd / _META_FILENAME
-    if not meta_path.exists():
-        return None
     try:
         meta = orjson.loads(meta_path.read_bytes())
     except (OSError, ValueError):

--- a/src/haute/_json_shred.py
+++ b/src/haute/_json_shred.py
@@ -51,6 +51,7 @@ from haute._api_input_schema import (
     ColumnType,
     PathSeg,
     array_depth,
+    derive_identifier_label,
     make_table_path,
     parse_column_path,
     parse_column_path_full,
@@ -1144,7 +1145,7 @@ def load_per_port_cache(
 def load_v2_api_source(
     data_path: str,
     config: dict[str, Any],
-) -> pl.LazyFrame | dict[str, pl.LazyFrame]:  # pragma: no mutate
+) -> dict[str, pl.LazyFrame]:  # pragma: no mutate
     """Resolve a v2 apiInput's per-port cache and return its frame(s).
 
     The single runtime entry point shared by the executor's source builder
@@ -1162,8 +1163,7 @@ def load_v2_api_source(
       ``committed/`` (the deploy / fresh-server case); a missing/stale cache
       (schema fingerprint OR data-file signature mismatch) raises the
       "click Cache as Parquet" message.
-    - 1 emitting label → a bare ``LazyFrame`` (single-frame shorthand); 2+ →
-      a ``dict[port_label, LazyFrame]`` in schema order.
+    - 1+ emitting labels → a ``dict[port_label, LazyFrame]`` in schema order.
 
     Frame resolution uses the shared :func:`table_is_emitting` predicate, so
     an emit-true table with zero selected columns contributes no frame and —
@@ -1200,10 +1200,9 @@ def load_v2_api_source(
             "API Input cache changed while it was being loaded; missing parquet "
             f"frame(s): {missing_labels}. {_STALE_CACHE_MESSAGE}",
         )
-    # Single-frame shorthand: bare LazyFrame instead of a one-entry dict.
-    if len(emit_labels) == 1:
-        return bundle[emit_labels[0]]
-    # Multi-frame: preserve schema order so executor logs/errors are deterministic.
+    # Preserve schema order so executor logs/errors are deterministic.  A
+    # one-frame source deliberately has the same bundle shape as a multi-frame
+    # source; downstream routing always selects by the edge's source handle.
     return {label: bundle[label] for label in emit_labels}
 
 
@@ -1463,7 +1462,7 @@ def infer_v2_schema_from_data(
     for record in records:
         _walk(record, (), ())
 
-    tables: list[dict[str, Any]] = []
+    table_entries: list[tuple[tuple[PathSeg, ...], dict[str, Any], str]] = []
     all_levels = set(levels) | set(scalar_levels)
     for level in sorted(all_levels, key=lambda s: (array_depth(s), len(s), tuple(s))):
         table_path = make_table_path(level)
@@ -1496,16 +1495,46 @@ def infer_v2_schema_from_data(
                 }
                 for opath in col_paths
             ]
-        tables.append(
-            {
-                "path": table_path,
-                "label": table_path,
-                "displayPath": None,
-                "emit": array_depth(level) == 0,  # pragma: no mutate  # root level only
-                "row_id_column": None,
-                "columns": columns,
-            },
+        base_label = "root" if not level else derive_identifier_label(level[-1][0])
+        table_entries.append(
+            (
+                level,
+                {
+                    "path": table_path,
+                    "label": base_label,
+                    "displayPath": table_path,
+                    "emit": array_depth(level) == 0,  # pragma: no mutate  # root level only
+                    "row_id_column": None,
+                    "columns": columns,
+                },
+                base_label,
+            ),
         )
+
+    base_label_counts: dict[str, int] = {}
+    for _level, _table, base_label in table_entries:
+        folded = base_label.casefold()
+        base_label_counts[folded] = base_label_counts.get(folded, 0) + 1
+
+    assigned_labels: list[tuple[dict[str, Any], str]] = []
+    for level, table, base_label in table_entries:
+        if base_label_counts[base_label.casefold()] > 1 and level:
+            label = "_".join(derive_identifier_label(key) for key, _is_array in level)
+        else:
+            label = base_label
+        assigned_labels.append((table, label))
+
+    used_labels: set[str] = set()
+    for table, label in assigned_labels:
+        candidate = label
+        suffix = 2
+        while candidate.casefold() in used_labels:
+            candidate = f"{label}_{suffix}"
+            suffix += 1
+        table["label"] = candidate
+        used_labels.add(candidate.casefold())
+
+    tables = [table for _level, table, _base_label in table_entries]
     return {"tables": tables}
 
 

--- a/src/haute/_json_shred.py
+++ b/src/haute/_json_shred.py
@@ -16,9 +16,14 @@ that no table cares about.
 
 On-disk layout in a cache directory (working/<hash>/ or committed/<hash>/):
 
-- one ``<sanitised_label>.parquet`` per emit-true table.
+- one ``<sanitised_label>.parquet`` artifact per current emit-true table.
 - one ``meta.json`` carrying ``{schema_mode: "v2", schema_fingerprint,
-  tables: [{label, parquet, row_count, column_count}, ...]}``.
+  tables: [{label, parquet, row_count, column_count, content_signature}, ...]}``.
+
+At runtime each compressed parquet is read exactly once, its signature is
+verified over those exact bytes, and Polars scans an in-memory compressed
+snapshot. LazyFrames and their clones therefore keep the selected generation
+even if the single on-disk generation is later rebuilt, mirrored, or cleared.
 
 The per-frame schema for each parquet is also embedded in the parquet's
 footer key-value metadata (DUAL_CACHE.md §3) so each file is
@@ -29,6 +34,7 @@ schema-wrote-but-data-failed race.
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import shutil
 import threading
@@ -53,7 +59,6 @@ from haute._api_input_schema import (
     array_depth,
     derive_identifier_label,
     make_table_path,
-    parse_column_path,
     parse_column_path_full,
     parse_table_path,
     validate_v2_schema,
@@ -67,10 +72,6 @@ logger = get_logger(component="json_shred")
 
 
 _META_FILENAME = "meta.json"
-_STALE_CACHE_MESSAGE = (
-    "API Input data hasn't been cached for the current schema, or the cache is stale. "
-    "Click 'Cache as Parquet' on the API Input node to (re)build."
-)
 
 # A JSON *scalar* array (e.g. ``coverages: ["TPFT", "comprehensive"]``)
 # becomes its own child table with a single ``value`` column — exactly how
@@ -277,6 +278,56 @@ def _hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _file_content_signature(path: Path) -> dict[str, Any]:
+    """Return the size/SHA-256 identity recorded for a cache artifact."""
+    st = path.stat()
+    digest = _hash_file(path)
+    final_st = path.stat()
+    if (st.st_size, st.st_mtime_ns) != (final_st.st_size, final_st.st_mtime_ns):
+        raise OSError(f"file changed while its content signature was computed: {path}")
+    return {"size": final_st.st_size, "sha256": digest}
+
+
+def _content_signature_parts(recorded: Any) -> tuple[int, str] | None:
+    """Parse a strict size/SHA-256 record, rejecting bool sizes and bad hex."""
+    if not isinstance(recorded, dict):
+        return None
+    size = recorded.get("size")
+    digest = recorded.get("sha256")
+    if type(size) is not int or size < 0:  # bool is not a valid byte count
+        return None
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(ch not in "0123456789abcdef" for ch in digest)
+    ):
+        return None
+    return size, digest
+
+
+def _file_content_matches(recorded: Any, path: Path) -> bool:
+    """Return whether *path* exactly matches a strict size/SHA-256 record."""
+    parts = _content_signature_parts(recorded)
+    if parts is None:
+        return False
+    size, digest = parts
+    try:
+        if path.stat().st_size != size:
+            return False
+        return _hash_file(path) == digest
+    except OSError:
+        return False
+
+
+def _payload_content_matches(recorded: Any, payload: bytes) -> bool:
+    """Return whether exact in-memory bytes match a strict signature."""
+    parts = _content_signature_parts(recorded)
+    if parts is None:
+        return False
+    size, digest = parts
+    return len(payload) == size and hashlib.sha256(payload).hexdigest() == digest
+
+
 def _data_file_matches(recorded: Any, data_path: Path) -> bool:
     """True iff the data file on disk still matches the recorded signature.
 
@@ -295,15 +346,7 @@ def _data_file_matches(recorded: Any, data_path: Path) -> bool:
     validity path; the deploy-copy case (mtime moved, content identical)
     still validates because the hash matches.
     """
-    if not isinstance(recorded, dict):
-        return False
-    try:
-        st = data_path.stat()
-    except OSError:
-        return False
-    if st.st_size != recorded.get("size"):
-        return False
-    return _hash_file(data_path) == recorded.get("sha256")
+    return _file_content_matches(recorded, data_path)
 
 
 # ---------------------------------------------------------------------------
@@ -547,6 +590,25 @@ _LeafSpec = tuple[str, str, str]  # (column_name, leaf_path_dotted, type_token)
 _WalkSpec = tuple[str, str, str, int]
 
 
+@dataclass(frozen=True)
+class _EmittingTableSpec:
+    """One validated emitting table, parsed once for every shred consumer.
+
+    ``columns`` carries the full walk-time form (including source array depth)
+    needed for ancestor broadcasts. Cache writes and in-memory runtime loads
+    derive their leaf-only frame schema from the same objects, so the two paths
+    cannot disagree about selected columns, names, types, or paths.
+    """
+
+    label: str
+    segments: tuple[PathSeg, ...]
+    columns: tuple[_WalkSpec, ...]
+
+    @property
+    def leaf_specs(self) -> list[_LeafSpec]:
+        return [(name, leaf, type_token) for name, leaf, type_token, _depth in self.columns]
+
+
 def _resolve_leaf(value: Any, leaf: str) -> Any:
     """Resolve a dotted leaf path within a single dict.
 
@@ -630,11 +692,45 @@ def _reject_reserved_leaf_collision(label: str, own_depth: int, col_specs: list[
         )
 
 
+def _emitting_table_specs(v2_config: dict[str, Any]) -> tuple[_EmittingTableSpec, ...]:
+    """Validate *v2_config* and parse every emitting table exactly one way."""
+    validate_v2_schema(v2_config)
+
+    table_specs: list[_EmittingTableSpec] = []
+    for table in v2_config["tables"]:
+        if not table_is_emitting(table):
+            continue
+        segments = parse_table_path(table["path"])
+        columns: list[_WalkSpec] = []
+        for col in table.get("columns", []) or []:
+            if not col.get("selected"):
+                continue
+            locating, leaf = parse_column_path_full(col["path"])
+            columns.append(
+                (
+                    col["name"],
+                    leaf,
+                    col["type"],
+                    array_depth(locating),
+                ),
+            )
+        _reject_reserved_leaf_collision(table["label"], array_depth(segments), columns)
+        table_specs.append(
+            _EmittingTableSpec(
+                label=table["label"],
+                segments=segments,
+                columns=tuple(columns),
+            ),
+        )
+    return tuple(table_specs)
+
+
 def shred_to_buffers(
     records: Iterable[dict[str, Any]],
     v2_config: dict[str, Any],
     *,  # pragma: no mutate
     stats: ShredSkipStats | None = None,  # pragma: no mutate
+    _table_specs: tuple[_EmittingTableSpec, ...] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Shred *records* according to *v2_config*, returning per-frame row buffers.
 
@@ -649,19 +745,11 @@ def shred_to_buffers(
     selected column) get a buffer, matching exactly the set of parquets
     the build writes and validity demands. *stats*, when provided, counts
     every array element dropped at an emitting table's depth because its
-    shape mismatched that table (W2 item 2.7); the production build always
-    passes one.
+    shape mismatched that table (W2 item 2.7); cache builds and direct runtime
+    materialisation both pass one through :func:`_shred_data_file`.
     """
-    validate_v2_schema(v2_config)
+    table_specs = _emitting_table_specs(v2_config) if _table_specs is None else _table_specs
 
-    # Tables we'll actually emit — the shared predicate (W2 item 2.5). Each
-    # column spec is (name, leaf, type_token, source_depth); source_depth is
-    # the array-iteration depth at which the column's value lives. It equals
-    # the table's own depth for a normal column, or a SHALLOWER depth for an
-    # ancestor column (W1) — whose value is filled into every descendant row
-    # at emission (walk-time distribution, never a post-shred join).
-    # validate_v2_schema (above) has already guaranteed source_depth is the
-    # table's depth or a proper-ancestor prefix of it.
     # Each table's POSITION is its full ``(key, is_array)`` segment tuple: the
     # array hops set its relational depth, the object hops only LOCATE it. A
     # column spec is (name, leaf, type_token, source_depth); source_depth is the
@@ -670,19 +758,7 @@ def shred_to_buffers(
     # column (W1), filled into every descendant row at emission (walk-time
     # distribution, never a post-shred join). validate_v2_schema (above) has
     # guaranteed source_depth is the table's depth or a proper-ancestor prefix.
-    emit_tables: list[tuple[str, tuple[PathSeg, ...], list[_WalkSpec]]] = []
-    for table in v2_config["tables"]:
-        if not table_is_emitting(table):
-            continue
-        segments = parse_table_path(table["path"])
-        col_specs: list[_WalkSpec] = []
-        for col in table.get("columns", []) or []:
-            if not col.get("selected"):
-                continue
-            locating, leaf = parse_column_path_full(col["path"])
-            col_specs.append((col["name"], leaf, col.get("type", "str"), array_depth(locating)))
-        _reject_reserved_leaf_collision(table["label"], array_depth(segments), col_specs)
-        emit_tables.append((table["label"], segments, col_specs))
+    emit_tables = [(spec.label, spec.segments, list(spec.columns)) for spec in table_specs]
 
     # Group tables by their full-segment position — the place the walk emits.
     tables_by_pos: dict[tuple[PathSeg, ...], list[tuple[str, list[_WalkSpec]]]] = {}
@@ -795,6 +871,47 @@ def shred_to_buffers(
     return buffers
 
 
+def _shred_data_file(
+    data_path: Path,
+    v2_config: dict[str, Any],
+    table_specs: tuple[_EmittingTableSpec, ...],
+) -> tuple[dict[str, list[dict[str, Any]]], ShredSkipStats]:
+    """Shred one source file with shared skip accounting and conservation."""
+    skip_stats = ShredSkipStats()
+    record_count = 0
+
+    def _counted_records() -> Iterator[dict[str, Any]]:
+        nonlocal record_count
+        for record in _iter_records(data_path, stats=skip_stats):
+            record_count += 1
+            yield record
+
+    buffers = shred_to_buffers(
+        _counted_records(),
+        v2_config,
+        stats=skip_stats,
+        _table_specs=table_specs,
+    )
+
+    # Every object record contributes exactly one row to each emitting root
+    # table, or is explicitly counted as a shape mismatch. Keep this invariant
+    # on both cache builds and direct runtime materialisation.
+    for table_spec in table_specs:
+        if table_spec.segments:
+            continue
+        emitted = len(buffers.get(table_spec.label, []))
+        skipped = skip_stats.skipped_rows_by_table.get(table_spec.label, 0)
+        if emitted + skipped != record_count:
+            raise RuntimeError(
+                "json shred conservation violation for root table "
+                f"{table_spec.label!r}: {emitted} emitted + {skipped} skipped "
+                f"!= {record_count} records read â€” a row was lost or "
+                "duplicated without accounting",
+            )
+
+    return buffers, skip_stats
+
+
 # ---------------------------------------------------------------------------
 # Frame construction and write
 # ---------------------------------------------------------------------------
@@ -810,6 +927,169 @@ _POLARS_TYPE_MAP: dict[ColumnType, type[pl.DataType]] = {
     "bool": pl.Boolean,
     "date": pl.Date,
 }
+
+
+def _declared_frame_schema(table_spec: _EmittingTableSpec) -> pl.Schema:
+    """Return the exact selected-column schema a cache frame must expose."""
+    return pl.Schema(
+        {
+            name: _POLARS_TYPE_MAP[cast(ColumnType, type_token)]
+            for name, _leaf, type_token, _depth in table_spec.columns
+        },
+    )
+
+
+@dataclass(frozen=True)
+class _CacheProbeFailure:
+    reason: str
+    label: str | None = None
+    expected_schema: pl.Schema | None = None
+    actual_schema: pl.Schema | None = None
+
+
+def _cache_manifest_structure_failure(
+    meta: dict[str, Any],
+    *,
+    expected_labels: tuple[str, ...] | None = None,
+) -> _CacheProbeFailure | None:
+    """Validate signed table entries and their derived parquet names.
+
+    Manifest ``parquet`` values are checked for consistency but never trusted
+    as paths: every artifact name is derived from its validated table label.
+    Missing, extra, duplicate, or legacy-unsigned entries make the candidate
+    unusable. Artifact bytes are deliberately checked by the caller: runtime
+    probes must verify the exact payload they subsequently hand to Polars.
+    """
+    raw_tables = meta.get("tables")
+    if not isinstance(raw_tables, list):
+        return _CacheProbeFailure("malformed_manifest")
+
+    entries_by_label: dict[str, dict[str, Any]] = {}
+    seen_casefolded: set[str] = set()
+    for raw_entry in raw_tables:
+        if not isinstance(raw_entry, dict):
+            return _CacheProbeFailure("malformed_manifest")
+        label = raw_entry.get("label")
+        if not isinstance(label, str) or not label:
+            return _CacheProbeFailure("malformed_manifest")
+        folded = label.casefold()
+        if folded in seen_casefolded:
+            return _CacheProbeFailure("duplicate_manifest_table", label=label)
+        seen_casefolded.add(folded)
+        entries_by_label[label] = raw_entry
+
+    if expected_labels is not None:
+        expected_set = set(expected_labels)
+        actual_set = set(entries_by_label)
+        if actual_set != expected_set:
+            missing = next((label for label in expected_labels if label not in actual_set), None)
+            extra = next((label for label in entries_by_label if label not in expected_set), None)
+            return _CacheProbeFailure("manifest_table_mismatch", label=missing or extra)
+
+    for label, entry in entries_by_label.items():
+        signature = entry.get("content_signature")
+        signature_parts = _content_signature_parts(signature)
+        if signature_parts is None:
+            return _CacheProbeFailure("missing_content_signature", label=label)
+        filename = f"{_sanitise_label(label)}.parquet"
+        if entry.get("parquet") != filename:
+            return _CacheProbeFailure("manifest_parquet_name_mismatch", label=label)
+    return None
+
+
+def _cache_manifest_failure(
+    cache_dir: Path,
+    meta: dict[str, Any],
+    *,
+    expected_labels: tuple[str, ...] | None = None,
+) -> _CacheProbeFailure | None:
+    """Validate one manifest and every path-backed artifact it signs."""
+    structure_failure = _cache_manifest_structure_failure(
+        meta,
+        expected_labels=expected_labels,
+    )
+    if structure_failure is not None:
+        return structure_failure
+
+    for entry in meta["tables"]:
+        label = entry["label"]
+        signature = entry["content_signature"]
+        signature_parts = _content_signature_parts(signature)
+        assert signature_parts is not None
+        parquet_path = cache_dir / f"{_sanitise_label(label)}.parquet"
+        if not parquet_path.exists():
+            return _CacheProbeFailure("missing_frame", label=label)
+        if not _file_content_matches(signature, parquet_path):
+            return _CacheProbeFailure("content_signature_mismatch", label=label)
+    return None
+
+
+def _cache_manifest_files_match(cache_dir: Path, meta: dict[str, Any]) -> bool:
+    """Return whether a self-contained cache manifest matches its artifacts."""
+    return _cache_manifest_failure(cache_dir, meta) is None
+
+
+def _probe_cache_bundle(
+    cache_dir: Path,
+    table_specs: tuple[_EmittingTableSpec, ...],
+    meta: dict[str, Any],
+) -> tuple[dict[str, pl.LazyFrame], _CacheProbeFailure | None]:
+    """Load cache frames whose name→dtype mappings match current specs.
+
+    Physical parquet column order is deliberately irrelevant to the schema
+    fingerprint. Each accepted lazy frame is projected into the current editor
+    order, preserving that invariant without allowing missing/extra/renamed or
+    differently typed columns through the fast path.
+
+    Each parquet is physically read exactly once. Its signature is verified
+    over that exact compressed payload and the same bytes are handed to Polars
+    via :class:`io.BytesIO`. This closes the hash-then-reopen race while keeping
+    parquet decoding and projection lazy. Polars retains the compressed source
+    in the logical plan, so the frame and its clones are independent of later
+    rebuilds, mirrors, or explicit cache deletion. Memory usage is bounded by
+    compressed sources belonging to live LazyFrames rather than an ever-growing
+    set of on-disk generations.
+    """
+    manifest_failure = _cache_manifest_structure_failure(
+        meta,
+        expected_labels=tuple(spec.label for spec in table_specs),
+    )
+    if manifest_failure is not None:
+        return {}, manifest_failure
+
+    bundle: dict[str, pl.LazyFrame] = {}
+    manifest_entries = {entry["label"]: entry for entry in meta["tables"]}
+    for table_spec in table_specs:
+        expected_schema = _declared_frame_schema(table_spec)
+        entry = manifest_entries[table_spec.label]
+        signature_parts = _content_signature_parts(entry["content_signature"])
+        assert signature_parts is not None
+        parquet_path = cache_dir / f"{_sanitise_label(table_spec.label)}.parquet"
+        try:
+            payload = parquet_path.read_bytes()
+        except FileNotFoundError:
+            return bundle, _CacheProbeFailure(
+                "missing_frame",
+                label=table_spec.label,
+                expected_schema=expected_schema,
+            )
+        if not _payload_content_matches(entry["content_signature"], payload):
+            return bundle, _CacheProbeFailure(
+                "content_signature_mismatch",
+                label=table_spec.label,
+                expected_schema=expected_schema,
+            )
+        frame = pl.scan_parquet(io.BytesIO(payload))
+        actual_schema = frame.collect_schema()
+        if dict(actual_schema.items()) != dict(expected_schema.items()):
+            return bundle, _CacheProbeFailure(
+                "schema_mismatch",
+                label=table_spec.label,
+                expected_schema=expected_schema,
+                actual_schema=actual_schema,
+            )
+        bundle[table_spec.label] = frame.select(expected_schema.names())
+    return bundle, None
 
 
 def _buffer_to_frame(
@@ -900,7 +1180,8 @@ def build_per_port_cache(
     layer to target.
 
     Returns a summary dict with ``schema_mode``, ``schema_fingerprint``,
-    ``tables`` (per-port row/column counts + on-disk parquet paths),
+    ``tables`` (per-port row/column counts, derived parquet names, and
+    size/SHA-256 content signatures),
     ``data_file`` (the data-file signature validity checks against — W2
     item 2.4), and ``skipped`` (counts of shape-mismatched inputs dropped
     during the shred — W2 item 2.7). Also writes ``meta.json`` into
@@ -908,22 +1189,23 @@ def build_per_port_cache(
     need to re-shred to know what's there.
 
     The build is **serialized** per cache directory (a concurrent build of
-    the same cache waits) and **atomic**: everything is written into a
-    sibling temp directory which is swapped into place only once complete,
-    so a failed or interrupted build can never corrupt a previously valid
-    cache or leave a half-written one (W2 item 2.6).
+    the same cache waits) and **atomic**: one complete generation is written
+    into a sibling staging directory and swapped into place only after every
+    parquet and ``meta.json`` is materialised. Runtime LazyFrames snapshot the
+    verified compressed bytes, so replacing this sole on-disk generation does
+    not change already-returned plans (W2 item 2.6).
     """
     dp = Path(data_path)
     cd = Path(cache_dir)
 
-    validate_v2_schema(v2_config)
+    table_specs = _emitting_table_specs(v2_config)
 
     with _build_lock_for(cd):
         # No-op trapdoor: if the existing meta.json's fingerprint matches the
-        # current v2 schema, the recorded data-file signature still matches
-        # the file on disk, AND all expected per-port parquets exist, skip
-        # the rebuild entirely. Repeated cache-button clicks then don't churn
-        # the preview cache via commit 1's mtime-in-fingerprint invalidation.
+        # current v2 schema, the recorded source signature still matches, and
+        # every expected parquet matches its signed manifest entry and footer
+        # schema, skip the rebuild entirely. Repeated cache-button clicks then
+        # don't churn the preview cache.
         if is_per_port_cache_valid(cd, v2_config, data_path=dp):
             existing_meta = read_per_port_cache_meta(cd)
             if existing_meta is not None:
@@ -949,63 +1231,22 @@ def build_per_port_cache(
         # rather than being masked.
         data_file_sig = _data_file_signature(dp)
 
-        # Re-parse table-paths + columns so we can stream-write per-port
-        # parquets immediately after the shred. Same emitting predicate as
-        # the shred, validity and load (W2 item 2.5).
-        emit_tables: list[tuple[str, list[_LeafSpec]]] = []
-        for table in v2_config["tables"]:
-            if not table_is_emitting(table):
-                continue
-            col_specs: list[_LeafSpec] = []
-            for col in table.get("columns", []) or []:
-                if not col.get("selected"):
-                    continue
-                leaf = parse_column_path(col["path"], table["path"])
-                col_specs.append((col["name"], leaf, col.get("type", "str")))
-            emit_tables.append((table["label"], col_specs))
+        # The shared parsed specs drive both walking and frame construction;
+        # cache builds and direct runtime loads therefore have one selected-
+        # column/name/type/path contract.
+        emit_tables = [(spec.label, spec.leaf_specs) for spec in table_specs]
 
         # Shred — single pass, with skip accounting (W2 item 2.7). The record
         # iterator is consumed directly (not materialised into a list) so the
         # build doesn't hold a full extra Python-object copy of the file
-        # alongside the row buffers (W1). A tiny wrapper counts the object
-        # records as they flow through so the conservation assertion below can
-        # cross-check that no row silently vanished.
-        skip_stats = ShredSkipStats()
-        record_count = 0
+        # alongside the row buffers (W1). The shared file-shred helper counts
+        # object records and asserts root conservation for cache and direct
+        # materialisation alike.
+        buffers, skip_stats = _shred_data_file(dp, v2_config, table_specs)
 
-        def _counted_records() -> Iterator[dict[str, Any]]:
-            nonlocal record_count
-            for rec in _iter_records(dp, stats=skip_stats):
-                record_count += 1
-                yield rec
-
-        buffers = shred_to_buffers(_counted_records(), v2_config, stats=skip_stats)
-
-        # Conservation assertion (W1): at the ROOT array level, every object
-        # record contributes EXACTLY one row to each emitting root table, or is
-        # counted as a shape-mismatch skip for it — never both, never neither.
-        # A violation means a row vanished (or duplicated) without accounting,
-        # i.e. a shred bug; fail loud rather than write a cache that silently
-        # lost data. (Non-object top-level inputs are counted separately in
-        # ``skipped_records`` and are not yielded, so they don't enter this sum.)
-        for table in v2_config["tables"]:  # pragma: no mutate
-            if not table_is_emitting(table) or parse_table_path(table["path"]) != ():
-                continue  # pragma: no mutate
-            root_label = table["label"]
-            emitted = len(buffers.get(root_label, []))
-            skipped_here = skip_stats.skipped_rows_by_table.get(root_label, 0)
-            if emitted + skipped_here != record_count:
-                raise RuntimeError(
-                    "json shred conservation violation for root table "
-                    f"{root_label!r}: {emitted} emitted + {skipped_here} skipped "
-                    f"!= {record_count} records read — a row was lost or "
-                    "duplicated without accounting",
-                )
-
-        # Write per-port parquets + meta into a sibling temp dir, then swap
-        # it into place. Unique temp names prevent staging-dir collisions
-        # across xdist/CLI processes; the live-dir swap itself remains the
-        # atomic publish boundary.
+        # Fully materialise one generation in a sibling staging directory,
+        # then atomically swap the directory into place. Unique temp names
+        # prevent collisions across xdist/CLI processes.
         import pyarrow.parquet as pq  # local — keeps top-of-module import surface small
 
         fingerprint = _v2_fingerprint(v2_config)
@@ -1030,12 +1271,14 @@ def build_per_port_cache(
                     _per_frame_metadata(label, col_specs),
                 )
                 pq.write_table(arrow_tbl, parquet_path, compression="zstd")
+                content_signature = _file_content_signature(parquet_path)
                 table_summaries.append(
                     {
                         "label": label,
                         "parquet": parquet_path.name,
                         "row_count": frame.height,
                         "column_count": frame.width,
+                        "content_signature": content_signature,
                     },
                 )
 
@@ -1119,50 +1362,110 @@ def load_per_port_cache(
     cache_dir: str | Path,  # pragma: no mutate
     v2_config: dict[str, Any],
 ) -> dict[str, pl.LazyFrame]:
-    """Scan the per-port parquets in *cache_dir* for each emitting table.
+    """Return the complete signed snapshot bundle selected by ``meta.json``.
 
-    "Emitting" is the shared :func:`table_is_emitting` predicate (emit AND
-    ≥1 selected column) — exactly the set of parquets the build writes.
-    Returns ``{table_label: LazyFrame}``. A missing parquet (e.g. a table
-    that was emitting at build time but is now disabled) is skipped — the
-    caller is expected to validate cache freshness via
-    :func:`is_per_port_cache_valid` before this.
+    "Emitting" uses the shared :func:`table_is_emitting` predicate (emit and
+    at least one selected column), exactly the set the build writes. Every
+    label-derived artifact must exist, match its signature, and expose the
+    declared schema. The exact verified compressed bytes seed the returned
+    in-memory LazyFrames; a missing or mismatched member rejects the whole
+    bundle and returns ``{}`` rather than serving a partial generation.
+
+    Callers needing source-file freshness must additionally use
+    :func:`is_per_port_cache_valid` or :func:`load_v2_api_source`.
     """
     cd = Path(cache_dir)
-    out: dict[str, pl.LazyFrame] = {}
-    for table in v2_config.get("tables", []) or []:
-        if not table_is_emitting(table):
-            continue
-        label = table.get("label")
-        if not isinstance(label, str):
-            continue
-        parquet_path = cd / f"{_sanitise_label(label)}.parquet"
-        if parquet_path.exists():
-            out[label] = pl.scan_parquet(parquet_path)
-    return out
+    table_specs = _emitting_table_specs(v2_config)
+    meta = read_per_port_cache_meta(cd)
+    if (
+        meta is None
+        or meta.get("schema_mode") != "v2"
+        or meta.get("schema_fingerprint") != _v2_fingerprint(v2_config)
+    ):
+        return {}
+    try:
+        bundle, failure = _probe_cache_bundle(
+            cd,
+            table_specs,
+            meta,
+        )
+    except (OSError, pl.exceptions.PolarsError):
+        return {}
+    return bundle if failure is None else {}
+
+
+def _cache_meta_matches_config_and_source(
+    meta: dict[str, Any],
+    v2_config: dict[str, Any],
+    *,
+    data_path: str | Path,
+) -> bool:
+    """Return whether captured metadata identifies this schema and source."""
+    if meta.get("schema_mode") != "v2":
+        return False
+    try:
+        expected_fingerprint = _v2_fingerprint(v2_config)
+    except ApiInputSchemaError:
+        # Preserve the bool contract for status/save callers that probe a
+        # malformed in-memory config. Build and load boundaries validate loud.
+        return False
+    return (
+        meta.get("schema_fingerprint") == expected_fingerprint
+        and _data_file_matches(meta.get("data_file"), Path(data_path))
+    )
+
+
+def _read_matching_cache_meta(
+    cache_dir: str | Path,
+    v2_config: dict[str, Any],
+    *,
+    data_path: str | Path,
+) -> dict[str, Any] | None:
+    """Read metadata once and return it when schema/source identity matches.
+
+    This deliberately does not touch parquet files. Runtime and public
+    validity pass the returned object into the same signed-artifact/footer
+    probe, avoiding a second ``meta.json`` read and validation drift.
+    """
+    cd = Path(cache_dir)
+    meta_path = cd / _META_FILENAME
+    if not meta_path.exists():
+        return None
+    try:
+        meta = orjson.loads(meta_path.read_bytes())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    if not _cache_meta_matches_config_and_source(
+        meta,
+        v2_config,
+        data_path=data_path,
+    ):
+        return None
+    return meta
 
 
 def load_v2_api_source(
     data_path: str,
     config: dict[str, Any],
 ) -> dict[str, pl.LazyFrame]:  # pragma: no mutate
-    """Resolve a v2 apiInput's per-port cache and return its frame(s).
+    """Load a v2 apiInput as an emit-gated per-port frame bundle.
 
     The single runtime entry point shared by the executor's source builder
     (:func:`haute._builders._make_api_source_v2`) and the generated/deploy
     code (:func:`haute._codegen_builders._api_input_template`), so the two
-    can't drift. Assumes *config* has already passed :func:`validate_v2_schema`
-    (both callers validate first — at build time and at module import
-    respectively).
+    can't drift. Validates *config* itself so direct callers receive the same
+    typed schema errors as the executor and generated module boundaries.
 
     Behaviour:
 
     - 0 emit-true tables → ``RuntimeError`` (tick an ``emit`` toggle).
     - emit-true tables but none with a selected column → ``RuntimeError``.
-    - resolves the dual-cache ``working/`` layer, falling back to
-      ``committed/`` (the deploy / fresh-server case); a missing/stale cache
-      (schema fingerprint OR data-file signature mismatch) raises the
-      "click Cache as Parquet" message.
+    - prefers a valid, readable, schema-matching ``working/`` parquet cache,
+      then ``committed/`` (the deploy / fresh-server case).
+    - when neither cache can serve the current schema and source signature,
+      shreds JSON/JSONL directly for this run without writing cache state.
     - 1+ emitting labels → a ``dict[port_label, LazyFrame]`` in schema order.
 
     Frame resolution uses the shared :func:`table_is_emitting` predicate, so
@@ -1171,39 +1474,97 @@ def load_v2_api_source(
     """
     from haute._json_flatten import _json_cache_dir
 
-    tables = config.get("tables", []) or []
+    table_specs = _emitting_table_specs(config)
+    tables = config["tables"]
     emit_true_tables = [t for t in tables if t.get("emit")]
     if not emit_true_tables:
         raise RuntimeError(
             "API Input has no emitting tables. Open the node, tick the 'emit' "
-            "toggle on at least one table, then click 'Cache as Parquet' before "
-            "previewing.",
+            "toggle on at least one table, then preview again.",
         )
-    emit_labels = [t["label"] for t in emit_true_tables if table_is_emitting(t)]
+    emit_labels = [spec.label for spec in table_specs]
     if not emit_labels:
         labels = [t["label"] for t in emit_true_tables]
         raise RuntimeError(
             "API Input has emit-true tables but none has any selected columns. "
             f"Open the node and tick at least one column on the emitting "
-            f"table(s): {labels}. Then click 'Cache as Parquet' before previewing.",
+            f"table(s): {labels}, then preview again.",
         )
-    cache_dir = _json_cache_dir(data_path, "working")
-    if not is_per_port_cache_valid(cache_dir, config, data_path=data_path):
-        # Fall back to the committed layer (deploy / fresh-server case).
-        cache_dir = _json_cache_dir(data_path, "committed")
-        if not is_per_port_cache_valid(cache_dir, config, data_path=data_path):
-            raise RuntimeError(_STALE_CACHE_MESSAGE)
-    bundle = load_per_port_cache(cache_dir, config)
-    missing_labels = [label for label in emit_labels if label not in bundle]
-    if missing_labels:
-        raise RuntimeError(
-            "API Input cache changed while it was being loaded; missing parquet "
-            f"frame(s): {missing_labels}. {_STALE_CACHE_MESSAGE}",
+    # A valid parquet cache is an optimization, not a runtime prerequisite.
+    # Prefer the user's current working cache, then the saved/deployable
+    # committed cache. If either disappears between validation and scanning,
+    # continue to the next candidate rather than restoring the old hard cache
+    # dependency.
+    for layer in ("working", "committed"):
+        cache_dir = _json_cache_dir(data_path, layer)
+        cache_meta = _read_matching_cache_meta(
+            cache_dir,
+            config,
+            data_path=data_path,
         )
-    # Preserve schema order so executor logs/errors are deterministic.  A
-    # one-frame source deliberately has the same bundle shape as a multi-frame
-    # source; downstream routing always selects by the edge's source handle.
-    return {label: bundle[label] for label in emit_labels}
+        if cache_meta is None:
+            continue
+        try:
+            bundle, probe_failure = _probe_cache_bundle(
+                cache_dir,
+                table_specs,
+                cache_meta,
+            )
+        except (OSError, pl.exceptions.PolarsError) as exc:
+            logger.warning(
+                "json_shred_cache_candidate_rejected",
+                data_path=data_path,
+                cache_dir=str(cache_dir),
+                layer=layer,
+                reason="unreadable_parquet",
+                error_type=type(exc).__name__,
+            )
+            continue
+        if probe_failure is not None:
+            logger.warning(
+                "json_shred_cache_candidate_rejected",
+                data_path=data_path,
+                cache_dir=str(cache_dir),
+                layer=layer,
+                reason=probe_failure.reason,
+                label=probe_failure.label,
+                expected_schema=(
+                    str(probe_failure.expected_schema)
+                    if probe_failure.expected_schema is not None
+                    else None
+                ),
+                actual_schema=(
+                    str(probe_failure.actual_schema)
+                    if probe_failure.actual_schema is not None
+                    else None
+                ),
+            )
+            continue
+        return {label: bundle[label] for label in emit_labels}
+
+    # Neither cache can serve the current post-schema shape. Shred the source
+    # for this execution only; do not write, refresh, or promote cache state.
+    buffers, skip_stats = _shred_data_file(Path(data_path), config, table_specs)
+    direct_bundle = {
+        table_spec.label: _buffer_to_frame(
+            buffers.get(table_spec.label, []),
+            table_spec.leaf_specs,
+        ).lazy()
+        for table_spec in table_specs
+    }
+    if skip_stats.total:
+        logger.warning(
+            "json_shred_direct_records_skipped",
+            data_path=data_path,
+            skipped_records=skip_stats.skipped_records,
+            skipped_rows_by_table=skip_stats.skipped_rows_by_table,
+        )
+    logger.info(
+        "json_shred_loaded_direct",
+        data_path=data_path,
+        table_count=len(table_specs),
+    )
+    return direct_bundle
 
 
 def is_per_port_cache_valid(
@@ -1212,11 +1573,14 @@ def is_per_port_cache_valid(
     *,  # pragma: no mutate
     data_path: str | Path,  # pragma: no mutate
 ) -> bool:
-    """Cheap validity check: meta.json's fingerprint matches the v2 schema,
-    the recorded data-file signature still matches *data_path* on disk
-    (W2 item 2.4 — an edited data file means the cached rows are stale),
-    AND a parquet exists for every emitting table (shared
-    :func:`table_is_emitting` predicate — W2 item 2.5).
+    """Return whether a complete, readable cache can serve the current input.
+
+    ``meta.json`` must match the v2 schema fingerprint and recorded source-file
+    signature (W2 item 2.4). Every emitting table must have exactly one signed
+    manifest entry whose derived parquet matches its size/SHA-256, then expose
+    the exact declared name-to-Polars-dtype mapping. Physical parquet column
+    order does not affect validity; accepted frames are projected into current
+    editor order by :func:`_probe_cache_bundle` at load time.
 
     The data-file check ALWAYS verifies the recorded content hash: ``size``
     is only a cheap pre-reject (a size mismatch is stale without hashing),
@@ -1224,46 +1588,23 @@ def is_per_port_cache_valid(
     same-mtime byte-changing rewrite as fresh (matching
     :func:`_data_file_matches`). The committed-layer deploy fallback still
     survives file copies because the hash matches when only the mtime moved.
-    A meta without a recorded signature (pre-W2 cache) is stale by
+    A meta without a recorded source or per-parquet signature is stale by
     construction — one-time invalidation on upgrade.
     """
+    cache_meta = _read_matching_cache_meta(
+        cache_dir,
+        v2_config,
+        data_path=data_path,
+    )
+    if cache_meta is None:
+        return False
     cd = Path(cache_dir)
-    meta_path = cd / _META_FILENAME
-    if not meta_path.exists():
-        return False
     try:
-        meta = orjson.loads(meta_path.read_bytes())
-    except (OSError, ValueError):
+        table_specs = _emitting_table_specs(v2_config)
+        _bundle, probe_failure = _probe_cache_bundle(cd, table_specs, cache_meta)
+    except (ApiInputSchemaError, OSError, pl.exceptions.PolarsError):
         return False
-    if not isinstance(meta, dict):
-        return False
-    if meta.get("schema_mode") != "v2":
-        return False
-    try:
-        expected_fingerprint = _v2_fingerprint(v2_config)
-    except ApiInputSchemaError:
-        # A config so malformed it can't even be fingerprinted (a non-dict
-        # table/column) cannot match a validly-built cache — treat it as
-        # stale/invalid, never fresh. This keeps the predicate's bool contract
-        # for direct validity probes on unvalidated on-disk configs (e.g.
-        # GET /status), while _v2_fingerprint itself still fails loud so no two
-        # distinct malformed configs silently collapse to one fingerprint. The
-        # build path validates the schema before it ever reaches here.
-        return False
-    if meta.get("schema_fingerprint") != expected_fingerprint:
-        return False
-    if not _data_file_matches(meta.get("data_file"), Path(data_path)):
-        return False
-    for table in v2_config.get("tables", []) or []:
-        if not table_is_emitting(table):
-            continue
-        label = table.get("label")
-        if not isinstance(label, str):
-            return False
-        parquet_path = cd / f"{_sanitise_label(label)}.parquet"
-        if not parquet_path.exists():
-            return False
-    return True
+    return probe_failure is None
 
 
 def _infer_type(value: Any) -> str:

--- a/src/haute/chunking.py
+++ b/src/haute/chunking.py
@@ -25,7 +25,7 @@ from haute._execution_context import ExecutionProfile
 from haute._io import read_data_source
 from haute._logging import get_logger
 from haute._polars_utils import DEFAULT_STREAMING_CHUNK_SIZE, streaming_collect
-from haute._types import GraphNode, NodeType, PipelineGraph
+from haute._types import GraphEdge, GraphNode, NodeType, PipelineGraph
 from haute.errors import ChunkPlanUnsupportedError, ContractMismatchError
 from haute.execution import plan_prepared_execution_strategy
 from haute.projection import _children_of, prepare_graph
@@ -1075,6 +1075,12 @@ def iter_chunked_frames(request: ChunkRunnerRequest) -> Iterator[ChunkBatch]:
         for node_id, capability in plan.capabilities.items()
         if capability.model_reuse_lifetime == "batch"
     }
+    incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in prepared.relevant_edges:
+        incoming_edges_by_target.setdefault(edge.target, []).append(edge)
+    all_incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in graph.edges:
+        all_incoming_edges_by_target.setdefault(edge.target, []).append(edge)
     funcs = _build_funcs(
         list(plan.node_ids),
         node_map,
@@ -1082,6 +1088,9 @@ def iter_chunked_frames(request: ChunkRunnerRequest) -> Iterator[ChunkBatch]:
         prepared.id_to_name,
         graph.parents_of,
         request.build_node_fn,
+        incoming_edges_by_target=incoming_edges_by_target,
+        all_incoming_edges_by_target=all_incoming_edges_by_target,
+        all_node_map=graph.node_map,
         preamble_ns=request.preamble_ns,
         source="live",
         required_output_columns_by_node=builder_required,

--- a/src/haute/codegen.py
+++ b/src/haute/codegen.py
@@ -31,7 +31,12 @@ from haute._edge_join import (
     resolve_edge_join_role_indices,
 )
 from haute._graph_shape import validate_pipeline_graph_shape_contracts
-from haute._graph_utils import _sanitize_func_name, build_instance_mapping
+from haute._graph_utils import (
+    _sanitize_func_name,
+    build_instance_mapping,
+    duplicate_input_names,
+    edge_input_name,
+)
 from haute._logging import get_logger
 from haute._registry import NODE_REGISTRY
 from haute._topo import topo_sort_ids
@@ -334,6 +339,7 @@ def _node_to_code(
     node: GraphNode,
     source_names: list[str] | None = None,
     source_ids: list[str] | None = None,
+    source_func_names: list[str] | None = None,
 ) -> str:
     """Generate code for a single node.
 
@@ -348,9 +354,40 @@ def _node_to_code(
     if source_ids is None:
         source_ids = []
 
+    original_source_ids = source_ids
     source_names, source_ids = _role_order_node_sources(node, source_names, source_ids)
+    if source_func_names is not None:
+        source_func_names, _ = _role_order_node_sources(
+            node,
+            source_func_names,
+            original_source_ids,
+        )
 
     code = _generate_node_code(node, source_names)
+
+    # Edge-join role metadata identifies the connected source functions so
+    # the parser can reconstruct the graph.  The function parameters above
+    # are intentionally the edge-derived input names (an apiInput frame is a
+    # frame label), so keep those names in the signature/body while emitting
+    # source-function names in the role kwargs.
+    if node.data.nodeType == NodeType.EDGE_JOIN and source_func_names is not None:
+        if len(source_func_names) != 2 or len(source_names) != 2:
+            raise ParseError(
+                "edgeJoin codegen source function names and input names are out of sync.",
+                node_id=node.id,
+                node_label=node.data.label,
+                source_names=source_names,
+                source_func_names=source_func_names,
+            )
+        code = code.replace(
+            f"base_input={_safe_str(source_names[0])}",
+            f"base_input={_safe_str(source_func_names[0])}",
+            1,
+        ).replace(
+            f"join_input={_safe_str(source_names[1])}",
+            f"join_input={_safe_str(source_func_names[1])}",
+            1,
+        )
 
     node_type = node.data.nodeType
     if has_config_folder(node_type):
@@ -564,24 +601,57 @@ def _error_on_name_collisions(labels: list[str]) -> None:
     )
 
 
-def _build_node_sources(
+def _edge_input_name_for_codegen(edge: GraphEdge, source_node: GraphNode) -> str:
+    """Derive one emitted parameter name from an incoming graph edge.
+
+    ``edge_input_name`` is the single source of truth shared with execution.
+    Codegen adds the parser-facing error context for the one malformed graph
+    state that the editor cannot create: an apiInput edge without a frame
+    handle.
+    """
+    if source_node.data.nodeType == NodeType.API_INPUT and not edge.sourceHandle:
+        raise ParseError(
+            "apiInput edge has no source_port/sourceHandle.",
+            edge_id=edge.id,
+            source_node=source_node.id,
+            source_node_label=source_node.data.label,
+        )
+    return edge_input_name(edge, source_node)
+
+
+def _build_node_input_metadata(
     edges: list[GraphEdge],
-    id_to_func: dict[str, str],
-) -> dict[str, list[str]]:
-    """Map target node ID -> list of source function names."""
-    sources: dict[str, list[str]] = {}
+    source_nodes: dict[str, GraphNode],
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Build per-target input names and source IDs in edge declaration order."""
+    names_by_target: dict[str, list[str]] = {}
+    ids_by_target: dict[str, list[str]] = {}
     for edge in edges:
-        src_name = id_to_func.get(edge.source, edge.source)
-        sources.setdefault(edge.target, []).append(src_name)
-    return sources
+        source_node = source_nodes[edge.source]
+        names_by_target.setdefault(edge.target, []).append(
+            _edge_input_name_for_codegen(edge, source_node)
+        )
+        ids_by_target.setdefault(edge.target, []).append(edge.source)
+    return names_by_target, ids_by_target
 
 
-def _build_node_source_ids(edges: list[GraphEdge]) -> dict[str, list[str]]:
-    """Map target node ID -> list of source node IDs in edge order."""
-    sources: dict[str, list[str]] = {}
-    for edge in edges:
-        sources.setdefault(edge.target, []).append(edge.source)
-    return sources
+def _validate_duplicate_node_inputs(
+    node_sources: dict[str, list[str]],
+    target_nodes: dict[str, GraphNode],
+) -> None:
+    """Reject ambiguous per-edge parameters before any builder is called."""
+    for target_id, names in node_sources.items():
+        duplicates = duplicate_input_names(names)
+        if not duplicates:
+            continue
+        target_node = target_nodes[target_id]
+        raise ParseError(
+            "Duplicate derived input name for one node.",
+            node_id=target_node.id,
+            node_label=target_node.data.label,
+            input_name=duplicates[0],
+            duplicate_names=duplicates,
+        )
 
 
 def _order_edge_join_incoming_edges(
@@ -630,7 +700,10 @@ def _build_instance_of_map(sorted_nodes: list[GraphNode]) -> dict[str, str]:
 
 
 #: Type alias for a function that generates code for a single node.
-_NodeCodeFn = Callable[[GraphNode, list[str] | None, list[str] | None], str]
+_NodeCodeFn = Callable[
+    [GraphNode, list[str] | None, list[str] | None, list[str] | None],
+    str,
+]
 _ConnectPair = tuple[str, str, str | None, str | None]
 
 
@@ -644,6 +717,7 @@ def _generate_pipeline_lines(
     id_to_func: dict[str, str],
     node_sources: dict[str, list[str]],
     connect_pairs: list[_ConnectPair],
+    node_source_func_names: dict[str, list[str]] | None = None,
     node_source_ids: dict[str, list[str]] | None = None,
     preserved_blocks: list[str] | None = None,
     submodel_imports: list[str] | None = None,
@@ -707,7 +781,8 @@ def _generate_pipeline_lines(
     for node in originals:
         srcs = node_sources.get(node.id, [])
         src_ids = (node_source_ids or {}).get(node.id, [])
-        lines.append(node_to_code_fn(node, srcs, src_ids))
+        src_func_names = (node_source_func_names or {}).get(node.id, [])
+        lines.append(node_to_code_fn(node, srcs, src_ids, src_func_names))
         lines.append("")
 
     for node in instances:
@@ -851,13 +926,19 @@ def _submodel_node_to_code(
     node: GraphNode,
     source_names: list[str] | None = None,
     source_ids: list[str] | None = None,
+    source_func_names: list[str] | None = None,
 ) -> str:
     """Generate code for a single node inside a submodel file.
 
     Identical to ``_node_to_code`` but uses ``@submodel.<type>`` instead of
     ``@pipeline.<type>``.
     """
-    code = _node_to_code(node, source_names=source_names, source_ids=source_ids)
+    code = _node_to_code(
+        node,
+        source_names=source_names,
+        source_ids=source_ids,
+        source_func_names=source_func_names,
+    )
     code = code.replace("@pipeline.", "@submodel.", 1)
     if node.data.nodeType == NodeType.EDGE_JOIN:
         code = code.replace("pipeline._apply_edge_join(", "submodel._apply_edge_join(")
@@ -907,8 +988,12 @@ def graph_to_code_multi(
         sorted_nodes = _topo_sort(nodes, edges)
 
         id_to_func = _build_id_to_func(sorted_nodes)
-        node_sources = _build_node_sources(edges, id_to_func)
-        node_source_ids = _build_node_source_ids(edges)
+        node_sources, node_source_ids = _build_node_input_metadata(edges, node_map)
+        _validate_duplicate_node_inputs(node_sources, node_map)
+        node_source_func_names = {
+            target_id: [id_to_func[source_id] for source_id in source_ids]
+            for target_id, source_ids in node_source_ids.items()
+        }
 
         all_preserved = preserved_blocks if preserved_blocks is not None else graph.preserved_blocks
 
@@ -934,6 +1019,7 @@ def graph_to_code_multi(
             id_to_func=id_to_func,
             node_sources=node_sources,
             connect_pairs=connect_pairs,
+            node_source_func_names=node_source_func_names,
             node_source_ids=node_source_ids,
             preserved_blocks=all_preserved or None,
             node_to_code_fn=_node_to_code,
@@ -981,8 +1067,11 @@ def graph_to_code_multi(
 
         sorted_sm_nodes = _topo_sort(sm_nodes, sm_edges)
         sm_id_to_func = _build_id_to_func(sorted_sm_nodes)
-        sm_node_sources = _build_node_sources(sm_edges, sm_id_to_func)
-        sm_node_source_ids = _build_node_source_ids(sm_edges)
+        sm_node_sources, sm_node_source_ids = _build_node_input_metadata(sm_edges, sm_node_map)
+        sm_node_source_func_names = {
+            target_id: [sm_id_to_func[source_id] for source_id in source_ids]
+            for target_id, source_ids in sm_node_source_ids.items()
+        }
 
         # Also include cross-boundary inputs from parent graph edges.
         # Every edge targeting the submodel placeholder must carry a valid
@@ -1016,12 +1105,15 @@ def graph_to_code_multi(
                     submodel=sm_name,
                     known_children=sorted(sm_child_ids),
                 )
-            src_name = root_id_to_func.get(edge.source, _sanitize_func_name(edge.source))
+            src_name = _edge_input_name_for_codegen(edge, node_map[edge.source])
             existing = sm_node_sources.setdefault(child_id, [])
             existing_ids = sm_node_source_ids.setdefault(child_id, [])
-            if src_name not in existing:
-                existing.append(src_name)
-                existing_ids.append(edge.source)
+            existing.append(src_name)
+            existing_ids.append(edge.source)
+            sm_node_source_func_names.setdefault(child_id, []).append(
+                root_id_to_func.get(edge.source, _sanitize_func_name(edge.source))
+            )
+        _validate_duplicate_node_inputs(sm_node_sources, sm_node_map)
         # Validate out__ cross-boundary edges early, during submodel-file
         # generation, so a malformed source handle fails with a clear
         # ParseError here rather than a confusing downstream error when the
@@ -1074,6 +1166,7 @@ def graph_to_code_multi(
             id_to_func=sm_id_to_func,
             node_sources=sm_node_sources,
             connect_pairs=sm_connect_pairs,
+            node_source_func_names=sm_node_source_func_names,
             node_source_ids=sm_node_source_ids,
             node_to_code_fn=_submodel_node_to_code,
             obj_name="submodel",
@@ -1136,8 +1229,17 @@ def graph_to_code_multi(
 
     # Build source names per root node from root-level edges AND
     # cross-boundary edges (resolving submodel handles to child node names).
+    submodel_node_maps: dict[str, dict[str, GraphNode]] = {}
+    for sm_name, sm_meta in submodels.items():
+        sm_nodes = [
+            GraphNode.model_validate(raw) if isinstance(raw, dict) else raw
+            for raw in sm_meta.get("graph", {}).get("nodes", [])
+        ]
+        submodel_node_maps[f"submodel__{sm_name}"] = {node.id: node for node in sm_nodes}
+
     root_node_sources: dict[str, list[str]] = {}
     root_node_source_ids: dict[str, list[str]] = {}
+    root_node_source_func_names: dict[str, list[str]] = {}
     for edge in edges:
         src = edge.source
         tgt = edge.target
@@ -1163,12 +1265,21 @@ def graph_to_code_multi(
         # Only care about edges feeding into root nodes
         if actual_tgt not in root_node_ids:
             continue
-        src_name = root_id_to_func.get(actual_src, _sanitize_func_name(actual_src))
+        if src in submodel_node_ids:
+            source_node = submodel_node_maps[src][actual_src]
+        else:
+            source_node = node_map[src]
+        src_name = _edge_input_name_for_codegen(edge, source_node)
         root_node_sources.setdefault(actual_tgt, []).append(src_name)
         # Use the RESOLVED source id (child node id for a cross-boundary edge),
         # not the raw submodel placeholder id, so ids and names stay aligned
         # and _parent_name_by_id builds a correct id->func map.
         root_node_source_ids.setdefault(actual_tgt, []).append(actual_src)
+        root_node_source_func_names.setdefault(actual_tgt, []).append(
+            root_id_to_func.get(actual_src, _sanitize_func_name(actual_src))
+        )
+
+    _validate_duplicate_node_inputs(root_node_sources, node_map)
 
     # Build connect pairs for ALL edges (cross-boundary use real node names).
     # Triple shape: (src_func, tgt_func, source_port).
@@ -1239,6 +1350,7 @@ def graph_to_code_multi(
         id_to_func=root_id_to_func,
         node_sources=root_node_sources,
         connect_pairs=root_connect_pairs,
+        node_source_func_names=root_node_source_func_names,
         node_source_ids=root_node_source_ids,
         preserved_blocks=all_preserved or None,
         submodel_imports=sm_imports,

--- a/src/haute/deploy/_pruner.py
+++ b/src/haute/deploy/_pruner.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from haute._graph_utils import edge_input_name
 from haute._logging import get_logger
 from haute.graph_utils import (
     GraphEdge,
     GraphNode,
     NodeType,
     PipelineGraph,
-    _sanitize_func_name,
     ancestors,
 )
 
@@ -19,11 +19,11 @@ def _live_only_edges(
     nodes: list[GraphNode],
     edges: list[GraphEdge],
 ) -> list[GraphEdge]:
-    """Filter edges so liveSwitch nodes only keep their first (live) input.
+    """Filter edges so liveSwitch nodes only keep their live input.
 
-    For deployment we only want the live branch.  The first input edge
-    (by source order matching the function's first parameter) is kept;
-    all other input edges to the liveSwitch are dropped.
+    For deployment we only want the live branch.  Input names are derived
+    from each incoming edge, so multiple frames emitted by one apiInput are
+    routed independently.
     """
     switch_ids: set[str] = set()
     for n in nodes:
@@ -33,45 +33,50 @@ def _live_only_edges(
     if not switch_ids:
         return edges
 
-    # For each switch, identify the first input param name from config
-    switch_live_source: dict[str, str | None] = {}
+    # For each switch, identify the live input name from config and retain
+    # only edges whose shared edge-derived name matches it.
+    switch_live_edge_ids: dict[str, set[str]] = {}
     node_map = {n.id: n for n in nodes}
+
+    def _matching_edge_ids(switch_id: str, input_name: str) -> set[str]:
+        return {
+            edge.id
+            for edge in edges
+            if edge.target == switch_id
+            and edge_input_name(edge, node_map[edge.source]) == input_name
+        }
+
     for sid in switch_ids:
         config = node_map[sid].data.config
         input_scenario_map = config.get("input_scenario_map", {})
-        live_input_name = next(
+        mapped_live_input_name = next(
             (k for k, v in input_scenario_map.items() if v == "live"),
             None,
         )
-        if live_input_name is None:
-            # Fallback: use inputs[0] from config as the live input name,
-            # then match it against edges by label.
+        if mapped_live_input_name is None:
+            # Legacy fallback: use inputs[0] as the live input name and match
+            # it against each connected edge using the same derivation.
             inputs = config.get("inputs", [])
-            live_input_name = inputs[0] if inputs else None
-            if live_input_name:
-                for e in edges:
-                    if e.target == sid:
-                        src_label = node_map[e.source].data.label
-                        if _sanitize_func_name(src_label) == live_input_name:
-                            switch_live_source[sid] = e.source
-                            break
+            live_input_name = inputs[0] if isinstance(inputs, list) and inputs else "<missing>"
         else:
-            for e in edges:
-                if e.target == sid:
-                    src_label = node_map[e.source].data.label
-                    if _sanitize_func_name(src_label) == live_input_name:
-                        switch_live_source[sid] = e.source
-                        break
-            if sid not in switch_live_source:
-                raise ValueError(
-                    f"LiveSwitch node '{sid}': input_scenario_map live input "
-                    f"'{live_input_name}' does not match any connected node"
-                )
+            live_input_name = mapped_live_input_name
+        matching_edges = _matching_edge_ids(sid, live_input_name)
+        if not matching_edges:
+            source = (
+                "input_scenario_map live input"
+                if mapped_live_input_name is not None
+                else "inputs[0]"
+            )
+            raise ValueError(
+                f"LiveSwitch node '{sid}': {source} '{live_input_name}' "
+                "does not match any connected node"
+            )
+        switch_live_edge_ids[sid] = matching_edges
 
     filtered: list[GraphEdge] = []
     for e in edges:
         if e.target in switch_ids:
-            if switch_live_source.get(e.target) == e.source:
+            if e.id in switch_live_edge_ids.get(e.target, set()):
                 filtered.append(e)
         else:
             filtered.append(e)

--- a/src/haute/deploy/_scorer.py
+++ b/src/haute/deploy/_scorer.py
@@ -24,7 +24,7 @@ from haute._cache import canonical_json
 from haute._code_extraction import _strip_generated_boilerplate_from_code
 from haute._execution_admission import create_admitted_execution_context
 from haute._execution_context import ExecutionContext, ExecutionProfile
-from haute._graph_utils import upstream_node_ids
+from haute._graph_utils import edge_input_name, upstream_node_ids
 from haute._hashing import content_hash_bytes
 from haute._io import load_external_object, read_data_source
 from haute._logging import get_logger
@@ -167,6 +167,29 @@ def _deploy_model_score_source(execution_context: ExecutionContext) -> str:
     if execution_context.profile == ExecutionProfile.DEPLOY_BATCH:
         return ExecutionProfile.DEPLOY_BATCH.value
     return "live"
+
+
+def _validate_deploy_input_edges(graph: PipelineGraph) -> None:
+    """Reject apiInput edges that do not identify a frame at deploy time.
+
+    A post-convergence graph always stores an apiInput frame label on every
+    outgoing edge.  Validate that invariant before the shared builder gets a
+    chance to bind positional inputs: a legacy bare-frame source would
+    otherwise let the builder omit the input name and fail later in user code
+    with an unrelated ``NameError``.
+    """
+    node_by_id = {node.id: node for node in graph.nodes}
+    for edge in graph.edges:
+        source_node = node_by_id.get(edge.source)
+        if source_node is None or source_node.data.nodeType != NodeType.API_INPUT:
+            continue
+        try:
+            edge_input_name(edge, source_node)
+        except ValueError as exc:
+            raise ValueError(
+                f"Malformed deploy graph: apiInput edge {edge.id!r} from source "
+                f"node {edge.source!r} has no sourceHandle/frame label."
+            ) from exc
 
 
 def _model_score_has_configured_source(config: dict[str, Any]) -> bool:
@@ -497,6 +520,7 @@ def score_graph_lazy(
         _resolve_runtime_graph_paths(graph),
         remap,
     )
+    _validate_deploy_input_edges(graph)
     node_by_id = {node.id: node for node in graph.nodes}
     parents_of = graph.parents_of
     input_set = set(input_node_ids)

--- a/src/haute/execution.py
+++ b/src/haute/execution.py
@@ -742,9 +742,9 @@ def build_linear_execution_chain_functions(
     if not chain_ids:
         return {}
 
-    from haute._execute_lazy import _build_funcs, _prepare_graph
+    from haute._execute_lazy import _build_funcs, _prepare_graph_with_edges
 
-    node_map, _order, _parents_of, id_to_name = _prepare_graph(
+    node_map, _order, _parents_of, id_to_name, relevant_edges = _prepare_graph_with_edges(
         graph,
         target_node_id,
         source=routing_source,
@@ -762,6 +762,13 @@ def build_linear_execution_chain_functions(
         chain_parents[chain_id] = [parent_id]
         parent_id = chain_id
 
+    incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in relevant_edges:
+        incoming_edges_by_target.setdefault(edge.target, []).append(edge)
+    all_incoming_edges_by_target: dict[str, list[GraphEdge]] = {}
+    for edge in graph.edges:
+        all_incoming_edges_by_target.setdefault(edge.target, []).append(edge)
+
     reuse_loaded_model_by_node = (
         {
             chain_id: True
@@ -778,6 +785,9 @@ def build_linear_execution_chain_functions(
         id_to_name,
         graph.parents_of,
         build_node_fn,
+        incoming_edges_by_target=incoming_edges_by_target,
+        all_incoming_edges_by_target=all_incoming_edges_by_target,
+        all_node_map=graph.node_map,
         preamble_ns=preamble_ns,
         source=build_source,
         required_output_columns_by_node=required_output_columns_by_node,

--- a/src/haute/execution.py
+++ b/src/haute/execution.py
@@ -516,10 +516,9 @@ def _runtime_file_signature_paths(graph: PipelineGraph, node: GraphNode) -> dict
     gets read, nothing else:
 
     * **apiInput** - signs the configured raw path for both flat files
-      and JSON/JSONL. JSON-shape inputs preview from the built per-frame
-      parquet cache, but the raw file owns cache validity; signing it
-      prevents serving a stale preview before execution can raise the
-      stale-cache error.
+      and JSON/JSONL. JSON-shape inputs prefer a valid per-frame parquet
+      cache and otherwise shred that raw file directly; signing it prevents
+      a stale preview from hiding either fresh direct data or a raw-file error.
     * **databricks dataSource** — preview consumes the LOCAL table-cache
       parquet (``read_cached_table``), which the GUI Fetch Data route
       rewrites in place; the derived cache path is signed (including

--- a/src/haute/pipeline.py
+++ b/src/haute/pipeline.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Self
+from typing import Any, Self, cast
 
 import polars as pl
 
@@ -462,7 +462,7 @@ class Pipeline(NodeRegistry):
             terminals=[n.name for n in leaves],
         )
 
-    def _execute_transform(self, n: Node, outputs: dict[str, pl.DataFrame]) -> None:
+    def _execute_transform(self, n: Node, outputs: dict[str, Any]) -> None:
         """Resolve *n*'s wired inputs from *outputs* and store its result.
 
         Shared by :meth:`run` and :meth:`score`.  Fails loud when the node
@@ -470,12 +470,12 @@ class Pipeline(NodeRegistry):
         node carries unresolved instance references the standalone executor
         cannot honour.
         """
-        input_names = self._get_inputs(n.name)
-        if not input_names:
+        input_edges = self._get_input_edges(n.name)
+        if not input_edges:
             raise ValueError(
                 f"Node '{n.name}' has no inbound edges. Use pipeline.connect() to wire it up."
             )
-        missing = [name for name in input_names if name not in outputs]
+        missing = [edge.source for edge in input_edges if edge.source not in outputs]
         if missing:
             raise ValueError(
                 f"Node '{n.name}' is missing input(s) from: {missing}. "
@@ -488,7 +488,24 @@ class Pipeline(NodeRegistry):
                 "the graph executor, or inline the referenced logic into this node.",
                 node=n.name,
             )
-        input_dfs = [outputs[name] for name in input_names]
+        from haute._execute_lazy import _pick_source_frame
+
+        input_dfs: list[pl.DataFrame] = [
+            cast(
+                pl.DataFrame,
+                _pick_source_frame(
+                    outputs[edge.source],
+                    GraphEdge(
+                        id=_edge_id(edge.source, edge.target, edge.source_port, edge.target_port),
+                        source=edge.source,
+                        target=edge.target,
+                        sourceHandle=edge.source_port,
+                        targetHandle=edge.target_port,
+                    ),
+                ),
+            )
+            for edge in input_edges
+        ]
         outputs[n.name] = n(*input_dfs)
 
     def run(self) -> pl.DataFrame:
@@ -501,7 +518,7 @@ class Pipeline(NodeRegistry):
         _token = _scenario_ctx.set("batch")
         try:
             order = self._topo_order()
-            outputs: dict[str, pl.DataFrame] = {}
+            outputs: dict[str, Any] = {}
 
             for n in order:
                 if n.is_source:
@@ -509,11 +526,11 @@ class Pipeline(NodeRegistry):
                 else:
                     self._execute_transform(n, outputs)
 
-            return outputs[self._resolve_output_node(order).name]
+            return cast(pl.DataFrame, outputs[self._resolve_output_node(order).name])
         finally:
             _scenario_ctx.reset(_token)
 
-    def score(self, df: pl.DataFrame) -> pl.DataFrame:
+    def score(self, df: pl.DataFrame | dict[str, pl.DataFrame]) -> pl.DataFrame:
         """Run the pipeline on an input DataFrame, seeding the live input.
 
         Sources marked as the live API input — via the ``@pipeline.api_input``
@@ -532,7 +549,7 @@ class Pipeline(NodeRegistry):
         _token = _scenario_ctx.set("live")
         try:
             order = self._topo_order()
-            outputs: dict[str, pl.DataFrame] = {}
+            outputs: dict[str, Any] = {}
 
             sources = [n for n in order if n.is_source]
             deploy_inputs = [n for n in sources if n.is_deploy_input]
@@ -551,10 +568,46 @@ class Pipeline(NodeRegistry):
                     sources=[n.name for n in sources],
                 )
 
-            seed_names = {n.name for n in (deploy_inputs or sources)}
+            seed_nodes = deploy_inputs or sources
+            seed_names = {n.name for n in seed_nodes}
+            connected_ports = list(
+                dict.fromkeys(
+                    edge.source_port
+                    for edge in self._edges
+                    if edge.source in seed_names and edge.source_port is not None
+                )
+            )
+            if isinstance(df, dict):
+                expected_ports = set(connected_ports)
+                supplied_ports = set(df)
+                if not expected_ports:
+                    unknown_ports = sorted(supplied_ports)
+                    raise ExecutionError(
+                        "score() received a frame dictionary for a source with no connected ports.",
+                        source_nodes=sorted(seed_names),
+                        unknown_ports=unknown_ports,
+                    )
+                missing_ports = sorted(expected_ports - supplied_ports)
+                unknown_ports = sorted(supplied_ports - expected_ports)
+                if missing_ports or unknown_ports:
+                    raise ExecutionError(
+                        "score() frame dictionary must match the connected source ports exactly.",
+                        connected_ports=connected_ports,
+                        missing_ports=missing_ports,
+                        unknown_ports=unknown_ports,
+                    )
+                seed_value: Any = df
+            else:
+                if len(connected_ports) > 1:
+                    raise ExecutionError(
+                        "score() cannot seed a bare DataFrame across multiple "
+                        "connected source ports; provide a frame dictionary.",
+                        connected_ports=connected_ports,
+                    )
+                seed_value = df
             for n in sources:
                 if n.name in seed_names:
-                    outputs[n.name] = df
+                    outputs[n.name] = seed_value
                 else:
                     # Not a deploy input - run its own load logic.
                     outputs[n.name] = n()
@@ -564,7 +617,7 @@ class Pipeline(NodeRegistry):
                     continue
                 self._execute_transform(n, outputs)
 
-            return outputs[self._resolve_output_node(order).name]
+            return cast(pl.DataFrame, outputs[self._resolve_output_node(order).name])
         finally:
             _scenario_ctx.reset(_token)
 

--- a/src/haute/projection.py
+++ b/src/haute/projection.py
@@ -22,7 +22,7 @@ from haute._edge_join import (
     resolve_edge_join_role_indices,
 )
 from haute._execution_context import ExecutionProfile
-from haute._graph_utils import _sanitize_func_name, build_parents_of
+from haute._graph_utils import _sanitize_func_name, build_parents_of, edge_input_name
 from haute._topo import ancestors, topo_sort_ids
 from haute._types import GraphEdge, GraphNode, NodeType, PipelineGraph
 from haute.errors import ContractMismatchError, ProjectionImpossibleError
@@ -2102,7 +2102,7 @@ def prune_live_switch_edges(
     if not switch_nodes:
         return edges
 
-    exclude: set[tuple[str, str]] = set()
+    exclude_edge_ids: set[str] = set()
     for nid, node in switch_nodes.items():
         input_scenario_map = node.data.config.get("input_scenario_map", {})
         if not input_scenario_map:
@@ -2115,14 +2115,14 @@ def prune_live_switch_edges(
             parent = node_map.get(edge.source)
             if parent is None:
                 continue
-            parent_name = _sanitize_func_name(parent.data.label)
-            mapped = input_scenario_map.get(parent_name)
+            input_name = edge_input_name(edge, parent)
+            mapped = input_scenario_map.get(input_name)
             if mapped is not None and mapped != source:
-                exclude.add((edge.source, nid))
+                exclude_edge_ids.add(edge.id)
 
-    if not exclude:
+    if not exclude_edge_ids:
         return edges
-    return [edge for edge in edges if (edge.source, edge.target) not in exclude]
+    return [edge for edge in edges if edge.id not in exclude_edge_ids]
 
 
 def prepare_graph(

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -822,7 +822,7 @@ class SavePipelineService:
             if not data_path.is_relative_to(self._root):
                 continue
             try:
-                mirror_cache_to_committed(str(data_path))
+                mirror_cache_to_committed(str(data_path), cfg)
             except Exception as exc:  # pragma: no cover - logged for operator
                 logger.error(
                     "json_cache_mirror_failed",

--- a/tests/fixtures/pipeline.py
+++ b/tests/fixtures/pipeline.py
@@ -74,7 +74,7 @@ def results_write(calculate_premium: pl.LazyFrame) -> pl.LazyFrame:
     return calculate_premium
 
 
-pipeline.connect("quotes", "policies")
+pipeline.connect("quotes", "policies", source_port="quotes")
 pipeline.connect("batch_quotes", "policies")
 pipeline.connect("policies", "area_lookup")
 pipeline.connect("area_lookup", "calculate_premium")

--- a/tests/test_apiinput_multi_port_runtime.py
+++ b/tests/test_apiinput_multi_port_runtime.py
@@ -3,8 +3,8 @@
 Exercises the v2 apiInput at runtime end-to-end through execute_graph:
 
 - 0 emit-true tables → preview fails loud with a configuration message.
-- 1 emit-true table → single-port shorthand; source emits a bare
-  LazyFrame; downstream edges with null ``sourceHandle`` bind correctly.
+- 1 emit-true table → source emits a one-key dict just like a multi-frame
+  source; downstream edges select it by its required ``sourceHandle``.
 - 2+ emit-true tables → source emits a dict[port_label, LazyFrame]; the
   executor's edge-resolution picks per edge via ``sourceHandle``.
 - Cache absent → fail with the "click Cache as Parquet" hint.
@@ -153,10 +153,10 @@ def test_zero_emit_true_fails_loud(isolated_root) -> None:
     assert "tick" in error_msg or "configure" in error_msg or "configuration" in error_msg
 
 
-# ─── 2. single-port: bare frame, null-sourceHandle edge works ─────
+# ─── 2. single-port: one-key dict, labelled edge routing ──────────
 
 
-def test_single_port_emits_bare_frame_through_passthrough_consumer(isolated_root) -> None:
+def test_single_port_dict_routes_through_labelled_edge(isolated_root) -> None:
     data_path = isolated_root / "data.json"
     data_path.write_text(json.dumps(_rating_records()))
     config = _single_port_config(data_path)
@@ -175,10 +175,7 @@ def test_single_port_emits_bare_frame_through_passthrough_consumer(isolated_root
                 ),
             ),
         ],
-        edges=[
-            # Single-port: null sourceHandle (the shorthand).
-            GraphEdge(id="e", source="api", target="downstream", sourceHandle=None),
-        ],
+        edges=[GraphEdge(id="e", source="api", target="downstream", sourceHandle="policies")],
     )
     results = execute_graph(graph, target_node_id="downstream")
     assert results["api"].status == "ok"
@@ -187,6 +184,29 @@ def test_single_port_emits_bare_frame_through_passthrough_consumer(isolated_root
     assert results["api"].row_count == 2
     # Downstream passed it through unchanged.
     assert results["downstream"].row_count == 2
+
+
+def test_single_port_dict_with_null_source_handle_fails_loud(isolated_root) -> None:
+    data_path = isolated_root / "data.json"
+    data_path.write_text(json.dumps(_rating_records()))
+    config = _single_port_config(data_path)
+    _build_cache_for(isolated_root, data_path, config)
+    graph = PipelineGraph(
+        nodes=[
+            _api_input_node("api", config),
+            GraphNode(
+                id="downstream",
+                data=NodeData(label="downstream", nodeType=NodeType.POLARS, config={}),
+            ),
+        ],
+        edges=[GraphEdge(id="e", source="api", target="downstream")],
+    )
+
+    results = execute_graph(graph, target_node_id="downstream")
+
+    assert results["downstream"].status == "error"
+    error_msg = results["downstream"].error or ""
+    assert "sourceHandle" in error_msg
 
 
 # ─── 3. multi-port: dict emit, sourceHandle picks per edge ────────

--- a/tests/test_apiinput_multi_port_runtime.py
+++ b/tests/test_apiinput_multi_port_runtime.py
@@ -7,7 +7,7 @@ Exercises the v2 apiInput at runtime end-to-end through execute_graph:
   source; downstream edges select it by its required ``sourceHandle``.
 - 2+ emit-true tables → source emits a dict[port_label, LazyFrame]; the
   executor's edge-resolution picks per edge via ``sourceHandle``.
-- Cache absent → fail with the "click Cache as Parquet" hint.
+- Cache absent → shred JSON directly and execute successfully.
 - Multi-port edge with null ``sourceHandle`` → executor raises a clear
   diagnostic naming the available ports.
 
@@ -17,10 +17,12 @@ the surface focused on routing, not transform semantics.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
 
+import polars as pl
 import pytest
 
 from haute._json_flatten import _json_cache_dir
@@ -285,10 +287,10 @@ def test_multi_port_row_limit_caps_each_port(isolated_root) -> None:
     assert results["d_drivers"].row_count == 1  # capped from 3
 
 
-# ─── 4. cache absent: clear error message ─────────────────────────
+# ─── 4. cache absent: direct runtime shred ─────────────────────────
 
 
-def test_runtime_fails_when_cache_missing(isolated_root) -> None:
+def test_runtime_shreds_directly_when_cache_missing(isolated_root) -> None:
     data_path = isolated_root / "data.json"
     data_path.write_text(json.dumps(_rating_records()))
     config = _single_port_config(data_path)
@@ -296,9 +298,8 @@ def test_runtime_fails_when_cache_missing(isolated_root) -> None:
 
     graph = PipelineGraph(nodes=[_api_input_node("api", config)], edges=[])
     results = execute_graph(graph, target_node_id="api")
-    assert results["api"].status == "error"
-    error_msg = (results["api"].error or "").lower()
-    assert "cache" in error_msg and "parquet" in error_msg
+    assert results["api"].status == "ok", results["api"].error
+    assert results["api"].row_count == 2
 
 
 # ─── 5. multi-port edge with null sourceHandle: loud error ────────
@@ -806,30 +807,41 @@ def test_multi_port_ancestor_row_limit_caps_collected_target(isolated_root) -> N
     assert results["d_drivers"].row_count == 1  # capped from 3 through a lazy ancestor
 
 
-def test_apiinput_preview_invalidates_when_cache_rebuilt(isolated_root) -> None:
-    """Bug-class regression for the commit 1 invalidation: a v2 apiInput
-    whose cache gets rebuilt mid-session must show fresh data on the next
-    preview, not the stale failure cached from a previous attempt.
-    """
+def test_apiinput_preview_invalidates_when_optional_cache_is_built(isolated_root) -> None:
+    """A direct preview must rerun against a newly built optional cache."""
     data_path = isolated_root / "data.json"
     data_path.write_text(json.dumps(_rating_records()))
     config = _single_port_config(data_path)
 
     graph = PipelineGraph(nodes=[_api_input_node("api", config)], edges=[])
 
-    # 1. Preview before any cache build: expect error.
+    # 1. Preview before any cache build succeeds by shredding JSON directly.
     first = execute_graph(graph, target_node_id="api")
-    assert first["api"].status == "error"
+    assert first["api"].status == "ok", first["api"].error
+    assert first["api"].row_count == 2
 
-    # 2. Build the cache out-of-band.
+    # 2. Build the cache out-of-band, then give its frame a distinct row count
+    # while preserving the exact declared schema. This makes a stale preview
+    # cache hit observable rather than merely asserting the same values twice.
     _build_cache_for(isolated_root, data_path, config)
+    cache_dir = _json_cache_dir(data_path, "working")
+    pl.DataFrame({"policy_id": [999]}, schema={"policy_id": pl.Int64}).write_parquet(
+        cache_dir / "policies.parquet"
+    )
+    parquet_payload = (cache_dir / "policies.parquet").read_bytes()
+    meta_path = cache_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["tables"][0]["content_signature"] = {
+        "size": len(parquet_payload),
+        "sha256": hashlib.sha256(parquet_payload).hexdigest(),
+    }
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
-    # 3. Preview again — should now succeed (commit 1's per-data-file
-    # mtime in the preview fingerprint forces a cache miss after the
-    # meta.json appears).
+    # 3. meta.json appearing changes the preview key, so the next preview uses
+    # the cache fast path instead of reusing the earlier direct result.
     second = execute_graph(graph, target_node_id="api")
     assert second["api"].status == "ok", second["api"].error
-    assert second["api"].row_count == 2
+    assert second["api"].row_count == 1
 
 
 # ─── 9. per-frame preview select (commit 6: port_label) ───────────

--- a/tests/test_bug_regressions.py
+++ b/tests/test_bug_regressions.py
@@ -430,11 +430,11 @@ class TestBugB5PrunerLiveBranchSelection:
         from haute._types import PipelineGraph
         from haute.deploy._pruner import _live_only_edges
 
-        def _node(nid, ntype="polars", config=None):
+        def _node(nid, ntype="polars", config=None, *, label=None):
             return {
                 "id": nid,
                 "position": {"x": 0, "y": 0},
-                "data": {"label": nid, "nodeType": ntype, "config": config or {}},
+                "data": {"label": label or nid, "nodeType": ntype, "config": config or {}},
             }
 
         def _edge(src, tgt):
@@ -444,28 +444,31 @@ class TestBugB5PrunerLiveBranchSelection:
         graph = PipelineGraph.model_validate(
             {
                 "nodes": [
-                    _node("batch_src"),
-                    _node("live_src"),
+                    _node("batch_parent", label="Batch-Source"),
+                    _node("live_parent", label="Live Source"),
                     _node(
                         "sw",
                         "liveSwitch",
                         {
-                            "inputs": ["batch_src", "live_src"],
-                            "input_scenario_map": {"live_src": "live", "batch_src": "batch"},
+                            "inputs": ["Batch_Source", "Live_Source"],
+                            "input_scenario_map": {
+                                "Live_Source": "live",
+                                "Batch_Source": "batch",
+                            },
                         },
                     ),
                 ],
                 "edges": [
-                    _edge("batch_src", "sw"),
-                    _edge("live_src", "sw"),
+                    _edge("batch_parent", "sw"),
+                    _edge("live_parent", "sw"),
                 ],
             }
         )
         result = _live_only_edges(graph.nodes, graph.edges)
         result_pairs = {(e.source, e.target) for e in result}
-        # Should keep the live edge (live_src->sw), not batch (batch_src->sw)
-        assert ("live_src", "sw") in result_pairs
-        assert ("batch_src", "sw") not in result_pairs
+        # Matching is by sanitised display label, not the unrelated node ids.
+        assert ("live_parent", "sw") in result_pairs
+        assert ("batch_parent", "sw") not in result_pairs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chunk_runner.py
+++ b/tests/test_chunk_runner.py
@@ -212,6 +212,61 @@ def test_chunk_runner_matches_full_lazy_for_chunk_safe_chain(
     assert "unused_payload" not in actual.columns
 
 
+def test_chunk_runner_derives_start_input_name_from_api_frame_edge() -> None:
+    """A supplied intermediate frame must not make chunking forget its edge identity."""
+    graph = make_graph(
+        {
+            "nodes": [
+                _node("api", "apiInput"),
+                _node("chunk_start", "polars"),
+                _node("target", "polars"),
+            ],
+            "edges": [
+                {
+                    "id": "api_chunk_start",
+                    "source": "api",
+                    "target": "chunk_start",
+                    "sourceHandle": "quotes",
+                },
+                make_edge("chunk_start", "target").model_dump(),
+            ],
+        }
+    )
+    plan = chunk_plan(
+        ChunkPlanRequest(
+            graph=graph,
+            target_node_id="target",
+            chunk_start_node_id="chunk_start",
+            chunk_size=2,
+            required_columns_by_node={"target": {"x"}},
+        )
+    )
+    captured_source_names: dict[str, list[str]] = {}
+
+    def recording_builder(
+        node: GraphNode,
+        *,
+        source_names: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[str, Callable[..., Any], bool]:
+        captured_source_names[node.id] = list(source_names or [])
+        return node.id, lambda *frames: frames[0], node.data.nodeType == "apiInput"
+
+    batches = list(
+        iter_chunked_frames(
+            ChunkRunnerRequest(
+                graph=graph,
+                plan=plan,
+                build_node_fn=recording_builder,
+                start_frame=pl.DataFrame({"x": [1, 2, 3]}),
+            )
+        )
+    )
+
+    assert sum(batch.output_rows for batch in batches) == 3
+    assert captured_source_names["chunk_start"] == ["quotes"]
+
+
 def test_chunk_runner_projects_source_columns_before_first_map_node(tmp_path: Path) -> None:
     output_fields = ["quote_id", "age_band", "scenario_index"]
     required_columns = _required_columns(output_fields)

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1923,7 +1923,7 @@ class TestApiInputCodegen:
         _compile_node_code(code)
 
     def test_uppercase_json_api_input(self):
-        """Case-insensitive: .JSON should use v2 shred cache, not scan_parquet."""
+        """Case-insensitive: .JSON uses v2 cached-or-direct shred, not a flat scan."""
         code = _node_to_code(self._make_api_node("input.JSON", "UpperIn"))
         assert "load_v2_api_source" in code
         assert "scan_parquet" not in code

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -24,6 +24,7 @@ from haute.codegen import (
     graph_to_code,
     graph_to_code_multi,
 )
+from haute.errors import ParseError
 from tests.conftest import (
     compile_node_code as _compile_node_code,
 )
@@ -2528,14 +2529,11 @@ class TestBuildExtraKwargsEdgeCases:
 
 
 class TestConnectDeduplication:
-    """Catch: in multi-submodel mode, cross-boundary edges can produce
-    duplicate connect() calls. ``dedup_connects=True`` must eliminate them.
-    Without dedup, the pipeline would wire the same pair twice, potentially
-    causing double-execution or confusing the executor."""
+    """Separate invalid graph duplicates from boundary-resolution duplicates."""
 
-    def test_duplicate_connects_deduplicated(self):
-        """Two edges between the same pair in submodel mode should produce one connect."""
-        graph = _g(
+    @staticmethod
+    def _submodel_graph(edges: list[dict]):
+        return _g(
             {
                 "nodes": [
                     {
@@ -2551,20 +2549,7 @@ class TestConnectDeduplication:
                         "data": {"label": "ChildA", "nodeType": "polars", "config": {}},
                     },
                 ],
-                "edges": [
-                    {
-                        "id": "e1",
-                        "source": "src",
-                        "target": "submodel__sm1",
-                        "targetHandle": "in__child_a",
-                    },
-                    {
-                        "id": "e2",
-                        "source": "src",
-                        "target": "submodel__sm1",
-                        "targetHandle": "in__child_a",
-                    },
-                ],
+                "edges": edges,
                 "submodels": {
                     "sm1": {
                         "file": "modules/sm1.py",
@@ -2582,11 +2567,54 @@ class TestConnectDeduplication:
                 },
             }
         )
+
+    def test_duplicate_graph_edges_raise_duplicate_input_name(self):
+        graph = self._submodel_graph(
+            [
+                {
+                    "id": "e1",
+                    "source": "src",
+                    "target": "submodel__sm1",
+                    "targetHandle": "in__child_a",
+                },
+                {
+                    "id": "e2",
+                    "source": "src",
+                    "target": "submodel__sm1",
+                    "targetHandle": "in__child_a",
+                },
+            ]
+        )
+
+        with pytest.raises(ParseError) as exc_info:
+            graph_to_code_multi(graph, pipeline_name="main")
+
+        message = str(exc_info.value)
+        assert "child_a" in message
+        assert "Source" in message
+
+    def test_boundary_resolution_connect_pair_is_deduplicated(self):
+        """A direct child edge and its boundary form resolve to one connect."""
+        graph = self._submodel_graph(
+            [
+                {
+                    "id": "direct-child-edge",
+                    "source": "src",
+                    "target": "child_a",
+                },
+                {
+                    "id": "boundary-edge",
+                    "source": "src",
+                    "target": "submodel__sm1",
+                    "targetHandle": "in__child_a",
+                },
+            ]
+        )
+
         files = graph_to_code_multi(graph, pipeline_name="main")
         main_code = files["main.py"]
-        # Count connect calls for the same pair
-        connect_count = main_code.count('pipeline.connect("Source", "ChildA")')
-        assert connect_count == 1, f"Expected 1 connect call after dedup, got {connect_count}"
+
+        assert main_code.count('pipeline.connect("Source", "ChildA")') == 1
         compile(main_code, "<test>", "exec")
 
 

--- a/tests/test_codegen_builders.py
+++ b/tests/test_codegen_builders.py
@@ -916,7 +916,27 @@ class TestGraphToCodeWithBuilders:
                         "data": {
                             "label": "API",
                             "nodeType": "apiInput",
-                            "config": {"path": "data/input.parquet"},
+                            "config": {
+                                "path": "data/input.json",
+                                "tables": [
+                                    {
+                                        "path": "$[:]",
+                                        "label": "quotes",
+                                        "emit": True,
+                                        "row_id_column": None,
+                                        "columns": [
+                                            {
+                                                "name": "id",
+                                                "path": "$[:].id",
+                                                "type": "int",
+                                                "status": "Confirmed",
+                                                "selected": True,
+                                                "levels": None,
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
                         },
                     },
                     {
@@ -928,13 +948,20 @@ class TestGraphToCodeWithBuilders:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "api", "target": "t"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "api",
+                        "target": "t",
+                        "sourceHandle": "quotes",
+                    }
+                ],
             }
         )
         code = graph_to_code(graph)
         assert "def API()" in code
-        assert "def Process(API: pl.LazyFrame)" in code
-        assert 'pipeline.connect("API", "Process")' in code
+        assert "def Process(quotes: pl.LazyFrame)" in code
+        assert 'pipeline.connect("API", "Process", source_port="quotes")' in code
         compile(code, "<test>", "exec")
 
     def test_pipeline_with_constant_compiles(self) -> None:
@@ -1299,12 +1326,8 @@ class TestCodegenExecValidation:
         assert set(collected.columns) == {"premium", "Area"}
         assert collected.to_dicts() == [{"premium": 1.0, "Area": "A"}]
 
-    def test_multi_frame_output_dedupes_duplicate_params(self) -> None:
-        """A multi-frame OUTPUT (one apiInput feeding several edges) must codegen
-        VALID Python. Duplicate parameter names are a compile-time SyntaxError —
-        ast.parse tolerates them (so the canvas works) but the file can't be
-        imported/deployed — so the params must be de-duplicated and the result
-        must compile()."""
+    def test_multi_frame_output_uses_supplied_frame_params(self) -> None:
+        """OUTPUT receives the distinct frame names already derived per edge."""
         node = _make_codegen_node(
             "output",
             {
@@ -1320,15 +1343,13 @@ class TestCodegenExecValidation:
             },
             label="Quote_Response",
         )
-        # Four edges, all from the same multi-frame source node `quotes`.
-        code = _node_to_code(node, source_names=["quotes", "quotes", "quotes", "quotes"])
-        # Distinct, valid params — not four bare `quotes`.
-        assert "quotes: pl.LazyFrame, quotes_2: pl.LazyFrame" in code
-        assert "quotes_3: pl.LazyFrame, quotes_4: pl.LazyFrame" in code
-        # The body forwards ALL frames (deduped names) to the shared assembler.
+        frame_names = ["quotes", "drivers", "licences", "vehicles"]
+        code = _node_to_code(node, source_names=frame_names)
+        assert "quotes: pl.LazyFrame, drivers: pl.LazyFrame" in code
+        assert "licences: pl.LazyFrame, vehicles: pl.LazyFrame" in code
+        # The body forwards every supplied frame name to the shared assembler.
         assert "assemble_output_from_config(" in code
-        assert "source_names=['quotes', 'quotes_2', 'quotes_3', 'quotes_4']" in code
-        # compile() (unlike ast.parse) rejects duplicate arg names — must pass.
+        assert "source_names=['quotes', 'drivers', 'licences', 'vehicles']" in code
         _compile_node_code(code)
 
     def test_banding_exec_applies_sidecar_config(self, tmp_path: Path) -> None:

--- a/tests/test_codegen_builders.py
+++ b/tests/test_codegen_builders.py
@@ -110,6 +110,7 @@ class TestGenApiInput:
         assert 'config="config/quote_input/CSVInput.json"' in code
         assert "def CSVInput()" in code
         assert "read_data_source" in code
+        assert "def CSVInput() -> pl.LazyFrame:" in code
         assert 'Path(__file__).parent / "data/input.csv"' in code
         _compile_node_code(code)
 
@@ -139,6 +140,7 @@ class TestGenApiInput:
         assert 'config="config/quote_input/JSONInput.json"' in code
         assert "def JSONInput()" in code
         assert "load_v2_api_source" in code
+        assert "def JSONInput() -> dict[str, pl.LazyFrame]:" in code
         assert 'Path(__file__).parent / "config/quote_input/JSONInput.json"' in code
         _compile_node_code(code)
 
@@ -1167,9 +1169,9 @@ class TestCodegenExecValidation:
     def test_api_input_exec_produces_lazyframe(self) -> None:
         """apiInput code for a JSON file compiles and contains v2 shred markers.
 
-        v2 generated code requires a live config file and pre-built per-port
-        cache, so we verify compilation and v2 structural markers rather than
-        executing the generated function directly.
+        This fixture lacks a matching sidecar config, so we verify compilation
+        and v2 structural markers here; standalone direct-vs-cached execution is
+        covered by ``test_codegen_execution_equivalence.py``.
         """
         node = _make_codegen_node(
             "apiInput",
@@ -1211,14 +1213,15 @@ class TestCodegenExecValidation:
             ns,
         )
 
-        with pytest.raises(RuntimeError, match="no v2 schema"):
+        with pytest.raises(RuntimeError, match="no v2 schema") as exc_info:
             ns["quotes"]()
+        assert "Cache as Parquet" not in str(exc_info.value)
 
     def test_json_api_input_exec_fails_loudly_without_selected_columns(
         self,
         tmp_path: Path,
     ) -> None:
-        """Generated JSON apiInput separates emit-without-columns from cache misses."""
+        """Generated JSON apiInput reports the config action, not a cache action."""
         config_dir = tmp_path / "config" / "quote_input"
         config_dir.mkdir(parents=True)
         (config_dir / "quotes.json").write_text(
@@ -1262,8 +1265,9 @@ class TestCodegenExecValidation:
 
         with pytest.raises(
             RuntimeError, match="emit-true tables but none has any selected columns"
-        ):
+        ) as exc_info:
             ns["quotes"]()
+        assert "Cache as Parquet" not in str(exc_info.value)
 
     def test_output_exec_assembles_document(self, tmp_path: Path) -> None:
         """The generated OUTPUT body assembles the response document.

--- a/tests/test_codegen_execution_equivalence.py
+++ b/tests/test_codegen_execution_equivalence.py
@@ -22,17 +22,23 @@ regression and pass only when both sides share one code path.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 
 from haute._builders import _build_node_fn
 from haute._config_io import collect_node_configs
 from haute._execute_lazy import _execute_lazy
+from haute._json_flatten import _json_cache_dir
+from haute._json_shred import build_per_port_cache
 from haute._model_scorer import _scenario_ctx
+from haute._sandbox import _get_project_root, set_project_root
 from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
 from haute.codegen import graph_to_code
 
@@ -45,8 +51,13 @@ def _node(nid: str, label: str, node_type: NodeType, config: dict) -> GraphNode:
     return GraphNode(id=nid, data=NodeData(label=label, nodeType=node_type, config=config))
 
 
-def _edge(src: str, tgt: str) -> GraphEdge:
-    return GraphEdge(id=f"e_{src}_{tgt}", source=src, target=tgt)
+def _edge(src: str, tgt: str, *, source_port: str | None = None) -> GraphEdge:
+    return GraphEdge(
+        id=f"e_{src}_{tgt}_{source_port or 'default'}",
+        source=src,
+        target=tgt,
+        sourceHandle=source_port,
+    )
 
 
 def _const(nid: str, label: str, values: list[dict]) -> GraphNode:
@@ -95,6 +106,127 @@ def _executor_node_fn(node: GraphNode, source_names, source_ids, source: str):
         source=source,
     )
     return fn
+
+
+@pytest.fixture
+def isolated_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    """Keep generated modules and apiInput caches inside one temp project."""
+    original = _get_project_root()
+    monkeypatch.chdir(tmp_path)
+    set_project_root(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        set_project_root(original)
+
+
+def _column(name: str, path: str, type_: str = "int") -> dict:
+    return {"name": name, "path": path, "type": type_, "selected": True}
+
+
+def _cached_api_graph(
+    project: Path,
+    *,
+    records: list[dict],
+    tables: list[dict],
+    code: str,
+    ports: list[str],
+) -> PipelineGraph:
+    data_path = project / "request.json"
+    data_path.write_text(json.dumps(records), encoding="utf-8")
+    config = {
+        "path": str(data_path),
+        "contract": "opaque",
+        "tables": tables,
+    }
+    build_per_port_cache(data_path, config, _json_cache_dir(data_path, "working"))
+
+    api = _node("api", "Quote Input", NodeType.API_INPUT, config)
+    transform = _node("transform", "Price Transform", NodeType.POLARS, {"code": code})
+    return PipelineGraph(
+        nodes=[api, transform],
+        edges=[_edge("api", "transform", source_port=port) for port in ports],
+    )
+
+
+# ---------------------------------------------------------------------------
+# apiInput frame identity — generated standalone execution must bind the same
+# per-edge names as the canvas executor for both one- and multi-frame sources.
+# ---------------------------------------------------------------------------
+
+
+def test_one_frame_api_input_run_matches_executor_by_frame_label(
+    isolated_project: Path,
+) -> None:
+    graph = _cached_api_graph(
+        isolated_project,
+        records=[{"quote_id": 7}, {"quote_id": 11}],
+        tables=[
+            {
+                "path": "$[:]",
+                "label": "quotes",
+                "emit": True,
+                "columns": [_column("quote_id", "$[:].quote_id")],
+            }
+        ],
+        code="df = quotes.with_columns((pl.col('quote_id') * 2).alias('double_id'))",
+        ports=["quotes"],
+    )
+
+    module = _write_and_import(graph, isolated_project)
+    standalone = _collect(module.pipeline.run())
+    reference = _executor_frame(graph, "transform", source="batch")
+
+    assert standalone["double_id"].to_list() == [14, 22]
+    assert_frame_equal(standalone, reference)
+
+
+def test_multi_frame_api_input_run_matches_executor_by_each_frame_label(
+    isolated_project: Path,
+) -> None:
+    graph = _cached_api_graph(
+        isolated_project,
+        records=[
+            {"policy_id": 1, "drivers": [{"driver_id": 10}, {"driver_id": 11}]},
+            {"policy_id": 2, "drivers": [{"driver_id": 20}]},
+        ],
+        tables=[
+            {
+                "path": "$[:]",
+                "label": "quotes",
+                "emit": True,
+                "columns": [_column("policy_id", "$[:].policy_id")],
+            },
+            {
+                "path": "$[:].drivers[:]",
+                "label": "drivers",
+                "emit": True,
+                "columns": [
+                    _column("policy_id", "$[:].policy_id"),
+                    _column("driver_id", "$[:].drivers[:].driver_id"),
+                ],
+            },
+        ],
+        code=(
+            "df = quotes.join(drivers, on='policy_id', how='inner')"
+            ".select('policy_id', 'driver_id')"
+        ),
+        ports=["quotes", "drivers"],
+    )
+
+    module = _write_and_import(graph, isolated_project)
+    standalone = _collect(module.pipeline.run())
+    reference = _executor_frame(graph, "transform", source="batch")
+
+    assert standalone.to_dicts() == [
+        {"policy_id": 1, "driver_id": 10},
+        {"policy_id": 1, "driver_id": 11},
+        {"policy_id": 2, "driver_id": 20},
+    ]
+    assert_frame_equal(standalone, reference)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codegen_execution_equivalence.py
+++ b/tests/test_codegen_execution_equivalence.py
@@ -134,6 +134,7 @@ def _cached_api_graph(
     tables: list[dict],
     code: str,
     ports: list[str],
+    build_cache: bool = True,
 ) -> PipelineGraph:
     data_path = project / "request.json"
     data_path.write_text(json.dumps(records), encoding="utf-8")
@@ -142,7 +143,8 @@ def _cached_api_graph(
         "contract": "opaque",
         "tables": tables,
     }
-    build_per_port_cache(data_path, config, _json_cache_dir(data_path, "working"))
+    if build_cache:
+        build_per_port_cache(data_path, config, _json_cache_dir(data_path, "working"))
 
     api = _node("api", "Quote Input", NodeType.API_INPUT, config)
     transform = _node("transform", "Price Transform", NodeType.POLARS, {"code": code})
@@ -182,6 +184,40 @@ def test_one_frame_api_input_run_matches_executor_by_frame_label(
 
     assert standalone["double_id"].to_list() == [14, 22]
     assert_frame_equal(standalone, reference)
+
+
+def test_uncached_api_input_generated_run_matches_executor_and_cached_fast_path(
+    isolated_project: Path,
+) -> None:
+    graph = _cached_api_graph(
+        isolated_project,
+        records=[{"quote_id": 7}, {"quote_id": 11}],
+        tables=[
+            {
+                "path": "$[:]",
+                "label": "quotes",
+                "emit": True,
+                "columns": [_column("quote_id", "$[:].quote_id")],
+            }
+        ],
+        code="df = quotes.with_columns((pl.col('quote_id') * 2).alias('double_id'))",
+        ports=["quotes"],
+        build_cache=False,
+    )
+    module = _write_and_import(graph, isolated_project)
+
+    standalone_direct = _collect(module.pipeline.run())
+    executor_direct = _executor_frame(graph, "transform", source="batch")
+    assert_frame_equal(standalone_direct, executor_direct)
+
+    api_config = graph.nodes[0].data.config
+    data_path = Path(api_config["path"])
+    build_per_port_cache(data_path, api_config, _json_cache_dir(data_path, "working"))
+
+    standalone_cached = _collect(module.pipeline.run())
+    executor_cached = _executor_frame(graph, "transform", source="batch")
+    assert_frame_equal(standalone_cached, executor_cached)
+    assert_frame_equal(standalone_direct, standalone_cached)
 
 
 def test_multi_frame_api_input_run_matches_executor_by_each_frame_label(

--- a/tests/test_codegen_input_identity.py
+++ b/tests/test_codegen_input_identity.py
@@ -1,0 +1,258 @@
+"""Codegen contracts for edge-derived input identity.
+
+These tests exercise the public graph-to-source boundary: input names are
+observable Python parameters and persisted ``connect`` metadata.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+import haute._codegen_builders as codegen_builders
+from haute._codegen_builders import _build_params
+from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
+from haute.codegen import graph_to_code, graph_to_code_multi
+from haute.errors import ParseError
+
+
+def _node(
+    node_id: str,
+    label: str,
+    node_type: NodeType,
+    config: dict | None = None,
+) -> GraphNode:
+    return GraphNode(
+        id=node_id,
+        data=NodeData(
+            label=label,
+            nodeType=node_type,
+            config={"contract": "opaque", **(config or {})},
+        ),
+    )
+
+
+def _edge(
+    edge_id: str,
+    source: str,
+    target: str,
+    *,
+    source_port: str | None = None,
+    target_port: str | None = None,
+) -> GraphEdge:
+    return GraphEdge(
+        id=edge_id,
+        source=source,
+        target=target,
+        sourceHandle=source_port,
+        targetHandle=target_port,
+    )
+
+
+def _api_config(*labels: str) -> dict:
+    return {
+        "path": "payload.json",
+        "tables": [
+            {
+                "path": f"$[:].{label}[:]",
+                "label": label,
+                "emit": True,
+                "row_id_column": None,
+                "columns": [
+                    {
+                        "name": "id",
+                        "path": f"$[:].{label}[:].id",
+                        "type": "int",
+                        "status": "Confirmed",
+                        "selected": True,
+                        "levels": None,
+                    }
+                ],
+            }
+            for label in labels
+        ],
+    }
+
+
+def _function_args(code: str, function_name: str) -> list[str]:
+    tree = ast.parse(code)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    return [argument.arg for argument in function.args.args]
+
+
+def test_generated_params_follow_edge_order_across_all_source_kinds() -> None:
+    api_input = _node(
+        "api",
+        "API Input",
+        NodeType.API_INPUT,
+        _api_config("quotes"),
+    )
+    ordinary_source = _node("ordinary", "ordinary source", NodeType.CONSTANT)
+    nested_child = _node("child", "nested child source", NodeType.CONSTANT)
+    target = _node(
+        "target",
+        "combine inputs",
+        NodeType.POLARS,
+        {"code": "df = quotes"},
+    )
+
+    graph = PipelineGraph(
+        nodes=[api_input, ordinary_source, nested_child, target],
+        edges=[
+            _edge("api-edge", "api", "target", source_port="quotes"),
+            _edge("ordinary-edge", "ordinary", "target"),
+            _edge(
+                "child-edge",
+                "submodel__rating",
+                "target",
+                source_port="out__child",
+            ),
+        ],
+        submodels={
+            "rating": {
+                "file": "modules/rating.py",
+                "childNodeIds": ["child"],
+                "graph": {
+                    "nodes": [nested_child.model_dump(by_alias=True)],
+                    "edges": [],
+                },
+            }
+        },
+    )
+
+    code = graph_to_code_multi(graph, pipeline_name="main")["main.py"]
+
+    assert _function_args(code, "combine_inputs") == [
+        "quotes",
+        "ordinary_source",
+        "nested_child_source",
+    ]
+
+
+def test_sole_frame_api_input_uses_frame_param_and_explicit_source_port() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "API Input", NodeType.API_INPUT, _api_config("quotes")),
+            _node("target", "use quote", NodeType.POLARS, {"code": "df = quotes"}),
+        ],
+        edges=[_edge("quote-edge", "api", "target", source_port="quotes")],
+    )
+
+    code = graph_to_code(graph, pipeline_name="main")
+
+    assert _function_args(code, "use_quote") == ["quotes"]
+    assert 'pipeline.connect("API_Input", "use_quote", source_port="quotes")' in code
+    assert 'pipeline.connect("API_Input", "use_quote")' not in code
+
+
+def test_multi_frame_api_input_uses_each_frame_name_and_source_port_in_edge_order() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node(
+                "api",
+                "API Input",
+                NodeType.API_INPUT,
+                _api_config("quotes", "drivers"),
+            ),
+            _node(
+                "target",
+                "combine frames",
+                NodeType.POLARS,
+                {"code": "df = quotes.join(drivers, how='cross')"},
+            ),
+        ],
+        edges=[
+            _edge("quotes-edge", "api", "target", source_port="quotes"),
+            _edge("drivers-edge", "api", "target", source_port="drivers"),
+        ],
+    )
+
+    code = graph_to_code(graph, pipeline_name="main")
+
+    assert _function_args(code, "combine_frames") == ["quotes", "drivers"]
+    connect_lines = [
+        line
+        for line in code.splitlines()
+        if line.startswith('pipeline.connect("API_Input", "combine_frames"')
+    ]
+    assert connect_lines == [
+        'pipeline.connect("API_Input", "combine_frames", source_port="quotes")',
+        'pipeline.connect("API_Input", "combine_frames", source_port="drivers")',
+    ]
+
+
+def test_duplicate_derived_input_name_raises_instead_of_suffixing() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node(
+                "api-source",
+                "API Input",
+                NodeType.API_INPUT,
+                _api_config("clean_data"),
+            ),
+            _node("ordinary-source", "clean data", NodeType.CONSTANT),
+            _node(
+                "pricing-target",
+                "Pricing Transform",
+                NodeType.POLARS,
+                {"code": "df = clean_data"},
+            ),
+        ],
+        edges=[
+            _edge(
+                "frame-edge",
+                "api-source",
+                "pricing-target",
+                source_port="clean_data",
+            ),
+            _edge("ordinary-edge", "ordinary-source", "pricing-target"),
+        ],
+    )
+
+    with pytest.raises(ParseError) as exc_info:
+        graph_to_code(graph, pipeline_name="main")
+
+    message = str(exc_info.value)
+    assert "clean_data" in message
+    assert "pricing-target" in message
+
+
+def test_portless_api_edge_raises_and_names_edge_and_source() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api-source", "API Source", NodeType.API_INPUT, _api_config("quotes")),
+            _node("target", "Target", NodeType.POLARS, {"code": "df = df"}),
+        ],
+        edges=[_edge("edge-without-port", "api-source", "target")],
+    )
+
+    with pytest.raises(ParseError) as exc_info:
+        graph_to_code(graph, pipeline_name="main")
+
+    message = str(exc_info.value)
+    assert "edge-without-port" in message
+    assert "api-source" in message
+
+
+def test_dedup_param_helper_is_removed() -> None:
+    assert not hasattr(codegen_builders, "_dedup_param_names")
+
+
+def test_build_params_preserves_supplied_names_one_to_one() -> None:
+    params = _build_params(["quotes", "drivers"])
+
+    assert params == "quotes: pl.LazyFrame, drivers: pl.LazyFrame"
+
+
+def test_build_params_rejects_duplicate_supplied_names_loudly() -> None:
+    with pytest.raises(AssertionError) as exc_info:
+        _build_params(["quotes", "quotes"])
+
+    message = str(exc_info.value)
+    assert "duplicate" in message
+    assert "quotes" in message

--- a/tests/test_codegen_roundtrip_property.py
+++ b/tests/test_codegen_roundtrip_property.py
@@ -35,6 +35,7 @@ Known W5 tensions intentionally scoped here:
 
 from __future__ import annotations
 
+import ast
 import json
 import tempfile
 from pathlib import Path
@@ -203,10 +204,22 @@ def _capstone_root_graph(
                     "path": "inputs/request (v2).json",
                     "tables": [
                         {
-                            "name": "quotes/table {v2}",
+                            "path": "$[:]",
+                            "label": "quotes",
+                            "emit": True,
                             "columns": [
-                                {"name": "quote_id", "dtype": "Utf8"},
-                                {"name": "premium (gross)", "dtype": "Float64"},
+                                {
+                                    "name": "quote_id",
+                                    "path": "$[:].quote_id",
+                                    "type": "str",
+                                    "selected": True,
+                                },
+                                {
+                                    "name": "premium (gross)",
+                                    "path": "$[:]['premium (gross)']",
+                                    "type": "float",
+                                    "selected": True,
+                                },
                             ],
                         }
                     ],
@@ -479,11 +492,11 @@ def _capstone_root_graph(
                 {
                     "input_scenario_map": {
                         _sanitize_func_name('Left Source "{cafe}"'): "live",
-                        _sanitize_func_name("API Input \u6771\u4eac"): "test_batch",
+                        "quotes": "test_batch",
                     },
                     "inputs": [
                         _sanitize_func_name('Left Source "{cafe}"'),
-                        _sanitize_func_name("API Input \u6771\u4eac"),
+                        "quotes",
                     ],
                 }
             ),
@@ -493,7 +506,7 @@ def _capstone_root_graph(
 
     edges = [
         _edge(left, join, source_handle=f"left output {handle_text}", target_handle="base"),
-        _edge(api, join, source_handle=f"quotes/table {handle_text}", target_handle="join"),
+        _edge(api, join, source_handle="quotes", target_handle="join"),
         _edge(const, transform, source_handle="constant {port}"),
         _edge(join, transform),
         _edge(transform, score),
@@ -509,7 +522,7 @@ def _capstone_root_graph(
         _edge(transform, explore),
         _edge(transform, external),
         _edge(left, switch, source_handle="live (left)"),
-        _edge(api, switch, source_handle="batch {api}"),
+        _edge(api, switch, source_handle="quotes"),
     ]
 
     return PipelineGraph(
@@ -738,6 +751,80 @@ def test_corpus_graphs_cover_all_supported_node_types() -> None:
 def test_corpus_roundtrip_semantics_and_source_bytes() -> None:
     for graph in _corpus_graphs():
         _assert_roundtrip_invariants(graph)
+
+
+def test_frame_named_api_parameters_are_a_byte_identical_roundtrip_fixpoint() -> None:
+    api = _node(
+        "api-source",
+        "Request Bundle",
+        NodeType.API_INPUT,
+        _opaque(
+            {
+                "path": "inputs/request.json",
+                "tables": [
+                    {
+                        "path": "$[:]",
+                        "label": "quotes",
+                        "emit": True,
+                        "columns": [
+                            {
+                                "name": "quote_id",
+                                "path": "$[:].quote_id",
+                                "type": "int",
+                                "selected": True,
+                            }
+                        ],
+                    },
+                    {
+                        "path": "$[:].drivers[:]",
+                        "label": "drivers",
+                        "emit": True,
+                        "columns": [
+                            {
+                                "name": "quote_id",
+                                "path": "$[:].quote_id",
+                                "type": "int",
+                                "selected": True,
+                            },
+                            {
+                                "name": "driver_id",
+                                "path": "$[:].drivers[:].driver_id",
+                                "type": "int",
+                                "selected": True,
+                            },
+                        ],
+                    },
+                ],
+            }
+        ),
+    )
+    merge = _node(
+        "merge",
+        "Merge Frames",
+        NodeType.POLARS,
+        _opaque({"code": "df = quotes.join(drivers, on='quote_id', how='left')"}),
+    )
+    graph = PipelineGraph(
+        nodes=[api, merge],
+        edges=[
+            _edge("api-source", "merge", source_handle="quotes"),
+            _edge("api-source", "merge", source_handle="drivers"),
+        ],
+        pipeline_name="frame_named_roundtrip",
+        pipeline_description="",
+    )
+
+    first, parsed, second = _roundtrip(graph)
+
+    _assert_semantically_equal(graph, parsed)
+    assert second == first
+    generated = ast.parse(first["main.py"])
+    merge_fn = next(
+        node
+        for node in generated.body
+        if isinstance(node, ast.FunctionDef) and node.name == "Merge_Frames"
+    )
+    assert [arg.arg for arg in merge_fn.args.args] == ["quotes", "drivers"]
 
 
 def test_submodel_container_types_are_explicitly_budgeted() -> None:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -184,10 +184,10 @@ class TestPruner:
                             "nodeType": "liveSwitch",
                             "config": {
                                 "input_scenario_map": {
-                                    "live_src": "live",
+                                    "quotes": "live",
                                     "batch_src": "test_batch",
                                 },
-                                "inputs": ["live_src", "batch_src"],
+                                "inputs": ["quotes", "batch_src"],
                             },
                         },
                     },
@@ -202,7 +202,12 @@ class TestPruner:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "live_src", "target": "switch"},
+                    {
+                        "id": "e1",
+                        "source": "live_src",
+                        "target": "switch",
+                        "sourceHandle": "quotes",
+                    },
                     {"id": "e2", "source": "batch_src", "target": "switch"},
                     {"id": "e3", "source": "switch", "target": "score"},
                     {"id": "e4", "source": "score", "target": "out"},
@@ -216,6 +221,143 @@ class TestPruner:
         assert "score" in kept_set
         assert "out" in kept_set
         assert "batch_src" in set(removed)
+
+    def test_prune_routes_two_frames_from_one_api_input_independently(self) -> None:
+        """One source node can contribute both the live and batch switch branches."""
+        from haute.deploy._pruner import prune_for_deploy
+
+        graph = _g(
+            {
+                "nodes": [
+                    {
+                        "id": "request",
+                        "data": {
+                            "label": "Quote Request",
+                            "nodeType": "apiInput",
+                            "config": {"path": "quotes.json"},
+                        },
+                    },
+                    {
+                        "id": "switch",
+                        "data": {
+                            "label": "Route Input",
+                            "nodeType": "liveSwitch",
+                            "config": {
+                                "input_scenario_map": {
+                                    "quotes": "live",
+                                    "drivers": "batch",
+                                },
+                                "inputs": ["quotes", "drivers"],
+                            },
+                        },
+                    },
+                    {
+                        "id": "out",
+                        "data": {
+                            "label": "Response",
+                            "nodeType": "output",
+                            "config": make_output_config([]),
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "request__quotes__switch",
+                        "source": "request",
+                        "target": "switch",
+                        "sourceHandle": "quotes",
+                    },
+                    {
+                        "id": "request__drivers__switch",
+                        "source": "request",
+                        "target": "switch",
+                        "sourceHandle": "drivers",
+                    },
+                    {"id": "switch__out", "source": "switch", "target": "out"},
+                ],
+            }
+        )
+
+        pruned, kept, removed = prune_for_deploy(graph, "out")
+
+        assert [edge.id for edge in pruned.edges] == [
+            "request__quotes__switch",
+            "switch__out",
+        ]
+        assert kept == ["out", "request", "switch"]
+        assert removed == []
+
+    @pytest.mark.parametrize(
+        ("fallback_inputs", "unmatched_name"),
+        [
+            pytest.param(None, "<missing>", id="absent-fallback"),
+            pytest.param(["not_connected"], "not_connected", id="unmatched-fallback"),
+        ],
+    )
+    def test_prune_live_switch_without_live_mapping_rejects_invalid_fallback(
+        self,
+        fallback_inputs: list[str] | None,
+        unmatched_name: str,
+    ) -> None:
+        """A missing live branch cannot silently erase every switch input edge."""
+        from haute.deploy._pruner import prune_for_deploy
+
+        switch_config: dict[str, object] = {
+            "input_scenario_map": {"connected_source": "batch"},
+        }
+        if fallback_inputs is not None:
+            switch_config["inputs"] = fallback_inputs
+
+        graph = _g(
+            {
+                "nodes": [
+                    {
+                        "id": "connected_source",
+                        "data": {
+                            "label": "connected_source",
+                            "nodeType": "dataSource",
+                            "config": {},
+                        },
+                    },
+                    {
+                        "id": "route_switch",
+                        "data": {
+                            "label": "Route Switch",
+                            "nodeType": "liveSwitch",
+                            "config": switch_config,
+                        },
+                    },
+                    {
+                        "id": "out",
+                        "data": {
+                            "label": "out",
+                            "nodeType": "output",
+                            "config": make_output_config([]),
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "connected_source__route_switch",
+                        "source": "connected_source",
+                        "target": "route_switch",
+                    },
+                    {
+                        "id": "route_switch__out",
+                        "source": "route_switch",
+                        "target": "out",
+                    },
+                ],
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            prune_for_deploy(graph, "out")
+
+        detail = str(exc_info.value)
+        assert "route_switch" in detail
+        assert "inputs[0]" in detail
+        assert unmatched_name in detail
 
     def test_prune_missing_output_raises(self, full_graph: dict) -> None:
         from haute.deploy._pruner import prune_for_deploy

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1077,7 +1077,14 @@ class TestScorer:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "ms"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 

--- a/tests/test_deploy_contract_integrity.py
+++ b/tests/test_deploy_contract_integrity.py
@@ -252,7 +252,7 @@ class TestValidateDeployFailsOnTestQuotes:
 
         inp = _make_node("api_in", node_type=NodeType.API_INPUT)
         out = _make_node("output", node_type=NodeType.OUTPUT, config=make_output_config([]))
-        edge = GraphEdge(id="e1", source="api_in", target="output")
+        edge = GraphEdge(id="e1", source="api_in", target="output", sourceHandle="api_in")
         resolved = _make_resolved(
             nodes=[inp, out],
             edges=[edge],
@@ -280,7 +280,7 @@ class TestValidateDeployFailsOnTestQuotes:
         )
         inp = _make_node("api_in", node_type=NodeType.API_INPUT)
         out = _make_node("output", node_type=NodeType.OUTPUT, config=make_output_config([]))
-        edge = GraphEdge(id="e1", source="api_in", target="output")
+        edge = GraphEdge(id="e1", source="api_in", target="output", sourceHandle="api_in")
         resolved = _make_resolved(
             nodes=[inp, out],
             edges=[edge],
@@ -457,7 +457,12 @@ class TestFeatureContractBundled:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "api_in", "target": "ms_contract"},
+                    {
+                        "id": "e1",
+                        "source": "api_in",
+                        "target": "ms_contract",
+                        "sourceHandle": "api_in",
+                    },
                     {"id": "e2", "source": "ms_contract", "target": "output"},
                 ],
             }

--- a/tests/test_deploy_identity_parity.py
+++ b/tests/test_deploy_identity_parity.py
@@ -66,7 +66,12 @@ def _model_score_graph(config: dict, *, output_column: str = "x"):
                 },
             ],
             "edges": [
-                {"id": "e1", "source": "src", "target": "ms"},
+                {
+                    "id": "e1",
+                    "source": "src",
+                    "target": "ms",
+                    "sourceHandle": "src",
+                },
                 {"id": "e2", "source": "ms", "target": "out"},
             ],
         }
@@ -95,7 +100,14 @@ def _passthrough_schema_graph(parquet_path):
                     },
                 },
             ],
-            "edges": [{"id": "e1", "source": "src", "target": "out"}],
+            "edges": [
+                {
+                    "id": "e1",
+                    "source": "src",
+                    "target": "out",
+                    "sourceHandle": "src",
+                }
+            ],
         }
     )
 

--- a/tests/test_deploy_internals.py
+++ b/tests/test_deploy_internals.py
@@ -41,6 +41,36 @@ if TYPE_CHECKING:
 PIPELINE_FILE = FIXTURE_DIR / "pipeline.py"
 
 
+def _single_frame_api_input_config(
+    column_name: str,
+    column_type: str = "str",
+    *,
+    label: str = "quotes",
+    **overrides: object,
+) -> dict[str, object]:
+    """Minimal converged apiInput config with one labelled emitted frame."""
+    config: dict[str, object] = {
+        "path": "",
+        "tables": [
+            {
+                "path": "$[:]",
+                "label": label,
+                "emit": True,
+                "columns": [
+                    {
+                        "name": column_name,
+                        "path": f"$[:].{column_name}",
+                        "type": column_type,
+                        "selected": True,
+                    }
+                ],
+            }
+        ],
+    }
+    config.update(overrides)
+    return config
+
+
 def _passthrough_input_graph(parquet_path):
     """apiInput ``src`` (reads ``parquet_path``) → output ``out`` (passthrough)."""
     return _g(
@@ -51,7 +81,9 @@ def _passthrough_input_graph(parquet_path):
                     "data": {
                         "label": "src",
                         "nodeType": "apiInput",
-                        "config": {"path": str(parquet_path)},
+                        "config": _single_frame_api_input_config(
+                            "x", "float", label="src", path=str(parquet_path)
+                        ),
                     },
                 },
                 {
@@ -63,7 +95,14 @@ def _passthrough_input_graph(parquet_path):
                     },
                 },
             ],
-            "edges": [{"id": "e1", "source": "src", "target": "out"}],
+            "edges": [
+                {
+                    "id": "e1",
+                    "source": "src",
+                    "target": "out",
+                    "sourceHandle": "src",
+                }
+            ],
         }
     )
 
@@ -520,7 +559,9 @@ class TestInferOutputSchema:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": "d.parquet"},
+                            "config": _single_frame_api_input_config(
+                                "x", "float", label="src", path="d.parquet"
+                            ),
                         },
                     },
                     {
@@ -532,7 +573,14 @@ class TestInferOutputSchema:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -573,7 +621,9 @@ class TestInferOutputSchema:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": str(pq_path)},
+                            "config": _single_frame_api_input_config(
+                                "x", "float", label="src", path=str(pq_path)
+                            ),
                         },
                     },
                     {
@@ -585,7 +635,14 @@ class TestInferOutputSchema:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -619,7 +676,9 @@ class TestInferOutputSchema:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": str(pq_path)},
+                            "config": _single_frame_api_input_config(
+                                "x", "float", label="src", path=str(pq_path)
+                            ),
                         },
                     },
                     {
@@ -631,7 +690,14 @@ class TestInferOutputSchema:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -676,7 +742,9 @@ class TestInferOutputSchema:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": str(pq_path)},
+                            "config": _single_frame_api_input_config(
+                                "x", "float", label="src", path=str(pq_path)
+                            ),
                         },
                     },
                     {
@@ -688,7 +756,14 @@ class TestInferOutputSchema:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -722,7 +797,9 @@ class TestInferOutputSchema:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": str(pq_path)},
+                            "config": _single_frame_api_input_config(
+                                "x", "float", label="src", path=str(pq_path)
+                            ),
                         },
                     },
                     {
@@ -734,7 +811,14 @@ class TestInferOutputSchema:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -849,7 +933,7 @@ class TestScoreGraphApiInputInjection:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -861,7 +945,14 @@ class TestScoreGraphApiInputInjection:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -878,6 +969,119 @@ class TestScoreGraphApiInputInjection:
         assert "x" in result.columns
         assert "y" in result.columns
 
+    def test_api_input_frame_label_is_the_deploy_parameter_name(self):
+        """Deploy user code binds the edge's frame name, not its source-node label."""
+        from haute.deploy._scorer import score_graph
+
+        graph = _g(
+            {
+                "nodes": [
+                    {
+                        "id": "request",
+                        "data": {
+                            "label": "Quote Request Node",
+                            "nodeType": "apiInput",
+                            "config": _single_frame_api_input_config("value", "int"),
+                        },
+                    },
+                    {
+                        "id": "tag_quote",
+                        "data": {
+                            "label": "Tag Quote",
+                            "nodeType": "polars",
+                            "config": {
+                                "code": ('df = quotes.with_columns(bound_input=pl.lit("quotes"))'),
+                            },
+                        },
+                    },
+                    {
+                        "id": "out",
+                        "data": {
+                            "label": "Response",
+                            "nodeType": "output",
+                            "config": make_output_config(
+                                ["value", "bound_input"],
+                                source_port="Tag_Quote",
+                            ),
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "request__quotes__tag",
+                        "source": "request",
+                        "target": "tag_quote",
+                        "sourceHandle": "quotes",
+                    },
+                    {"id": "tag__out", "source": "tag_quote", "target": "out"},
+                ],
+            }
+        )
+
+        result = score_graph(
+            graph=graph,
+            input_df=pl.DataFrame({"value": [17]}),
+            input_node_ids=["request"],
+            output_node_id="out",
+        )
+
+        assert result.to_dicts() == [{"value": 17, "bound_input": "quotes"}]
+
+    def test_null_handle_api_input_edge_raises_value_error_naming_edge(self):
+        """A malformed apiInput edge cannot silently drop its source frame."""
+        from haute.deploy._scorer import score_graph
+
+        graph = _g(
+            {
+                "nodes": [
+                    {
+                        "id": "request",
+                        "data": {
+                            "label": "Request",
+                            "nodeType": "apiInput",
+                            "config": _single_frame_api_input_config("value", "int"),
+                        },
+                    },
+                    {
+                        "id": "build",
+                        "data": {
+                            "label": "build",
+                            "nodeType": "polars",
+                            "config": {
+                                "code": 'df = pl.DataFrame({"ok": [True]}).lazy()',
+                            },
+                        },
+                    },
+                    {
+                        "id": "out",
+                        "data": {
+                            "label": "out",
+                            "nodeType": "output",
+                            "config": make_output_config(["ok"], source_port="build"),
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "request_edge_missing_frame_port",
+                        "source": "request",
+                        "target": "build",
+                    },
+                    {"id": "build__out", "source": "build", "target": "out"},
+                ],
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            score_graph(
+                graph=graph,
+                input_df=pl.DataFrame({"value": [17]}),
+                input_node_ids=["request"],
+                output_node_id="out",
+            )
+
+        assert "request_edge_missing_frame_port" in str(exc_info.value)
+
     def test_multiple_api_inputs(self):
         """Multiple apiInput nodes all receive the same input_df."""
         from haute.deploy._scorer import score_graph
@@ -890,7 +1094,7 @@ class TestScoreGraphApiInputInjection:
                         "data": {
                             "label": "src1",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("val", "int", label="src1"),
                         },
                     },
                     {
@@ -898,7 +1102,7 @@ class TestScoreGraphApiInputInjection:
                         "data": {
                             "label": "src2",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("val", "int", label="src2"),
                         },
                     },
                     {
@@ -911,8 +1115,18 @@ class TestScoreGraphApiInputInjection:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src1", "target": "out"},
-                    {"id": "e2", "source": "src2", "target": "out"},
+                    {
+                        "id": "e1",
+                        "source": "src1",
+                        "target": "out",
+                        "sourceHandle": "src1",
+                    },
+                    {
+                        "id": "e2",
+                        "source": "src2",
+                        "target": "out",
+                        "sourceHandle": "src2",
+                    },
                 ],
             }
         )
@@ -943,7 +1157,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -955,7 +1169,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -983,7 +1204,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -995,7 +1216,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
         output_lf = pl.DataFrame({"x": [1.0], "y": [2.0], "z": [3.0]}).lazy()
@@ -1030,7 +1258,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1042,7 +1270,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
         output_lf = pl.DataFrame({"x": [1.0], "z": [3.0]}).lazy()
@@ -1085,7 +1320,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("keep", "float", label="src"),
                         },
                     },
                     {
@@ -1097,7 +1332,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
         retained_ref: weakref.ReferenceType[pl.LazyFrame] | None = None
@@ -1143,7 +1385,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1155,7 +1397,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
         output_lf = pl.DataFrame({"x": [1.0, 2.0]}).lazy()
@@ -1192,7 +1441,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1204,7 +1453,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -1230,7 +1486,7 @@ class TestScoreGraphOutputFields:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1242,7 +1498,14 @@ class TestScoreGraphOutputFields:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -1401,7 +1664,7 @@ class TestScoreGraphBadInput:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("VehPower", "float"),
                         },
                     },
                     {
@@ -1411,7 +1674,7 @@ class TestScoreGraphBadInput:
                             "nodeType": "polars",
                             "config": {
                                 "code": (
-                                    "df = df.with_columns("
+                                    "df = quotes.with_columns("
                                     'result=pl.col("VehPower").cast(pl.Float64) * 2)'
                                 ),
                                 "contract": {
@@ -1431,7 +1694,12 @@ class TestScoreGraphBadInput:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "calc"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "calc",
+                        "sourceHandle": "quotes",
+                    },
                     {"id": "e2", "source": "calc", "target": "out"},
                 ],
             }
@@ -1480,7 +1748,7 @@ class TestScoreGraphBadInput:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1492,7 +1760,14 @@ class TestScoreGraphBadInput:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
 
@@ -1556,7 +1831,7 @@ class TestScoreGraphExternalFileRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1582,7 +1857,12 @@ class TestScoreGraphExternalFileRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ext"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ext",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ext", "target": "out"},
                 ],
             }
@@ -1617,7 +1897,7 @@ class TestScoreGraphExternalFileRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1642,7 +1922,12 @@ class TestScoreGraphExternalFileRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ext"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ext",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ext", "target": "out"},
                 ],
             }
@@ -1682,7 +1967,7 @@ class TestScoreGraphOptimiserApplyRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1708,7 +1993,12 @@ class TestScoreGraphOptimiserApplyRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "opt"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "opt",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "opt", "target": "out"},
                 ],
             }
@@ -1774,7 +2064,7 @@ class TestScoreGraphOptimiserApplyRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("quote_id", label="src"),
                         },
                     },
                     {
@@ -1823,8 +2113,18 @@ class TestScoreGraphOptimiserApplyRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "opt"},
-                    {"id": "e2", "source": "src", "target": "band"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "opt",
+                        "sourceHandle": "src",
+                    },
+                    {
+                        "id": "e2",
+                        "source": "src",
+                        "target": "band",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e3", "source": "band", "target": "opt"},
                     {"id": "e4", "source": "opt", "target": "out"},
                 ],
@@ -1871,7 +2171,7 @@ class TestScoreGraphOptimiserApplyRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1897,7 +2197,12 @@ class TestScoreGraphOptimiserApplyRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "opt"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "opt",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "opt", "target": "out"},
                 ],
             }
@@ -1933,6 +2238,7 @@ class TestScoreGraphModelScoreRemap:
 
     def test_model_score_remap_loads_bundled_model(self, tmp_path):
         """modelScore with remap loads from bundled local path."""
+        from haute._mlflow_io import ScoringModel
         from haute.deploy._scorer import score_graph
 
         cbm_path = tmp_path / "model.cbm"
@@ -1941,6 +2247,12 @@ class TestScoreGraphModelScoreRemap:
         mock_model = MagicMock()
         mock_model.feature_names_ = ["x"]
         mock_model.predict.return_value = np.array([42.0])
+        scoring_model = ScoringModel(
+            model=mock_model,
+            feature_names=["x"],
+            cat_feature_names=frozenset(),
+            flavor="catboost",
+        )
 
         graph = _g(
             {
@@ -1950,7 +2262,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -1977,7 +2289,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -1986,7 +2303,10 @@ class TestScoreGraphModelScoreRemap:
         input_df = pl.DataFrame({"x": [1.0]})
         remap = {"ms__model.cbm": str(cbm_path)}
 
-        with patch("haute._mlflow_io._load_catboost_model", return_value=mock_model):
+        with (
+            patch("haute._mlflow_io._load_catboost_model", return_value=mock_model),
+            patch("haute._mlflow_io.load_mlflow_model", return_value=scoring_model),
+        ):
             result = score_graph(
                 graph=graph,
                 input_df=input_df,
@@ -2036,7 +2356,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -2064,7 +2384,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2132,10 +2457,11 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {
-                                "path": "",
-                                "categorical_levels": {"region": ["north", "south"]},
-                            },
+                            "config": _single_frame_api_input_config(
+                                "region",
+                                label="src",
+                                categorical_levels={"region": ["north", "south"]},
+                            ),
                         },
                     },
                     {
@@ -2162,7 +2488,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2218,7 +2549,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("region", label="src"),
                         },
                     },
                     {
@@ -2242,7 +2573,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2291,12 +2627,11 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {
-                                "path": "",
-                                "categorical_levels": {
-                                    "region": ["north", "east"],
-                                },
-                            },
+                            "config": _single_frame_api_input_config(
+                                "region",
+                                label="src",
+                                categorical_levels={"region": ["north", "east"]},
+                            ),
                         },
                     },
                     {
@@ -2320,7 +2655,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2367,12 +2707,11 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {
-                                "path": "",
-                                "categorical_levels": {
-                                    "region": ["north", "south"],
-                                },
-                            },
+                            "config": _single_frame_api_input_config(
+                                "region",
+                                label="src",
+                                categorical_levels={"region": ["north", "south"]},
+                            ),
                         },
                     },
                     {
@@ -2396,7 +2735,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2444,12 +2788,11 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {
-                                "path": "",
-                                "categorical_levels": {
-                                    "region": ["north", "south"],
-                                },
-                            },
+                            "config": _single_frame_api_input_config(
+                                "region",
+                                label="src",
+                                categorical_levels={"region": ["north", "south"]},
+                            ),
                         },
                     },
                     {
@@ -2473,7 +2816,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2521,7 +2869,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("region", label="src"),
                         },
                     },
                     {
@@ -2545,7 +2893,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2593,10 +2946,10 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {
-                                "path": "",
-                                "categorical_levels": {"region": ["north", "east"]},
-                            },
+                            "config": _single_frame_api_input_config(
+                                "region",
+                                categorical_levels={"region": ["north", "east"]},
+                            ),
                         },
                     },
                     {
@@ -2604,7 +2957,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "prep",
                             "nodeType": "polars",
-                            "config": {"code": "df = df"},
+                            "config": {"code": "df = quotes"},
                         },
                     },
                     {
@@ -2628,7 +2981,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "prep"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "prep",
+                        "sourceHandle": "quotes",
+                    },
                     {"id": "e2", "source": "prep", "target": "ms"},
                     {"id": "e3", "source": "ms", "target": "out"},
                 ],
@@ -2665,7 +3023,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -2692,7 +3050,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2742,7 +3105,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -2769,7 +3132,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2777,6 +3145,7 @@ class TestScoreGraphModelScoreRemap:
 
         with (
             patch("haute._mlflow_io.load_local_model", return_value=scoring_model),
+            patch("haute._mlflow_io.load_mlflow_model", return_value=scoring_model),
             patch(
                 "haute._model_scorer._run_score_pipeline",
                 side_effect=fake_run_score_pipeline,
@@ -2831,7 +3200,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -2858,7 +3227,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -2925,7 +3299,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -2933,7 +3307,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "aux",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="aux"),
                         },
                     },
                     {
@@ -2965,8 +3339,18 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
-                    {"id": "e2", "source": "aux", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
+                    {
+                        "id": "e2",
+                        "source": "aux",
+                        "target": "ms",
+                        "sourceHandle": "aux",
+                    },
                     {"id": "e3", "source": "ms", "target": "out"},
                 ],
             }
@@ -3013,7 +3397,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -3040,7 +3424,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -3094,7 +3483,7 @@ class TestScoreGraphModelScoreRemap:
                         "data": {
                             "label": "src",
                             "nodeType": "apiInput",
-                            "config": {"path": ""},
+                            "config": _single_frame_api_input_config("x", "float", label="src"),
                         },
                     },
                     {
@@ -3121,7 +3510,12 @@ class TestScoreGraphModelScoreRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -4281,13 +4675,28 @@ class TestValidateDeployEdgeCases:
             pruned_graph=_g(
                 {
                     "nodes": [
-                        {"id": "policies", "data": {"nodeType": "apiInput", "config": {}}},
+                        {
+                            "id": "policies",
+                            "data": {
+                                "nodeType": "apiInput",
+                                "config": _single_frame_api_input_config(
+                                    "col", "int", label="policies"
+                                ),
+                            },
+                        },
                         {
                             "id": "output",
                             "data": {"nodeType": "output", "config": make_output_config([])},
                         },
                     ],
-                    "edges": [{"id": "e1", "source": "policies", "target": "output"}],
+                    "edges": [
+                        {
+                            "id": "e1",
+                            "source": "policies",
+                            "target": "output",
+                            "sourceHandle": "policies",
+                        }
+                    ],
                 }
             ),
             input_node_ids=["policies"],
@@ -4312,13 +4721,28 @@ class TestValidateDeployEdgeCases:
             pruned_graph=_g(
                 {
                     "nodes": [
-                        {"id": "policies", "data": {"nodeType": "apiInput", "config": {}}},
+                        {
+                            "id": "policies",
+                            "data": {
+                                "nodeType": "apiInput",
+                                "config": _single_frame_api_input_config(
+                                    "col", "int", label="policies"
+                                ),
+                            },
+                        },
                         {
                             "id": "output",
                             "data": {"nodeType": "output", "config": make_output_config([])},
                         },
                     ],
-                    "edges": [{"id": "e1", "source": "policies", "target": "output"}],
+                    "edges": [
+                        {
+                            "id": "e1",
+                            "source": "policies",
+                            "target": "output",
+                            "sourceHandle": "policies",
+                        }
+                    ],
                 }
             ),
             input_node_ids=["policies"],

--- a/tests/test_deploy_scorer_artifact_cache.py
+++ b/tests/test_deploy_scorer_artifact_cache.py
@@ -98,7 +98,12 @@ def _model_score_graph() -> Any:
                 },
             ],
             "edges": [
-                {"id": "e1", "source": "src", "target": "ms"},
+                {
+                    "id": "e1",
+                    "source": "src",
+                    "target": "ms",
+                    "sourceHandle": "src",
+                },
                 {"id": "e2", "source": "ms", "target": "out"},
             ],
         }
@@ -353,7 +358,14 @@ class TestDeployArtifactPathFingerprints:
                         },
                     },
                 ],
-                "edges": [{"id": "e1", "source": "src", "target": "out"}],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "out",
+                        "sourceHandle": "src",
+                    }
+                ],
             }
         )
         real_content_hash = execution_mod.content_hash

--- a/tests/test_deploy_scorer_coverage.py
+++ b/tests/test_deploy_scorer_coverage.py
@@ -215,7 +215,12 @@ class TestScoreGraphModelScoreContractOnly:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "ms",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "ms", "target": "out"},
                 ],
             }
@@ -379,7 +384,12 @@ class TestScoreGraphStaticDataSourceRemap:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "src", "target": "static_ds"},
+                    {
+                        "id": "e1",
+                        "source": "src",
+                        "target": "static_ds",
+                        "sourceHandle": "src",
+                    },
                     {"id": "e2", "source": "static_ds", "target": "out"},
                 ],
             }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,7 +31,7 @@ EXPECTED_FIXTURE_PREMIUM = 2.75
 
 @pytest.fixture(autouse=True)
 def _isolate_json_cache(tmp_path, monkeypatch, _widen_sandbox_root):
-    """Redirect the JSON parquet cache to a temp dir and pre-populate it.
+    """Redirect the JSON parquet cache to a temp dir and prewarm it.
 
     Without this, a stale .haute_cache/ in the working directory (from a
     previous real-data run) can poison the fixture pipeline's api-input
@@ -40,8 +40,9 @@ def _isolate_json_cache(tmp_path, monkeypatch, _widen_sandbox_root):
     Under v2 (post-commit-5.5) the per-port cache replaces the v1 single
     parquet. We pre-populate the cache via ``build_per_port_cache`` so
     the executor's apiInput consumer (which reads from the per-port
-    cache via ``load_per_port_cache``) finds its data ready — the same
-    step a user performs by clicking "Cache as Parquet" in the GUI.
+    cache via ``load_per_port_cache``) exercises the performance fast path.
+    This mirrors the optional "Cache as Parquet" prewarm action; uncached
+    execution is covered separately and reads the JSON source directly.
     """
     import json
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -95,6 +95,8 @@ class TestEndToEnd:
         }
         assert node_ids == expected_nodes
         assert len(graph.edges) == 6
+        quotes_edge = next(edge for edge in graph.edges if edge.source == "quotes")
+        assert quotes_edge.sourceHandle == "quotes"
 
     def test_execute_all_nodes(self):
         """All nodes execute and the fixture premium matches the oracle."""
@@ -251,8 +253,13 @@ def _make_node(nid: str, label: str, node_type: NodeType, config: dict | None = 
     )
 
 
-def _make_edge(src: str, tgt: str) -> GraphEdge:
-    return GraphEdge(id=f"e_{src}_{tgt}", source=src, target=tgt)
+def _make_edge(src: str, tgt: str, *, source_port: str | None = None) -> GraphEdge:
+    return GraphEdge(
+        id=f"e_{src}_{tgt}",
+        source=src,
+        target=tgt,
+        sourceHandle=source_port,
+    )
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -371,7 +378,35 @@ class TestAllNodeTypesRoundtrip:
         # source_names correctly and the parser can reconstruct edges.
         nodes = [
             _make_node("ds", "ds", NodeType.DATA_SOURCE, {"path": _posix_path(data_path)}),
-            _make_node("api", "api", NodeType.API_INPUT, {"path": _posix_path(json_path)}),
+            _make_node(
+                "api",
+                "api",
+                NodeType.API_INPUT,
+                {
+                    "path": _posix_path(json_path),
+                    "tables": [
+                        {
+                            "path": "$[:]",
+                            "label": "api",
+                            "emit": True,
+                            "columns": [
+                                {
+                                    "name": "x",
+                                    "path": "$[:].x",
+                                    "type": "int",
+                                    "selected": True,
+                                },
+                                {
+                                    "name": "region",
+                                    "path": "$[:].region",
+                                    "type": "str",
+                                    "selected": True,
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ),
             _make_node(
                 "const",
                 "const",
@@ -497,7 +532,7 @@ class TestAllNodeTypesRoundtrip:
         # Chain them linearly so every node has a source_name
         edges = [
             _make_edge("ds", "switch"),
-            _make_edge("api", "switch"),
+            _make_edge("api", "switch", source_port="api"),
             _make_edge("switch", "transform"),
             _make_edge("transform", "band"),
             _make_edge("band", "rating"),

--- a/tests/test_execute_lazy.py
+++ b/tests/test_execute_lazy.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import polars as pl
 import pytest
 
+import haute.projection as projection_planner
 from haute._execute_lazy import (
     EagerResult,
     _apply_selected_columns,
@@ -42,10 +43,26 @@ def _e(src: str, tgt: str) -> GraphEdge:
     return GraphEdge(id=f"e_{src}_{tgt}", source=src, target=tgt)
 
 
+def _port_edge(src: str, tgt: str, port: str) -> GraphEdge:
+    return GraphEdge(
+        id=f"e_{src}_{tgt}_{port}",
+        source=src,
+        target=tgt,
+        sourceHandle=port,
+    )
+
+
 def _source_node(nid: str, label: str | None = None) -> GraphNode:
     return GraphNode(
         id=nid,
         data=NodeData(label=label or nid, nodeType=NodeType.DATA_SOURCE),
+    )
+
+
+def _api_input_node(nid: str, label: str | None = None) -> GraphNode:
+    return GraphNode(
+        id=nid,
+        data=NodeData(label=label or nid, nodeType=NodeType.API_INPUT),
     )
 
 
@@ -102,6 +119,47 @@ class TestPruneLiveSwitchEdges:
         sources = [e.source for e in result]
         assert "live_input" in sources
         assert "batch_input" not in sources
+
+    @pytest.mark.parametrize(
+        ("scenario", "expected_edge_id"),
+        [
+            ("live", "e_api_sw_quotes"),
+            ("batch", "e_api_sw_drivers"),
+        ],
+    )
+    def test_routes_api_input_frames_individually_by_edge_name(
+        self,
+        scenario: str,
+        expected_edge_id: str,
+    ) -> None:
+        """Two ports from one source remain independently selectable."""
+        edges = [
+            _port_edge("api", "sw", "quotes"),
+            _port_edge("api", "sw", "drivers"),
+        ]
+        node_map = {
+            "api": _api_input_node("api", "API Input"),
+            "sw": _live_switch_node("sw", {"quotes": "live", "drivers": "batch"}),
+        }
+
+        result = _prune_live_switch_edges(edges, node_map, scenario)
+
+        assert [edge.id for edge in result] == [expected_edge_id]
+
+    def test_ordinary_parent_mapping_still_uses_sanitised_source_labels(self) -> None:
+        edges = [_e("live_src", "sw"), _e("batch_src", "sw")]
+        node_map = {
+            "live_src": _source_node("live_src", "Live Source"),
+            "batch_src": _source_node("batch_src", "Batch-Source"),
+            "sw": _live_switch_node(
+                "sw",
+                {"Live_Source": "live", "Batch_Source": "batch"},
+            ),
+        }
+
+        result = _prune_live_switch_edges(edges, node_map, "live")
+
+        assert [edge.id for edge in result] == ["e_live_src_sw"]
 
     def test_keeps_both_when_scenario_not_in_map(self):
         """If active scenario is not in any ISM value, keep all edges (fallback)."""
@@ -178,6 +236,34 @@ class TestPrepareGraph:
         _, order, parents, _ = _prepare_graph(g, source="live")
         # "batch" should not be a parent of "sw" in live scenario
         assert "batch" not in parents.get("sw", [])
+
+    @pytest.mark.parametrize(
+        ("scenario", "expected_edge_id"),
+        [
+            ("live", "e_api_sw_quotes"),
+            ("batch", "e_api_sw_drivers"),
+        ],
+    )
+    def test_projection_preparation_retains_only_the_selected_api_frame_edge(
+        self,
+        scenario: str,
+        expected_edge_id: str,
+    ) -> None:
+        """Projection preparation must preserve the per-edge liveSwitch choice."""
+        graph = PipelineGraph(
+            nodes=[
+                _api_input_node("api", "API Input"),
+                _live_switch_node("sw", {"quotes": "live", "drivers": "batch"}),
+            ],
+            edges=[
+                _port_edge("api", "sw", "quotes"),
+                _port_edge("api", "sw", "drivers"),
+            ],
+        )
+
+        prepared = projection_planner.prepare_graph(graph, target_node_id="sw", source=scenario)
+
+        assert [edge.id for edge in prepared.relevant_edges] == [expected_edge_id]
 
     def test_id_to_name_sanitizes_labels(self):
         g = PipelineGraph(

--- a/tests/test_execution_context.py
+++ b/tests/test_execution_context.py
@@ -2834,7 +2834,7 @@ def test_deploy_batch_graph_routing_stays_live_for_source_switch(tmp_path) -> No
                 {
                     "id": "live_src",
                     "data": {
-                        "label": "live_src",
+                        "label": "Live API Request",
                         "nodeType": NodeType.API_INPUT.value,
                         "config": {"path": ""},
                     },
@@ -2854,7 +2854,7 @@ def test_deploy_batch_graph_routing_stays_live_for_source_switch(tmp_path) -> No
                         "nodeType": NodeType.LIVE_SWITCH.value,
                         "config": {
                             "input_scenario_map": {
-                                "live_src": "live",
+                                "quotes": "live",
                                 "batch_src": ExecutionProfile.DEPLOY_BATCH.value,
                             }
                         },
@@ -2870,7 +2870,9 @@ def test_deploy_batch_graph_routing_stays_live_for_source_switch(tmp_path) -> No
                 },
             ],
             "edges": [
-                make_edge("live_src", "switch").model_dump(),
+                make_edge("live_src", "switch")
+                .model_copy(update={"sourceHandle": "quotes"})
+                .model_dump(),
                 make_edge("batch_src", "switch").model_dump(),
                 make_edge("switch", "output").model_dump(),
             ],

--- a/tests/test_graph_input_identity.py
+++ b/tests/test_graph_input_identity.py
@@ -1,0 +1,136 @@
+"""RED contracts for edge-derived pipeline input names.
+
+The input name is an observable graph contract: it is shown to users and later
+becomes the generated Python parameter.  These tests deliberately exercise the
+pure derivation before executor/codegen call sites are changed.
+"""
+
+from __future__ import annotations
+
+import haute._graph_utils as graph_utils
+from haute._types import GraphEdge, GraphNode, NodeData, NodeType
+
+
+def _node(node_id: str, label: str, node_type: NodeType) -> GraphNode:
+    return GraphNode(
+        id=node_id,
+        data=NodeData(label=label, nodeType=node_type),
+    )
+
+
+def _edge(
+    source: str,
+    target: str = "consumer",
+    *,
+    source_handle: str | None = None,
+) -> GraphEdge:
+    return GraphEdge(
+        id=f"e_{source}_{target}_{source_handle or 'default'}",
+        source=source,
+        target=target,
+        sourceHandle=source_handle,
+    )
+
+
+def test_api_input_edge_uses_raw_frame_label_verbatim() -> None:
+    source = _node("request", "API Request", NodeType.API_INPUT)
+    # Schema validation rejects non-ASCII labels separately.  This pure helper
+    # must still preserve the persisted edge identity rather than sanitising it.
+    edge = _edge("request", source_handle="café")
+
+    assert graph_utils.edge_input_name(edge, source) == "café"
+
+
+def test_api_input_frame_name_can_equal_an_ordinary_sanitised_label() -> None:
+    """A mixed-source collision is reported instead of secretly rewritten."""
+    api_source = _node("request", "API Request", NodeType.API_INPUT)
+    ordinary_source = _node("quotes_node", "quote-id", NodeType.POLARS)
+    api_edge = _edge("request", source_handle="quote_id")
+    ordinary_edge = _edge("quotes_node")
+
+    names = [
+        graph_utils.edge_input_name(api_edge, api_source),
+        graph_utils.edge_input_name(ordinary_edge, ordinary_source),
+    ]
+
+    assert names == ["quote_id", "quote_id"]
+    assert graph_utils.duplicate_input_names(names) == ["quote_id"]
+
+
+def test_ordinary_edge_uses_sanitised_source_label_not_its_handle() -> None:
+    source = _node("claims", "Driver Claims-Step", NodeType.POLARS)
+    edge = _edge("claims", source_handle="must_not_become_the_input_name")
+
+    assert graph_utils.edge_input_name(edge, source) == "Driver_Claims_Step"
+
+
+def test_edge_derived_names_preserve_incoming_edge_order() -> None:
+    api_source = _node("request", "API Request", NodeType.API_INPUT)
+    ordinary_source = _node("rating", "Rating Step", NodeType.RATING_STEP)
+    incoming_edges = [
+        _edge("request", source_handle="drivers"),
+        _edge("rating"),
+        _edge("request", source_handle="quotes"),
+    ]
+    source_nodes = {
+        "request": api_source,
+        "rating": ordinary_source,
+    }
+
+    names = [
+        graph_utils.edge_input_name(edge, source_nodes[edge.source]) for edge in incoming_edges
+    ]
+
+    assert names == ["drivers", "Rating_Step", "quotes"]
+
+
+def test_flattened_submodel_output_uses_child_node_label() -> None:
+    """A flattened boundary edge names the child frame, not its old container."""
+    child_source = _node("frequency_child", "Frequency Model Child", NodeType.POLARS)
+    # flatten_graph rewires ``submodel__frequency`` -> consumer to this child source.
+    flattened_edge = _edge("frequency_child")
+
+    assert graph_utils.edge_input_name(flattened_edge, child_source) == "Frequency_Model_Child"
+
+
+def test_edge_input_name_does_not_mutate_its_inputs() -> None:
+    source = _node("request", "API Request", NodeType.API_INPUT)
+    edge = _edge("request", source_handle="quotes")
+    source_before = source.model_copy(deep=True)
+    edge_before = edge.model_copy(deep=True)
+
+    first = graph_utils.edge_input_name(edge, source)
+    second = graph_utils.edge_input_name(edge, source)
+
+    assert first == second == "quotes"
+    assert source == source_before
+    assert edge == edge_before
+
+
+def test_duplicate_input_names_returns_empty_for_unique_names() -> None:
+    assert graph_utils.duplicate_input_names([]) == []
+    assert graph_utils.duplicate_input_names(["quotes", "drivers", "claims"]) == []
+
+
+def test_duplicate_input_names_orders_by_first_duplicate_occurrence() -> None:
+    # Initial occurrences are alpha then beta, but beta becomes a duplicate first.
+    names = ["alpha", "beta", "beta", "alpha"]
+
+    assert graph_utils.duplicate_input_names(names) == ["beta", "alpha"]
+
+
+def test_duplicate_input_names_reports_each_repeated_name_once() -> None:
+    names = ["quotes", "drivers", "drivers", "quotes", "drivers", "quotes"]
+
+    assert graph_utils.duplicate_input_names(names) == ["drivers", "quotes"]
+
+
+def test_duplicate_input_names_does_not_mutate_its_input() -> None:
+    names = ["quotes", "drivers", "drivers", "quotes", "drivers"]
+    names_before = names.copy()
+
+    first = graph_utils.duplicate_input_names(names)
+    second = graph_utils.duplicate_input_names(names)
+
+    assert first == second == ["drivers", "quotes"]
+    assert names == names_before

--- a/tests/test_inference_identifier_labels.py
+++ b/tests/test_inference_identifier_labels.py
@@ -1,0 +1,192 @@
+"""RED contracts for identifier-safe labels minted by schema inference."""
+
+from __future__ import annotations
+
+import json
+import keyword
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import haute._api_input_schema as api_input_schema
+from haute._api_input_schema import validate_v2_schema
+from haute._json_shred import infer_v2_schema_from_data
+
+
+def _write(tmp_path: Path, record: dict[str, Any], name: str = "data.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps([record]), encoding="utf-8")
+    return path
+
+
+def _tables_by_path(schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {table["path"]: table for table in schema["tables"]}
+
+
+def _assert_inferred_identity(
+    table: dict[str, Any],
+    *,
+    path: str,
+    label: str,
+) -> None:
+    assert table["label"] == label
+    assert table["path"] == path
+    assert table["displayPath"] == path
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("  quotes  ", "quotes", id="strips-outer-whitespace"),
+        pytest.param("quote-id frame", "quote_id_frame", id="spaces-and-hyphens"),
+        pytest.param("Plan_42.!/@#", "Plan_42", id="ascii-kept-or-dropped"),
+        pytest.param("café/β", "caf_xe9__x3b2_", id="unicode-hex-encoding"),
+        pytest.param("", "table", id="empty"),
+        pytest.param("  !@#  ", "table", id="empty-after-character-filter"),
+        pytest.param("123_frame", "_123_frame", id="digit-leading"),
+        pytest.param("class", "class_", id="hard-keyword"),
+        pytest.param("match", "match", id="soft-keyword-match"),
+        pytest.param("case", "case", id="soft-keyword-case"),
+        pytest.param("type", "type", id="soft-keyword-type"),
+        pytest.param("_", "_", id="soft-keyword-underscore"),
+    ],
+)
+def test_derive_identifier_label_uses_the_specified_pipeline_and_repairs(
+    raw: str,
+    expected: str,
+) -> None:
+    assert api_input_schema.derive_identifier_label(raw) == expected
+
+
+def test_inference_labels_root_and_children_without_replacing_paths(tmp_path: Path) -> None:
+    schema = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "policy_id": 1,
+                "proposer": {"claims": [{"amount": 100}]},
+                "class": [{"code": "A"}],
+            },
+        )
+    )
+    tables = _tables_by_path(schema)
+
+    _assert_inferred_identity(tables["$[:]"], path="$[:]", label="root")
+    _assert_inferred_identity(
+        tables["$[:].proposer.claims[:]"],
+        path="$[:].proposer.claims[:]",
+        label="claims",
+    )
+    _assert_inferred_identity(
+        tables["$[:].class[:]"],
+        path="$[:].class[:]",
+        label="class_",
+    )
+
+
+def test_inference_qualifies_every_shared_innermost_label_symmetrically(
+    tmp_path: Path,
+) -> None:
+    schema = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "id": 1,
+                "a": {"items": [{"value": "A"}]},
+                "b": {"items": [{"value": "B"}]},
+            },
+        )
+    )
+    tables = _tables_by_path(schema)
+
+    _assert_inferred_identity(
+        tables["$[:].a.items[:]"],
+        path="$[:].a.items[:]",
+        label="a_items",
+    )
+    _assert_inferred_identity(
+        tables["$[:].b.items[:]"],
+        path="$[:].b.items[:]",
+        label="b_items",
+    )
+    assert "items" not in {table["label"] for table in schema["tables"]}
+
+
+def test_inference_uses_deterministic_numeric_suffixes_as_the_final_backstop(
+    tmp_path: Path,
+) -> None:
+    schema = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "id": 1,
+                "a_b_items": [{"value": "top"}],
+                "a_b": {"items": [{"value": "joined"}]},
+                "a": {"b": {"items": [{"value": "split"}]}},
+            },
+        )
+    )
+
+    assert [(table["path"], table["label"]) for table in schema["tables"]] == [
+        ("$[:]", "root"),
+        ("$[:].a_b_items[:]", "a_b_items"),
+        ("$[:].a_b.items[:]", "a_b_items_2"),
+        ("$[:].a.b.items[:]", "a_b_items_3"),
+    ]
+
+
+def test_inferred_schema_passes_validation_unchanged(tmp_path: Path) -> None:
+    schema = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "id": 1,
+                "class": [{"code": "A"}],
+                "a_b_items": [{"value": "top"}],
+                "a_b": {"items": [{"value": "joined"}]},
+                "a": {"b": {"items": [{"value": "split"}]}},
+            },
+        )
+    )
+    inferred = deepcopy(schema)
+
+    validate_v2_schema(schema)
+
+    assert schema == inferred
+    for table in schema["tables"]:
+        label = table["label"]
+        assert label.isascii()
+        assert label.isidentifier()
+        assert not keyword.iskeyword(label)
+
+
+def test_inference_closure_resolves_case_only_filename_collisions(
+    tmp_path: Path,
+) -> None:
+    first = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "Foo": [{"value": "same"}],
+                "foo": [{"value": "same"}],
+            },
+            "first.json",
+        )
+    )
+    reordered = infer_v2_schema_from_data(
+        _write(
+            tmp_path,
+            {
+                "foo": [{"value": "same"}],
+                "Foo": [{"value": "same"}],
+            },
+            "reordered.json",
+        )
+    )
+
+    assert reordered == first
+    validate_v2_schema(first)
+    labels = [table["label"] for table in first["tables"]]
+    assert len({label.casefold() for label in labels}) == len(labels)

--- a/tests/test_json_cache_corrupt_and_errors.py
+++ b/tests/test_json_cache_corrupt_and_errors.py
@@ -248,8 +248,11 @@ def test_infer_then_build_scalar_array_end_to_end(client: TestClient, tmp_path: 
     infer = client.post("/api/json-cache/infer", json={"path": "data.json"})
     assert infer.status_code == 200, infer.text
     tables = infer.json()["tables"]
-    labels = {t["label"] for t in tables}
-    assert "$[:].coverages[:]" in labels  # scalar array became a child table
+    labels_by_path = {t["path"]: t["label"] for t in tables}
+    assert labels_by_path == {
+        "$[:]": "root",
+        "$[:].coverages[:]": "coverages",
+    }
     for t in tables:
         t["emit"] = True  # user opts the child table in
 

--- a/tests/test_json_cache_coverage_uplift.py
+++ b/tests/test_json_cache_coverage_uplift.py
@@ -23,14 +23,11 @@ fingerprint format changes) that mock-based tests wouldn't.
 
 from __future__ import annotations
 
-import hashlib
-import io
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import orjson
-import polars as pl
 import pytest
 from fastapi.testclient import TestClient
 
@@ -47,7 +44,7 @@ from haute._json_flatten import (
     clear_json_cache,
     mirror_cache_to_committed,
 )
-from haute._json_shred import _data_file_signature, _v2_fingerprint
+from haute._json_shred import build_per_port_cache
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -83,7 +80,7 @@ def _mirror_config(*, type_: str = "int") -> dict[str, Any]:
                 "columns": [
                     {
                         "name": "value",
-                        "path": "$.value",
+                        "path": "$[:].value",
                         "type": type_,
                         "status": "Confirmed",
                         "selected": True,
@@ -109,42 +106,11 @@ def _write_signed_cache(
     *,
     data_path: Path,
     v2_config: dict[str, Any],
-    parquet_bytes: bytes,
 ) -> dict[str, Any]:
-    """Create a signed cache matching a real source and editor schema."""
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    type_token = v2_config["tables"][0]["columns"][0]["type"]
-    marker = parquet_bytes.decode("utf-8")
-    if type_token == "int":
-        value: int | str = int.from_bytes(hashlib.sha256(parquet_bytes).digest()[:4])
-        dtype = pl.Int64
-    elif type_token == "str":
-        value = marker
-        dtype = pl.String
-    else:  # pragma: no cover - helper is deliberately narrow
-        raise AssertionError(f"unsupported mirror fixture type: {type_token}")
-    parquet_buffer = io.BytesIO()
-    pl.DataFrame({"value": [value]}, schema={"value": dtype}).write_parquet(parquet_buffer)
-    artifact_bytes = parquet_buffer.getvalue()
-    digest = hashlib.sha256(artifact_bytes).hexdigest()
-    parquet_name = f"frame_{digest}.parquet"
-    (cache_dir / parquet_name).write_bytes(artifact_bytes)
-    payload = {
-        "schema_fingerprint": _v2_fingerprint(v2_config),
-        "schema_mode": "v2",
-        "data_file": _data_file_signature(data_path),
-        "tables": [
-            {
-                "label": "data",
-                "parquet": parquet_name,
-                "content_signature": {
-                    "size": len(artifact_bytes),
-                    "sha256": digest,
-                },
-            }
-        ],
-    }
-    _json_cache_meta_path(cache_dir).write_bytes(orjson.dumps(payload))
+    """Create a fully valid cache using the production cache builder."""
+    build_per_port_cache(data_path, v2_config, cache_dir)
+    payload = _read_cache_meta(cache_dir)
+    assert payload is not None
     return payload
 
 
@@ -422,18 +388,21 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"same-content",
         )
         _write_signed_cache(
             committed_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"same-content",
         )
 
         assert mirror_cache_to_committed(data_path, v2_config) is False
         # committed/ untouched
-        assert _current_parquet(committed_dir).read_bytes() == b"same-content"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
 
     def test_different_fingerprints_promotes_atomically(
         self,
@@ -449,19 +418,24 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"new-content",
         )
+        old_config = _mirror_config()
+        old_config["tables"][0]["row_id_column"] = "value"
         _write_signed_cache(
             committed_dir,
             data_path=data_path,
-            v2_config=_mirror_config(type_="str"),
-            parquet_bytes=b"old-content",
+            v2_config=old_config,
         )
         assert mirror_cache_to_committed(data_path, v2_config) is True
         # committed/ now has working/'s content
-        assert _current_parquet(committed_dir).read_bytes() == b"new-content"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
         # And working/ is still there (mirror doesn't move, it copies)
-        assert _current_parquet(working_dir).read_bytes() == b"new-content"
+        assert _current_parquet(working_dir).exists()
 
     def test_no_committed_yet_creates_it(
         self,
@@ -475,7 +449,6 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"new",
         )
 
         committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
@@ -483,7 +456,12 @@ class TestMirrorCacheToCommitted:
 
         assert mirror_cache_to_committed(data_path, v2_config) is True
         assert committed_dir.exists()
-        assert _current_parquet(committed_dir).read_bytes() == b"new"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
 
     def test_holds_build_lock_during_copy(
         self,
@@ -505,7 +483,6 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"new",
         )
 
         lock = _build_lock_for(working_dir)
@@ -538,7 +515,6 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"new",
         )
 
         committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
@@ -558,7 +534,12 @@ class TestMirrorCacheToCommitted:
         # swallows the first failure and succeeds on retry.
         assert mirror_cache_to_committed(data_path, v2_config) is True
         assert calls["n"] >= 2
-        assert _current_parquet(committed_dir).read_bytes() == b"new"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
 
     def test_corrupt_committed_meta_proceeds_to_copy(
         self,
@@ -576,7 +557,6 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"fresh",
         )
 
         # Corrupt committed meta — orjson.loads would raise mid-mirror.
@@ -585,7 +565,12 @@ class TestMirrorCacheToCommitted:
         (committed_dir / "data.parquet").write_bytes(b"stale")
 
         assert mirror_cache_to_committed(data_path, v2_config) is True
-        assert _current_parquet(committed_dir).read_bytes() == b"fresh"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
         # The corrupt meta got replaced by the working/ meta.
         assert _read_cache_meta(committed_dir) == working_meta
 
@@ -603,7 +588,6 @@ class TestMirrorCacheToCommitted:
             working_dir,
             data_path=data_path,
             v2_config=v2_config,
-            parquet_bytes=b"new",
         )
 
         tmp_dir = committed_dir.with_name(committed_dir.name + ".tmp")
@@ -612,7 +596,12 @@ class TestMirrorCacheToCommitted:
 
         assert mirror_cache_to_committed(data_path, v2_config) is True
         assert not tmp_dir.exists()
-        assert _current_parquet(committed_dir).read_bytes() == b"new"
+        assert (
+            _current_parquet(committed_dir).read_bytes()
+            == _current_parquet(
+                working_dir,
+            ).read_bytes()
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_json_cache_coverage_uplift.py
+++ b/tests/test_json_cache_coverage_uplift.py
@@ -23,11 +23,14 @@ fingerprint format changes) that mock-based tests wouldn't.
 
 from __future__ import annotations
 
+import hashlib
+import io
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import orjson
+import polars as pl
 import pytest
 from fastapi.testclient import TestClient
 
@@ -44,6 +47,7 @@ from haute._json_flatten import (
     clear_json_cache,
     mirror_cache_to_committed,
 )
+from haute._json_shred import _data_file_signature, _v2_fingerprint
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -67,10 +71,88 @@ def client(isolated_cwd: Path) -> TestClient:
     return TestClient(app)
 
 
-def _write_meta(cache_dir: Path, payload: dict[str, Any]) -> None:
-    """Helper: create cache_dir + write meta.json with the given payload."""
+def _mirror_config(*, type_: str = "int") -> dict[str, Any]:
+    """Return a small valid v2 schema for save-time mirror tests."""
+    return {
+        "tables": [
+            {
+                "path": "$[:]",
+                "label": "data",
+                "emit": True,
+                "row_id_column": None,
+                "columns": [
+                    {
+                        "name": "value",
+                        "path": "$.value",
+                        "type": type_,
+                        "status": "Confirmed",
+                        "selected": True,
+                        "levels": None,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture()
+def mirror_case(isolated_cwd: Path) -> tuple[Path, dict[str, Any]]:
+    """Create the source file and editor schema authoritative for a mirror."""
+    data_path = isolated_cwd / "data" / "x.json"
+    data_path.parent.mkdir(parents=True)
+    data_path.write_bytes(orjson.dumps([{"value": 1}]))
+    return data_path, _mirror_config()
+
+
+def _write_signed_cache(
+    cache_dir: Path,
+    *,
+    data_path: Path,
+    v2_config: dict[str, Any],
+    parquet_bytes: bytes,
+) -> dict[str, Any]:
+    """Create a signed cache matching a real source and editor schema."""
     cache_dir.mkdir(parents=True, exist_ok=True)
+    type_token = v2_config["tables"][0]["columns"][0]["type"]
+    marker = parquet_bytes.decode("utf-8")
+    if type_token == "int":
+        value: int | str = int.from_bytes(hashlib.sha256(parquet_bytes).digest()[:4])
+        dtype = pl.Int64
+    elif type_token == "str":
+        value = marker
+        dtype = pl.String
+    else:  # pragma: no cover - helper is deliberately narrow
+        raise AssertionError(f"unsupported mirror fixture type: {type_token}")
+    parquet_buffer = io.BytesIO()
+    pl.DataFrame({"value": [value]}, schema={"value": dtype}).write_parquet(parquet_buffer)
+    artifact_bytes = parquet_buffer.getvalue()
+    digest = hashlib.sha256(artifact_bytes).hexdigest()
+    parquet_name = f"frame_{digest}.parquet"
+    (cache_dir / parquet_name).write_bytes(artifact_bytes)
+    payload = {
+        "schema_fingerprint": _v2_fingerprint(v2_config),
+        "schema_mode": "v2",
+        "data_file": _data_file_signature(data_path),
+        "tables": [
+            {
+                "label": "data",
+                "parquet": parquet_name,
+                "content_signature": {
+                    "size": len(artifact_bytes),
+                    "sha256": digest,
+                },
+            }
+        ],
+    }
     _json_cache_meta_path(cache_dir).write_bytes(orjson.dumps(payload))
+    return payload
+
+
+def _current_parquet(cache_dir: Path) -> Path:
+    meta = _read_cache_meta(cache_dir)
+    assert meta is not None
+    entry = next(table for table in meta["tables"] if table["label"] == "data")
+    return cache_dir / entry["parquet"]
 
 
 # ---------------------------------------------------------------------------
@@ -290,79 +372,123 @@ class TestClearJsonCache:
 
 
 class TestMirrorCacheToCommitted:
-    def test_no_session_consultation_returns_false(self, isolated_cwd: Path) -> None:
+    def test_no_session_consultation_returns_false(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """Trapdoor: if this session never consulted the cache for this
         data_path, the mirror is a no-op. Avoids promoting stale on-disk
         working/ from a previous session."""
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
+        data_path, v2_config = mirror_case
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
         working_dir.mkdir(parents=True, exist_ok=True)
         (working_dir / "data.parquet").write_bytes(b"data")
         # NOT calling _mark_working_consulted → trapdoor closes
-        assert mirror_cache_to_committed("data/x.json") is False
+        assert mirror_cache_to_committed(data_path, v2_config) is False
 
-    def test_consulted_but_no_working_no_committed_returns_false(self, isolated_cwd: Path) -> None:
+    def test_consulted_but_no_working_no_committed_returns_false(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """Session consulted but nothing on disk to mirror or wipe → False."""
-        _mark_working_consulted("data/x.json")
-        assert mirror_cache_to_committed("data/x.json") is False
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        assert mirror_cache_to_committed(data_path, v2_config) is False
 
-    def test_consulted_no_working_with_committed_wipes_committed(self, isolated_cwd: Path) -> None:
+    def test_consulted_no_working_with_committed_wipes_committed(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """Delete-then-save flow: working was cleared by user, committed
         from previous save should be wiped. Returns True."""
-        _mark_working_consulted("data/x.json")
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
         committed_dir.mkdir(parents=True, exist_ok=True)
         (committed_dir / "data.parquet").write_bytes(b"stale")
-        assert mirror_cache_to_committed("data/x.json") is True
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         assert not committed_dir.exists()
 
-    def test_matching_fingerprints_is_noop(self, isolated_cwd: Path) -> None:
+    def test_matching_fingerprints_is_noop(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """Working + committed exist with same fingerprint → no-op, False."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
-        same = {"schema_fingerprint": "abc123", "schema_mode": "v2"}
-        _write_meta(working_dir, same)
-        _write_meta(committed_dir, same)
-        (working_dir / "data.parquet").write_bytes(b"working")
-        (committed_dir / "data.parquet").write_bytes(b"committed")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"same-content",
+        )
+        _write_signed_cache(
+            committed_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"same-content",
+        )
 
-        assert mirror_cache_to_committed("data/x.json") is False
+        assert mirror_cache_to_committed(data_path, v2_config) is False
         # committed/ untouched
-        assert (committed_dir / "data.parquet").read_bytes() == b"committed"
+        assert _current_parquet(committed_dir).read_bytes() == b"same-content"
 
-    def test_different_fingerprints_promotes_atomically(self, isolated_cwd: Path) -> None:
+    def test_different_fingerprints_promotes_atomically(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """Fingerprints differ → atomic swap, working/ contents land in
         committed/. Returns True."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        _write_meta(committed_dir, {"schema_fingerprint": "old", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"new-content")
-        (committed_dir / "data.parquet").write_bytes(b"old-content")
-
-        assert mirror_cache_to_committed("data/x.json") is True
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"new-content",
+        )
+        _write_signed_cache(
+            committed_dir,
+            data_path=data_path,
+            v2_config=_mirror_config(type_="str"),
+            parquet_bytes=b"old-content",
+        )
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         # committed/ now has working/'s content
-        assert (committed_dir / "data.parquet").read_bytes() == b"new-content"
+        assert _current_parquet(committed_dir).read_bytes() == b"new-content"
         # And working/ is still there (mirror doesn't move, it copies)
-        assert (working_dir / "data.parquet").read_bytes() == b"new-content"
+        assert _current_parquet(working_dir).read_bytes() == b"new-content"
 
-    def test_no_committed_yet_creates_it(self, isolated_cwd: Path) -> None:
+    def test_no_committed_yet_creates_it(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """First save: no committed/ exists; working/ gets copied over."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"new")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"new",
+        )
 
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
         assert not committed_dir.exists()
 
-        assert mirror_cache_to_committed("data/x.json") is True
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         assert committed_dir.exists()
-        assert (committed_dir / "data.parquet").read_bytes() == b"new"
+        assert _current_parquet(committed_dir).read_bytes() == b"new"
 
     def test_holds_build_lock_during_copy(
-        self, isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """F010: the mirror must serialize against a concurrent build of the
         SAME working dir by holding ``_build_lock_for(working_dir)`` across
@@ -372,10 +498,15 @@ class TestMirrorCacheToCommitted:
 
         from haute._json_shred import _build_lock_for
 
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"new")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"new",
+        )
 
         lock = _build_lock_for(working_dir)
         held: dict[str, bool] = {}
@@ -386,24 +517,31 @@ class TestMirrorCacheToCommitted:
             return real_copytree(src, dst, *a, **k)
 
         monkeypatch.setattr("haute._json_flatten.shutil.copytree", _spy_copytree)
-        assert mirror_cache_to_committed("data/x.json") is True
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         assert held["locked"] is True
         # Lock released after the mirror returns.
         assert lock.locked() is False
 
     def test_survives_transient_rename_permission_error(
-        self, isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """F010: a bare ``Path.rename`` can raise ``PermissionError`` on
         Windows when a scanner briefly holds a handle. The mirror must reuse
         the sibling Windows-safe rename-with-retry (via ``_swap_dir_into_place``)
         so a transient lock doesn't abort the promotion."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"new")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"new",
+        )
 
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
         assert not committed_dir.exists()
 
         real_rename = Path.rename
@@ -418,50 +556,63 @@ class TestMirrorCacheToCommitted:
         monkeypatch.setattr(Path, "rename", _flaky_rename)
         # Bare rename would propagate the PermissionError; the retry helper
         # swallows the first failure and succeeds on retry.
-        assert mirror_cache_to_committed("data/x.json") is True
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         assert calls["n"] >= 2
-        assert (committed_dir / "data.parquet").read_bytes() == b"new"
+        assert _current_parquet(committed_dir).read_bytes() == b"new"
 
-    def test_corrupt_committed_meta_proceeds_to_copy(self, isolated_cwd: Path) -> None:
+    def test_corrupt_committed_meta_proceeds_to_copy(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """F307: a corrupt ``committed/meta.json`` must be treated as a
         mismatch (degrade-to-stale, like ``is_per_port_cache_valid``) so the
         mirror overwrites it with the fresh working/ copy — NOT abort before
         the copytree that would have repaired it."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"fresh")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
+        working_meta = _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"fresh",
+        )
 
         # Corrupt committed meta — orjson.loads would raise mid-mirror.
         committed_dir.mkdir(parents=True, exist_ok=True)
         _json_cache_meta_path(committed_dir).write_bytes(b"{ not json")
         (committed_dir / "data.parquet").write_bytes(b"stale")
 
-        assert mirror_cache_to_committed("data/x.json") is True
-        assert (committed_dir / "data.parquet").read_bytes() == b"fresh"
+        assert mirror_cache_to_committed(data_path, v2_config) is True
+        assert _current_parquet(committed_dir).read_bytes() == b"fresh"
         # The corrupt meta got replaced by the working/ meta.
-        assert _read_cache_meta(committed_dir) == {
-            "schema_fingerprint": "new",
-            "schema_mode": "v2",
-        }
+        assert _read_cache_meta(committed_dir) == working_meta
 
-    def test_stale_tmp_dir_gets_wiped_before_copy(self, isolated_cwd: Path) -> None:
+    def test_stale_tmp_dir_gets_wiped_before_copy(
+        self,
+        mirror_case: tuple[Path, dict[str, Any]],
+    ) -> None:
         """If a previous mirror attempt left a `.tmp` sibling, the new
         attempt cleans it before reusing the slot."""
-        _mark_working_consulted("data/x.json")
-        working_dir = _json_cache_dir("data/x.json", _LAYER_WORKING)
-        committed_dir = _json_cache_dir("data/x.json", _LAYER_COMMITTED)
-        _write_meta(working_dir, {"schema_fingerprint": "new", "schema_mode": "v2"})
-        (working_dir / "data.parquet").write_bytes(b"new")
+        data_path, v2_config = mirror_case
+        _mark_working_consulted(data_path)
+        working_dir = _json_cache_dir(data_path, _LAYER_WORKING)
+        committed_dir = _json_cache_dir(data_path, _LAYER_COMMITTED)
+        _write_signed_cache(
+            working_dir,
+            data_path=data_path,
+            v2_config=v2_config,
+            parquet_bytes=b"new",
+        )
 
         tmp_dir = committed_dir.with_name(committed_dir.name + ".tmp")
         tmp_dir.mkdir(parents=True)
         (tmp_dir / "leftover").write_bytes(b"stale-tmp")
 
-        assert mirror_cache_to_committed("data/x.json") is True
+        assert mirror_cache_to_committed(data_path, v2_config) is True
         assert not tmp_dir.exists()
-        assert (committed_dir / "data.parquet").read_bytes() == b"new"
+        assert _current_parquet(committed_dir).read_bytes() == b"new"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_json_cache_coverage_uplift.py
+++ b/tests/test_json_cache_coverage_uplift.py
@@ -524,7 +524,7 @@ class TestBuildJsonCacheExceptions:
             json={
                 "path": "data/missing.json",
                 "volatile_schema": {
-                    "tables": [{"path": "$[:]", "label": "$[:]", "emit": True, "columns": []}]
+                    "tables": [{"path": "$[:]", "label": "root", "emit": True, "columns": []}]
                 },
             },
         )
@@ -544,7 +544,7 @@ class TestBuildJsonCacheExceptions:
                     "tables": [
                         {
                             "path": "$[:]",
-                            "label": "$[:]",
+                            "label": "root",
                             "emit": True,
                             "columns": [
                                 {
@@ -583,7 +583,7 @@ class TestBuildJsonCacheExceptions:
                         "tables": [
                             {
                                 "path": "$[:]",
-                                "label": "$[:]",
+                                "label": "root",
                                 "emit": True,
                                 "columns": [
                                     {
@@ -627,7 +627,7 @@ class TestStatusBranches:
                     "tables": [
                         {
                             "path": "$[:]",
-                            "label": "$[:]",
+                            "label": "root",
                             "emit": True,
                             "columns": [
                                 {
@@ -723,7 +723,7 @@ class TestStatusAndDispatchBranches:
                     "tables": [
                         {
                             "path": "$[:]",
-                            "label": "$[:]",
+                            "label": "root",
                             "emit": True,
                             "columns": [
                                 {
@@ -762,7 +762,7 @@ class TestStatusAndDispatchBranches:
                     "tables": [
                         {
                             "path": "$[:]",
-                            "label": "$[:]",
+                            "label": "root",
                             "emit": True,
                             "columns": [
                                 # On-disk says column is named "wrong"
@@ -789,7 +789,7 @@ class TestStatusAndDispatchBranches:
                     "tables": [
                         {
                             "path": "$[:]",
-                            "label": "$[:]",
+                            "label": "root",
                             "emit": True,
                             "columns": [
                                 {

--- a/tests/test_json_cache_integrity.py
+++ b/tests/test_json_cache_integrity.py
@@ -12,9 +12,9 @@ One coherent build/validity/load rework, pinned end to end:
 - **2.5** — one shared predicate (``table_is_emitting``: emit AND >=1
   selected column) used by build, validity AND load, killing the permanent
   wedge where build skips a parquet that validity then demands forever.
-- **2.6** — the build is atomic (temp dir + swap) and serialized (per-cache
-  lock), so a failed or concurrent rebuild can never corrupt a previously
-  valid cache or stamp one schema's meta onto another's parquets.
+- **2.6** — the build is atomic (fully staged directory swap) and serialized
+  (per-cache lock), so a failed or concurrent rebuild can never corrupt a
+  previously valid cache or stamp one schema's meta onto another's parquets.
 - **2.7** — records dropped on shape mismatch (non-object JSONL lines, mixed
   arrays) are counted and surfaced in the build summary, meta.json, and the
   route responses. Zero silent loss.
@@ -41,6 +41,7 @@ from haute._json_flatten import (
     _is_working_consulted,
     _json_cache_dir,
     _mark_working_consulted,
+    clear_json_cache,
     mirror_cache_to_committed,
 )
 from haute._json_shred import (
@@ -92,6 +93,29 @@ def _write_json(path: Path, records: list[Any]) -> None:
     path.write_text(json.dumps(records), encoding="utf-8")
 
 
+def _corrupt_parquet_data_page(path: Path) -> None:
+    import pyarrow.parquet as pq
+
+    column = pq.ParquetFile(path).metadata.row_group(0).column(0)
+    offset = column.data_page_offset + 1
+    payload = bytearray(path.read_bytes())
+    payload[offset] ^= 0x01
+    path.write_bytes(payload)
+
+
+def _cache_meta(cache_dir: Path) -> dict[str, Any]:
+    meta = orjson.loads((cache_dir / "meta.json").read_bytes())
+    assert isinstance(meta, dict)
+    return meta
+
+
+def _current_parquet(cache_dir: Path, label: str = "root") -> Path:
+    """Resolve the current table artifact through the signed manifest."""
+    meta = _cache_meta(cache_dir)
+    entry = next(table for table in meta["tables"] if table["label"] == label)
+    return cache_dir / entry["parquet"]
+
+
 @pytest.fixture()
 def isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Chdir into a fresh tmp dir and reset the consulted-hashes session set."""
@@ -132,7 +156,7 @@ class TestCommittedMirrorOnProductionBuild:
 
         assert _is_working_consulted(str(data.resolve())) is True
         # And the production save-time mirror is therefore live, not dead code:
-        assert mirror_cache_to_committed(str(data.resolve())) is True
+        assert mirror_cache_to_committed(str(data.resolve()), cfg) is True
         assert _json_cache_dir(str(data.resolve()), "committed").exists()
 
     def test_failed_route_build_does_not_mark_consulted(
@@ -374,18 +398,233 @@ class TestDataFileSignatureValidity:
         working_dir = _json_cache_dir(str(data), "working")
         build_per_port_cache(data, cfg, working_dir)
         _mark_working_consulted(str(data))
-        assert mirror_cache_to_committed(str(data)) is True
+        assert mirror_cache_to_committed(str(data), cfg) is True
 
         # Edit data + rebuild working under the SAME schema.
         _write_json(data, [{"id": 1}, {"id": 2}])
         build_per_port_cache(data, cfg, working_dir)
 
-        assert mirror_cache_to_committed(str(data)) is True, (
+        assert mirror_cache_to_committed(str(data), cfg) is True, (
             "mirror no-opped on a data-only rebuild — committed/ kept stale rows"
         )
         committed_dir = _json_cache_dir(str(data), "committed")
         frames = load_per_port_cache(committed_dir, cfg)
         assert frames["root"].collect()["id"].to_list() == [1, 2]
+
+    def test_save_upgrades_legacy_unsigned_committed_manifest(
+        self,
+        isolated_cwd: Path,
+    ) -> None:
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        working_dir = _json_cache_dir(str(data), "working")
+        committed_dir = _json_cache_dir(str(data), "committed")
+        build_per_port_cache(data, cfg, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg) is True
+
+        committed_meta_path = committed_dir / "meta.json"
+        committed_meta = orjson.loads(committed_meta_path.read_bytes())
+        committed_meta["tables"][0].pop("content_signature", None)
+        committed_meta_path.write_bytes(orjson.dumps(committed_meta))
+
+        assert mirror_cache_to_committed(str(data), cfg) is True
+
+        working_meta = orjson.loads((working_dir / "meta.json").read_bytes())
+        repaired_committed_meta = orjson.loads(committed_meta_path.read_bytes())
+        assert repaired_committed_meta["tables"] == working_meta["tables"]
+        assert is_per_port_cache_valid(committed_dir, cfg, data_path=data) is True
+
+    def test_save_repairs_committed_parquet_whose_bytes_no_longer_match_manifest(
+        self,
+        isolated_cwd: Path,
+    ) -> None:
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        working_dir = _json_cache_dir(str(data), "working")
+        committed_dir = _json_cache_dir(str(data), "committed")
+        build_per_port_cache(data, cfg, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg) is True
+        committed_parquet = _current_parquet(committed_dir)
+        working_parquet = _current_parquet(working_dir)
+        _corrupt_parquet_data_page(committed_parquet)
+        assert committed_parquet.read_bytes() != working_parquet.read_bytes()
+
+        assert mirror_cache_to_committed(str(data), cfg) is True
+
+        assert committed_parquet.read_bytes() == working_parquet.read_bytes()
+        assert is_per_port_cache_valid(committed_dir, cfg, data_path=data) is True
+
+    def test_committed_lazy_frame_stays_pinned_across_later_mirror(
+        self,
+        isolated_cwd: Path,
+    ) -> None:
+        import shutil
+
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        working_dir = _json_cache_dir(str(data), "working")
+        build_per_port_cache(data, cfg, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg) is True
+
+        shutil.rmtree(working_dir)
+        generation_a = load_v2_api_source(str(data), cfg)["root"]
+
+        _write_json(data, [{"id": 2}])
+        build_per_port_cache(data, cfg, working_dir)
+        assert mirror_cache_to_committed(str(data), cfg) is True
+        generation_b = load_v2_api_source(str(data), cfg)["root"]
+
+        assert generation_a.collect()["id"].to_list() == [1]
+        assert generation_b.collect()["id"].to_list() == [2]
+
+    @pytest.mark.parametrize(
+        "damage",
+        ["corrupt_bytes", "unsigned_manifest", "malformed_manifest"],
+    )
+    def test_save_never_promotes_invalid_working_over_healthy_committed(
+        self,
+        isolated_cwd: Path,
+        damage: str,
+    ) -> None:
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        working_dir = _json_cache_dir(str(data), "working")
+        committed_dir = _json_cache_dir(str(data), "committed")
+        build_per_port_cache(data, cfg, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg) is True
+        committed_meta = (committed_dir / "meta.json").read_bytes()
+        committed_parquet_path = _current_parquet(committed_dir)
+        committed_parquet = committed_parquet_path.read_bytes()
+
+        if damage == "corrupt_bytes":
+            _corrupt_parquet_data_page(_current_parquet(working_dir))
+        else:
+            working_meta_path = working_dir / "meta.json"
+            if damage == "unsigned_manifest":
+                working_meta = orjson.loads(working_meta_path.read_bytes())
+                working_meta["tables"][0].pop("content_signature")
+                working_meta_path.write_bytes(orjson.dumps(working_meta))
+            else:
+                working_meta_path.write_bytes(b"{")
+
+        assert mirror_cache_to_committed(str(data), cfg) is False
+
+        assert (committed_dir / "meta.json").read_bytes() == committed_meta
+        assert committed_parquet_path.read_bytes() == committed_parquet
+        assert is_per_port_cache_valid(committed_dir, cfg, data_path=data) is True
+
+    @pytest.mark.parametrize(
+        "damage",
+        [
+            "wrong_schema_mode",
+            "malformed_schema_fingerprint",
+            "stale_data_file_signature",
+            "malformed_data_file_signature",
+        ],
+    )
+    def test_save_rejects_invalid_top_level_working_meta_and_preserves_committed(
+        self,
+        isolated_cwd: Path,
+        damage: str,
+    ) -> None:
+        """A parseable manifest is not mirrorable unless its cache identity is valid."""
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        working_dir = _json_cache_dir(str(data), "working")
+        committed_dir = _json_cache_dir(str(data), "committed")
+        build_per_port_cache(data, cfg, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg) is True
+
+        committed_meta = (committed_dir / "meta.json").read_bytes()
+        committed_parquet_path = _current_parquet(committed_dir)
+        committed_parquet = committed_parquet_path.read_bytes()
+
+        working_meta_path = working_dir / "meta.json"
+        working_meta = orjson.loads(working_meta_path.read_bytes())
+        if damage == "wrong_schema_mode":
+            working_meta["schema_mode"] = "broken"
+        elif damage == "malformed_schema_fingerprint":
+            working_meta["schema_fingerprint"] = "not-a-sha256"
+        elif damage == "stale_data_file_signature":
+            working_meta["data_file"]["sha256"] = "0" * 64
+        else:
+            working_meta["data_file"] = {
+                "size": "not-an-integer",
+                "mtime_ns": 0,
+                "sha256": "0" * 64,
+            }
+        working_meta_path.write_bytes(orjson.dumps(working_meta))
+
+        assert mirror_cache_to_committed(str(data), cfg) is False
+
+        assert (committed_dir / "meta.json").read_bytes() == committed_meta
+        assert committed_parquet_path.read_bytes() == committed_parquet
+        assert is_per_port_cache_valid(committed_dir, cfg, data_path=data) is True
+        assert load_per_port_cache(committed_dir, cfg)["root"].collect().to_dict(
+            as_series=False,
+        ) == {"id": [1]}
+        assert list(committed_dir.parent.glob(f"{committed_dir.name}*.tmp*")) == []
+        assert list(committed_dir.glob("*.tmp*")) == []
+
+    @pytest.mark.parametrize("staged_damage", ["parquet", "meta"])
+    def test_save_rejects_staging_tamper_and_preserves_committed(
+        self,
+        isolated_cwd: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        staged_damage: str,
+    ) -> None:
+        """The copied mirror is revalidated before it may replace committed/."""
+        import haute._json_flatten as flatten_mod
+
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"a": 1, "b": 2}])
+        cfg_a = _root_cfg(_col("a", "$[:].a"))
+        cfg_b = _root_cfg(_col("b", "$[:].b"))
+        working_dir = _json_cache_dir(str(data), "working")
+        committed_dir = _json_cache_dir(str(data), "committed")
+        build_per_port_cache(data, cfg_a, working_dir)
+        _mark_working_consulted(str(data))
+        assert mirror_cache_to_committed(str(data), cfg_a) is True
+
+        committed_meta = (committed_dir / "meta.json").read_bytes()
+        committed_parquet_path = _current_parquet(committed_dir)
+        committed_parquet = committed_parquet_path.read_bytes()
+        build_per_port_cache(data, cfg_b, working_dir)
+
+        real_copytree = flatten_mod.shutil.copytree
+
+        def _tampering_copytree(source: Any, target: Any, *args: Any, **kwargs: Any) -> Any:
+            copied = real_copytree(source, target, *args, **kwargs)
+            staged_dir = Path(target)
+            if staged_damage == "parquet":
+                _corrupt_parquet_data_page(_current_parquet(staged_dir))
+            else:
+                staged_meta_path = staged_dir / "meta.json"
+                staged_meta = orjson.loads(staged_meta_path.read_bytes())
+                staged_meta["schema_fingerprint"] = "tampered-after-copy"
+                staged_meta_path.write_bytes(orjson.dumps(staged_meta))
+            return copied
+
+        monkeypatch.setattr(flatten_mod.shutil, "copytree", _tampering_copytree)
+
+        assert mirror_cache_to_committed(str(data), cfg_b) is False
+
+        assert (committed_dir / "meta.json").read_bytes() == committed_meta
+        assert committed_parquet_path.read_bytes() == committed_parquet
+        assert load_per_port_cache(committed_dir, cfg_a)["root"].collect().to_dict(
+            as_series=False,
+        ) == {"a": [1]}
+        assert not committed_dir.with_name(committed_dir.name + ".tmp").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -445,8 +684,8 @@ class TestSharedEmittingPredicate:
         cache_dir = tmp_path / "cache"
         build_per_port_cache(data, cfg, cache_dir)
 
-        assert (cache_dir / "root.parquet").exists()
-        assert not (cache_dir / "drivers.parquet").exists()
+        assert _current_parquet(cache_dir).exists()
+        assert all(table["label"] != "drivers" for table in _cache_meta(cache_dir)["tables"])
         assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True, (
             "validity demands a parquet the build deliberately skipped — permanent wedge"
         )
@@ -667,9 +906,45 @@ class TestAtomicSerializedBuild:
         assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True
         assert load_per_port_cache(cache_dir, cfg)["root"].collect()["a"].to_list() == [1]
 
+    def test_lazy_frame_snapshot_survives_later_cache_rebuild(self, tmp_path: Path) -> None:
+        """A cache-backed frame owns its compressed bytes, not a mutable disk path."""
+        data = tmp_path / "data.json"
+        _write_json(data, [{"a": 1, "b": 2}])
+        cfg_a = _root_cfg(_col("a", "$[:].a"))
+        cfg_b = _root_cfg(_col("b", "$[:].b"))
+        cache_dir = tmp_path / "cache"
+        build_per_port_cache(data, cfg_a, cache_dir)
+        generation_a_path = _current_parquet(cache_dir)
+        generation_a = load_per_port_cache(cache_dir, cfg_a)["root"]
+
+        build_per_port_cache(data, cfg_b, cache_dir)
+        generation_b_path = _current_parquet(cache_dir)
+
+        assert generation_b_path == generation_a_path
+        assert generation_b_path.exists()
+        assert generation_a.collect().to_dict(as_series=False) == {"a": [1]}
+        assert load_per_port_cache(cache_dir, cfg_b)["root"].collect().to_dict(
+            as_series=False,
+        ) == {"b": [2]}
+        assert is_per_port_cache_valid(cache_dir, cfg_b, data_path=data) is True
+
+    def test_lazy_frame_snapshot_survives_explicit_cache_clear(
+        self,
+        isolated_cwd: Path,
+    ) -> None:
+        data = isolated_cwd / "data.json"
+        _write_json(data, [{"id": 1}])
+        cfg = _root_cfg(_col("id", "$[:].id"))
+        cache_dir = _json_cache_dir(str(data), "working")
+        build_per_port_cache(data, cfg, cache_dir)
+        cached_frame = load_v2_api_source(str(data), cfg)["root"]
+
+        assert clear_json_cache(str(data)) is True
+        assert not cache_dir.exists()
+        assert cached_frame.collect().to_dict(as_series=False) == {"id": [1]}
+
     def test_leftover_build_old_backup_is_cleaned_on_next_swap(self, tmp_path: Path) -> None:
-        """A `.build-old` backup left by a crash mid-swap is removed when the
-        next rebuild swaps over an existing live cache."""
+        """A `.build-old` backup left by a crash mid-swap is removed on rebuild."""
         data = tmp_path / "data.json"
         _write_json(data, [{"a": 1, "b": 2}])
         cfg_a = _root_cfg(_col("a", "$[:].a"))
@@ -681,15 +956,14 @@ class TestAtomicSerializedBuild:
         stale_backup.mkdir(parents=True)
         (stale_backup / "junk").write_bytes(b"stale")
 
-        build_per_port_cache(data, cfg_b, cache_dir)  # schema change -> real swap
+        build_per_port_cache(data, cfg_b, cache_dir)
         assert not stale_backup.exists()
         assert is_per_port_cache_valid(cache_dir, cfg_b, data_path=data) is True
 
     def test_swap_restores_live_dir_when_final_rename_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If the tmp→live rename fails mid-swap, the previous live dir is
-        restored before the error propagates — the cache is never left missing."""
+        """If tmp→live fails, the previous cache is restored before re-raising."""
         from haute._json_shred import _swap_dir_into_place
 
         live = tmp_path / "cache"
@@ -709,7 +983,6 @@ class TestAtomicSerializedBuild:
         monkeypatch.setattr(Path, "rename", _failing_rename)
         with pytest.raises(OSError, match="simulated rename failure"):
             _swap_dir_into_place(tmp, live)
-        monkeypatch.setattr(Path, "rename", real_rename)
 
         assert live.exists()
         assert (live / "old.parquet").read_bytes() == b"old"
@@ -718,8 +991,7 @@ class TestAtomicSerializedBuild:
     def test_swap_cleans_tmp_when_live_to_backup_rename_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If live->backup fails before the swap starts, the UUID tmp dir
-        must still be removed so the failed build leaves no orphan staging dir."""
+        """If live→backup fails, the UUID staging directory is still removed."""
         from haute._json_shred import _swap_dir_into_place
 
         live = tmp_path / "cache"
@@ -739,19 +1011,17 @@ class TestAtomicSerializedBuild:
         monkeypatch.setattr(Path, "rename", _failing_rename)
         with pytest.raises(OSError, match="simulated live-to-backup rename failure"):
             _swap_dir_into_place(tmp, live)
-        monkeypatch.setattr(Path, "rename", real_rename)
 
         assert live.exists()
         assert (live / "old.parquet").read_bytes() == b"old"
-        assert not tmp.exists(), "failed live->backup rename leaked the UUID build temp directory"
+        assert not tmp.exists(), "failed live→backup rename leaked the staging directory"
         assert list(tmp_path.glob("cache.build-old-*")) == []
 
-    def test_load_fails_loud_when_parquet_disappears_after_validity(
+    def test_load_falls_back_to_raw_when_parquet_disappears_after_validity(
         self, isolated_cwd: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If a cache file disappears between validity and scan, loading must
-        raise the cache-stale action message rather than KeyError or a partial
-        multi-port bundle."""
+        """A cache race must continue to committed/direct, never return a
+        partial bundle or restore a hard dependency on parquet."""
         import haute._json_shred as shred_mod
 
         data = isolated_cwd / "data.json"
@@ -760,26 +1030,39 @@ class TestAtomicSerializedBuild:
         cache_dir = _json_cache_dir(str(data), "working")
         build_per_port_cache(data, cfg, cache_dir)
 
-        real_valid = shred_mod.is_per_port_cache_valid
+        real_read_matching_meta = shred_mod._read_matching_cache_meta
         removed = False
 
-        def _valid_then_remove(
+        def _matching_meta_then_remove(
             checked_cache_dir: str | Path,
             checked_config: dict[str, Any],
             *,
             data_path: str | Path,
-        ) -> bool:
+        ) -> dict[str, Any] | None:
             nonlocal removed
-            valid = real_valid(checked_cache_dir, checked_config, data_path=data_path)
-            if valid and not removed:
+            matching_meta = real_read_matching_meta(
+                checked_cache_dir,
+                checked_config,
+                data_path=data_path,
+            )
+            if matching_meta is not None and not removed:
                 removed = True
-                (Path(checked_cache_dir) / "root.parquet").unlink()
-            return valid
+                entry = next(table for table in matching_meta["tables"] if table["label"] == "root")
+                (Path(checked_cache_dir) / entry["parquet"]).unlink()
+            return matching_meta
 
-        monkeypatch.setattr(shred_mod, "is_per_port_cache_valid", _valid_then_remove)
+        monkeypatch.setattr(
+            shred_mod,
+            "_read_matching_cache_meta",
+            _matching_meta_then_remove,
+        )
 
-        with pytest.raises(RuntimeError, match="cache.*changed|Cache as Parquet"):
-            load_v2_api_source(str(data), cfg)
+        out = load_v2_api_source(str(data), cfg)
+
+        assert removed is True
+        current_name = _cache_meta(cache_dir)["tables"][0]["parquet"]
+        assert not (cache_dir / current_name).exists()
+        assert out["root"].collect()["id"].to_list() == [1]
 
     def test_swap_retries_transient_permission_error_for_empty_live_dir(
         self,

--- a/tests/test_json_cache_integrity.py
+++ b/tests/test_json_cache_integrity.py
@@ -116,7 +116,7 @@ def _current_parquet(cache_dir: Path, label: str = "root") -> Path:
     return cache_dir / entry["parquet"]
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Chdir into a fresh tmp dir and reset the consulted-hashes session set."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_json_cache_integrity.py
+++ b/tests/test_json_cache_integrity.py
@@ -212,8 +212,10 @@ class TestCommittedMirrorOnProductionBuild:
         shutil.rmtree(_json_cache_dir(str(data.resolve()), "working"))
 
         out = load_v2_api_source(str(data.resolve()), cfg)
-        assert isinstance(out, pl.LazyFrame)
-        assert out.collect()["id"].to_list() == [1, 2]
+        assert isinstance(out, dict)
+        assert list(out) == ["root"]
+        assert isinstance(out["root"], pl.LazyFrame)
+        assert out["root"].collect()["id"].to_list() == [1, 2]
 
 
 # ---------------------------------------------------------------------------
@@ -291,8 +293,10 @@ class TestDataFileSignatureValidity:
         )
 
         out = load_v2_api_source(str(data.resolve()), cfg)
-        assert isinstance(out, pl.LazyFrame)
-        assert out.collect()["id"].to_list() == [10, 20, 30]
+        assert isinstance(out, dict)
+        assert list(out) == ["root"]
+        assert isinstance(out["root"], pl.LazyFrame)
+        assert out["root"].collect()["id"].to_list() == [10, 20, 30]
 
     def test_validity_false_after_data_file_edit(self, tmp_path: Path) -> None:
         data = tmp_path / "data.json"
@@ -456,8 +460,10 @@ class TestSharedEmittingPredicate:
         build_per_port_cache(data, cfg, _json_cache_dir(str(data), "working"))
 
         out = load_v2_api_source(str(data), cfg)
-        assert isinstance(out, pl.LazyFrame)  # single EMITTING port -> bare frame
-        assert out.collect()["id"].to_list() == [7]
+        assert isinstance(out, dict)
+        assert list(out) == ["root"]
+        assert isinstance(out["root"], pl.LazyFrame)
+        assert out["root"].collect()["id"].to_list() == [7]
 
     def test_route_wedge_shape_builds_and_reports_cached(
         self, client: TestClient, isolated_cwd: Path

--- a/tests/test_json_shred_mut_lifecycle.py
+++ b/tests/test_json_shred_mut_lifecycle.py
@@ -9,8 +9,6 @@ the exact operator.
 Survivors covered:
 - 847  ``if existing_meta is not None:``  (Eq_GtE) — no-op trapdoor idempotency
 - 940  ``if skip_stats.total:``           (AddNot) — skip-warning gate
-- 1089 ``if len(emit_labels) == 1:``      — single vs multi frame return shape
-- 1090 ``return bundle[emit_labels[0]]``  — single-frame index
 - 1123 ``if meta.get("schema_mode") != "v2":`` (NotEq) — schema_mode gate
 - 1128 ``return False`` (FalseWithTrue)   — non-str label invalidates
 - 1131 ``continue`` (ContinueWithBreak)   — missing-parquet skips non-emit
@@ -150,32 +148,25 @@ def test_skip_warning_fires_only_when_records_skipped(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 1089 / 1090 — single emitting label returns a bare LazyFrame; 2+ returns a
-# dict keyed by label.
+# Runtime shape — every positive emitting-label count returns a dict keyed by
+# label; the former bare-frame single-table shorthand is removed.
 # ---------------------------------------------------------------------------
 
 
-def test_single_emitting_table_returns_bare_lazyframe(tmp_path: Path) -> None:
-    """One emitting label → bare LazyFrame (count boundary `== 1` + index 0).
-
-    Kills 1089 (`== 1` boundary): if it were `>= 1`, two-table configs would
-    wrongly return a frame too. Kills 1090's index: the single frame returned
-    must be the one keyed by the only emitting label."""
+def test_single_emitting_table_returns_dict_keyed_by_label(tmp_path: Path) -> None:
+    """One emitting label uses the same per-port bundle shape as many labels."""
     data = _write(tmp_path, [{"id": 10}, {"id": 20}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     build_per_port_cache(str(data), cfg, _working_cache(data))
     out = load_v2_api_source(str(data), cfg)
-    assert isinstance(out, pl.LazyFrame)
-    assert out.collect()["id"].to_list() == [10, 20]
+    assert isinstance(out, dict)
+    assert list(out) == ["root"]
+    assert isinstance(out["root"], pl.LazyFrame)
+    assert out["root"].collect()["id"].to_list() == [10, 20]
 
 
 def test_two_emitting_tables_return_dict_keyed_by_label(tmp_path: Path) -> None:
-    """Two emitting labels → dict keyed by label, NOT a bare frame.
-
-    Kills the 1089 count boundary: with `== 1` two tables fall through to the
-    dict branch; a mutation to `>= 1` / `> 1` / `<= 1` would change the shape
-    for one of the two arities. Pairing this with the single-table test pins
-    the boundary at exactly 1."""
+    """Two emitting labels preserve schema order and both labelled payloads."""
     data = _write(
         tmp_path,
         [{"id": 1, "drivers": [{"age": 30}, {"age": 40}]}],
@@ -194,6 +185,7 @@ def test_two_emitting_tables_return_dict_keyed_by_label(tmp_path: Path) -> None:
     out = load_v2_api_source(str(data), cfg)
     assert isinstance(out, dict)
     assert list(out) == ["root", "drivers"]
+    assert all(isinstance(frame, pl.LazyFrame) for frame in out.values())
     assert out["root"].collect()["id"].to_list() == [1]
     assert out["drivers"].collect()["age"].to_list() == [30, 40]
 

--- a/tests/test_json_shred_mut_lifecycle.py
+++ b/tests/test_json_shred_mut_lifecycle.py
@@ -261,13 +261,12 @@ def test_non_string_label_on_emitting_table_invalidates(tmp_path: Path) -> None:
 def test_non_emitting_table_is_skipped_then_later_table_checked(
     tmp_path: Path,
 ) -> None:
-    """A non-emitting table must be `continue`d over (not `break`), so a LATER
-    emitting table with a missing parquet still drives validity to False.
+    """A non-emitting table must be skipped so a later emitting table is probed.
 
-    Kills 1131 (ContinueWithBreak): order the tables as [non-emitting,
-    emitting-with-missing-parquet]. With `break` the loop stops at the
-    non-emitting table and never checks the emitting one → wrongly valid.
-    With `continue` it proceeds and the missing parquet → invalid."""
+    The tables are ordered [non-emitting, emitting-with-missing-parquet]. If
+    table-spec construction stopped at the first entry, the missing emitting
+    frame would be overlooked and the cache would be reported as valid.
+    """
     data = _write(tmp_path, [{"id": 1, "x": 2}])
     # Build a cache for ONLY the emitting "root" table so its parquet exists,
     # then validate against a config whose first table is non-emitting and
@@ -288,15 +287,12 @@ def test_non_emitting_table_is_skipped_then_later_table_checked(
     meta["schema_fingerprint"] = _v2_fingerprint(check_cfg)
     meta_path.write_bytes(orjson.dumps(meta))
 
-    # "extra" parquet does not exist → the emitting-table loop must reach it
-    # (continue past "skipme") and return False.
+    # "extra" parquet does not exist → the candidate probe must reach it after
+    # filtering out "skipme" and return False.
     assert not (cache_dir / "extra.parquet").exists()
     assert is_per_port_cache_valid(cache_dir, check_cfg, data_path=data) is False
 
-    # Sanity: if instead the second emitting table's parquet DID exist, the
-    # same config would be valid — confirming "extra"'s absence is the cause
-    # (and that the loop genuinely reaches the second table).
-    import shutil
-
-    shutil.copyfile(cache_dir / "root.parquet", cache_dir / "extra.parquet")
+    # Sanity: rebuilding writes the later emitting frame plus its signed
+    # manifest entry, making the same schema valid.
+    build_per_port_cache(str(data), check_cfg, cache_dir)
     assert is_per_port_cache_valid(cache_dir, check_cfg, data_path=data) is True

--- a/tests/test_json_shred_mut_stragglers.py
+++ b/tests/test_json_shred_mut_stragglers.py
@@ -138,7 +138,7 @@ def test_validity_rejects_when_data_file_changed(tmp_path: Path) -> None:
     assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
 
 
-# ─── 1019 / 1022 — load_per_port_cache skip branches use continue ────
+# ─── 1019 — load_per_port_cache non-emitting skip uses continue ──────
 
 
 def test_load_skips_non_emitting_table_then_loads_later_one(tmp_path: Path) -> None:
@@ -158,26 +158,6 @@ def test_load_skips_non_emitting_table_then_loads_later_one(tmp_path: Path) -> N
     }
     out = load_per_port_cache(cache_dir, load_cfg)
     assert "root" in out  # continue past skipme; break would drop root
-    assert out["root"].collect()["id"].to_list() == [1, 2]
-
-
-def test_load_skips_non_str_label_then_loads_later_one(tmp_path: Path) -> None:
-    # L1022 ``if not isinstance(label, str): continue``. An emitting table whose
-    # label is non-str must be skipped, with a valid emitting table after it
-    # still loaded. break would drop the valid frame.
-    data = _write(tmp_path, [{"id": 1}, {"id": 2}])
-    cache_dir = tmp_path / "cache"
-    build_per_port_cache(
-        str(data), {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}, cache_dir
-    )
-    load_cfg = {
-        "tables": [
-            _table("$[:]", 123, [_col("id", "$[:].id")]),  # emitting, non-str label
-            _table("$[:]", "root", [_col("id", "$[:].id")]),
-        ]
-    }
-    out = load_per_port_cache(cache_dir, load_cfg)
-    assert "root" in out
     assert out["root"].collect()["id"].to_list() == [1, 2]
 
 

--- a/tests/test_json_shred_mut_stragglers.py
+++ b/tests/test_json_shred_mut_stragglers.py
@@ -146,16 +146,14 @@ def test_load_skips_non_emitting_table_then_loads_later_one(tmp_path: Path) -> N
     # ordered BEFORE the emitting one must be skipped, not break the loop —
     # otherwise the real frame after it is never loaded.
     data = _write(tmp_path, [{"id": 1}, {"id": 2}])
-    cache_dir = tmp_path / "cache"
-    build_per_port_cache(
-        str(data), {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}, cache_dir
-    )
     load_cfg = {
         "tables": [
             _table("$[:]", "skipme", [_col("id", "$[:].id")], emit=False),
             _table("$[:]", "root", [_col("id", "$[:].id")]),
         ]
     }
+    cache_dir = tmp_path / "cache"
+    build_per_port_cache(str(data), load_cfg, cache_dir)
     out = load_per_port_cache(cache_dir, load_cfg)
     assert "root" in out  # continue past skipme; break would drop root
     assert out["root"].collect()["id"].to_list() == [1, 2]

--- a/tests/test_load_v2_api_source.py
+++ b/tests/test_load_v2_api_source.py
@@ -2,13 +2,16 @@
 
 ``load_v2_api_source`` is the single function both the executor's source
 builder and the generated/deploy code now call, so its behaviour (emit
-checks, working→committed cache resolution, uniform per-port return shape) is
+checks, working→committed→direct resolution, uniform per-port return shape) is
 the contract that keeps the two paths from drifting.
 """
 
 from __future__ import annotations
 
+import gc
+import hashlib
 import json
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +19,8 @@ import orjson
 import polars as pl
 import pytest
 
-from haute._json_flatten import _json_cache_dir
+from haute._api_input_schema import ApiInputSchemaError
+from haute._json_flatten import _json_cache_dir, clear_json_cache
 from haute._json_shred import (
     build_per_port_cache,
     is_per_port_cache_valid,
@@ -26,11 +30,17 @@ from haute._json_shred import (
 )
 
 
-def _col(name: str, path: str, *, selected: bool = True) -> dict[str, Any]:
+def _col(
+    name: str,
+    path: str,
+    *,
+    selected: bool = True,
+    type_token: str = "int",
+) -> dict[str, Any]:
     return {
         "name": name,
         "path": path,
-        "type": "int",
+        "type": type_token,
         "status": "Confirmed",
         "selected": selected,
         "levels": None,
@@ -51,6 +61,47 @@ def _write(tmp_path: Path, records: list[dict[str, Any]]) -> Path:
 
 def _build(data_path: Path, config: dict[str, Any], layer: str = "working") -> None:
     build_per_port_cache(str(data_path), config, _json_cache_dir(str(data_path), layer))
+
+
+def _corrupt_parquet_data_page(path: Path) -> None:
+    """Damage parquet payload bytes while leaving its footer schema readable."""
+    import pyarrow.parquet as pq
+
+    column = pq.ParquetFile(path).metadata.row_group(0).column(0)
+    offset = column.data_page_offset + 1
+    payload = bytearray(path.read_bytes())
+    assert 0 <= offset < len(payload)
+    payload[offset] ^= 0x01
+    path.write_bytes(payload)
+
+
+def _refresh_content_signature(cache_dir: Path, label: str) -> None:
+    parquet = cache_dir / f"{label}.parquet"
+    payload = parquet.read_bytes()
+    meta_path = cache_dir / "meta.json"
+    meta = orjson.loads(meta_path.read_bytes())
+    entry = next(table for table in meta["tables"] if table["label"] == label)
+    entry["content_signature"] = {
+        "size": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+    }
+    meta_path.write_bytes(orjson.dumps(meta))
+
+
+def _deny_path_operation(
+    monkeypatch: pytest.MonkeyPatch,
+    denied_path: Path,
+    operation: str,
+) -> None:
+    """Make one metadata-path operation fail without affecting other files."""
+    original = getattr(Path, operation)
+
+    def _permission_denied(path: Path, *args: Any, **kwargs: Any) -> Any:
+        if path == denied_path:
+            raise PermissionError(f"permission denied: {path}")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, operation, _permission_denied)
 
 
 def test_single_port_returns_one_entry_dict(tmp_path: Path) -> None:
@@ -95,11 +146,719 @@ def test_emit_without_selected_columns_raises(tmp_path: Path) -> None:
         load_v2_api_source(str(data), cfg)
 
 
-def test_missing_cache_raises_with_actionable_message(tmp_path: Path) -> None:
+def test_never_cached_input_shreds_in_memory_without_creating_cache(tmp_path: Path) -> None:
     data = _write(tmp_path, [{"id": 1}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
-    # No cache built in either layer.
-    with pytest.raises(RuntimeError, match="Cache as Parquet"):
+
+    working = _json_cache_dir(str(data), "working")
+    committed = _json_cache_dir(str(data), "committed")
+    assert not working.exists()
+    assert not committed.exists()
+
+    out = load_v2_api_source(str(data), cfg)
+
+    assert out["root"].collect().to_dict(as_series=False) == {"id": [1]}
+    assert not working.exists()
+    assert not committed.exists()
+
+
+def test_never_cached_jsonl_shreds_in_memory(tmp_path: Path) -> None:
+    data = tmp_path / "data.jsonl"
+    data.write_text('{"id": 1}\n\n{"id": 2}\n', encoding="utf-8")
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [1, 2]
+    assert not _json_cache_dir(str(data), "working").exists()
+    assert not _json_cache_dir(str(data), "committed").exists()
+
+
+def test_stale_cache_after_cascade_shreds_ancestor_into_child_without_rebuild(
+    tmp_path: Path,
+) -> None:
+    data = _write(
+        tmp_path,
+        [
+            {"policy_id": 1001, "drivers": [{"age": 30}, {"age": 40}]},
+            {"policy_id": 1002, "drivers": [{"age": 50}]},
+        ],
+    )
+    cfg = {
+        "tables": [
+            _table("$[:]", "root", [_col("policy_id", "$[:].policy_id")]),
+            _table(
+                "$[:].drivers[:]",
+                "drivers",
+                [_col("age", "$[:].drivers[:].age")],
+            ),
+        ]
+    }
+    _build(data, cfg)
+    working = _json_cache_dir(str(data), "working")
+    old_meta = (working / "meta.json").read_bytes()
+
+    # Cascading the root key down changes the post-schema cache fingerprint.
+    cfg["tables"][1]["columns"].append(_col("policy_id", "$[:].policy_id"))
+    assert not is_per_port_cache_valid(working, cfg, data_path=data)
+
+    out = load_v2_api_source(str(data), cfg)
+
+    assert out["drivers"].collect().to_dict(as_series=False) == {
+        "age": [30, 40, 50],
+        "policy_id": [1001, 1001, 1002],
+    }
+    assert (working / "meta.json").read_bytes() == old_meta
+    assert not is_per_port_cache_valid(working, cfg, data_path=data)
+
+
+def test_stale_cache_after_selecting_column_uses_current_schema(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1, "premium": 12.5}])
+    cfg = {
+        "tables": [
+            _table(
+                "$[:]",
+                "root",
+                [
+                    _col("id", "$[:].id"),
+                    _col(
+                        "premium",
+                        "$[:].premium",
+                        selected=False,
+                        type_token="float",
+                    ),
+                ],
+            )
+        ]
+    }
+    _build(data, cfg)
+    cfg["tables"][0]["columns"][1]["selected"] = True
+
+    out = load_v2_api_source(str(data), cfg)
+
+    assert out["root"].collect().to_dict(as_series=False) == {
+        "id": [1],
+        "premium": [12.5],
+    }
+
+
+def test_stale_cache_after_type_change_uses_current_schema(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"premium": 1}, {"premium": 2}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("premium", "$[:].premium")])]}
+    _build(data, cfg)
+    cfg["tables"][0]["columns"][0]["type"] = "float"
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame.schema == pl.Schema({"premium": pl.Float64})
+    assert frame["premium"].to_list() == [1.0, 2.0]
+
+
+def test_stale_cache_after_column_rename_uses_current_schema(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 7}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg)
+    cfg["tables"][0]["columns"][0]["name"] = "quote_id"
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame.to_dict(as_series=False) == {"quote_id": [7]}
+
+
+@pytest.mark.parametrize("layer", ["working", "committed"])
+def test_valid_cache_fast_path_does_not_reshred_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    layer: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg, layer=layer)
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("a valid parquet cache must not re-shred the JSON source")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    frame = load_v2_api_source(str(data), cfg)["root"]
+
+    assert isinstance(frame, pl.LazyFrame)
+    assert frame.collect()["id"].to_list() == [9]
+
+
+def test_lazy_cache_frame_stays_pinned_to_generation_across_data_rebuild(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 1}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    generation_a = load_v2_api_source(str(data), cfg)["root"]
+
+    data.write_text(json.dumps([{"id": 2}]), encoding="utf-8")
+    build_per_port_cache(str(data), cfg, cache_dir)
+    generation_b = load_v2_api_source(str(data), cfg)["root"]
+
+    assert generation_a.collect().to_dict(as_series=False) == {"id": [1]}
+    assert generation_b.collect().to_dict(as_series=False) == {"id": [2]}
+
+
+def test_lazy_cache_frame_schema_cannot_leak_from_later_generation(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1}])
+    cfg_a = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg_a)
+    generation_a = load_v2_api_source(str(data), cfg_a)["root"]
+
+    data.write_text(json.dumps([{"id": 3}]), encoding="utf-8")
+    cfg_b = {"tables": [_table("$[:]", "root", [_col("new_id", "$[:].id")])]}
+    build_per_port_cache(str(data), cfg_b, cache_dir)
+    generation_b = load_v2_api_source(str(data), cfg_b)["root"]
+
+    assert generation_a.collect().to_dict(as_series=False) == {"id": [1]}
+    assert generation_b.collect().to_dict(as_series=False) == {"new_id": [3]}
+
+
+def test_lazy_cache_frame_snapshot_survives_clear_and_repeated_collect(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 1}, {"id": 2}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg)
+    generation = load_v2_api_source(str(data), cfg)["root"]
+
+    assert clear_json_cache(str(data), layer="working") is True
+
+    expected = {"id": [1, 2]}
+    assert generation.collect().to_dict(as_series=False) == expected
+    assert generation.collect().to_dict(as_series=False) == expected
+
+
+def test_derived_lazy_plan_keeps_snapshot_after_original_is_released(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 1}, {"id": 2}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg)
+    generation = load_v2_api_source(str(data), cfg)["root"]
+    derived = generation.select(pl.col("id").alias("generation_a_id")).with_columns(
+        (pl.col("generation_a_id") * 2).alias("doubled")
+    )
+
+    del generation
+    gc.collect()
+    assert clear_json_cache(str(data), layer="working") is True
+
+    expected = {"generation_a_id": [1, 2], "doubled": [2, 4]}
+    for _ in range(2):
+        collected = derived.collect()
+        assert collected.schema == pl.Schema({"generation_a_id": pl.Int64, "doubled": pl.Int64})
+        assert collected.to_dict(as_series=False) == expected
+
+
+def test_cache_probe_reads_each_parquet_once_and_collects_from_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": 1, "drivers": [{"age": 30}, {"age": 40}]}])
+    cfg = {
+        "tables": [
+            _table("$[:]", "root", [_col("id", "$[:].id")]),
+            _table("$[:].drivers[:]", "drivers", [_col("age", "$[:].drivers[:].age")]),
+        ]
+    }
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    cache_paths = {
+        cache_dir / "root.parquet",
+        cache_dir / "drivers.parquet",
+    }
+    opens = dict.fromkeys(cache_paths, 0)
+    reads = dict.fromkeys(cache_paths, 0)
+    scan_sources: list[Any] = []
+    real_open = Path.open
+    real_read_bytes = Path.read_bytes
+    real_scan_parquet = pl.scan_parquet
+
+    def _count_cache_opens(path: Path, *args: Any, **kwargs: Any) -> Any:
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if path in opens and "r" in mode:
+            opens[path] += 1
+        return real_open(path, *args, **kwargs)
+
+    def _count_cache_reads(path: Path) -> bytes:
+        if path in reads:
+            reads[path] += 1
+        return real_read_bytes(path)
+
+    def _capture_scan_source(source: Any, *args: Any, **kwargs: Any) -> pl.LazyFrame:
+        scan_sources.append(source)
+        return real_scan_parquet(source, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _count_cache_opens)
+    monkeypatch.setattr(Path, "read_bytes", _count_cache_reads)
+    monkeypatch.setattr("haute._json_shred.pl.scan_parquet", _capture_scan_source)
+
+    frames = load_v2_api_source(str(data), cfg)
+    for _ in range(2):
+        assert frames["root"].collect().to_dict(as_series=False) == {"id": [1]}
+        assert frames["drivers"].collect().to_dict(as_series=False) == {"age": [30, 40]}
+
+    assert opens == dict.fromkeys(cache_paths, 1)
+    assert reads == dict.fromkeys(cache_paths, 1)
+    assert len(scan_sources) == len(cache_paths)
+    assert all(isinstance(source, BytesIO) for source in scan_sources)
+
+
+def test_data_page_corrupt_working_cache_falls_through_to_committed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg, layer="working")
+    _build(data, cfg, layer="committed")
+    working = _json_cache_dir(str(data), "working") / "root.parquet"
+    _corrupt_parquet_data_page(working)
+    assert pl.scan_parquet(working).collect_schema() == pl.Schema({"id": pl.Int64})
+    with pytest.raises(pl.exceptions.ComputeError):
+        pl.read_parquet(working)
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("the valid committed cache should serve after rejecting working")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [9]
+
+
+def test_data_page_corrupt_both_caches_fall_back_direct_without_writes(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    damaged_bytes: dict[str, bytes] = {}
+    for layer in ("working", "committed"):
+        _build(data, cfg, layer=layer)
+        parquet = _json_cache_dir(str(data), layer) / "root.parquet"
+        _corrupt_parquet_data_page(parquet)
+        assert pl.scan_parquet(parquet).collect_schema() == pl.Schema({"id": pl.Int64})
+        damaged_bytes[layer] = parquet.read_bytes()
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [9]
+    for layer, expected_bytes in damaged_bytes.items():
+        parquet = _json_cache_dir(str(data), layer) / "root.parquet"
+        assert parquet.read_bytes() == expected_bytes
+
+
+def test_data_page_corrupt_cache_is_invalid_and_build_repairs_it(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    parquet = cache_dir / "root.parquet"
+    _corrupt_parquet_data_page(parquet)
+    damaged_bytes = parquet.read_bytes()
+    assert pl.scan_parquet(parquet).collect_schema() == pl.Schema({"id": pl.Int64})
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
+
+    build_per_port_cache(str(data), cfg, cache_dir)
+
+    assert parquet.read_bytes() != damaged_bytes
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True
+    assert pl.read_parquet(parquet)["id"].to_list() == [9]
+
+
+def test_manifest_without_parquet_content_signature_is_invalid(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    meta_path = cache_dir / "meta.json"
+    meta = orjson.loads(meta_path.read_bytes())
+    meta["tables"][0].pop("content_signature", None)
+    meta_path.write_bytes(orjson.dumps(meta))
+    legacy_meta_bytes = meta_path.read_bytes()
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [9]
+    assert meta_path.read_bytes() == legacy_meta_bytes
+
+    build_per_port_cache(str(data), cfg, cache_dir)
+
+    repaired_meta = orjson.loads(meta_path.read_bytes())
+    assert "content_signature" in repaired_meta["tables"][0]
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True
+
+
+@pytest.mark.parametrize("damage", ["missing_table", "duplicate_table"])
+def test_manifest_table_entries_must_match_emitting_tables_exactly(
+    tmp_path: Path,
+    damage: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 9}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    meta_path = cache_dir / "meta.json"
+    meta = orjson.loads(meta_path.read_bytes())
+    if damage == "missing_table":
+        meta["tables"] = []
+    else:
+        meta["tables"].append(dict(meta["tables"][0]))
+    meta_path.write_bytes(orjson.dumps(meta))
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
+
+
+def test_stale_working_cache_falls_through_to_valid_committed_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": 13}])
+    old_cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    current_cfg = {"tables": [_table("$[:]", "root", [_col("quote_id", "$[:].id")])]}
+    _build(data, old_cfg, layer="working")
+    _build(data, current_cfg, layer="committed")
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("the valid committed cache should serve after stale working")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    frame = load_v2_api_source(str(data), current_cfg)["root"].collect()
+    assert frame.to_dict(as_series=False) == {"quote_id": [13]}
+
+
+def test_valid_working_cache_wins_when_both_layers_are_valid(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg, layer="working")
+    _build(data, cfg, layer="committed")
+    working_dir = _json_cache_dir(str(data), "working")
+    committed_dir = _json_cache_dir(str(data), "committed")
+    working = working_dir / "root.parquet"
+    committed = committed_dir / "root.parquet"
+    pl.DataFrame({"id": [101]}, schema={"id": pl.Int64}).write_parquet(working)
+    pl.DataFrame({"id": [202]}, schema={"id": pl.Int64}).write_parquet(committed)
+    _refresh_content_signature(working_dir, "root")
+    _refresh_content_signature(committed_dir, "root")
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [101]
+
+
+@pytest.mark.parametrize("damage", ["corrupt", "wrong_name", "wrong_dtype"])
+def test_unusable_working_cache_falls_through_to_valid_committed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    damage: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 17, "amount": 3}])
+    cfg = {
+        "tables": [
+            _table(
+                "$[:]",
+                "root",
+                [_col("id", "$[:].id"), _col("amount", "$[:].amount")],
+            )
+        ]
+    }
+    _build(data, cfg, layer="working")
+    _build(data, cfg, layer="committed")
+    working_dir = _json_cache_dir(str(data), "working")
+    working_parquet = working_dir / "root.parquet"
+    if damage == "corrupt":
+        working_parquet.write_bytes(b"not parquet")
+    elif damage == "wrong_name":
+        pl.DataFrame({"wrong_name": [999], "amount": [3]}).write_parquet(working_parquet)
+    else:
+        pl.DataFrame({"id": ["999"], "amount": [3]}).write_parquet(working_parquet)
+    _refresh_content_signature(working_dir, "root")
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("the valid committed cache should serve after rejecting working")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame.to_dict(as_series=False) == {"id": [17], "amount": [3]}
+
+
+@pytest.mark.parametrize("damage", ["corrupt", "wrong_name", "wrong_dtype"])
+def test_cache_build_repairs_unreadable_or_schema_incompatible_parquet(
+    tmp_path: Path,
+    damage: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 17, "amount": 3}])
+    cfg = {
+        "tables": [
+            _table(
+                "$[:]",
+                "root",
+                [_col("id", "$[:].id"), _col("amount", "$[:].amount")],
+            )
+        ]
+    }
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    parquet_path = cache_dir / "root.parquet"
+    if damage == "corrupt":
+        parquet_path.write_bytes(b"not parquet")
+    elif damage == "wrong_name":
+        pl.DataFrame({"renamed": [17], "amount": [3]}).write_parquet(parquet_path)
+    else:
+        pl.DataFrame({"id": ["17"], "amount": [3]}).write_parquet(parquet_path)
+    _refresh_content_signature(cache_dir, "root")
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
+
+    build_per_port_cache(str(data), cfg, cache_dir)
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True
+    assert pl.read_parquet(parquet_path).to_dict(as_series=False) == {
+        "id": [17],
+        "amount": [3],
+    }
+
+
+def test_column_order_only_change_reuses_cache_and_projects_current_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": 17, "amount": 3}])
+    cfg = {
+        "tables": [
+            _table(
+                "$[:]",
+                "root",
+                [_col("id", "$[:].id"), _col("amount", "$[:].amount")],
+            )
+        ]
+    }
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    meta_path = cache_dir / "meta.json"
+    parquet_path = cache_dir / "root.parquet"
+    original_meta = meta_path.read_bytes()
+    original_parquet = parquet_path.read_bytes()
+
+    cfg["tables"][0]["columns"].reverse()
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is True
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("an order-only schema edit should reuse the existing cache")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    build_per_port_cache(str(data), cfg, cache_dir)
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert meta_path.read_bytes() == original_meta
+    assert parquet_path.read_bytes() == original_parquet
+    assert frame.columns == ["amount", "id"]
+    assert frame.to_dict(as_series=False) == {"amount": [3], "id": [17]}
+
+
+def test_corrupt_working_and_committed_caches_fall_back_to_direct_shred(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 23}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    for layer in ("working", "committed"):
+        _build(data, cfg, layer=layer)
+        cache_dir = _json_cache_dir(str(data), layer)
+        (cache_dir / "root.parquet").write_bytes(b"not parquet")
+        _refresh_content_signature(cache_dir, "root")
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [23]
+    for layer in ("working", "committed"):
+        cache_dir = _json_cache_dir(str(data), layer)
+        assert (cache_dir / "root.parquet").read_bytes() == b"not parquet"
+
+
+def test_unreadable_cache_candidate_is_logged_before_direct_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": 23}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg)
+    cache_dir = _json_cache_dir(str(data), "working")
+    (cache_dir / "root.parquet").write_bytes(b"not parquet")
+    _refresh_content_signature(cache_dir, "root")
+    warnings: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "haute._json_shred.logger.warning",
+        lambda event, **fields: warnings.append((event, fields)),
+    )
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame["id"].to_list() == [23]
+    assert [event for event, _fields in warnings] == ["json_shred_cache_candidate_rejected"]
+    assert warnings[0][1]["reason"] == "unreadable_parquet"
+
+
+def test_uncached_direct_shred_excludes_non_emitting_sibling(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1, "ignored": 2}])
+    cfg = {
+        "tables": [
+            _table("$[:]", "root", [_col("id", "$[:].id")]),
+            _table(
+                "$[:]",
+                "ignored",
+                [_col("ignored", "$[:].ignored")],
+                emit=False,
+            ),
+        ]
+    }
+
+    out = load_v2_api_source(str(data), cfg)
+
+    assert list(out) == ["root"]
+    assert out["root"].collect()["id"].to_list() == [1]
+
+
+def test_uncached_direct_shred_logs_every_skipped_record_and_child_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = tmp_path / "data.json"
+    data.write_text(
+        json.dumps([{"items": [{"value": 1}, 2]}, 7]),
+        encoding="utf-8",
+    )
+    cfg = {
+        "tables": [
+            _table(
+                "$[:].items[:]",
+                "items",
+                [_col("value", "$[:].items[:].value")],
+            )
+        ]
+    }
+    warnings: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture_warning(event: str, **fields: Any) -> None:
+        warnings.append((event, fields))
+
+    monkeypatch.setattr("haute._json_shred.logger.warning", _capture_warning)
+
+    frame = load_v2_api_source(str(data), cfg)["items"].collect()
+
+    assert frame["value"].to_list() == [1]
+    assert warnings == [
+        (
+            "json_shred_direct_records_skipped",
+            {
+                "data_path": str(data),
+                "skipped_records": 1,
+                "skipped_rows_by_table": {"items": 1},
+            },
+        )
+    ]
+
+
+def test_uncached_scalar_array_ignores_empty_arrays_and_broadcasts_ancestor(
+    tmp_path: Path,
+) -> None:
+    data = _write(
+        tmp_path,
+        [
+            {"quote_id": 1, "tags": ["new", "renewal"]},
+            {"quote_id": 2, "tags": []},
+        ],
+    )
+    cfg = {
+        "tables": [
+            _table(
+                "$[:].tags[:]",
+                "tags",
+                [
+                    _col("value", "$[:].tags[:].$value", type_token="str"),
+                    _col("quote_id", "$[:].quote_id"),
+                ],
+            )
+        ]
+    }
+
+    frame = load_v2_api_source(str(data), cfg)["tags"].collect()
+
+    assert frame.to_dict(as_series=False) == {
+        "value": ["new", "renewal"],
+        "quote_id": [1, 1],
+    }
+
+
+def test_uncached_all_empty_array_preserves_declared_frame_schema(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"tags": []}])
+    cfg = {
+        "tables": [
+            _table(
+                "$[:].tags[:]",
+                "tags",
+                [_col("value", "$[:].tags[:].$value", type_token="str")],
+            )
+        ]
+    }
+
+    frame = load_v2_api_source(str(data), cfg)["tags"].collect()
+
+    assert frame.schema == pl.Schema({"value": pl.String})
+    assert frame.height == 0
+
+
+def test_uncached_malformed_schema_raises_typed_error(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1}])
+
+    with pytest.raises(ApiInputSchemaError, match=r"tables\[0\].*dict"):
+        load_v2_api_source(str(data), {"tables": ["not-a-table"]})
+
+
+def test_uncached_declared_type_mismatch_names_column_and_type(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = _write(tmp_path, [{"id": "not-an-int"}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    info_events: list[str] = []
+    monkeypatch.setattr(
+        "haute._json_shred.logger.info",
+        lambda event, **_fields: info_events.append(event),
+    )
+
+    with pytest.raises(ApiInputSchemaError, match=r"column 'id'.*declared type 'int'"):
+        load_v2_api_source(str(data), cfg)
+    assert "json_shred_loaded_direct" not in info_events
+
+
+def test_uncached_malformed_json_surfaces_decode_error(tmp_path: Path) -> None:
+    data = tmp_path / "data.json"
+    data.write_text('[{"id": 1},', encoding="utf-8")
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+
+    with pytest.raises(orjson.JSONDecodeError):
+        load_v2_api_source(str(data), cfg)
+
+
+def test_missing_raw_source_stays_a_file_not_found_error(tmp_path: Path) -> None:
+    data = tmp_path / "missing.json"
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+
+    with pytest.raises(FileNotFoundError, match="missing.json"):
         load_v2_api_source(str(data), cfg)
 
 
@@ -114,6 +873,114 @@ def test_load_per_port_cache_skips_non_emit_tables(tmp_path: Path) -> None:
     _build(data, cfg)
     frames = load_per_port_cache(_json_cache_dir(str(data), "working"), cfg)
     assert set(frames) == {"root"}  # the emit:false table is not loaded
+
+
+def test_load_per_port_cache_rejects_wrong_schema_mode(tmp_path: Path) -> None:
+    data = _write(tmp_path, [{"id": 1}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg)
+    cache_dir = _json_cache_dir(str(data), "working")
+    meta_path = cache_dir / "meta.json"
+    meta = orjson.loads(meta_path.read_bytes())
+    meta["schema_mode"] = "v1"
+    meta_path.write_bytes(orjson.dumps(meta))
+
+    assert load_per_port_cache(cache_dir, cfg) == {}
+
+
+def test_load_per_port_cache_rejects_schema_fingerprint_mismatch(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 1, "alternate": 2}])
+    cached_cfg = {
+        "tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]
+    }
+    changed_path_cfg = {
+        "tables": [_table("$[:]", "root", [_col("id", "$[:].alternate")])]
+    }
+    _build(data, cached_cfg)
+    cache_dir = _json_cache_dir(str(data), "working")
+
+    # Label, output name, and declared dtype are deliberately unchanged, so
+    # accepting this cache would silently serve values from the old JSON path.
+    assert load_per_port_cache(cache_dir, changed_path_cfg) == {}
+
+
+def test_load_per_port_cache_returns_empty_for_signed_unreadable_member(
+    tmp_path: Path,
+) -> None:
+    data = _write(tmp_path, [{"id": 1, "drivers": [{"age": 30}]}])
+    cfg = {
+        "tables": [
+            _table("$[:]", "root", [_col("id", "$[:].id")]),
+            _table("$[:].drivers[:]", "drivers", [_col("age", "$[:].drivers[:].age")]),
+        ]
+    }
+    _build(data, cfg)
+    cache_dir = _json_cache_dir(str(data), "working")
+    (cache_dir / "drivers.parquet").write_bytes(b"not parquet")
+    _refresh_content_signature(cache_dir, "drivers")
+
+    # Loading a bundle is all-or-empty: a later invalid member must neither
+    # expose the valid root frame nor leak the Parquet reader's exception.
+    assert load_per_port_cache(cache_dir, cfg) == {}
+
+
+@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
+def test_permission_denied_working_meta_falls_through_to_committed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 31}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg, layer="working")
+    _build(data, cfg, layer="committed")
+    working_meta = _json_cache_dir(str(data), "working") / "meta.json"
+    _deny_path_operation(monkeypatch, working_meta, operation)
+
+    def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
+        pytest.fail("a valid committed cache must serve when working meta is unreadable")
+
+    monkeypatch.setattr("haute._json_shred._iter_records", _unexpected_reshred)
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame.to_dict(as_series=False) == {"id": [31]}
+
+
+@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
+def test_permission_denied_working_meta_falls_back_to_direct_shred(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 37}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    _build(data, cfg, layer="working")
+    working_meta = _json_cache_dir(str(data), "working") / "meta.json"
+    _deny_path_operation(monkeypatch, working_meta, operation)
+
+    frame = load_v2_api_source(str(data), cfg)["root"].collect()
+
+    assert frame.to_dict(as_series=False) == {"id": [37]}
+
+
+@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
+def test_permission_denied_meta_is_invalid_and_unloadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 41}])
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, cfg)
+    _deny_path_operation(monkeypatch, cache_dir / "meta.json", operation)
+
+    assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
+    assert read_per_port_cache_meta(cache_dir) is None
+    assert load_per_port_cache(cache_dir, cfg) == {}
 
 
 def test_is_per_port_cache_valid_false_states(tmp_path: Path) -> None:
@@ -166,15 +1033,15 @@ def test_is_per_port_cache_valid_rejects_non_string_label_on_emitting_table(
     assert is_per_port_cache_valid(cache_dir, bad, data_path=data) is False
 
 
-def test_load_per_port_cache_skips_non_string_label(tmp_path: Path) -> None:
+def test_load_per_port_cache_rejects_non_string_label(tmp_path: Path) -> None:
     data = _write(tmp_path, [{"id": 1}])
     good = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     cache_dir = tmp_path / "cache"
     build_per_port_cache(str(data), good, cache_dir)
     weird = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     weird["tables"][0]["label"] = 123
-    frames = load_per_port_cache(cache_dir, weird)
-    assert frames == {}
+    with pytest.raises(ApiInputSchemaError, match="label.*non-empty string"):
+        load_per_port_cache(cache_dir, weird)
 
 
 def test_is_per_port_cache_valid_tolerates_non_dict_tables_and_columns(tmp_path: Path) -> None:
@@ -206,8 +1073,50 @@ def test_is_per_port_cache_valid_tolerates_non_dict_tables_and_columns(tmp_path:
     assert is_per_port_cache_valid(cache_dir, weird, data_path=data) is False
 
 
+@pytest.mark.parametrize(
+    ("bad_config", "error_match"),
+    [
+        ({"tables": None}, "tables.*list"),
+        (
+            {
+                "tables": [
+                    {
+                        "path": "$[:]",
+                        "label": "root",
+                        "emit": True,
+                        "row_id_column": None,
+                        "columns": 1,
+                    }
+                ]
+            },
+            "columns.*list",
+        ),
+    ],
+    ids=["null-tables", "non-list-columns"],
+)
+def test_malformed_container_shapes_are_invalid_for_probe_but_loud_at_boundaries(
+    tmp_path: Path,
+    bad_config: dict[str, Any],
+    error_match: str,
+) -> None:
+    data = _write(tmp_path, [{"id": 43}])
+    good = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    cache_dir = _json_cache_dir(str(data), "working")
+    _build(data, good)
+
+    assert is_per_port_cache_valid(cache_dir, bad_config, data_path=data) is False
+    with pytest.raises(ApiInputSchemaError, match=error_match):
+        load_v2_api_source(str(data), bad_config)
+    with pytest.raises(ApiInputSchemaError, match=error_match):
+        build_per_port_cache(str(data), bad_config, tmp_path / "invalid-cache")
+
+
 def test_read_meta_missing_file_returns_none(tmp_path: Path) -> None:
-    assert read_per_port_cache_meta(tmp_path / "no-such-dir") is None
+    cache_dir = tmp_path / "no-such-dir"
+    cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+
+    assert read_per_port_cache_meta(cache_dir) is None
+    assert load_per_port_cache(cache_dir, cfg) == {}
 
 
 def test_falls_back_to_committed_layer(tmp_path: Path) -> None:

--- a/tests/test_load_v2_api_source.py
+++ b/tests/test_load_v2_api_source.py
@@ -2,8 +2,8 @@
 
 ``load_v2_api_source`` is the single function both the executor's source
 builder and the generated/deploy code now call, so its behaviour (emit
-checks, working→committed cache resolution, single/multi-port return) is the
-contract that keeps the two paths from drifting.
+checks, working→committed cache resolution, uniform per-port return shape) is
+the contract that keeps the two paths from drifting.
 """
 
 from __future__ import annotations
@@ -53,13 +53,15 @@ def _build(data_path: Path, config: dict[str, Any], layer: str = "working") -> N
     build_per_port_cache(str(data_path), config, _json_cache_dir(str(data_path), layer))
 
 
-def test_single_port_returns_bare_lazyframe(tmp_path: Path) -> None:
+def test_single_port_returns_one_entry_dict(tmp_path: Path) -> None:
     data = _write(tmp_path, [{"id": 1}, {"id": 2}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     _build(data, cfg)
     out = load_v2_api_source(str(data), cfg)
-    assert isinstance(out, pl.LazyFrame)
-    assert out.collect()["id"].to_list() == [1, 2]
+    assert isinstance(out, dict)
+    assert list(out) == ["root"]
+    assert isinstance(out["root"], pl.LazyFrame)
+    assert out["root"].collect()["id"].to_list() == [1, 2]
 
 
 def test_multi_port_returns_dict_in_schema_order(tmp_path: Path) -> None:
@@ -74,6 +76,8 @@ def test_multi_port_returns_dict_in_schema_order(tmp_path: Path) -> None:
     out = load_v2_api_source(str(data), cfg)
     assert isinstance(out, dict)
     assert list(out) == ["root", "drivers"]
+    assert all(isinstance(frame, pl.LazyFrame) for frame in out.values())
+    assert out["root"].collect()["id"].to_list() == [1]
     assert out["drivers"].collect()["age"].to_list() == [30, 40]
 
 
@@ -212,5 +216,7 @@ def test_falls_back_to_committed_layer(tmp_path: Path) -> None:
     # Only the committed layer is populated (the deploy / fresh-server case).
     _build(data, cfg, layer="committed")
     out = load_v2_api_source(str(data), cfg)
-    assert isinstance(out, pl.LazyFrame)
-    assert out.collect()["id"].to_list() == [7]
+    assert isinstance(out, dict)
+    assert list(out) == ["root"]
+    assert isinstance(out["root"], pl.LazyFrame)
+    assert out["root"].collect()["id"].to_list() == [7]

--- a/tests/test_load_v2_api_source.py
+++ b/tests/test_load_v2_api_source.py
@@ -30,6 +30,12 @@ from haute._json_shred import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_cache_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep production cache helpers inside each test's temporary project."""
+    monkeypatch.chdir(tmp_path)
+
+
 def _col(
     name: str,
     path: str,
@@ -892,12 +898,8 @@ def test_load_per_port_cache_rejects_schema_fingerprint_mismatch(
     tmp_path: Path,
 ) -> None:
     data = _write(tmp_path, [{"id": 1, "alternate": 2}])
-    cached_cfg = {
-        "tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]
-    }
-    changed_path_cfg = {
-        "tables": [_table("$[:]", "root", [_col("id", "$[:].alternate")])]
-    }
+    cached_cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
+    changed_path_cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].alternate")])]}
     _build(data, cached_cfg)
     cache_dir = _json_cache_dir(str(data), "working")
 
@@ -926,18 +928,16 @@ def test_load_per_port_cache_returns_empty_for_signed_unreadable_member(
     assert load_per_port_cache(cache_dir, cfg) == {}
 
 
-@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
 def test_permission_denied_working_meta_falls_through_to_committed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    operation: str,
 ) -> None:
     data = _write(tmp_path, [{"id": 31}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     _build(data, cfg, layer="working")
     _build(data, cfg, layer="committed")
     working_meta = _json_cache_dir(str(data), "working") / "meta.json"
-    _deny_path_operation(monkeypatch, working_meta, operation)
+    _deny_path_operation(monkeypatch, working_meta, "read_bytes")
 
     def _unexpected_reshred(*_args: Any, **_kwargs: Any) -> Any:
         pytest.fail("a valid committed cache must serve when working meta is unreadable")
@@ -949,34 +949,30 @@ def test_permission_denied_working_meta_falls_through_to_committed(
     assert frame.to_dict(as_series=False) == {"id": [31]}
 
 
-@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
 def test_permission_denied_working_meta_falls_back_to_direct_shred(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    operation: str,
 ) -> None:
     data = _write(tmp_path, [{"id": 37}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     _build(data, cfg, layer="working")
     working_meta = _json_cache_dir(str(data), "working") / "meta.json"
-    _deny_path_operation(monkeypatch, working_meta, operation)
+    _deny_path_operation(monkeypatch, working_meta, "read_bytes")
 
     frame = load_v2_api_source(str(data), cfg)["root"].collect()
 
     assert frame.to_dict(as_series=False) == {"id": [37]}
 
 
-@pytest.mark.parametrize("operation", ["exists", "read_bytes"])
 def test_permission_denied_meta_is_invalid_and_unloadable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    operation: str,
 ) -> None:
     data = _write(tmp_path, [{"id": 41}])
     cfg = {"tables": [_table("$[:]", "root", [_col("id", "$[:].id")])]}
     cache_dir = _json_cache_dir(str(data), "working")
     _build(data, cfg)
-    _deny_path_operation(monkeypatch, cache_dir / "meta.json", operation)
+    _deny_path_operation(monkeypatch, cache_dir / "meta.json", "read_bytes")
 
     assert is_per_port_cache_valid(cache_dir, cfg, data_path=data) is False
     assert read_per_port_cache_meta(cache_dir) is None

--- a/tests/test_offset_scoring.py
+++ b/tests/test_offset_scoring.py
@@ -719,7 +719,12 @@ class TestDeployScorerOffset:
                     },
                 ],
                 "edges": [
-                    {"id": "e1", "source": "api_in", "target": "ms"},
+                    {
+                        "id": "e1",
+                        "source": "api_in",
+                        "target": "ms",
+                        "sourceHandle": "api_in",
+                    },
                     {"id": "e2", "source": "ms", "target": "output"},
                 ],
             }

--- a/tests/test_output_nested_roundtrip.py
+++ b/tests/test_output_nested_roundtrip.py
@@ -228,7 +228,7 @@ def test_nested_output_renders_through_deploy_scorer() -> None:
                 ),
             ),
         ],
-        edges=[GraphEdge(id="e", source="src", target="out")],
+        edges=[GraphEdge(id="e", source="src", target="out", sourceHandle="src")],
     )
 
     result = score_graph(

--- a/tests/test_parser_roundtrip.py
+++ b/tests/test_parser_roundtrip.py
@@ -385,7 +385,16 @@ def _pipeline_graph(draw: st.DrawFn) -> PipelineGraph:
     for i in range(len(nodes) - 1):
         src_id = nodes[i].id
         tgt_id = nodes[i + 1].id
-        edges.append(GraphEdge(id=f"e_{src_id}_{tgt_id}", source=src_id, target=tgt_id))
+        edges.append(
+            GraphEdge(
+                id=f"e_{src_id}_{tgt_id}",
+                source=src_id,
+                target=tgt_id,
+                sourceHandle=(
+                    "api_frame" if nodes[i].data.nodeType == NodeType.API_INPUT else None
+                ),
+            )
+        )
 
     return PipelineGraph(
         nodes=nodes,
@@ -936,7 +945,14 @@ class TestEdgeCases:
                     ),
                 ),
             ],
-            edges=[GraphEdge(id="e1", source="api", target="process")],
+            edges=[
+                GraphEdge(
+                    id="e1",
+                    source="api",
+                    target="process",
+                    sourceHandle="api_frame",
+                )
+            ],
             pipeline_name="roundtrip_test",
         )
         parsed = _parse_roundtrip(graph, tmp_path)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -409,6 +409,206 @@ class TestPipeline:
 
 
 # ---------------------------------------------------------------------------
+# Standalone port-aware execution
+# ---------------------------------------------------------------------------
+
+
+class TestPipelinePortAwareExecution:
+    @staticmethod
+    def _one_port_score_pipeline() -> Pipeline:
+        p = Pipeline("one_port_score")
+
+        @p.api_input
+        def api_source() -> dict[str, pl.DataFrame]:
+            raise AssertionError("score() must seed the apiInput source")
+
+        @p.polars
+        def consume(quotes: pl.DataFrame) -> pl.DataFrame:
+            return quotes
+
+        p.connect("api_source", "consume", source_port="quotes")
+        return p
+
+    @staticmethod
+    def _two_port_score_pipeline() -> Pipeline:
+        p = Pipeline("two_port_score")
+
+        @p.api_input
+        def api_source() -> dict[str, pl.DataFrame]:
+            raise AssertionError("score() must seed the apiInput source")
+
+        @p.polars
+        def combine(quotes: pl.DataFrame, drivers: pl.DataFrame) -> pl.DataFrame:
+            if not isinstance(quotes, pl.DataFrame) or not isinstance(drivers, pl.DataFrame):
+                return pl.DataFrame({"quote_id": [-1], "driver_id": [-1]})
+            return pl.DataFrame(
+                {
+                    "quote_id": quotes["quote_id"],
+                    "driver_id": drivers["driver_id"],
+                }
+            )
+
+        p.connect("api_source", "combine", source_port="quotes")
+        p.connect("api_source", "combine", source_port="drivers")
+        return p
+
+    def test_run_selects_the_frame_from_a_one_frame_api_input_dict(self):
+        p = Pipeline("one_frame_run")
+        expected = pl.DataFrame({"quote_id": [17]})
+
+        @p.api_input
+        def api_source() -> dict[str, pl.DataFrame]:
+            return {"quotes": expected}
+
+        @p.polars
+        def consume(quotes: pl.DataFrame) -> pl.DataFrame:
+            return quotes
+
+        p.connect("api_source", "consume", source_port="quotes")
+
+        result = p.run()
+        assert isinstance(result, pl.DataFrame)
+        assert result.to_dict(as_series=False) == {"quote_id": [17]}
+
+    def test_run_selects_each_named_frame_from_a_many_frame_api_input_dict(self):
+        p = Pipeline("many_frame_run")
+
+        @p.api_input
+        def api_source() -> dict[str, pl.DataFrame]:
+            return {
+                "quotes": pl.DataFrame({"quote_id": [17]}),
+                "drivers": pl.DataFrame({"driver_id": [31]}),
+            }
+
+        @p.polars
+        def combine(quotes: pl.DataFrame, drivers: pl.DataFrame) -> pl.DataFrame:
+            if not isinstance(quotes, pl.DataFrame) or not isinstance(drivers, pl.DataFrame):
+                return pl.DataFrame({"quote_id": [-1], "driver_id": [-1]})
+            return pl.DataFrame(
+                {
+                    "quote_id": quotes["quote_id"],
+                    "driver_id": drivers["driver_id"],
+                }
+            )
+
+        p.connect("api_source", "combine", source_port="quotes")
+        p.connect("api_source", "combine", source_port="drivers")
+
+        assert p.run().to_dict(as_series=False) == {
+            "quote_id": [17],
+            "driver_id": [31],
+        }
+
+    def test_score_accepts_a_bare_frame_for_a_source_only_pipeline(self):
+        p = Pipeline("source_only_score")
+
+        @p.api_input
+        def api_source() -> pl.DataFrame:
+            raise AssertionError("score() must seed the apiInput source")
+
+        seed = pl.DataFrame({"quote_id": [17]})
+        assert p.score(seed).to_dict(as_series=False) == {"quote_id": [17]}
+
+    def test_score_accepts_a_bare_frame_for_exactly_one_connected_port(self):
+        p = self._one_port_score_pipeline()
+        seed = pl.DataFrame({"quote_id": [17]})
+
+        assert p.score(seed).to_dict(as_series=False) == {"quote_id": [17]}
+
+    def test_score_rejects_a_bare_frame_for_multiple_connected_ports(self):
+        p = self._two_port_score_pipeline()
+
+        with pytest.raises(ExecutionError) as exc_info:
+            p.score(pl.DataFrame({"quote_id": [17], "driver_id": [31]}))
+
+        message = str(exc_info.value)
+        assert "quotes" in message
+        assert "drivers" in message
+
+    def test_score_accepts_an_exact_one_key_dict_for_one_connected_port(self):
+        p = self._one_port_score_pipeline()
+
+        result = p.score({"quotes": pl.DataFrame({"quote_id": [17]})})
+
+        assert isinstance(result, pl.DataFrame)
+        assert result.to_dict(as_series=False) == {"quote_id": [17]}
+
+    def test_score_accepts_an_exact_dict_for_multiple_connected_ports(self):
+        p = self._two_port_score_pipeline()
+
+        result = p.score(
+            {
+                "quotes": pl.DataFrame({"quote_id": [17]}),
+                "drivers": pl.DataFrame({"driver_id": [31]}),
+            }
+        )
+
+        assert result.to_dict(as_series=False) == {
+            "quote_id": [17],
+            "driver_id": [31],
+        }
+
+    def test_score_reports_missing_and_unknown_ports_from_the_same_dict(self):
+        p = self._two_port_score_pipeline()
+
+        with pytest.raises(ExecutionError) as exc_info:
+            p.score(
+                {
+                    "quotes": pl.DataFrame({"quote_id": [17]}),
+                    "rogue": pl.DataFrame({"other_id": [99]}),
+                }
+            )
+
+        message = str(exc_info.value)
+        assert "missing" in message.lower()
+        assert "drivers" in message
+        assert "unknown" in message.lower()
+        assert "rogue" in message
+
+    def test_score_rejects_a_dict_with_an_unknown_extra_port(self):
+        p = self._one_port_score_pipeline()
+
+        with pytest.raises(ExecutionError) as exc_info:
+            p.score(
+                {
+                    "quotes": pl.DataFrame({"quote_id": [17]}),
+                    "drivers": pl.DataFrame({"driver_id": [31]}),
+                }
+            )
+
+        message = str(exc_info.value)
+        assert "unknown" in message.lower()
+        assert "drivers" in message
+
+    @pytest.mark.parametrize(
+        "seed, unknown_port",
+        [
+            ({}, None),
+            ({"quotes": pl.DataFrame({"quote_id": [17]})}, "quotes"),
+        ],
+        ids=["empty-dict", "non-empty-dict"],
+    )
+    def test_score_rejects_any_dict_for_a_source_with_zero_connected_ports(
+        self,
+        seed: dict[str, pl.DataFrame],
+        unknown_port: str | None,
+    ):
+        p = Pipeline("source_only_dict_score")
+
+        @p.api_input
+        def api_source() -> pl.DataFrame:
+            raise AssertionError("score() must seed the apiInput source")
+
+        with pytest.raises(ExecutionError) as exc_info:
+            p.score(seed)
+
+        message = str(exc_info.value)
+        assert "port" in message.lower()
+        if unknown_port is not None:
+            assert unknown_port in message
+
+
+# ---------------------------------------------------------------------------
 # Node edge cases
 # ---------------------------------------------------------------------------
 

--- a/tests/test_port_aware_executor.py
+++ b/tests/test_port_aware_executor.py
@@ -18,12 +18,21 @@ These tests cover the live pieces that keep multi-port data flow explicit:
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 import polars as pl
 import pytest
 from pydantic import ValidationError
 
-from haute._execute_lazy import _prepare_graph, _prepare_graph_with_edges
+from haute._execute_lazy import (
+    _build_funcs,
+    _execute_eager_core,
+    _prepare_graph,
+    _prepare_graph_with_edges,
+)
 from haute._types import GraphEdge, GraphNode, NodeData, NodeType, PipelineGraph
+from haute.errors import ConfigError
 
 # 1. Pydantic validator rejects "" handles
 
@@ -176,3 +185,341 @@ def test_passthrough_fn_empty_returns_empty_lazyframe() -> None:
     result = _passthrough_fn()
     assert isinstance(result, pl.LazyFrame)
     assert result.collect().shape == (0, 0)
+
+
+# 4. Every executable input name is derived from its own incoming edge
+
+
+def _node(
+    node_id: str,
+    label: str,
+    node_type: NodeType,
+    *,
+    config: dict[str, Any] | None = None,
+) -> GraphNode:
+    return GraphNode(
+        id=node_id,
+        data=NodeData(label=label, nodeType=node_type, config=config or {}),
+    )
+
+
+def _capture_builder_calls(
+    captured: dict[str, dict[str, Any]],
+) -> Callable[..., tuple[str, Callable[..., Any], bool]]:
+    def build_node_fn(
+        node: GraphNode,
+        *,
+        source_names: list[str] | None = None,
+        orig_source_names: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[str, Callable[..., Any], bool]:
+        captured[node.id] = {
+            "source_names": list(source_names or []),
+            "orig_source_names": (None if orig_source_names is None else list(orig_source_names)),
+        }
+        is_source = node.data.nodeType in {NodeType.API_INPUT, NodeType.DATA_SOURCE}
+        return node.id, lambda *frames: frames[0] if frames else pl.LazyFrame(), is_source
+
+    return build_node_fn
+
+
+def _build_graph_funcs(
+    graph: PipelineGraph,
+    build_node_fn: Callable[..., tuple[str, Callable[..., Any], bool]],
+) -> None:
+    node_map, order, parents_of, id_to_name, relevant_edges = _prepare_graph_with_edges(graph)
+    incoming: dict[str, list[GraphEdge]] = {}
+    for edge in relevant_edges:
+        incoming.setdefault(edge.target, []).append(edge)
+    _build_funcs(
+        order,
+        node_map,
+        parents_of,
+        id_to_name,
+        graph.parents_of,
+        build_node_fn,
+        incoming_edges_by_target=incoming,
+    )
+
+
+def test_build_funcs_derives_each_input_name_from_its_edge_in_declaration_order() -> None:
+    """API frames stay verbatim; ordinary and flattened child nodes are sanitised."""
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "API Input", NodeType.API_INPUT),
+            _node("ordinary", "Ordinary Source", NodeType.DATA_SOURCE),
+            # Submodel expansion has already replaced the boundary placeholder
+            # with this real child node by the time the executor sees the graph.
+            _node("child", "Frequency Model Child", NodeType.POLARS),
+            _node("target", "target", NodeType.POLARS),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_target",
+                source="api",
+                target="target",
+                sourceHandle="quotes",
+            ),
+            GraphEdge(id="ordinary_target", source="ordinary", target="target"),
+            GraphEdge(id="child_target", source="child", target="target"),
+        ],
+    )
+    captured: dict[str, dict[str, Any]] = {}
+
+    _build_graph_funcs(graph, _capture_builder_calls(captured))
+
+    assert captured["target"]["source_names"] == [
+        "quotes",
+        "Ordinary_Source",
+        "Frequency_Model_Child",
+    ]
+
+
+def test_single_frame_dict_source_binds_under_its_raw_frame_label() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "Quote Input", NodeType.API_INPUT),
+            _node("target", "target", NodeType.POLARS),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_target",
+                source="api",
+                target="target",
+                sourceHandle="quotes",
+            )
+        ],
+    )
+    observed: dict[str, Any] = {}
+
+    def build_node_fn(
+        node: GraphNode,
+        *,
+        source_names: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[str, Callable[..., Any], bool]:
+        if node.id == "api":
+            return node.id, lambda: {"quotes": pl.LazyFrame({"quote_id": [101]})}, True
+
+        def consume(frame: pl.LazyFrame) -> pl.LazyFrame:
+            observed["source_names"] = list(source_names or [])
+            observed["quote_ids"] = frame.collect()["quote_id"].to_list()
+            return frame
+
+        return node.id, consume, False
+
+    _execute_eager_core(graph, build_node_fn, swallow_errors=False)
+
+    assert observed == {"source_names": ["quotes"], "quote_ids": [101]}
+
+
+def test_execute_lazy_graph_binds_api_frame_under_raw_edge_name() -> None:
+    """The public lazy production entry point must supply incoming edge metadata."""
+    from haute.execution import execute_lazy_graph
+
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "Quote Input", NodeType.API_INPUT),
+            _node("target", "target", NodeType.POLARS),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_target",
+                source="api",
+                target="target",
+                sourceHandle="quotes",
+            )
+        ],
+    )
+    observed_names: list[str] = []
+
+    def build_node_fn(
+        node: GraphNode,
+        *,
+        source_names: list[str] | None = None,
+        **_kwargs: Any,
+    ) -> tuple[str, Callable[..., Any], bool]:
+        if node.id == "api":
+            return node.id, lambda: {"quotes": pl.LazyFrame({"quote_id": [101]})}, True
+
+        def consume(frame: pl.LazyFrame) -> pl.LazyFrame:
+            observed_names.extend(source_names or [])
+            return frame
+
+        return node.id, consume, False
+
+    outputs, *_ = execute_lazy_graph(graph, build_node_fn, target_node_id="target")
+
+    assert outputs["target"].collect()["quote_id"].to_list() == [101]
+    assert observed_names == ["quotes"]
+
+
+def test_reconnecting_api_input_edges_in_reverse_keeps_names_bound_to_their_frames() -> None:
+    def execute(edge_order: list[str]) -> list[tuple[str, str]]:
+        graph = PipelineGraph(
+            nodes=[
+                _node("api", "API Input", NodeType.API_INPUT),
+                _node("target", "target", NodeType.POLARS),
+            ],
+            edges=[
+                GraphEdge(
+                    id=f"api_target_{port}",
+                    source="api",
+                    target="target",
+                    sourceHandle=port,
+                )
+                for port in edge_order
+            ],
+        )
+        observed: list[tuple[str, str]] = []
+
+        def build_node_fn(
+            node: GraphNode,
+            *,
+            source_names: list[str] | None = None,
+            **_kwargs: Any,
+        ) -> tuple[str, Callable[..., Any], bool]:
+            if node.id == "api":
+                return (
+                    node.id,
+                    lambda: {
+                        "quotes": pl.LazyFrame({"origin": ["quote-frame"]}),
+                        "drivers": pl.LazyFrame({"origin": ["driver-frame"]}),
+                    },
+                    True,
+                )
+
+            def consume(*frames: pl.LazyFrame) -> pl.LazyFrame:
+                observed.extend(
+                    (name, frame.collect()["origin"][0])
+                    for name, frame in zip(source_names or [], frames, strict=True)
+                )
+                return frames[0]
+
+            return node.id, consume, False
+
+        _execute_eager_core(graph, build_node_fn, swallow_errors=False)
+        return observed
+
+    assert execute(["quotes", "drivers"]) == [
+        ("quotes", "quote-frame"),
+        ("drivers", "driver-frame"),
+    ]
+    assert execute(["drivers", "quotes"]) == [
+        ("drivers", "driver-frame"),
+        ("quotes", "quote-frame"),
+    ]
+
+
+def test_duplicate_derived_input_name_raises_config_error_naming_target_and_name() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "API Input", NodeType.API_INPUT),
+            _node("ordinary", "shared name", NodeType.DATA_SOURCE),
+            _node("pricing", "pricing", NodeType.POLARS),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_pricing",
+                source="api",
+                target="pricing",
+                sourceHandle="shared_name",
+            ),
+            GraphEdge(id="ordinary_pricing", source="ordinary", target="pricing"),
+        ],
+    )
+
+    with pytest.raises(ConfigError) as exc_info:
+        _build_graph_funcs(graph, _capture_builder_calls({}))
+
+    message = str(exc_info.value)
+    assert "pricing" in message
+    assert "shared_name" in message
+
+
+def test_null_handle_against_even_a_one_frame_dict_fails_loudly() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "API Input", NodeType.API_INPUT),
+            _node("target", "target", NodeType.POLARS),
+        ],
+        edges=[GraphEdge(id="api_target", source="api", target="target")],
+    )
+
+    def build_node_fn(
+        node: GraphNode,
+        **_kwargs: Any,
+    ) -> tuple[str, Callable[..., Any], bool]:
+        if node.id == "api":
+            return node.id, lambda: {"quotes": pl.LazyFrame({"x": [1]})}, True
+        return node.id, lambda frame: frame, False
+
+    with pytest.raises(ValueError) as exc_info:
+        _execute_eager_core(graph, build_node_fn, swallow_errors=False)
+
+    message = str(exc_info.value)
+    assert "api" in message
+    assert "sourceHandle" in message
+
+
+def test_instance_original_input_names_come_from_original_incoming_edges() -> None:
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "API Input", NodeType.API_INPUT),
+            _node("ordinary", "Ordinary Source", NodeType.DATA_SOURCE),
+            _node("original", "original", NodeType.POLARS),
+            _node("instance_source", "Instance Source", NodeType.DATA_SOURCE),
+            _node(
+                "instance",
+                "instance",
+                NodeType.POLARS,
+                config={"instanceOf": "original"},
+            ),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_original",
+                source="api",
+                target="original",
+                sourceHandle="quotes",
+            ),
+            GraphEdge(id="ordinary_original", source="ordinary", target="original"),
+            GraphEdge(id="instance_source_instance", source="instance_source", target="instance"),
+        ],
+    )
+    captured: dict[str, dict[str, Any]] = {}
+
+    _build_graph_funcs(graph, _capture_builder_calls(captured))
+
+    assert captured["instance"]["orig_source_names"] == ["quotes", "Ordinary_Source"]
+
+
+def test_optimiser_linear_builder_uses_original_edge_metadata_for_input_name() -> None:
+    """The execution.py chain used by optimiser execution keeps the frame label."""
+    from haute.execution import build_linear_execution_chain_functions
+
+    graph = PipelineGraph(
+        nodes=[
+            _node("api", "Quote Input", NodeType.API_INPUT),
+            _node("transform", "transform", NodeType.POLARS),
+        ],
+        edges=[
+            GraphEdge(
+                id="api_transform",
+                source="api",
+                target="transform",
+                sourceHandle="quotes",
+            )
+        ],
+    )
+    captured: dict[str, dict[str, Any]] = {}
+
+    build_linear_execution_chain_functions(
+        graph,
+        _capture_builder_calls(captured),
+        target_node_id="transform",
+        base_node_id="api",
+        chain_node_ids=["transform"],
+    )
+
+    assert captured["transform"]["source_names"] == ["quotes"]

--- a/tests/test_runtime_input_cache_invalidation.py
+++ b/tests/test_runtime_input_cache_invalidation.py
@@ -13,9 +13,9 @@ These tests pin:
   optimiserApply artifact — the cheapest real model fixture);
 * a vanished dataSource file surfaces the execution error instead of a
   stale ok frame;
-* trace recomputes after a dataSource edit and after a JSON-cache
-  rebuild (the trace key previously omitted the JSON-cache state
-  signature entirely);
+* trace recomputes after a dataSource edit, a raw JSON apiInput edit before
+  any cache rebuild, and a JSON-cache rebuild (the trace key previously
+  omitted the JSON-cache state signature entirely);
 * the stat-gated memo: unchanged files are content-hashed exactly once
   across previews (call-count pin, not timing), edited files re-hash;
 * the deliberate stat-gate semantics: an mtime bump with identical
@@ -36,6 +36,7 @@ import polars as pl
 import pytest
 
 from haute._json_flatten import _json_cache_dir, cache_state_signature_for_graph
+from haute._types import GraphEdge
 from haute.executor import _preview_cache, execute_graph
 from haute.trace import _cache as _trace_cache
 from haute.trace import execute_trace
@@ -161,9 +162,16 @@ def _json_api_input_graph(data: Path):
                         },
                     }
                 ),
-                _transform_node("t", "df = df.with_columns(y=pl.col('amount') * 2)"),
+                _transform_node("t", "df = root.with_columns(y=pl.col('amount') * 2)"),
             ],
-            "edges": [_edge("api", "t")],
+            "edges": [
+                GraphEdge(
+                    id="e_api_t",
+                    source="api",
+                    target="t",
+                    sourceHandle="root",
+                )
+            ],
         }
     )
 
@@ -322,8 +330,12 @@ class TestPreviewRuntimeFileInvalidation:
         results2 = execute_graph(graph)
         assert [row["x"] for row in results2["api"].preview] == [5, 6]
 
-    def test_json_api_input_raw_edit_errors_until_cache_rebuild(self, tmp_path, monkeypatch):
-        """Editing raw JSON invalidates preview before stale cache execution."""
+    def test_json_api_input_raw_edit_shreds_directly_before_cache_rebuild(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Editing raw JSON invalidates preview and bypasses the stale cache."""
         monkeypatch.chdir(tmp_path)
         data = tmp_path / "data.json"
         _export_and_cache_amount(data, 10)
@@ -337,10 +349,11 @@ class TestPreviewRuntimeFileInvalidation:
         _bump_mtime(data)
 
         results2 = execute_graph(graph, target_node_id="t")
-        assert results2["api"].status == "error"
-        assert "stale" in (results2["api"].error or "").lower()
-        assert results2["t"].status == "error"
+        assert results2["api"].status == "ok", results2["api"].error
+        assert results2["t"].status == "ok", results2["t"].error
+        assert results2["t"].preview == [{"amount": 50, "y": 100}]
 
+        # Rebuilding remains an optional prewarm and preserves the same result.
         _export_and_cache_amount(data, 50)
         _bump_mtime(data)
 
@@ -412,9 +425,16 @@ class TestTraceRuntimeInputInvalidation:
             {
                 "nodes": [
                     _flat_api_input_node("api", p),
-                    _transform_node("t", "df = df.with_columns(y=pl.col('x') * 2)"),
+                    _transform_node("t", "df = api.with_columns(y=pl.col('x') * 2)"),
                 ],
-                "edges": [_edge("api", "t")],
+                "edges": [
+                    GraphEdge(
+                        id="e_api_t",
+                        source="api",
+                        target="t",
+                        sourceHandle="api",
+                    )
+                ],
             }
         )
 
@@ -423,6 +443,26 @@ class TestTraceRuntimeInputInvalidation:
 
         _write_csv(p, [50])
         _bump_mtime(p)
+
+        result2 = execute_trace(graph, row_index=0, target_node_id="t", column="y")
+        assert result2.output_value == 100
+
+    def test_trace_recomputes_from_raw_json_before_cache_rebuild(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A stale parquet must not block a fresh trace from direct JSON."""
+        monkeypatch.chdir(tmp_path)
+        data = tmp_path / "data.json"
+        _export_and_cache_amount(data, 10)
+        graph = _json_api_input_graph(data)
+
+        result1 = execute_trace(graph, row_index=0, target_node_id="t", column="y")
+        assert result1.output_value == 20
+
+        data.write_text(json.dumps([{"amount": 50}]), encoding="utf-8")
+        _bump_mtime(data)
 
         result2 = execute_trace(graph, row_index=0, target_node_id="t", column="y")
         assert result2.output_value == 100

--- a/tests/test_scalar_array_and_inference.py
+++ b/tests/test_scalar_array_and_inference.py
@@ -164,11 +164,11 @@ def test_infer_then_build_scalar_array_no_crash(tmp_path: Path) -> None:
 
     summary = build_per_port_cache(p, schema, tmp_path / "cache")
     by_label = {t["label"]: t for t in summary["tables"]}
-    assert "$[:].tags[:]" in by_label
-    assert by_label["$[:].tags[:]"]["row_count"] == 3  # motor, fleet, home
+    assert "tags" in by_label
+    assert by_label["tags"]["row_count"] == 3  # motor, fleet, home
 
     frames = load_per_port_cache(tmp_path / "cache", schema)
-    tags = frames["$[:].tags[:]"].collect()
+    tags = frames["tags"].collect()
     assert tags["value"].to_list() == ["motor", "fleet", "home"]
 
 
@@ -182,7 +182,7 @@ def test_scalar_array_mixed_types_widen_to_str(tmp_path: Path) -> None:
 
     build_per_port_cache(p, _enable_all(schema), tmp_path / "cache")
     frames = load_per_port_cache(tmp_path / "cache", schema)
-    assert frames["$[:].vals[:]"].collect()["value"].to_list() == ["1", "x", "2.5"]
+    assert frames["vals"].collect()["value"].to_list() == ["1", "x", "2.5"]
 
 
 def test_scalar_array_numeric_widens_to_float(tmp_path: Path) -> None:
@@ -195,7 +195,7 @@ def test_scalar_array_numeric_widens_to_float(tmp_path: Path) -> None:
 
     build_per_port_cache(p, _enable_all(schema), tmp_path / "cache")
     frames = load_per_port_cache(tmp_path / "cache", schema)
-    assert frames["$[:].amts[:]"].collect()["value"].to_list() == [1.0, 2.0, 2.5]
+    assert frames["amts"].collect()["value"].to_list() == [1.0, 2.0, 2.5]
 
 
 def test_scalar_array_of_bools(tmp_path: Path) -> None:
@@ -208,7 +208,7 @@ def test_scalar_array_of_bools(tmp_path: Path) -> None:
 
     build_per_port_cache(p, _enable_all(schema), tmp_path / "cache")
     frames = load_per_port_cache(tmp_path / "cache", schema)
-    assert frames["$[:].flags[:]"].collect()["value"].to_list() == [True, False, True]
+    assert frames["flags"].collect()["value"].to_list() == [True, False, True]
 
 
 def test_empty_then_struct_array_is_object_table(tmp_path: Path) -> None:
@@ -408,7 +408,7 @@ def test_empty_array_only_produces_empty_child_table(tmp_path: Path) -> None:
     assert child["columns"][0]["type"] == "str"
     summary = build_per_port_cache(p, _enable_all(schema), tmp_path / "cache")
     by_label = {t["label"]: t for t in summary["tables"]}
-    assert by_label["$[:].tags[:]"]["row_count"] == 0
+    assert by_label["tags"]["row_count"] == 0
 
 
 def test_read_meta_returns_none_on_corrupt_meta(tmp_path: Path) -> None:
@@ -425,9 +425,9 @@ def test_scalar_array_with_nulls_preserves_row_count(tmp_path: Path) -> None:
     schema = _enable_all(infer_v2_schema_from_data(p))
     summary = build_per_port_cache(p, schema, tmp_path / "cache")
     by_label = {t["label"]: t for t in summary["tables"]}
-    assert by_label["$[:].tags[:]"]["row_count"] == 3  # a, null, b — count preserved
+    assert by_label["tags"]["row_count"] == 3  # a, null, b — count preserved
     frames = load_per_port_cache(tmp_path / "cache", schema)
-    assert frames["$[:].tags[:]"].collect()["value"].to_list() == ["a", None, "b"]
+    assert frames["tags"].collect()["value"].to_list() == ["a", None, "b"]
 
 
 def test_build_bool_in_numeric_column_fails_loud(tmp_path: Path) -> None:

--- a/tests/test_trace_multi_frame.py
+++ b/tests/test_trace_multi_frame.py
@@ -181,9 +181,8 @@ def _same_source_join_graph(api_config: dict[str, Any]) -> dict[str, Any]:
     """One apiInput feeding a single polars node through TWO edges (drivers +
     vehicles) — a join of two data-levels straight off the input.
 
-    The executor binds the first edge's frame as ``df`` and the last edge's
-    frame under the source's name (``api``), so the code joins drivers with
-    vehicles on their shared ancestor key.
+    Each edge's frame label is also its executable argument name, so the code
+    joins ``drivers`` with ``vehicles`` on their shared ancestor key.
     """
     return {
         "nodes": [
@@ -200,7 +199,7 @@ def _same_source_join_graph(api_config: dict[str, Any]) -> dict[str, Any]:
                 "data": {
                     "label": "j",
                     "nodeType": "polars",
-                    "config": {"code": "df = df.join(api, on='policy_id')"},
+                    "config": {"code": "df = drivers.join(vehicles, on='policy_id')"},
                 },
             },
         ],

--- a/tests/test_v1_removal_contract.py
+++ b/tests/test_v1_removal_contract.py
@@ -13,7 +13,7 @@ Test ID mapping (T1-T22 per handover):
   - T7: parquet footer kv_metadata carries per-table v2 schema
   - T8: malformed volatile_schema -> 422 with structured ApiInputSchemaError
   - T13: validate_v2_schema rejects unknown col.type
-  - T14: validate_v2_schema rejects sanitised-label collision
+  - T14: validate_v2_schema rejects former Unicode collision witnesses under B4
   - T15: validator + path parsers raise ApiInputSchemaError(HauteError)
   - T16: corrupt-mix (tables + flattenSchema) uses tables, no error
   - T17: save apiInput with empty tables -> SavePipelineResponse.warnings
@@ -455,41 +455,34 @@ def test_t13_validate_v2_schema_rejects_unknown_col_type() -> None:
         validate_v2_schema(cfg_bad_type)
 
 
-# ─── T14 — sanitised-label collision rejected ────────────────────────
+# ─── T14 — former Unicode B2 witnesses rejected by B4 ─────────────────
 
 
-def test_t14_validate_v2_schema_rejects_sanitised_label_collision() -> None:
-    """Two table labels sanitising to the same parquet filename → reject.
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("my\u00e9table", id="acute"),
+        pytest.param("my\u00e8table", id="grave"),
+        pytest.param("My\u00e9Table", id="case-composed"),
+    ],
+)
+def test_t14_validate_v2_schema_rejects_former_unicode_b2_witnesses_under_b4(
+    label: str,
+) -> None:
+    """Former B2 witnesses fail B4 first because labels must be ASCII.
 
-    Today: `build_per_port_cache` silently overwrites the parquet — the
-    second write clobbers the first, the first table's data is lost
-    after the cache builds. Guardrail B2.
-
-    The sanitisation rule (per `_FILESYSTEM_SAFE` / new
-    `_sanitise_label_for_filesystem`): non-filesystem-safe characters
-    collapse to a single character. Two distinct labels that produce
-    the same sanitised name must be rejected at validate-time.
+    B2 remains as defence in depth, but these Unicode identifiers are no longer
+    valid inputs to `validate_v2_schema`; the B4 error must name the offending
+    label and explain the ASCII-only rule rather than reporting a later collision.
     """
     from haute._api_input_schema import ApiInputSchemaError, validate_v2_schema
 
-    cfg_collision = {
-        "tables": [
-            {
-                "path": "$[:].a",
-                "label": "my$table",  # $ → underscore
-                "emit": True,
-                "columns": [{"name": "x", "path": "$[:].a.x", "type": "str"}],
-            },
-            {
-                "path": "$[:].b",
-                "label": "my%table",  # % → underscore (collision: both → "my_table")
-                "emit": True,
-                "columns": [{"name": "y", "path": "$[:].b.y", "type": "str"}],
-            },
-        ]
-    }
-    with pytest.raises(ApiInputSchemaError):
-        validate_v2_schema(cfg_collision)
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(_two_table_cfg(label, "safe_label"))
+
+    detail = str(exc_info.value)
+    assert label in detail
+    assert "ascii" in detail.casefold()
 
 
 def _two_table_cfg(label_a: str, label_b: str) -> dict:
@@ -514,7 +507,7 @@ def _two_table_cfg(label_a: str, label_b: str) -> dict:
 def test_t14b_validate_v2_schema_rejects_case_only_label_collision() -> None:
     """Labels differing only in case must be rejected (B2, casefolded).
 
-    ``Foo.parquet`` and ``foo.parquet`` are the SAME file on the
+    ``Items.parquet`` and ``items.parquet`` are the SAME file on the
     case-insensitive filesystems macOS and Windows default to: the
     shred write would silently clobber one table's parquet, and at
     runtime both frame labels would read the one survivor — wrong data
@@ -524,16 +517,35 @@ def test_t14b_validate_v2_schema_rejects_case_only_label_collision() -> None:
     from haute._api_input_schema import ApiInputSchemaError, validate_v2_schema
 
     with pytest.raises(ApiInputSchemaError) as exc_info:
-        validate_v2_schema(_two_table_cfg("Foo", "foo"))
-    assert "case" in str(exc_info.value)
+        validate_v2_schema(_two_table_cfg("Items", "items"))
 
-    # Case difference composed with a sanitised collision: 'My$Table' and
-    # 'my%table' both sanitise (case aside) to my_table.
-    with pytest.raises(ApiInputSchemaError):
-        validate_v2_schema(_two_table_cfg("My$Table", "my%table"))
+    detail = str(exc_info.value)
+    assert "Items" in detail
+    assert "items" in detail
+    assert exc_info.value.context.get("label_a") == "Items"
+    assert exc_info.value.context.get("label_b") == "items"
+    assert exc_info.value.context.get("sanitised") == "items"
 
 
-def test_t14c_validate_v2_schema_accepts_genuinely_distinct_labels() -> None:
+def test_t14c_exact_duplicate_label_reports_duplicate_before_b2_collision() -> None:
+    """An exact duplicate takes the raw-label duplicate error path before B2.
+
+    Exact duplicates also share a casefolded filesystem stem, but reporting
+    that secondary consequence would hide the simpler user mistake. Validation
+    order is therefore part of the fail-loud contract.
+    """
+    from haute._api_input_schema import ApiInputSchemaError, validate_v2_schema
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(_two_table_cfg("Items", "Items"))
+
+    detail = str(exc_info.value)
+    assert "Items" in detail
+    assert "appears more than once" in detail
+    assert {"label_a", "label_b", "sanitised"}.isdisjoint(exc_info.value.context)
+
+
+def test_t14d_validate_v2_schema_accepts_genuinely_distinct_labels() -> None:
     """The casefold guard must not over-trigger on distinct names."""
     from haute._api_input_schema import validate_v2_schema
 

--- a/tests/test_v2_codec_and_shred.py
+++ b/tests/test_v2_codec_and_shred.py
@@ -23,6 +23,8 @@ Layered:
 from __future__ import annotations
 
 import json
+import keyword
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -189,6 +191,92 @@ def _minimal_v2() -> dict[str, Any]:
 
 def test_validate_v2_schema_accepts_minimal() -> None:
     validate_v2_schema(_minimal_v2())  # raises on failure
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("quote id", id="embedded-space"),
+        pytest.param("1st_frame", id="leading-digit"),
+        pytest.param("with-hyphen", id="hyphen"),
+        pytest.param("driver\tclaims", id="embedded-tab"),
+    ],
+)
+def test_validate_v2_schema_rejects_labels_that_are_not_python_parameter_names(
+    label: str,
+) -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["label"] = label
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(cfg)
+
+    detail = str(exc_info.value)
+    assert label in detail or repr(label) in detail
+
+
+@pytest.mark.parametrize(
+    "label",
+    keyword.kwlist,
+)
+def test_validate_v2_schema_rejects_every_hard_python_keyword(label: str) -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["label"] = label
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(cfg)
+
+    detail = str(exc_info.value)
+    assert repr(label) in detail or exc_info.value.context.get("label") == label
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("caf\u00e9", id="latin-accent"),
+        pytest.param("\u53d8\u91cf", id="cjk"),
+    ],
+)
+def test_validate_v2_schema_rejects_valid_unicode_identifiers_with_ascii_rule(
+    label: str,
+) -> None:
+    assert label.isidentifier()
+    assert not label.isascii()
+    cfg = _minimal_v2()
+    cfg["tables"][0]["label"] = label
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(cfg)
+
+    detail = str(exc_info.value)
+    assert label in detail
+    assert "ascii" in detail.casefold()
+
+
+def test_validate_v2_schema_rejects_non_nfkc_unicode_identifier_with_ascii_rule() -> None:
+    label = "\N{KELVIN SIGN}elvin"
+    assert label.isidentifier()
+    assert unicodedata.normalize("NFKC", label) == "Kelvin"
+    cfg = _minimal_v2()
+    cfg["tables"][0]["label"] = label
+
+    with pytest.raises(ApiInputSchemaError) as exc_info:
+        validate_v2_schema(cfg)
+
+    detail = str(exc_info.value)
+    assert label in detail
+    assert "ascii" in detail.casefold()
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["quotes", "driver_claims", "_private", "MixedCase", "match", "case", "type", "_"],
+)
+def test_validate_v2_schema_accepts_ascii_identifiers_and_soft_keywords(label: str) -> None:
+    cfg = _minimal_v2()
+    cfg["tables"][0]["label"] = label
+
+    validate_v2_schema(cfg)
 
 
 def test_validate_rejects_missing_label() -> None:

--- a/tests/test_write_sandbox_lint.py
+++ b/tests/test_write_sandbox_lint.py
@@ -512,9 +512,14 @@ EXPECTED_VIOLATIONS: dict[str, int] = {
     "tests/test_file_ops.py": 18,
     "tests/test_git_graph.py": 5,
     "tests/test_graph_fingerprint_cached.py": 1,
-    "tests/test_json_cache_coverage_uplift.py": 19,
-    "tests/test_json_cache_integrity.py": 1,
+    # These writes resolve through isolated project/cache helper paths. The
+    # static scanner intentionally cannot infer taint through those helpers;
+    # the runtime sandbox census verifies that they remain under tmp_path.
+    "tests/test_apiinput_multi_port_runtime.py": 1,
+    "tests/test_json_cache_coverage_uplift.py": 9,
+    "tests/test_json_cache_integrity.py": 6,
     "tests/test_json_shred_mut_stragglers.py": 1,
+    "tests/test_load_v2_api_source.py": 10,
     # 2 pre-existing + 2 cache-key-contract tests writing through
     # _artifact_cache_path(tmp_path / ...) results (tmp_path-rooted, but the
     # static taint cannot see through the helper call).


### PR DESCRIPTION
## Summary

This PR resolves the API Input frame/input identity issues and makes JSON caching an optional performance optimization.

### Frame and node-input identity

- Align API Input connection handles and lines with their emitted frame rows.
- Show the emitted output name consistently for both sole-frame and multi-frame API Inputs.
- Give emitted frame names visual priority over the generic parent node name.
- Show the connected frame name on downstream input chips instead of repeating the parent API Input node name.
- Make the input name shown in the UI the actual generated function argument name, 1:1.
- Use one shared edge-to-input-name rule across the frontend, executor, code generation, projection, deploy pruning/scoring, pipeline config, and submodel boundaries.
- Carry explicit frame-labelled `sourceHandle`/`source_port` identity from one emitted frame upward; reject unresolved API Input handles and duplicate target input names instead of silently rebinding them.
- Validate API Input frame labels as stable ASCII Python identifiers suitable for generated arguments.
- Migrate connected edges, LiveSwitch `input_scenario_map` keys, and instance `inputMapping` keys/values atomically when a frame is renamed.

The UI work covers the four recorded issues in `docs/roadmap/api-input-ui-issues.md`: misaligned multi-frame connections, unnamed sole-frame outputs, generic node names dominating frame names, and downstream inputs displaying the parent name instead of the connected frame.

### Optional JSON cache

- Treat the API Input Parquet cache as a fast path rather than an execution prerequisite.
- Try the current working cache, then the committed cache, then shred the current JSON/JSONL source directly when caches are missing, stale, corrupt, or schema-incompatible.
- Preserve post-schema invalidation, exact per-port frame behavior, and valid-cache reuse.
- Keep direct execution read-only with respect to cache state; the explicit Cache as Parquet action remains a repeat-run optimization.
- Update generated pipeline behavior, editor messaging/status, cache integrity coverage, and the JSON-shredding specifications.

## Why

API Input frame identity previously diverged across canvas handles, downstream chips, generated parameters, executor binding, LiveSwitch mappings, and deploy paths. A graph could display one input name while executing under another, and sole-frame versus multi-frame sources followed different identity rules. Frame renames could also leave dependent mappings bound to stale names.

Separately, schema edits correctly invalidated the post-schema Parquet cache, but runtime treated that cache as mandatory and blocked until the user rebuilt it. Ordinary actions such as selecting a field or cascading a key therefore introduced an unnecessary manual caching step.

## User impact

- What a node lists as an input is now the name its code receives.
- API Input frame names and connection geometry remain consistent regardless of frame count.
- Invalid or ambiguous input identities fail early with actionable errors.
- Renaming a frame keeps dependent mappings aligned in one undoable update.
- API Input nodes can preview and execute without first caching JSON; valid caches are still used for performance.

## Validation

Local focused validation completed for frame identity, generated-code contracts, optional-cache runtime behavior, API Input editor behavior, Ruff, and ESLint.

The draft PR currently has CI failures under investigation, primarily legacy test graphs without the newly required API Input `sourceHandle`, cache-promotion fixtures that do not yet satisfy the strengthened manifest contract, one Ruff import-order error, frontend bundle/coverage budgets, and permission-path regressions. This section will be updated when the corrective commit is pushed.
