### PR TITLE
[WS-04] Fix server API and output assembly contracts

### DIFF
--- a/docs/opus-5-ws-04-server-api-output.md
+++ b/docs/opus-5-ws-04-server-api-output.md
@@ -1,9 +1,9 @@
 # WS-04 — Server API, routing & JSON output assembly
 
 Part of the Opus 5 review split (`opus-5-workstreams.md`). Evidence and fix guidance:
-`opus-5-review.md`. Owner: unassigned · Status: not started.
+`opus-5-review.md`. Owner: WS-04 · Status: complete; cross-stream deferrals recorded.
 
-**Branch:** `opus5/ws-04-server-api-output`
+**Branch:** `ws-04`
 
 ## Mission
 
@@ -107,6 +107,20 @@ Low (6): `failure-model-5`, `contracts-d-10`, `json-shredding-9`, `json-shreddin
 - `failure-model-2` frontend correction (`frontend-shared/high-level.md:270-273`) → WS-09.
 - `contracts-a-6` rename sweep touches `server-api` spec lines — WS-03 drives the rename;
   apply the two server-api lines here.
+
+## Implementation outcome
+
+The WS-04-owned server, route, OUTPUT/shred, canonical-spec, and regression-test changes are
+implemented on this branch. The following adjacent changes are deliberately deferred to
+their exclusive owners rather than being duplicated here:
+
+- `projection.py` incomplete-mapping parity remains with WS-03, which owns the execution
+  planner and its tests.
+- The canvas load-failure presentation and frontend-shared wording remain with WS-09; this
+  workstream supplies the backend 422 contract.
+- Save/submodel/codegen guarantee wording outside the server-api-owned text remains with
+  WS-05/WS-14, whose transaction boundaries determine those guarantees.
+- The FastAPI version stamp remains with WS-01's single coordinated version decision.
 
 ## Definition of done
 

--- a/docs/specs/json-shredding/high-level.md
+++ b/docs/specs/json-shredding/high-level.md
@@ -96,13 +96,32 @@ or at an ancestor boundary so an ancestor value can be distributed into child
 rows. The OUTPUT side consumes only active, complete mapping rows and requires
 the same single array-outer path grammar: `$[:]` at the root, dotted ASCII
 identifier keys, and `[:]` for array traversal. Its explicit structural
-validator rejects same-port duplicate or prefix-comparable destinations.
+validator rejects same-port duplicate or prefix-comparable destinations and a
+single source frame mapped to divergent emit prefixes. The runtime assembler invokes
+that validator before frame collection, so dry-run, direct runtime, generated, and
+deployed execution share one acceptance boundary. Each distinct path is parsed once
+per validation, then sorted adjacent comparisons enforce prefix rules in
+`O(n log n)` time rather than reparsing an `O(n²)` pair matrix. Incomplete editor
+rows are inactive and ignored consistently.
 Assembly returns a top-level list of objects:
 sibling array branches are nested independently (never cross-multiplied),
 same-level frames use a deterministic cut plan and bag semantics, unmatched
 partials survive, and null-valued/empty-collection object fields are pruned
 from the rendered document (null or empty-list elements already inside arrays
-remain array elements).
+remain array elements). A relation key is checked only in frames that actually
+carry that key: a missing column in another mapping frame is absence, not a null.
+An actual null relation-key component raises `OutputNestingKeyError`; nullable
+non-key payloads remain valid. In shredding, an ancestor `$value` column does not
+turn a descendant object table into a scalar table — scalar classification requires
+the sentinel at the table's own array depth.
+
+The complete bounded output document is converted to Polars with
+`infer_schema_length=None`, preserving a nested field whose first non-null value
+occurs beyond the default inference window. Input inference and shredding use one
+JSON-scalar compatibility rule: genuine scalars can render deterministically into a
+declared string, while objects and arrays remain shape values and fail or count as
+shape mismatches. Inference rejects source keys outside the canonical ASCII
+identifier grammar (and the reserved `$value` sentinel) before returning a schema.
 
 **Edge Join semantics.** The built-in `edgeJoin` accepts exactly the Polars
 strategies `inner`, `left`, `right`, `full`, `semi`, `anti`, and `cross`.
@@ -163,7 +182,17 @@ retries transient Windows file-handle locks and attempts to restore the previous
 directory if the second rename raises. A process-local per-cache lock prevents two
 threads building the *same* cache from interleaving their write phases; builds of
 different caches remain independent. The same swap primitive is used both by the
-shred's own build and by promoting `working/` to `committed/` at save time.
+shred's own build and by promoting `working/` to `committed/` at save time. Table
+spec construction, source-signature calculation, validity checking, staging, and
+publish all occur inside that critical section. Locks are weakly retained after use
+but strongly referenced for the whole active section. Cache paths are rooted from
+the process working directory selected for the project; callers must not assume they
+are relative to the source file.
+
+Within one logical raw-file load or cache-build operation, the source signature
+(size, mtime, and SHA-256) is computed once and shared by its consumers. A separate
+operation recomputes the signature, so same-size/same-mtime rewrites remain
+detectable.
 
 > NOTE: Replacing an existing directory is a two-rename swap, not one atomic
 > filesystem operation. Between `live -> backup` and `temp -> live`, a concurrent
@@ -209,14 +238,15 @@ strict build and raises a specific, column-named error instead.
 
 - A malformed v2 schema config (bad table/column shape) is rejected up front by
   schema validation before any shredding happens, not discovered mid-walk.
-- The OUTPUT dry-run route calls the structural validator before execution, so
-  its malformed mappings raise `OutputMappingSchemaError` before data is
-  assembled. The lower-level runtime assembly entry point does not call that
-  validator itself; malformed path syntax is still rejected while parsing, but
-  duplicate/prefix conflicts can instead reach Polars or produce ambiguous
-  assembly if a caller skipped validation. A missing source port/column still
-  surfaces from normal mapping/Polars lookup rather than being replaced with an
-  empty document.
+- Every OUTPUT assembly entry point calls the structural validator before frame
+  collection. Malformed syntax, duplicate/prefix conflicts, divergent per-frame
+  emit prefixes, and missing source ports/columns therefore fail loudly rather than
+  becoming ambiguous or empty output.
+- Any active parent or child row whose *present* simple/composite relation key has a
+  null component raises `OutputNestingKeyError(OutputMappingSchemaError)` with
+  `frame`, `output_path`, and `key`; the HTTP adapter maps it to 422. A frame that
+  does not carry that relation key is not participating and is not treated as a null
+  row. Null scalar payloads outside relation keys remain valid.
 - A source JSON key that would collide with the reserved scalar-array sentinel, or
   that contains the object-nesting separator character, is rejected loudly at
   inference time — there is no way to address it unambiguously as a column, so
@@ -240,103 +270,3 @@ strict build and raises a specific, column-named error instead.
 - `edgeJoin` node misconfiguration (ambiguous/missing base or join role, unsupported
   join strategy, keys on `cross`, missing/conflicting key forms, or mismatched key
   counts) raises `ConfigError` before any join runs.
-
-## Polars backend contracts (0.6.0)
-
-Remaining JSON-shredding improvement work is tracked in the
-[I/O layer roadmap](../../roadmap/io-layer.md).
-
-### OUTPUT assembly (Review-P04)
-
-Assembly must preserve the existing output shape, bag semantics, deterministic cut
-planning, pruning, and active-row rules while replacing repeated per-mapping-frame
-filtering with an indexed or near-linear grouping strategy.  The implementation
-must not introduce a Python-level quadratic scan over mapping rows or frame rows.
-
-Nesting uses a fail-loud orphan policy. Any active parent or child row participating
-in a nesting relation with null in any component of its simple or composite nesting
-key raises `OutputNestingKeyError(OutputMappingSchemaError)` before assembly or
-rendering. The error identifies the source frame, output path, and offending key, and
-the route/API contract maps it to HTTP 422. Such rows are never silently excluded or
-treated as non-matching. Null scalar payload values remain valid when those values do
-not participate in a relation key.
-
-One frame may not silently supply columns for multiple divergent `emit` prefixes.
-Such a mapping is rejected with `OutputMappingSchemaError` before collection or
-rendering, unless a future specification introduces an explicit, unambiguous mapping
-contract for it.  A rejection must name the frame and conflicting prefixes.  No
-source column may be silently dropped while applying this guard.
-
-The direct assembler, dry-run/route path, generated pipeline, and deployed execution
-path must accept, reject, and render equivalent mappings identically, including the
-null nesting-key error type, fields, and HTTP mapping.
-
-### Raw-file signatures (Review-P06 / FR17)
-
-Within one logical raw-file load or cache-build operation, the source signature
-(size, mtime, and content hash) is computed once and shared by all consumers of that
-operation.  This removes redundant hashing without weakening cache integrity:
-independent operations still verify source content, and a rewrite that preserves
-size and mtime is still detected by its changed hash.
-
-### Required tests and non-goals
-
-Tests must pin near-linear assembler work on large mapping/frame fixtures; fail-loud
-simple and composite null nesting keys on active parent and child rows; allowed null
-scalar payloads; divergent-prefix rejection; no silent row or column loss; HTTP 422;
-and direct/route/generated/deploy parity. Signature tests must pin one hash computation per logical operation,
-fresh hashing by an independent operation, and same-size/same-mtime content rewrite
-detection.
-
-The 0.6 pre-1.0 migration notes must call out that relation-key nulls now fail rather
-than being silently orphaned. This change does not alter output-path grammar, bag
-semantics for valid keys, pruning rules, cache directory layout, source-signature
-fields, or cache validity requirements. It does not define a divergent-prefix mapping
-feature; that requires a separate explicit contract.
-
-## I/O roadmap correctness hardening
-
-JSON shredding implements the accepted parts of
-[IO-IO03, IO-IO04, IO-IO07, IO-IO10, and IO-IO11](../../roadmap/io-layer.md).
-
-- OUTPUT document materialisation infers the Polars schema from the complete
-  bounded assembled document, including nested structs. A field whose first
-  non-null value occurs after Polars' default inference window remains present
-  with its inferred nullable type. The already-shared canvas/generated assembler
-  remains the sole execution path, and parity coverage includes this late-field
-  case.
-- API-input inference and shredding use one JSON-scalar compatibility rule.
-  When observations widen a column to `str`, strings remain unchanged and
-  numbers/booleans are rendered deterministically as strings; null remains null.
-  Objects and arrays are shape values, not strings, and still fail or count as a
-  shape mismatch according to the table contract. In a scalar-array table, a
-  nested array is counted as a skipped row rather than fabricated as a null
-  scalar row.
-- Inference rejects every source object key outside the path grammar's ASCII
-  identifier set, as well as the reserved `$value` sentinel, before returning a
-  schema. The error names the key and tells the user to rename it. Hand-authored
-  keys outside the dotted identifier grammar are rejected because the runtime
-  cannot represent them.
-- Config sidecars continue to use duplicate-key-rejecting loading. Raw
-  JSON/NDJSON source records retain the streaming decoder's native duplicate-key
-  semantics and are not rescanned solely to reject duplicates; inference and
-  build consume the same record iterator, so they remain mutually consistent.
-- JSON-cache build/status `columns` payloads contain real, label-qualified
-  column names and dtype strings from the emitted frames. Placeholder names and
-  the constant `"v2"` pseudo-dtype are not part of the public response.
-- Per-cache build locks may be weakly retained so completed, unreachable cache
-  identities do not grow a process-lifetime dictionary. A lock remains strongly
-  referenced for its entire active critical section, preserving same-key
-  serialisation.
-
-The operation-scoped raw-file signature contract already satisfies IO-IO10:
-one logical load/build hashes the source once and shares that signature, while
-each independent operation hashes again. This change does not introduce a
-cross-operation `(size, mtime)` validity shortcut, a columnar-buffer rewrite
-without benchmark evidence, or any relaxation of signed cache validation.
-
-Acceptance evidence covers late/null-first nested OUTPUT fields through direct
-and generated execution; an inference/build accepted-and-rejected value matrix;
-scalar-table nested-list skip accounting; early invalid-key diagnostics; real
-  cache-response columns; non-canonical path rejection; and lock reclamation without
-loss of concurrent build serialisation.

--- a/docs/specs/json-shredding/low-level.md
+++ b/docs/specs/json-shredding/low-level.md
@@ -6,7 +6,7 @@
 |---|---|
 | `src/haute/_api_input_schema.py` | V2 apiInput schema codec: `TypedDict` shapes, extension recognition, canonical table and column path semantics, filesystem label sanitisation, and fail-loud validation. |
 | `src/haute/_json_shred.py` | v2 per-frame JSON shred: single-pass record walk, buffer→parquet build, cache validity/load, schema inference from data. |
-| `src/haute/_json_flatten.py` | Dual-layer (`working/`/`committed/`) cache-directory infrastructure for JSON apiInput sources: path resolution, delete, save-time promotion, preview-cache fingerprint contribution. |
+| `src/haute/_json_flatten.py` | Dual-layer (`working/`/`committed/`) cache-directory infrastructure for JSON apiInput sources: process-CWD-rooted path resolution, delete, save-time promotion, and preview-cache fingerprint contribution. |
 | `src/haute/_json_safe.py` | Recursively converts Python/pipeline values into JSON-safe representations for API responses and preview rows. |
 | `src/haute/_jsonpath.py` | The shared canonical array-outer JSON path parser and writer used by both INPUT and OUTPUT path addressing. |
 | `src/haute/_output_assembler.py` | V2 OUTPUT mapping validation and document assembly: GYO residue/cut planning, bag-natural joins, array-prefix nesting, pruning, and collected-frame rendering. |
@@ -28,9 +28,11 @@ Submodel graph expansion and boundary rewiring are owned by
 
 **`_output_assembler.py`**
 
-- `OutputMappingSchemaError(HauteError)` is the OUTPUT grammar/structural
-  mapping error. `_Core` and `_CutPlan` record the deterministic feedback-edge
-  cut and the residual per-frame fields used for same-level assembly.
+- `OutputMappingSchemaError(HauteError)` is the OUTPUT grammar/structural mapping
+  error. `OutputNestingKeyError(OutputMappingSchemaError)` is the fail-loud
+  relation-key-null error with stable `frame`, `output_path`, and `key` fields.
+  `_Core` and `_CutPlan` record the deterministic feedback-edge cut and the
+  residual per-frame fields used for same-level assembly.
 - An active mapping row is enabled and has non-blank `source_column` and
   `output_path` fields; incomplete editor rows are ignored consistently by
   validation, contracts, and assembly.
@@ -119,30 +121,40 @@ delegates canonical rendering to the same writer.
 > annotations.
 
 **OUTPUT mapping** — `assemble_output_from_mapping(frames, mapping)` groups active
-rows by source port, selects/aliases source columns to output paths, and passes the
-field frames to `_assemble_document`. Frames emitting at the same array prefix are
+rows by source port after running `validate_v2_output_mapping`, selects/aliases source
+columns to output paths, and passes the field frames to `_assemble_document`. The
+validator parses every distinct active path once, sorts the parsed destinations, and
+uses adjacent comparisons for duplicate/prefix and array-prefix-chain conflicts
+(`O(n log n)`, not an `O(n²)` pair scan). It also rejects divergent emit prefixes
+within one source frame before any frame collection. Frames emitting at the same array prefix are
 planned by `_plan_cut` and `_execute_plan`; residual shared fields are full bag-
 joined (fan-out is retained), cut/disconnected groups are diagonal-concatenated as
 partials, and the prefix-tree builder nests child arrays by ancestor values without
-joining siblings. `_prune` removes null-valued object fields and empty collection
+joining siblings. Relation-key guards examine a row only when that row actually
+contains the key; an absent column in another mapping frame is not a null. A present
+null component raises `OutputNestingKeyError`. `_prune` removes null-valued object fields and empty collection
 values from objects, and removes empty-object elements from arrays; null or
 empty-list elements already present inside arrays are retained.
 `render_output_document` applies that same pruning to the collected Polars shape.
 
-`assemble_output_from_mapping` does not call `validate_v2_output_mapping`.
-Callers that need the injectivity/prefix-incomparability gate must invoke it
-explicitly; the dry-run route does, while the shared runtime/generated-code
-assembly path currently does not.
+`assemble_output_from_config` uses the same assembler and constructs the final
+document frame with `infer_schema_length=None`. The assembled response is already
+bounded and materialised, so complete-schema inference preserves late non-null nested
+fields without another upstream read.
 
 **Build a JSON cache** — `build_per_port_cache(data_path, v2_config, cache_dir)`:
 1. `validate_v2_schema(v2_config)` up front.
-2. Acquire the per-cache-directory lock (`_build_lock_for`).
+2. Acquire the per-cache-directory lock (`_build_lock_for`) and retain that lock
+   strongly for the complete critical section.
 3. No-op trapdoor: if `is_per_port_cache_valid` already holds for the current
    in-memory schema and on-disk data file, return the existing `meta.json` payload
    without rebuilding.
-4. Record the data-file signature (`_data_file_signature`) *before* reading records.
-5. Build the shared `_EmittingTableSpec`s once (`table_is_emitting` plus parsed
-   table/column paths); the walk and parquet frame construction consume the same specs.
+4. Still under the lock, record the data-file signature (`_data_file_signature`)
+   *before* reading records.
+5. Still under the lock, build the shared `_EmittingTableSpec`s once
+   (`table_is_emitting` plus parsed table/column paths); the walk and parquet frame
+   construction consume the same specs. The signature is shared for this logical
+   operation rather than rehashed by each consumer.
 6. `shred_to_buffers(_counted_records(), v2_config, stats=skip_stats)` — the shred
    core (below) — consuming `_iter_records` directly (not materialised into a list).
 7. Conservation assertion at the root level: for every emit-true root table,
@@ -161,7 +173,9 @@ assembly path currently does not.
    a shallower ancestor depth for a W1 "distribute a parent value to every
    descendant row" column).
 2. `_reject_reserved_leaf_collision` per table: a `$value` leaf may not coexist with
-   another own-depth column.
+   another own-depth column. A table is scalar only when `$value` itself lives at
+   that table's depth; an ancestor `$value` distributed into a descendant object
+   table does not change the descendant's shape classification.
 3. Group tables by their full `(key, is_array)` segment position
    (`tables_by_pos`), and compute the object-hop + array-key "descents" needed to
    reach each child array from its parent position (`descents_by_pos`).
@@ -169,7 +183,10 @@ assembly path currently does not.
    at `pos` (skipping — and counting — a shape-mismatched record for that table),
    then descends into each child array via `_walk_array`, which iterates the array
    and recurses into `_emit_at` per element (a `None` element is a real row for a
-   scalar table, a counted skip for an object table).
+   scalar table, a counted skip for an object table; a nested list is a counted
+   shape mismatch, never fabricated as a null scalar row). Declared string columns
+   use the shared deterministic JSON-scalar renderer; dict/list values remain
+   shape values and are rejected or counted rather than stringified.
 5. Returns `{table_label: [row_dict, ...]}`.
 
 **Runtime load** — `load_v2_api_source(data_path, config)`:
@@ -329,6 +346,20 @@ equal-length `leftOn`/`rightOn` values, and rejects mixing the two forms.
   footer schema probe, so a footer-readable data-page corruption is rejected.
 - **The build lock is process-local**, keyed by the normcased resolved cache-dir
   path; concurrent builds of *different* caches never block each other.
+  `_BUILD_LOCKS` weakly retains inactive identities, while the caller strongly owns
+  its lock throughout table-spec construction, source signing, validation, staging,
+  and publish. Cache directories are resolved from the selected project process CWD,
+  not relative to the source data file.
+- **Source signatures are operation-scoped**: one logical load/build shares its
+  `(size, mtime, SHA-256)` result, while a separately initiated operation hashes
+  again. No `(size, mtime)`-only cross-operation shortcut exists.
+- **Inference accepts only expressible keys** through
+  `_jsonpath.is_identifier_name`; non-ASCII/non-identifier keys, dots, and the
+  reserved `$value` sentinel fail before a schema is returned. Config sidecars use
+  duplicate-key-rejecting loading; raw JSON/NDJSON retains the streaming decoder's
+  native duplicate-key semantics and is not rescanned.
+- **Cache metadata exposes real columns** as label-qualified names with their dtype
+  strings. Placeholder names and the constant `"v2"` pseudo-dtype are never returned.
 - **`mirror_cache_to_committed`'s consulted-hash gate is intentionally never
   cleared** except by a test-only hook (`_clear_session`) that simulates a process
   restart — the user stays authoritative for a data file for the lifetime of the
@@ -337,14 +368,7 @@ equal-length `leftOn`/`rightOn` values, and rejects mixing the two forms.
   with at least one key and a non-empty suffix; `cross`/`full`/`right`, keyless
   joins, and an ambiguous suffixed-name-that-is-itself-a-real-column all return
   `None` (keep the parent boundary full-width) rather than guess.
-- **AST-based Polars demand inference is order-sensitive when it must be**: plain
-  rename-free code uses an unordered union walk (safe over-approximation); code
-  containing a `rename`, a `select`/`select_seq`, or a reference to a
-  column the same node derives is routed through an *ordered* backward
-  propagation instead, because the unordered walk would either re-add a
-  post-rename/derived name to the parent demand (over-demand a nonexistent parent
-  column) or under-demand a `select`'s unused-downstream inputs (the `select`
-  still executes every output expression regardless of what's needed downstream).
+
 ## Error handling
 
 - `haute._api_input_schema.ApiInputSchemaError` — raised by `_json_shred.py` for
@@ -371,16 +395,16 @@ equal-length `leftOn`/`rightOn` values, and rejects mixing the two forms.
   the caller injected as `error` — `ApiInputSchemaError` from the INPUT side,
   `OutputMappingSchemaError` from the OUTPUT side — carrying the offending
   `output_path`.
-- `OutputMappingSchemaError` also covers a non-array root, two different columns
-  from one port targeting the same path, and leaf/container prefix collisions.
-  Missing `frames[port]` or `pl.col(source_column)` failures are deliberately not
-  caught or converted into an empty output.
-  > NOTE: the duplicate/prefix cases are guarantees of
-  > `validate_v2_output_mapping`, not of `assemble_output_from_mapping` itself.
-  > The latter parses active output paths during assembly but does not run the
-  > structural validator, so runtime callers that bypass the dry-run validation
-  > boundary can receive a Polars error or ambiguous output instead of this typed
-  > exception.
+- `OutputMappingSchemaError` covers a non-array root, two different columns from
+  one port targeting the same path, leaf/container prefix collisions, and one frame
+  targeting divergent emit prefixes. `assemble_output_from_mapping` itself runs the
+  validator before collecting any frame, so direct/runtime and route callers receive
+  the same typed failure. Missing `frames[port]` or `pl.col(source_column)` failures
+  remain loud and are never converted into an empty output.
+- `OutputNestingKeyError(OutputMappingSchemaError)` is raised when an active
+  participating row contains null in a simple/composite nesting key. It identifies
+  `frame`, `output_path`, and `key` and maps to HTTP 422. Rows from frames that do not
+  carry the key are non-participants, not null-key orphans.
 
 ## Testing
 
@@ -390,7 +414,8 @@ Shred / inference / cache lifecycle (`_json_shred.py`, `_json_flatten.py`):
   root row per record, one scalar-array child row per element, order-independent
   inference (set-based type widening), full conservation accounting.
 - `tests/test_v2_codec_and_shred.py` — canonical schema validation and layered
-  per-port shred behaviour.
+  per-port shred behaviour, including that an ancestor `$value` distributed into
+  a descendant object table does not suppress that object's rows.
 - `tests/test_v2_object_nesting_inference.py` — the 2026-06-17 object-nesting
   transparency ruling, end to end through inference/shred/grammar agreement.
 - `tests/test_scalar_array_and_inference.py` — scalar-array-as-its-own-child-table
@@ -450,20 +475,20 @@ V2 schema codec and OUTPUT shape:
   rules.
 - `tests/test_output_assembler.py` owns mapping validation, deterministic cyclic
   cuts, bag fan-out, unmatched partials, sibling-array non-explosion, pruning,
-  rendering, and exact assembled shapes; `tests/test_output_nest_example_contract.py`
+  rendering, exact assembled shapes, one-parse-per-distinct-path validation,
+  incomplete editor rows, and multi-frame relation keys absent from a
+  non-participating frame; `tests/test_output_nest_example_contract.py`
   pins the fixture-level nested-document contract, while
   `tests/test_executor_builders.py` and `tests/test_codegen_builders.py` own the
   executor/generated-code integration boundary.
+- `tests/test_v1_removal_contract.py` owns the assertion that removed v1 schema
+  symbols stay absent; that compatibility-removal contract is not part of
+  `test_v2_codec_and_shred.py`.
 - `frontend/src/__tests__/editors/OutputEditor.test.tsx`,
   `frontend/src/__tests__/editors/OutputEditorPathTools.test.tsx`, and
   `frontend/src/__tests__/editors/jsonpath.test.ts` own the UI-adjacent mapping,
   conflict-display, CSV import/export, and canonical-path contracts;
   their production modules remain owned by the frontend editor spec.
-
-Known coverage gap: the direct/runtime assembler is not tested to enforce the
-structural validator's duplicate-path and prefix-collision rules, because it does
-not call that validator. Validation and assembly are tested separately, and only
-the dry-run route wires them together before execution.
 
 Edge join (`_edge_join.py`):
 
@@ -477,106 +502,6 @@ Edge join (`_edge_join.py`):
 
 Projection planning and its `tests/test_projection_planner.py` coverage are owned
 by [execution-engine](../execution-engine/low-level.md).
-
-## Polars backend contracts (0.6.0)
-
-Remaining JSON-shredding improvement work is tracked in the
-[I/O layer roadmap](../../roadmap/io-layer.md).
-
-### OUTPUT assembler (Review-P04)
-
-`_output_assembler.py` must construct reusable indexes/groupings for active mapping
-rows and collected-frame rows so the assembly pipeline is indexed or near-linear in
-the mapping/frame inputs.  It must preserve the existing deterministic cut plan and
-bag-natural-join output semantics; optimisation may not alter row multiplicity or
-the ordering contract already covered by assembler tests.
-
-Every internal nesting relation uses the shared fail-loud orphan guard. Before any
-grouping, assembly, or rendering, each active parent and child row participating in
-that relation is checked across every component of its simple or composite nesting
-key. A null component raises
-`OutputNestingKeyError(OutputMappingSchemaError)` with stable frame, output-path, and
-key fields; API translation returns HTTP 422. The guard belongs in the shared
-assembler relation primitive rather than one call site. It must not silently drop,
-exclude, or merely fail to match the row. Scalar payload columns remain nullable when
-they are not relation-key components.
-
-Before materialising or rendering, mapping validation must group each source frame's
-active rows by their `emit` prefix.  More than one divergent prefix for a frame must
-raise `OutputMappingSchemaError` containing the source frame/port and conflicting
-prefixes.  The guard must run in every execution entry point, including the direct
-assembler, route/dry-run flow, and generated/deploy flow.  It may not discard a
-column to make the mapping appear valid.  A future relaxation requires a separately
-specified, explicit unambiguous source-to-prefix mapping; none is introduced here.
-
-### Raw-file signatures (Review-P06 / FR17)
-
-`_json_shred.py` and cache-validity/build callers must carry an operation-scoped
-raw-file signature object containing the observed size, mtime, and SHA-256.  A
-logical `load_v2_api_source` attempt or cache build computes that signature once and
-passes it to every freshness/manifest consumer instead of independently rehashing
-the same file.  The scope must not persist between independently initiated loads,
-builds, or promotions: each independently initiated operation recomputes and checks
-content.  Stat values remain part of the manifest/signature, and SHA-256 remains
-authoritative, so a same-size/same-mtime rewrite is detected.
-
-### Tests and non-goals
-
-`tests/test_output_assembler.py` (and route/codegen/deploy integration coverage) must add
-large-fixture work-count or spy coverage proving indexed/near-linear behaviour;
-simple-key and every-position composite-key null rejection for active parent and child
-rows; allowed non-key scalar nulls; exact error fields and HTTP 422; divergent-prefix
-rejection; preservation of every valid source row and column; and equivalent direct,
-route, generated, and deployed acceptance, error, and rendering.
-JSON cache tests must prove one raw-file hash per logical operation, a fresh hash for
-an independent operation, and invalidation after a same-size/same-mtime rewrite.
-
-The 0.6 pre-1.0 migration notes document that null relation keys now raise instead of
-silently producing orphan/non-matching rows. No output-path grammar change,
-cache-layout migration, relaxation of cache content verification, or divergent-prefix
-feature is part of this work. Existing bag semantics for valid keys, deterministic
-cuts, pruning, and cache manifest fields remain unchanged.
-
-## I/O roadmap correctness hardening
-
-The corresponding high-level behaviour is
-[I/O roadmap correctness hardening](high-level.md#io-roadmap-correctness-hardening).
-
-- `assemble_output_from_config` constructs its final `LazyFrame` with
-  `infer_schema_length=None`. Tests use more than the default inference-window
-  number of null-first rows and a later nested struct field so the regression
-  cannot pass accidentally.
-- This full-document inference is a deliberate exemption from bounded source
-  inference: OUTPUT assembly has already materialised the complete response
-  document required by its contract, and a finite prefix cannot preserve a
-  field that first appears later. The constructor performs no additional
-  upstream read; request/output limits remain the boundary for response size.
-- `_emit_row` applies the shared scalar-to-string renderer to any declared
-  string column containing a genuine JSON scalar, not only the `$value`
-  sentinel. `_buffer_to_frame` remains strict and rejects list/dict values;
-  numeric/date silent-coercion guards are unchanged.
-- `_emit_at` distinguishes dictionaries, genuine JSON scalars, and lists.
-  Lists match neither object tables nor scalar tables and increment that
-  table's skip count. The explicit null-element branch remains a valid scalar
-  row.
-- `_jsonpath.is_identifier_name` owns the ASCII identifier predicate used by
-  the parser and inference. `_reject_unexpressible_key` uses it after its
-  sentinel/dot-specific diagnostics. `parse_path` accepts only the canonical
-  dotted spelling.
-- Sidecar loading rejects duplicate keys. Raw JSON/NDJSON records are decoded
-  once by the streaming record iterator and retain decoder-native duplicate-key
-  handling; inference and build deliberately share that iterator rather than
-  adding a second hot-path duplicate-key scan.
-- Per-table cache metadata records the canonical `columns` name-to-dtype map.
-  `_aggregate_v2_tables` exposes each as `<label>.<column>` directly from that
-  metadata; it does not infer columns by reading Parquet files when metadata is
-  incomplete.
-- `_BUILD_LOCKS` is a `WeakValueDictionary[str, threading.Lock]` protected by
-  `_BUILD_LOCKS_GUARD`. Callers retain the returned lock while it is acquired.
-
-The existing `data_file_signature` argument remains the only intra-operation
-hash-reuse seam. Tests continue to prove that a separate operation recomputes
-SHA-256 and detects a same-size/same-mtime rewrite.
 
 ## Approved change contract — canonical-only cache artifacts
 

--- a/docs/specs/json-shredding/low-level.md
+++ b/docs/specs/json-shredding/low-level.md
@@ -481,9 +481,6 @@ V2 schema codec and OUTPUT shape:
   pins the fixture-level nested-document contract, while
   `tests/test_executor_builders.py` and `tests/test_codegen_builders.py` own the
   executor/generated-code integration boundary.
-- `tests/test_v1_removal_contract.py` owns the assertion that removed v1 schema
-  symbols stay absent; that compatibility-removal contract is not part of
-  `test_v2_codec_and_shred.py`.
 - `frontend/src/__tests__/editors/OutputEditor.test.tsx`,
   `frontend/src/__tests__/editors/OutputEditorPathTools.test.tsx`, and
   `frontend/src/__tests__/editors/jsonpath.test.ts` own the UI-adjacent mapping,

--- a/docs/specs/server-api/high-level.md
+++ b/docs/specs/server-api/high-level.md
@@ -121,13 +121,16 @@ fingerprint already matches (no redundant payload). Edits the server itself make
 `/api/pipeline/save`) are tagged as self-writes so they never round-trip back through the watcher
 as a phantom external edit. A change to a `modules/*.py` file re-parses only the pipelines
 that import it; a change to a `config/*.json` file re-parses every discovered pipeline (a
-config change can affect any pipeline that reads it). Only direct pipeline `.py` changes
-invalidate the name→path index. Startup priming, watcher invalidation, and successful save
-invalidation are the index's lifecycle mutation points, and the module-dependency index uses
-the same lock so an invalidation cannot be overwritten by an in-flight rebuild. A failed
-debounced batch is retried at most three times with exponential backoff; after that the
-watcher logs abandonment and leaves the batch pending for the next filesystem event instead
-of creating an unbounded chain of retry tasks.
+config change can affect any pipeline that reads it). Direct pipeline `.py` additions,
+modifications, and deletions invalidate the name→path index; module/config-only batches do
+not. Startup priming, watcher invalidation, and successful save invalidation are the index's
+lifecycle mutation points. The module-dependency index scans under its own build lock and
+publishes only when the pipeline-index generation it observed is still current, so
+invalidation does not block on the AST scan and an in-flight rebuild cannot overwrite it. A
+failed debounced batch is retried at most three times with exponential backoff; after that
+the watcher isolates each change once, processes healthy entries, and logs and drops only
+the still-failing entries instead of poisoning future batches or creating an unbounded retry
+chain.
 
 **Pipeline CRUD, preview, trace, and output publication.** `GET /api/pipelines` lists every
 discovered pipeline with parse status; `GET /api/pipeline` returns an empty graph only when
@@ -337,8 +340,9 @@ turn that loudness into a well-typed HTTP response rather than a raw traceback.
 - **The file watcher is crash-resilient**: an unexpected exception in the watch loop is
   logged and the loop restarts after a short delay (`_watcher_forever`); a failure inside one
   debounced flush retries the same batch at most three times with exponential backoff. After
-  the retry cap it logs abandonment and leaves the paths pending for a later filesystem event;
-  it never self-schedules an unbounded retry chain.
+  the retry cap it isolates the batch into single-change attempts, processes healthy changes,
+  and logs and drops each still-failing event. A later event for that path is eligible again;
+  no poisoned batch is retained and no unbounded retry chain is scheduled.
 - **WebSocket sends never block the broadcaster indefinitely**: each client send has a hard
   1-second timeout; a stalled client is force-closed and dropped from the client set rather
   than stalling the fan-out to every other connected canvas.

--- a/docs/specs/server-api/high-level.md
+++ b/docs/specs/server-api/high-level.md
@@ -6,7 +6,7 @@ Haute's frontend is a React Flow canvas; this component is the FastAPI applicati
 backs it. It owns the app shell (lifespan, middleware, static SPA serving), the live
 code-to-canvas sync channel (file watcher + WebSocket), the request/response contract every
 route in the product speaks (Pydantic schemas, the typed error hierarchy, the sanitized-error
-convention), and the two largest route families itself: pipeline CRUD/preview/trace/sink and
+convention), and the two largest route families itself: pipeline CRUD/preview/trace/output and
 file/schema browsing. Every other route module (Databricks, Explore, MLflow, modelling,
 optimiser, submodel, git, JSON cache) is included into the same `FastAPI` app but owned by
 its own component; this one is the substrate they all sit on.
@@ -37,7 +37,8 @@ In scope:
   pipeline-name→path index, self-write tracking (watcher feedback-loop prevention), the
   WebSocket client registry and broadcast fan-out, and the on-disk sidecar (`.haute.json`)
   format.
-- The pipeline routes (`haute.routes.pipeline`): list/get/save/preview/trace/sink, their
+- The pipeline routes (`haute.routes.pipeline`): list/get/save/preview/trace/output-write
+  and output-destination preview, their
   request-supersession and concurrency-limiting behaviour, and the transactional save
   service (`haute.routes._save_pipeline`).
 - The file-browsing and schema-inspection routes (`haute.routes.files`), the utility-script
@@ -105,6 +106,9 @@ that cookie; an absent Origin is allowed only with a valid existing cookie.
 `OPTIONS` still requires a trusted Origin but bypasses the token check. WebSocket
 handshakes always require an explicit matching Origin plus cookie credential and close
 with code 1008 on rejection. `HAUTE_DISABLE_LOCAL_SESSION_AUTH` bypasses only session auth.
+An inbound `x-request-id` is retained only when it is a 1–64 character ASCII token matching
+`[A-Za-z0-9][A-Za-z0-9._:-]*`; missing or invalid values are replaced with a generated ID.
+Rejected values are logged only by bounded reason and numeric length, never by their bytes.
 
 **Live sync.** A pricing analyst can edit a pipeline's `.py` file directly in an IDE while
 the canvas is open. A background watcher (debounced 300ms) detects the change, re-parses
@@ -117,32 +121,47 @@ fingerprint already matches (no redundant payload). Edits the server itself make
 `/api/pipeline/save`) are tagged as self-writes so they never round-trip back through the watcher
 as a phantom external edit. A change to a `modules/*.py` file re-parses only the pipelines
 that import it; a change to a `config/*.json` file re-parses every discovered pipeline (a
-config change can affect any pipeline that reads it).
+config change can affect any pipeline that reads it). Only direct pipeline `.py` changes
+invalidate the name→path index. Startup priming, watcher invalidation, and successful save
+invalidation are the index's lifecycle mutation points, and the module-dependency index uses
+the same lock so an invalidation cannot be overwritten by an in-flight rebuild. A failed
+debounced batch is retried at most three times with exponential backoff; after that the
+watcher logs abandonment and leaves the batch pending for the next filesystem event instead
+of creating an unbounded chain of retry tasks.
 
-**Pipeline CRUD, preview, trace, sink.** `GET /api/pipelines` lists every discovered pipeline
-with parse status; `GET /api/pipeline` / `GET /api/pipeline/{name}` return one graph.
+**Pipeline CRUD, preview, trace, and output publication.** `GET /api/pipelines` lists every
+discovered pipeline with parse status; `GET /api/pipeline` returns an empty graph only when
+no pipeline file exists, and returns 422 with the first parse diagnostic when files exist but
+none can be parsed. `GET /api/pipeline/{name}` returns the named graph.
 `POST /api/pipeline/save` is the single write path for a pipeline's `.py` source, its
 per-node config JSON sidecars, and its `.haute.json` position sidecar — described in detail
 below. `POST /api/pipeline/preview` runs the graph up to one node and returns its schema,
 sample rows, and per-node timing/memory; `POST /api/pipeline/trace` follows one row's values
 through every node it passed through and returns typed correlation omissions plus generation
 provenance; `POST /api/pipeline/write-output` explicitly materialises a
-`dataOutput` node. Preview and trace are keyed on (graph fingerprint, source, node,
+`dataOutput` node, with `overwrite=false` by default. A pre-existing destination returns
+409 before graph execution; `POST /api/pipeline/output-destination` runs the same safe
+destination resolution without executing the graph or touching the target. Preview and
+trace are keyed on (graph fingerprint, source, node,
 row/column selectors): a newer request for the *same* key supersedes the older request's
 response and waits for its active slot to clear, so same-key workers never overlap. Preview
 also requests cooperative cancellation of the active worker; trace has no route-level
 cancellation token, so a newer trace must wait for the older trace thread to finish before it
 can start. A *different* key runs independently, bounded by a small per-operation concurrency
 semaphore. All three long-running endpoints enforce a response timeout
-(`HAUTE_{PREVIEW,TRACE,SINK}_TIMEOUT`, default 120s/120s/300s). Preview and sink
+(`HAUTE_{PREVIEW,TRACE,SINK}_TIMEOUT`, default 120s/120s/300s; the historical internal
+`SINK` setting governs output-write). Preview and output-write
 cooperatively cancel their execution token/context on timeout; trace's already-started thread
 finishes in the background. Preview/trace retain their supersession key and concurrency
-permit until that thread really finishes, despite having returned 504. Preview and sink use
+permit until that thread really finishes, despite having returned 504. Preview and output-write use
 memory admission control at this route boundary; trace does not create an admission context
-here.
+here. A timeout that carries a still-running background task takes precedence over a newer
+supersession generation, so it remains a 504 and retains both the key and execution context
+until the worker exits.
 
-**File browsing and schema inspection.** `GET /api/files` lists a directory (extension-
-filtered) for the file picker. `GET /api/schema` reads a data file's column schema, a 5-row
+**File browsing and schema inspection.** `GET /api/files` lists a directory for the file
+picker; when its `extensions` query is omitted, the effective readable extensions come from
+the installed I/O registry. `GET /api/schema` reads a data file's column schema, a 5-row
 preview, and (for parquet) an exact row count or (for JSONL) an estimated one, without
 loading the whole file. `GET /api/io-capabilities` exposes provider groups, the Polars I/O
 format registry (read/write capability, modes, accepted arguments, missing optional engines),
@@ -162,7 +181,21 @@ validates the mapping shape independently of any data, swaps it into the target 
 in-memory config (never touching disk), runs the graph up to that node, and returns the
 rendered document. The assembly algorithm itself (schema-determined cyclic-core detection,
 surgical cut, prefix-nested serialisation) lives in `_output_assembler.py` and is shared with
-the deploy-time render path.
+the deploy-time render path. Admission refusal uses the same structured 507 payload as the
+other execution routes. Ordinary success and failure release the admission context in
+`finally`; a 504 defers release to the still-running background task.
+
+**Execution diagnostics and public contract errors.** Execution-consuming endpoints expose
+the bounded version-1 strategy diagnostic DTO: canonical, capped collections describe
+boundaries, reasons, and provenance without frames, plans, or user data. The shared
+public-error adapter is a closed set mapped to synchronous HTTP 422 and background-job
+`contract_error`: `ApiInputSchemaError`, `PreambleError`, `ContractResolutionError`,
+`ChunkMemoryRiskError`, `GroupByExecutionUnsupportedError`,
+`TraceCorrelationUnsupportedError`, `RatingExtremaUndefinedError`,
+`RatingFactorMissingError`, `RatingFactorDtypeContractError`,
+`LiveSwitchScenarioError`, and `OutputNestingKeyError`. Every payload preserves the
+exception's stable code and named safe fields; malformed or unsupported diagnostic versions
+become diagnostic-unavailable rather than a fabricated success.
 
 ## Design rationale
 
@@ -268,8 +301,9 @@ turn that loudness into a well-typed HTTP response rather than a raw traceback.
   surface: save-time `ConfigError` → 400; output dry-run `ConfigError` /
   `ContractMismatchError` → 422; trace `ContractMismatchError` → 422; and preview
   config/contract failures are embedded in `NodeResult.error` so the canvas can show them
-  in-situ rather than as a banner. `ApiInputSchemaError` → a direct 422 JSON body with a
-  `type` discriminator, and `OutputMappingSchemaError` → FastAPI's
+  in-situ rather than as a banner. JSON-cache `ApiInputSchemaError` uses a direct 422 body
+  with a `type` discriminator, while preview/write execution uses the stable public-contract
+  payload under `detail`; `OutputMappingSchemaError` uses FastAPI's
   `{"detail": <message>}` 422 envelope.
 - **Everything else** — any exception not explicitly mapped — is normally caught at the
   route level, logged server-side, and returned as `{"detail": "Operation failed. Check the
@@ -278,11 +312,13 @@ turn that loudness into a well-typed HTTP response rather than a raw traceback.
   `{"detail": "Internal server error"}`. Neither exposes a traceback; outer trusted-host
   and session middleware rejections bypass request-ID middleware entirely.
 - **Resource limits** surface as their own status codes rather than a generic 500:
-  `ExecutionAdmissionError` / `ExecutionMemoryLimitExceededError` → 507 for preview/sink
-  (OUTPUT dry-run maps admission refusal to 503); a superseded request →
+  `ExecutionAdmissionError` / `ExecutionMemoryLimitExceededError` → 507 for preview,
+  output-write, and OUTPUT dry-run; a superseded request →
   `SupersededRequestError` → 409; a timed-out blocking operation → 504. Worker threads are
-  never forcibly killed: preview/sink request cooperative cancellation, while trace and
-  OUTPUT dry-run drain the late result/error after returning.
+  never forcibly killed: preview/output-write request cooperative cancellation, while trace and
+  OUTPUT dry-run drain the late result/error after returning. A timeout carrying a background
+  task is never masked by supersession, and OUTPUT dry-run releases its execution context
+  only after that task completes.
 - **Path-safety violations** (`validate_safe_path`, the save-time output-path allowlist,
   runtime-input-path validation) return 400 for malformed input (null bytes, empty codegen
   paths, traversal segments) and 403 for a resolved path that escapes its allowed root —
@@ -300,8 +336,9 @@ turn that loudness into a well-typed HTTP response rather than a raw traceback.
   misbehaving downstream consumer.
 - **The file watcher is crash-resilient**: an unexpected exception in the watch loop is
   logged and the loop restarts after a short delay (`_watcher_forever`); a failure inside one
-  debounced flush requeues that batch and reschedules rather than dropping the pending
-  changes.
+  debounced flush retries the same batch at most three times with exponential backoff. After
+  the retry cap it logs abandonment and leaves the paths pending for a later filesystem event;
+  it never self-schedules an unbounded retry chain.
 - **WebSocket sends never block the broadcaster indefinitely**: each client send has a hard
   1-second timeout; a stalled client is force-closed and dropped from the client set rather
   than stalling the fan-out to every other connected canvas.
@@ -311,140 +348,3 @@ turn that loudness into a well-typed HTTP response rather than a raw traceback.
 > `haute.toml` or an unreadable one raises `ConfigError` rather than falling back — the
 > asymmetry is deliberate (a missing key is a fresh-project state; a decode failure would
 > silently misroute every subsequent save/load to the wrong directory if swallowed).
-
-## Polars backend contracts (0.6.0)
-
-Execution-consuming endpoints will expose the execution engine's bounded, typed strategy
-diagnostic DTO. The producer emits integer `schema_version=1`; required fields are `status`,
-`strategy`, `profile`, `boundedness` (`bounded|unbounded|unknown`), `reason_code`,
-`detail_state` (`available|unavailable|truncated`), and the three bounded collection fields
-`boundaries`, `reasons`, and `provenance`. Blocking/remediation, cost, metric, and provenance
-item details are otherwise optional. The payload never contains frames, user data, or plans,
-and human messages/remediation are capped at 512 characters.
-
-Every bounded collection has exactly the wrapper
-`{state: available|unavailable|truncated, total_count: int|null, items: [...]}`. An `available`
-wrapper has `total_count == len(items)`; a `truncated` wrapper has
-`total_count > len(items)`; and an `unavailable` wrapper has `total_count=null` and no items.
-Counts are non-negative. Boundary and reason item arrays are capped at 32 entries and provenance
-at 128. The producer canonical-sorts the complete collection before truncating it. A consumer
-receiving an over-cap collection or a wrapper whose state/count/items disagree treats the entire
-strategy diagnostic as malformed and exposes diagnostic unavailable; client-side truncation is
-not permitted. Top-level `detail_state` is the worst of the three wrapper states, ordered
-`truncated` > `unavailable` > `available`; a disagreement is malformed.
-
-Boundary entries require `topological_rank`, `node_id`, `operator`, and `boundary_kind` and sort
-by that tuple. Ranks come from the graph's canonical topological sort, which breaks every ready-
-node tie by lexical `node_id`. Reason entries require `reason_code` and sort by
-`(topological_rank or max, node_id or '', reason_code, operator or '')`. Provenance entries
-require `column` and `origin_kind` and sort by
-`(column, origin_kind, source_node_id or '', source_column or '')`. String ordering is ascending
-Unicode code-point order. After the primary tuple, the producer uses the server's canonical JSON
-serialisation as an internal final tie-break so truncation is deterministic; byte-identical
-duplicates are retained. That tie-break is not a wire-order rule: consumers validate only that
-primary tuples are nondecreasing and accept any relative order within an equal-primary group.
-
-The version-1 mapping is authoritative: internal `projected` and `schema-all-except` map to
-API `projected`; `full-width-admitted-eager` to `admitted_eager`;
-`unprojected-streaming-boundary` and `materialisation-boundary` to `boundary`; `unsupported`
-to `rejected`; and `not-planned` to `not_planned`. Consumers accept version 1 and ignore
-unknown additive fields only within it. Missing or malformed required fields, unknown
-version-1 enum values, and unsupported higher versions become an explicit diagnostic-
-unavailable result, never a fabricated successful status.
-
-Group-by version 1 is either returned as `materialisation-boundary` after the active profile
-allows full materialisation and RAM admission succeeds, or fails before execution with
-`GroupByExecutionUnsupportedError(BoundedMemoryUnsupportedError)`. The public failure carries
-`node_id`, `operator`, `profile`, `reason_code`, `remediation`, and nullable
-`estimated_peak_bytes` and `headroom_bytes`. It is never ordinary checked execution or an
-unprojected streaming boundary.
-
-The shared route and background-job mapper maps these public errors to HTTP 422 and terminal
-`contract_error`, respectively: `PreambleError(ExecutionError)`,
-`ContractResolutionError(ExecutionError)`, `ChunkMemoryRiskError(BoundedMemoryUnsupportedError)`,
-`GroupByExecutionUnsupportedError`,
-`TraceCorrelationUnsupportedError(ExecutionError)`,
-`RatingExtremaUndefinedError(ExecutionError)`,
-`RatingFactorMissingError(SchemaMismatchError)`,
-`LiveSwitchScenarioError(ExecutionError)`, and
-`OutputNestingKeyError(OutputMappingSchemaError)`. Each response carries the exception's
-stable code and named fields. `TraceCorrelationUnsupportedError` uses stable code
-`trace_correlation_unsupported` and fields `node_id`, `key_columns`, `dtypes`, and `reason_code`;
-the two arrays preserve the engine's correlation-key order, correspond positionally, and contain
-at most 16 items each. This is an intentional pre-1.0 change in 0.6 from unsafe silent
-fallback to typed failure; release and migration notes are required, with no compatibility
-shim for the unsafe behaviour. The DTO reports decisions; the execution engine owns how they
-are made. Remaining server API improvement work is tracked in the
-[background jobs and API roadmap](../../roadmap/background-jobs-api.md).
-
-## Approved change contract — 0.7.0 data I/O API
-
-Remaining server API improvement work is tracked in the
-[background jobs and API roadmap](../../roadmap/background-jobs-api.md).
-
-- `GET /api/io-capabilities` replaces the flat format endpoint with a versioned, runtime-guarded
-  description of ordered input/output groups, providers, formats, fields, modes, arguments,
-  engines, direct batching, snapshot-build boundedness, output execution class, and publication
-  modes. The server derives it from the canonical registry; unsupported direction legs are
-  explicit, not inferred by the client.
-- A shared input-cache API owns Build/Refresh, job progress/status/cancel, snapshot status, and
-  Clear for every cache-capable `dataInput`. Build is an asynchronous job with a stable id and
-  cooperative cancellation, not a request thread allowed to continue invisibly after a 504.
-  Same-identity builds join one single flight; different identities may run under bounded global
-  concurrency. Responses separate local readiness, external freshness, build boundedness, and
-  typed failure.
-- `POST /api/pipeline/write-output` replaces the sink-named route and accepts only
-  `dataOutput`. It executes the unsaved graph supplied by the editor under normal admission,
-  cancellation, path, credential, and publication validation and returns measured/unavailable
-  row count plus destination and publication outcome. Preview, trace, load, and save never call
-  it implicitly.
-- Databricks retains only browsing endpoints under `/api/databricks`; its fetch/cache routes move
-  to the shared cache API. The old `/api/formats`, `/api/pipeline/sink`, and provider-specific
-  cache endpoints are removed without compatibility aliases.
-- Capability, cache, and write responses never expose resolved credentials, raw connector
-  errors, absolute paths outside approved user-facing scope, or background tracebacks. Typed
-  configuration/capability/cache/publication errors have stable codes and safe fields; unexpected
-  failures retain the common sanitised envelope.
-
-Acceptance includes schema/guard parity, capability ordering and completeness, secret redaction,
-cache single-flight/cancel/progress/status races, no orphaned job after timeout, cache corruption
-and identity mismatch, explicit output-write admission/cancellation/atomicity, and route absence
-for every removed endpoint.
-
-## I/O diagnostics and overwrite choice
-
-The server API implements the HTTP portion of
-[IO-IO01, IO-IO05, and IO-IO09](../../roadmap/io-layer.md).
-
-`GET /api/files` omits its extension default from the HTTP schema and derives
-the effective list from installed read capabilities. Its blocking enumeration
-runs in the server thread pool and never advertises symlink entries.
-
-`GET /api/schema` exposes only allow-listed, actionable user failures:
-missing file (404), unsupported extension (400), and a known file decoder
-failure (400 with a static format-specific remediation). Arbitrary
-`ValueError`, OS, and unexpected runtime text remains private in structured
-logs and returns the existing sanitised envelope.
-
-`POST /api/pipeline/write-output` accepts `overwrite: bool = false`.
-An existing file destination returns HTTP 409 with a safe detail naming the
-user-facing resolved destination. No graph execution or write starts on that
-preflight conflict. A true retry authorises replacement; false remains
-collision-safe at the final publication race.
-
-Destination preview and write share one validated request preparation path and
-resolve local targets against the selected Haute project root, independently of
-the server process working directory.
-
-Request/response model, OpenAPI, route, sanitisation, and frontend client
-contract tests cover both overwrite values and the 409 path.
-
-## Approved change contract — bounded request correlation
-
-An inbound `x-request-id` is retained only when it is a 1–64 character ASCII
-token matching `[A-Za-z0-9][A-Za-z0-9._:-]*`. Missing or invalid values are
-replaced with a server-generated identifier before structured context is bound.
-The rejection log records only a bounded reason and numeric input length, never
-the rejected bytes. Consequently oversized values and control characters cannot
-reach logs, error bodies, or response headers, while a valid caller identifier
-still correlates the response.

--- a/docs/specs/server-api/low-level.md
+++ b/docs/specs/server-api/low-level.md
@@ -406,7 +406,7 @@ use the same stable codes and named fields under terminal `contract_error`:
 | `ApiInputSchemaError` | `api_input_schema_invalid` | — |
 | `PreambleError` | `preamble_failed` | `source_line` |
 | `ContractResolutionError` | `contract_resolution_failed` | `node_id`, `node_type`, `failure_kind` |
-| `ChunkMemoryRiskError` | `chunk_memory_risk` | `target_node_id`, `reason_code`, `estimated_target_row_bytes`, `target_chunk_bytes` |
+| `ChunkMemoryRiskError` | `chunk_memory_risk` | `target_node_id`, `reason_code`, `estimated_target_row_bytes`, `estimated_minimum_chunk_bytes`, `row_expansion_factor`, `target_chunk_bytes` |
 | `GroupByExecutionUnsupportedError` | `group_by_execution_unsupported` | `node_id`, `operator`, `profile`, `reason_code`, `remediation`, `estimated_peak_bytes`, `headroom_bytes` |
 | `TraceCorrelationUnsupportedError` | `trace_correlation_unsupported` | `node_id`, `key_columns`, `dtypes`, `reason_code` |
 | `RatingExtremaUndefinedError` | `rating_extrema_undefined` | `output_column`, `operation` |

--- a/docs/specs/server-api/low-level.md
+++ b/docs/specs/server-api/low-level.md
@@ -6,14 +6,14 @@
 |---|---|
 | `src/haute/server.py` | App factory (`app = FastAPI(...)`), lifespan (bytecode clear, logging config, env load, marked optimiser-artifact reaping, pipeline-index priming, watcher task lifecycle), middleware registration, router inclusion, `/api/session` health/bootstrap routes, bounded request-ID selection, the API/WS 404 guard, the `/ws/sync` WebSocket endpoint, the debounced file watcher, and credential-free static SPA serving. |
 | `src/haute/_local_security.py` | Per-process local-session token, trusted-Origin/Host parsing (including bracketed IPv6), `LocalSessionMiddleware`, `LocalTrustedHostMiddleware`, and the HTTP/WebSocket token-validation contract. |
-| `src/haute/schemas.py` | Shared Pydantic request/response models used across the app — re-exports the canonical graph types from `_types.py` and defines per-feature model groups (pipeline save/preview/trace/sink, Explore, files/schema, Databricks, JSON cache, utility, submodel, modelling, MLflow, optimiser, git, I/O format capabilities). The OUTPUT dry-run models are the deliberate route-local exception. |
-| `src/haute/errors.py` | The `HauteError` root and its direct subclasses (`ConfigError`, `ParseError`, `ExecutionError` and its `PreambleError`, `ContractResolutionError`, `BoundedMemoryUnsupportedError`, `ChunkPlanUnsupportedError`, and `ChunkMemoryRiskError` descendants, `DeployError`, `FeatureMismatchError`, `SchemaMismatchError`, `ContractMismatchError`, `ProjectionImpossibleError`). |
+| `src/haute/schemas.py` | Shared Pydantic request/response models used across the app — re-exports the canonical graph types from `_types.py` and defines per-feature model groups (pipeline save/preview/trace/output write and destination, Explore, files/schema, Databricks, JSON cache, utility, submodel, modelling, MLflow, optimiser, git, I/O capabilities and execution diagnostics). The OUTPUT dry-run models are the deliberate route-local exception. |
+| `src/haute/errors.py` | The `HauteError` hierarchy, including execution, bounded-memory, schema/contract, deployment, and feature errors. Route-visible public subclasses carry stable `error_code` and `public_fields` metadata consumed by `_contract_errors.py`. |
 | `src/haute/_logging.py` | `configure_logging()` (structlog + stdlib bridge, dev-console vs. JSON-lines modes) and `get_logger()`. |
 | `src/haute/_event_bus.py` | `EventBus` — thread-safe synchronous pub/sub with typed `graph.update` / `parse.error` overloads; `default_bus` is the module-level singleton the watcher and server wire together. |
 | `src/haute/_types.py` | `NodeType` (`StrEnum`), the decorator↔NodeType maps, every per-node-type config `TypedDict`, the `SolveResultLike` Protocol family, and the canonical `NodeData` / `GraphNode` / `GraphEdge` / `PipelineGraph` Pydantic models (with `PipelineGraph`'s cached-property-invalidating `model_copy` override). |
 | `src/haute/routes/__init__.py` | Package docstring only — no code. |
 | `src/haute/routes/_helpers.py` | `SidecarModel` (the `.haute.json` on-disk schema); `validate_safe_path`; `pipeline_dir()`; the pipeline-name→path index (`_ensure_pipeline_index`, `invalidate_pipeline_index`, `lookup_pipeline_by_name`) and its module-dependency twin (`_ensure_module_deps`, `pipelines_importing_module`); self-write tracking (`mark_self_write`, `is_self_write`); watcher-pause (`pause_watcher`, `watcher_is_paused`); the WebSocket client registry and `broadcast()`; sidecar load/save (`load_sidecar`, `save_sidecar`); `parse_pipeline_to_graph` (parse + sidecar merge); `commit_pipeline_graph` (read-only historical-commit parse); the shared `save_lock` asyncio.Lock. |
-| `src/haute/routes/pipeline.py` | `/api/pipelines`, `/api/pipeline`, `/api/pipeline/{name}`, `/api/pipeline/save`, `/api/pipeline/read-json`, `/api/pipeline/trace`, `/api/pipeline/preview`, `/api/pipeline/write-output` — plus the supersession-key builders, `_prepare_runtime_graph` request-containment helper, runtime-input/output path validators, and memory-limit-to-HTTP-exception translators shared across graph-executing route families. |
+| `src/haute/routes/pipeline.py` | `/api/pipelines`, `/api/pipeline`, `/api/pipeline/{name}`, `/api/pipeline/save`, `/api/pipeline/read-json`, `/api/pipeline/trace`, `/api/pipeline/preview`, `/api/pipeline/write-output`, `/api/pipeline/output-destination` — plus the supersession-key builders, shared output-request preparation, `_prepare_runtime_graph` request containment, runtime-input/output path validators, and memory-limit-to-HTTP-exception translators shared across graph-executing route families. |
 | `src/haute/routes/files.py` | `/api/files` (directory browse) and `/api/schema` (flat-file schema+preview). |
 | `src/haute/routes/io_capabilities.py` | `/api/io-capabilities`, the versioned provider/format/cache capability contract consumed by the input and output editors. |
 | `src/haute/routes/input_cache.py` | `/api/input-cache/*`, the shared build/status/cancel/clear lifecycle for snapshot-backed inputs. |
@@ -26,7 +26,8 @@
 
 ## Key types and data structures
 
-**Exception hierarchy** (`errors.py`) — every subclass roots at `HauteError`, which renders
+**Exception hierarchy** (`errors.py`, abridged to route-relevant branches) — every subclass
+roots at `HauteError`, which renders
 `**context` kwargs into `str(err)` (`"message (k=v, k2=v2)"`) so structured fields reach log
 lines without manual formatting:
 ```
@@ -34,17 +35,26 @@ HauteError
 ├── ConfigError
 ├── ParseError
 ├── ExecutionError
+│   ├── PreambleError
+│   ├── ContractResolutionError
+│   ├── RatingExtremaUndefinedError
+│   ├── LiveSwitchScenarioError
+│   ├── TraceCorrelationUnsupportedError
 │   └── BoundedMemoryUnsupportedError
-│       └── ChunkPlanUnsupportedError
+│       ├── ChunkPlanUnsupportedError
+│       ├── ChunkMemoryRiskError
+│       └── GroupByExecutionUnsupportedError
 ├── DeployError
 ├── FeatureMismatchError
 ├── SchemaMismatchError
+│   ├── RatingFactorMissingError
+│   └── RatingFactorDtypeContractError
 └── ContractMismatchError
     └── ProjectionImpossibleError (also extends BoundedMemoryUnsupportedError)
 ```
-`_api_input_schema.ApiInputSchemaError` and `_output_assembler.OutputMappingSchemaError` are
-direct `HauteError` subclasses supplied by JSON-shredding and consumed by this component's
-routes, not defined in `errors.py`. Not
+`_api_input_schema.ApiInputSchemaError` and `_output_assembler.OutputMappingSchemaError`
+(with `OutputNestingKeyError`) are direct `HauteError` subclasses supplied by
+JSON-shredding and consumed by this component's routes, not defined in `errors.py`. Not
 every Haute exception is a `HauteError`: resource-exhaustion and deadline errors used
 elsewhere in the codebase deliberately extend `MemoryError` / `TimeoutError` /
 `FileNotFoundError` instead, so a single `except HauteError` does not catch the whole error
@@ -100,14 +110,15 @@ when a path/query/body fails model validation):
 | `GET /api/session` | No body | `SessionStatusResponse {ok: bool=true}` |
 | `POST /api/session/bootstrap` | No body; explicit exact local Origin required | `SessionStatusResponse {ok: bool=true}` plus HttpOnly, SameSite=Strict session cookie and no-store headers |
 | `GET /api/pipelines` | No body | `list[PipelineSummary]`; each item is `{name, description, file, node_count, error}` |
-| `GET /api/pipeline` | No body | `PipelineGraph` for the first discovered pipeline |
+| `GET /api/pipeline` | No body | First parseable `PipelineGraph`; an empty graph only when no pipeline file exists. If files exist but none parses, the first parse diagnostic is returned as 422. |
 | `GET /api/pipeline/{name}` | Pipeline name path parameter | `PipelineGraph` |
 | `POST /api/pipeline/save` | `SavePipelineRequest {name="main", description="", graph={}, preamble=null, preserved_blocks=[], source_file="", sources=["live"], active_source="live"}` | `SavePipelineResponse {status="saved", file, pipeline_name, warnings=[], git_sha=null}` |
 | `POST /api/pipeline/read-json` | `ReadJsonRequest {path}` | `ReadJsonResponse`, a root JSON object (arrays/scalars are rejected) |
 | `POST /api/pipeline/preview` | `PreviewNodeRequest {graph, node_id, row_limit=100 (1..10000), source="live", requested_preview_columns=null (non-empty when present), streaming_chunk_size=null (1..10000000, bool rejected), port_label=null}` | `PreviewNodeResponse`, extending `NodeResult` with `node_id`, timings/memory, per-node schemas/statuses, and optional execution metrics |
 | `POST /api/pipeline/trace` | `TraceRequest {graph, row_index=0 (>=0), target_node_id=null, column=null, row_limit=100 (1..10000), source="live", row_values=null, streaming_chunk_size=null}` | Explicit JSON `TraceResponse {status, trace}`. `trace` includes successful steps, typed omissions, correlation/waterfall evidence, UTC `generated_at`, source identity, and `execution_origin: fresh_execution|preview_cache|trace_cache`; the payload is serialized and `TraceResponse`-validated in the worker, then the returned `JSONResponse` skips a second event-loop validation pass |
-| `POST /api/pipeline/write-output` | `WriteOutputRequest {graph, node_id, source="live", streaming_chunk_size=null}` | `WriteOutputResponse` with status, row count, destination path/table, format, publication outcome, and execution metrics |
-| `GET /api/files` | Query `dir="."`, `extensions=".parquet,.csv,.json,.xml"` | `BrowseFilesResponse {dir, items:[{name,path,type,size?}]}` |
+| `POST /api/pipeline/write-output` | `WriteOutputRequest {graph, node_id, source="live", streaming_chunk_size=null, overwrite=false}` | `WriteOutputResponse` with status, row count, destination path/table, format, publication outcome, and execution metrics |
+| `POST /api/pipeline/output-destination` | `OutputDestinationRequest {graph, node_id}` | Safe destination display path, format, and suffix-mismatch flag; performs no graph execution or filesystem write |
+| `GET /api/files` | Query `dir="."`, `extensions=null`; omission derives readable extensions from the I/O registry | `BrowseFilesResponse {dir, items:[{name,path,type,size?}]}` |
 | `GET /api/io-capabilities` | No body | Versioned provider groups, format capabilities, modes, accepted arguments, optional engines, cache modes, and materialisation diagnostics |
 | `GET /api/schema` | Required query `path` | `SchemaResponse {path, columns, row_count?, row_count_estimated=false, column_count, preview=[]}` |
 | `POST /api/input-cache/build` | Canonical `dataInput` config and source identity | Starts or coalesces a cache-generation build and returns its job identity |
@@ -161,7 +172,9 @@ ID backstop returns `{"detail":"Internal server error"}` with the selected safe 
 an escaped exception; route
 catch-alls use the different `_INTERNAL_ERROR_DETAIL` string. `LocalSessionMiddleware`
 checks Origin before its `OPTIONS` exception, so a trusted preflight bypasses the token while
-an untrusted preflight still receives 403.
+an untrusted preflight still receives 403. `_select_request_id` retains only a 1–64
+character ASCII token matching `[A-Za-z0-9][A-Za-z0-9._:-]*`; otherwise it generates a new
+ID and logs only the bounded rejection reason and input length.
 
 **Route registration order matters.** The feature routers (`pipeline_router` through
 `git_router`, plus the assistant router owned by [assistant](../assistant/low-level.md)) are
@@ -197,8 +210,9 @@ crash. Every filesystem event batches into `pending_changes`; a 300ms debounce t
 4. Classifies each remaining `.py`/`.json` change: `config/*.json` → re-parse every
    discovered pipeline; `modules/*.py` → re-parse only pipelines importing that module stem
    (case-insensitively, via `_module_dep_key`); any other `.py` (excluding `utility/` and
-   dunder-prefixed files) → re-parse that pipeline directly, invalidating the pipeline index
-   first.
+   dunder-prefixed files) → re-parse that pipeline directly. Only this direct-source class
+   invalidates the pipeline name→path index before discovery; module and config changes do
+   not discard an otherwise valid index.
 5. For each changed pipeline: hash raw bytes first (cheap) and skip the parse entirely if the
    byte hash is unchanged *and* the change wasn't dependency-triggered (a module/config
    change always re-parses even if this pipeline's own bytes are unchanged, since its
@@ -206,8 +220,10 @@ crash. Every filesystem event batches into `pending_changes`; a 300ms debounce t
    graph payload + a content fingerprint + the wire-form source path; on failure, publish
    `parse.error` and evict the stale fingerprint so the next successful parse re-broadcasts
    even if the bytes happen to match a previous good state.
-6. If the flush body itself raises, the *entire* processed batch is requeued and a fresh
-   flush is scheduled — no event is silently dropped by an internal failure.
+6. If the flush body itself raises, the *entire* processed batch is requeued and `_flush`
+   retries it in the same task at most three times with exponential backoff. Exhaustion logs
+   `file_watcher_flush_abandoned` and leaves the paths in `pending_changes` for the next
+   filesystem event; it does not recursively schedule another flush task.
 
 **Pipeline save (`SavePipelineService.save`)**, run inside the process-wide `save_lock` (an
 `asyncio.Lock`, so it serialises against concurrent submodel create/dissolve as well as
@@ -271,6 +287,8 @@ helper raises a
 `BlockingWorkTimeoutError`, `SupersessionCoordinator` extracts its `background_task` and
 defers clearing `state.active` and releasing the semaphore until the task finishes. Same-key
 work therefore cannot overlap after a 504 and timed-out calls cannot create a worker storm.
+An error carrying that background task is re-raised before the post-worker generation check,
+so a newer request cannot mask the timeout as 409 or trigger early cleanup.
 Preview also cancels its token and defers admission release; trace has no cancellation token,
 so its thread runs to completion while retaining the key/permit.
 
@@ -278,16 +296,12 @@ so its thread runs to completion while retaining the key/permit.
 (`validate_v2_output_mapping`, data-independent) → flatten the graph → locate and type-check
 the target node → validate every runtime input path stays inside the project root → replace
 the node's `config` in-memory with the volatile mapping → `execute_graph(...,
-target_preview_only=True)` under a timeout → map the result's `status`/`error` to the
-response, or return the rendered `document` on success.
-
-> NOTE: unlike preview and sink, the implemented OUTPUT dry-run route never calls
-> `context.release_admission()` on success or failure, and its timeout handler also does not
-> call `context.cancel()`. It has no supersession coordinator retaining a concurrency permit.
-> `run_blocking_with_response_timeout` drains a late future (discarding a successful value and
-> logging an ordinary exception), but the route returns 504 while the thread continues. This
-> reservation-lifecycle gap is current behaviour, not an intended release/cancellation
-> guarantee.
+target_preview_only=True)` inside an admitted execution context and under a timeout → map the
+result's `status`/`error` to the response, or return the rendered `document` on success.
+Admission refusal is translated through the shared structured-memory adapter to 507. Normal
+success and failure release admission in `finally`; a `BlockingWorkTimeoutError` registers a
+background-task callback and transfers release ownership to it, so the context stays live
+until the worker actually exits.
 
 ## Edge cases and invariants
 
@@ -321,11 +335,12 @@ response, or return the rendered `document` on success.
   after the current send completes — so two rapid broadcasts to a slow client never race each
   other out of order. Each send (and each stalled-client close) has a hard 1-second timeout;
   a timeout marks the client dead and discards it rather than blocking the whole fan-out.
-- **The pipeline index has exactly two legitimate writers**: server startup and the file
-  watcher's `invalidate_pipeline_index()`. `_ensure_pipeline_index()` uses double-checked
-  locking so concurrent cold-cache readers never scan the filesystem twice, and the final
-  publish is a single dict-reference assignment (atomic in CPython) so no reader ever
-  observes a partially-built index.
+- **The pipeline index has three lifecycle mutation points**: startup priming, watcher
+  invalidation for a direct pipeline `.py` change, and invalidation after a successful save.
+  `_ensure_pipeline_index()` uses double-checked locking so concurrent cold-cache readers
+  never scan twice. The module-dependency twin uses the same lock and publishes its complete
+  map only while holding it, so an invalidator that arrives during a build cannot be
+  overwritten by that stale build.
 - **Module-dependency keys are casefolded** (`_module_dep_key`) because the build side
   derives a module stem from a `pipeline.submodel("modules/<name>.py")` *source literal*
   while the watcher derives it from an *on-disk filename* — on case-insensitive filesystems
@@ -354,9 +369,10 @@ response, or return the rendered `document` on success.
   from row values. `_prune` treats an empty array/object as "carries no data" and omits it —
   the documented round-trip invariant is equality *up to empty collections*, not bit-exact.
 - **`is_active_mapping_entry`** skips an OUTPUT mapping row with a blank `source_column` or
-  `output_path` everywhere it's consumed (contract, assembly, validation) — a half-finished
-  editor row (added but not yet wired to a column) never demands a `pl.col("")` or produces a
-  confusing `missing=['']` contract failure.
+  `output_path` in the shared OUTPUT contract, assembler, and WS-04-owned execution
+  consumers — a half-finished editor row never demands `pl.col("")` or produces a confusing
+  `missing=['']` failure. Projection planner parity is owned by the execution-engine
+  workstream.
 - **`GraphEdge` handle validation rejects `""` but accepts `None`** for `sourceHandle` /
   `targetHandle` — the two are semantically distinct (an unnamed port vs. no port specified)
   and coercing one into the other would mask a genuinely invalid empty-string port name.
@@ -367,15 +383,32 @@ response, or return the rendered `document` on success.
 |---|---|---|---|
 | `ConfigError` | save, preview, output-assemble dry-run | 400 / embedded `NodeResult.error` / 422 | Save: bad `haute.toml`. Preview: swallowed into the node result so the canvas shows it in-situ. |
 | `ContractMismatchError` | trace, preview, output-assemble dry-run | 422 / embedded `NodeResult.error` / 422 | Message already names the node + symmetric column diff. |
-| `ParseError` | preview | embedded `NodeResult.error` | Graph-shape issue surfaced per-node, not as a request failure. |
-| `ApiInputSchemaError` | (json-cache route, owned by caching) | 422 with `type` discriminator | Raised by JSON-shredding's schema codec and mapped by the consuming cache route. |
+| `ParseError` | primary pipeline load, preview | 422 / embedded `NodeResult.error` | Primary load returns the first parse diagnostic when files exist but none parses; preview surfaces graph-shape issues per node. |
+| `ApiInputSchemaError` | json-cache; preview/write execution | 422 | JSON cache retains its `type` discriminator envelope; execution routes use the public-contract adapter (`api_input_schema_invalid`). |
 | `OutputMappingSchemaError` | output-assemble dry-run | 422 | Raised both by the schema-only pre-check and if execution surfaces it deeper (an unmapped port). |
-| `ExecutionAdmissionError`, `ExecutionMemoryLimitExceededError` | preview, sink | 507 | Payload is `exc.to_payload()`, a structured body, not a plain string. OUTPUT dry-run maps `ExecutionAdmissionError` to 503 with `str(exc)`. |
-| `BoundedMemoryUnsupportedError` | sink | 422 | Distinguishes "cannot stream safely" from a hard resource limit. |
+| `ExecutionAdmissionError`, `ExecutionMemoryLimitExceededError` | preview, output write, output-assemble dry-run | 507 | Payload is `exc.to_payload()`, nested under `detail`, for every route. |
+| `BoundedMemoryUnsupportedError` | output write | 422 | Distinguishes "cannot stream safely" from a hard resource limit. |
 | `SupersededRequestError` | preview, trace | 409 | Raised by `SupersessionCoordinator`; the worker never runs for a superseded generation. |
-| `BlockingWorkTimeoutError`, `TimeoutError` | preview, trace, sink, output-assemble | 504 | Worker threads are never killed. Preview/sink request cooperative cancellation; trace retains its supersession key/permit until completion; OUTPUT dry-run only drains the late future. |
+| `BlockingWorkTimeoutError`, `TimeoutError` | preview, trace, output write, output-assemble | 504 | Worker threads are never killed. Preview/output write request cooperative cancellation; trace retains its supersession key/permit; OUTPUT dry-run defers context release until its late worker finishes. A background timeout is not masked by supersession. |
 | `HTTPException` (raised directly) | path validation, node lookup, syntax checks | 400 / 403 / 404 / 409 | `raise_node_not_found`, `raise_node_type_error`, `raise_pipeline_not_found`, `raise_validation_error` centralise the structured-log + raise pattern. |
 | Any other `Exception` | route catch-alls | 500 | Route handlers generally log and return `_INTERNAL_ERROR_DETAIL`; `_RequestIdMiddleware` is a separate backstop whose fixed detail is `Internal server error`. |
+
+The synchronous public-contract adapter maps this closed set to HTTP 422; background jobs
+use the same stable codes and named fields under terminal `contract_error`:
+
+| Exception | Stable code | Named fields |
+|---|---|---|
+| `ApiInputSchemaError` | `api_input_schema_invalid` | — |
+| `PreambleError` | `preamble_failed` | `source_line` |
+| `ContractResolutionError` | `contract_resolution_failed` | `node_id`, `node_type`, `failure_kind` |
+| `ChunkMemoryRiskError` | `chunk_memory_risk` | `target_node_id`, `reason_code`, `estimated_target_row_bytes`, `target_chunk_bytes` |
+| `GroupByExecutionUnsupportedError` | `group_by_execution_unsupported` | `node_id`, `operator`, `profile`, `reason_code`, `remediation`, `estimated_peak_bytes`, `headroom_bytes` |
+| `TraceCorrelationUnsupportedError` | `trace_correlation_unsupported` | `node_id`, `key_columns`, `dtypes`, `reason_code` |
+| `RatingExtremaUndefinedError` | `rating_extrema_undefined` | `output_column`, `operation` |
+| `RatingFactorMissingError` | `rating_factor_missing` | `table`, `factor` |
+| `RatingFactorDtypeContractError` | `rating_factor_dtype_contract` | `table`, `factor`, `saved_dtype`, `input_dtype` |
+| `LiveSwitchScenarioError` | `live_switch_scenario_missing` | `switch`, `scenario`, `available_mappings` |
+| `OutputNestingKeyError` | `output_nesting_key_null` | `frame`, `output_path`, `key` |
 
 Except for handlers that return a `JSONResponse` directly, `HTTPException` responses use
 FastAPI's `{"detail": <string-or-object>}` envelope; this includes structured 507 memory
@@ -383,8 +416,9 @@ payloads nested under `detail`. Pydantic request/query validation uses
 `{"detail": [validation-error...]}`. `_RequestIdMiddleware` constructs its 500 JSON directly.
 The JSON-cache router's `ApiInputSchemaError` is another deliberate direct-response exception:
 `{"detail": str, "type": "ApiInputSchemaError"}`. Pipeline-list and live-sync parse failures
-surface `str(exc)` as `PipelineSummary.error` / `parse_error.error`, rather than passing
-through the internal-error sanitizer.
+surface `str(exc)` as `PipelineSummary.error` / `parse_error.error`; primary pipeline load
+uses FastAPI's `{"detail": <parse diagnostic>}` 422 envelope when no discovered file parses.
+These diagnostics deliberately bypass the internal-error sanitizer.
 
 Two safety nets exist above individual route handlers: `_RequestIdMiddleware` catches any
 exception a route handler failed to catch and returns its separately pinned sanitized 500 shape (with a
@@ -428,9 +462,10 @@ for route-level tests, and direct unit tests for the pure-function modules.
   Windows filenames.
 - **`test_pipeline_route_supersession.py`** / **`test_request_supersession.py`** — supersession
   correctness under rapid repeated requests, including that a superseded waiter never runs
-  its worker and that cancellation actually propagates to the execution token.
+  its worker, cancellation propagates to the execution token, and a timeout carrying a
+  background worker remains 504 while retaining its key and execution context to completion.
 - **`test_pipeline_route_parity.py`** — shared guard behaviour (runtime input path
-  validation, printable-id checks) applied consistently across preview/trace/sink.
+  validation, printable-id checks) applied consistently across preview/trace/output-write.
 - **`test_trace_api.py`**, **`test_trace.py`**, **`test_trace_multi_frame.py`** —
   `/api/pipeline/trace` route and `execute_trace` coverage, including two fail-loud
   cases `trace_row` translates to HTTP errors rather than silently guessing: a
@@ -444,7 +479,8 @@ for route-level tests, and direct unit tests for the pure-function modules.
   route-level coverage of file browsing, the I/O format registry endpoint, and utility-script
   CRUD (including AST-syntax-error rejection with line numbers).
 - **`test_output_assemble_routes.py`** — the dry-run route: schema-pre-check ordering,
-  volatile-config swap-in behaviour, timeout/error-status mapping.
+  volatile-config swap-in behaviour, structured 507 admission mapping, timeout/error-status
+  mapping, and admission-context release on success.
 - The shared assembler and codec suites (`test_output_assembler.py` and
   `test_v2_codec_and_shred.py`) belong to
   [json-shredding](../json-shredding/low-level.md); this component's route tests verify
@@ -467,160 +503,6 @@ for route-level tests, and direct unit tests for the pure-function modules.
   frontend expects.
 - **`test_types.py`** — `_types.py` model construction, defaults, validation, and
   cached-property behaviour.
-
-Known gap: `test_output_assemble_routes.py` does not pin admission-context release; the
-implemented route currently omits release on every outcome, as noted above.
-
-## Polars backend contracts (0.6.0)
-
-Add one Pydantic execution-strategy diagnostic DTO at the shared API schema boundary. Its
-required fields are integer `schema_version` (the producer emits exactly `1`), `status`,
-`strategy`, `profile`, `boundedness` (`bounded|unbounded|unknown`), `reason_code`,
-`detail_state` (`available|unavailable|truncated`), and `boundaries`, `reasons`, and
-`provenance`. Blocking/remediation, cost, metric, and provenance item objects are otherwise
-optional; human messages/remediation have at most 512 characters. The DTO rejects plans,
-frames, source values, and other user data.
-
-`boundaries`, `reasons`, and `provenance` each use exactly
-`{state: available|unavailable|truncated, total_count: int|null, items: [...]}`. Validators
-enforce non-negative counts and these invariants:
-
-| `state` | `total_count` | `items` |
-|---|---|---|
-| `available` | `len(items)` | Complete collection |
-| `truncated` | Greater than `len(items)` | Deterministic prefix of the complete collection |
-| `unavailable` | `null` | Empty |
-
-Boundary and reason `items` have at most 32 entries; provenance `items` have at most 128. The
-producer canonical-sorts the complete collection and only then takes the capped prefix. An
-over-cap or internally inconsistent wrapper is invalid input to every consumer and maps to the
-typed diagnostic-unavailable result; consumers must not silently re-sort or truncate it.
-Top-level `detail_state` is derived as the worst collection state using
-`truncated` > `unavailable` > `available`, and a supplied inconsistent value is invalid.
-
-Boundary items require integer `topological_rank` plus string `node_id`, `operator`, and
-`boundary_kind`; their primary sort key is
-`(topological_rank, node_id, operator, boundary_kind)`. The rank is assigned by a canonical
-topological sort whose ready-node queue uses ascending lexical `node_id`. Reason items require
-`reason_code` and sort by
-`(topological_rank or max, node_id or '', reason_code, operator or '')`. Provenance items
-require `column` and `origin_kind` and sort by
-`(column, origin_kind, source_node_id or '', source_column or '')`. All string comparison is
-ascending Unicode code-point order. For all three collections, the producer appends its Python
-canonical-JSON serialization of the item as an internal final sort component so capped prefixes
-are deterministic; duplicate items, including identical canonical JSON, are retained. This
-server-only component is not a wire-order rule. Consumers validate nondecreasing primary tuples
-only and accept any relative order within an equal-primary group; in particular, browser code
-must not attempt to reproduce the Python serializer.
-
-Version 1 maps internal strategies to `status` exactly as follows:
-
-| `strategy` | `status` |
-|---|---|
-| `projected`, `schema-all-except` | `projected` |
-| `full-width-admitted-eager` | `admitted_eager` |
-| `unprojected-streaming-boundary`, `materialisation-boundary` | `boundary` |
-| `unsupported` | `rejected` |
-| `not-planned` | `not_planned` |
-
-Readers accept version 1 and ignore unknown additive fields only within version 1. A missing
-or malformed required field, unknown version-1 enum value, or unsupported higher schema
-version produces the typed diagnostic-unavailable result; it must not be coerced to a known
-status. All route adapters consume this DTO and never expose planner internals.
-
-Group-by route execution has only two version-1 outcomes: an admitted
-`materialisation-boundary` after both profile permission and RAM admission, or
-`GroupByExecutionUnsupportedError(BoundedMemoryUnsupportedError)` before execution. It must
-not be labelled as ordinary checked execution or `unprojected-streaming-boundary`. Its public
-fields are `node_id`, `operator`, `profile`, `reason_code`, `remediation`,
-`estimated_peak_bytes`, and `headroom_bytes`; the two byte estimates are nullable when the
-corresponding measurement could not be established.
-
-One shared exception adapter maps each of the following to HTTP 422 for synchronous routes
-and `contract_error` for background jobs, preserving its stable code and named fields:
-
-| Exception | Stable code | Named fields |
-|---|---|---|
-| `PreambleError` | `preamble_failed` | `source_line` |
-| `ContractResolutionError` | `contract_resolution_failed` | `node_id`, `node_type`, `failure_kind` |
-| `ChunkMemoryRiskError` | `chunk_memory_risk` | `target_node_id`, `reason_code`, `estimated_target_row_bytes`, `estimated_minimum_chunk_bytes`, `row_expansion_factor`, `target_chunk_bytes` |
-| `GroupByExecutionUnsupportedError` | `group_by_execution_unsupported` | `node_id`, `operator`, `profile`, `reason_code`, `remediation`, `estimated_peak_bytes`, `headroom_bytes` |
-| `TraceCorrelationUnsupportedError` | `trace_correlation_unsupported` | `node_id`, `key_columns`, `dtypes`, `reason_code` |
-| `RatingExtremaUndefinedError` | `rating_extrema_undefined` | `output_column`, `operation` |
-| `RatingFactorMissingError` | `rating_factor_missing` | `table`, `factor` |
-| `LiveSwitchScenarioError` | `live_switch_scenario_missing` | `switch`, `scenario`, `available_mappings` |
-| `OutputNestingKeyError` | `output_nesting_key_null` | `frame`, `output_path`, `key` |
-
-The declared inheritance is
-`GroupByExecutionUnsupportedError(BoundedMemoryUnsupportedError)`,
-`TraceCorrelationUnsupportedError(ExecutionError)`,
-`RatingExtremaUndefinedError(ExecutionError)`,
-`RatingFactorMissingError(SchemaMismatchError)`, `LiveSwitchScenarioError(ExecutionError)`,
-and `OutputNestingKeyError(OutputMappingSchemaError)`. `TraceCorrelationUnsupportedError`'s
-`key_columns` and `dtypes` arrays preserve correlation-key order, correspond positionally, and
-are each capped at 16 items. Error-response and background-job tests pin status/reason, code,
-and fields for every class. DTO tests pin every schema-version path, wrapper invariant,
-producer primary ordering and internal tie-break, consumer acceptance of equal-primary
-permutations, cap boundary, over-cap rejection, aggregate `detail_state`, and duplicate
-retention. Release 0.6 is an intentional
-pre-1.0 fail-loud compatibility change: release and migration notes are required, and no
-shim may preserve unsafe silent fallback. The execution-engine spec owns production of the
-strategy data. Remaining server API improvement work is tracked in the
-[background jobs and API roadmap](../../roadmap/background-jobs-api.md).
-
-## Approved change contract — 0.7.0 data I/O API
-
-Remaining server API improvement work is tracked in the
-[background jobs and API roadmap](../../roadmap/background-jobs-api.md).
-
-- `src/haute/routes/files.py` stops serving `/api/formats`; registry capability serving moves to
-  a focused `src/haute/routes/io_capabilities.py`. Add the exact versioned Pydantic response and
-  corresponding frontend guard.
-- Add `src/haute/routes/input_cache.py`, backed by the source-cache store and the existing
-  background-job/concurrency primitives. Build requests validate a retained `DataInputConfig`,
-  compute its redacted identity, enforce provider/build capability, then return `202` with job
-  id. Status/cancel are job-id addressed; snapshot status/clear are identity addressed through a
-  validated source descriptor rather than an arbitrary filesystem path.
-- In `src/haute/routes/databricks.py`, retain workspace browse endpoints and delete fetch,
-  progress, cache-status, and cache-delete endpoints after callers migrate.
-- Rename the explicit sink handler in `src/haute/routes/pipeline.py` to
-  `/api/pipeline/write-output`; validate exactly `NodeType.DATA_OUTPUT` and dispatch the unified
-  executor. Delete the legacy route and dual-type condition.
-- `src/haute/schemas.py` adds `IoCapabilitiesResponse`, input-cache job/request/status models, and
-  unified output-write request/response models. Stable error codes cover unsupported capability,
-  snapshot required/missing/stale/corrupt, build rejected/cancelled, secret-bearing config, and
-  unsupported publication. Guards reject unknown schema versions and malformed discriminants.
-- Route tests cover response-model exactness, same-key single flight, independent-key
-  concurrency, cancel/finish races, timeout ownership, safe errors/redaction, path containment,
-  unsaved graph execution, and removed route 404s. OpenAPI/frontend contract fixtures update in
-  the same batch.
-
-## I/O diagnostics and overwrite choice
-
-- `WriteOutputRequest` adds `overwrite: StrictBool = False`; the route forwards it
-  as a keyword argument to `write_data_output`.
-- `POST /api/pipeline/output-destination` accepts the current graph and output
-  node id, performs the same flattening, node/config validation, containment,
-  default-extension, and bare-name resolution as the write route, and returns
-  only the safe display path, format, and suffix-mismatch flag. It never
-  executes the graph or touches the destination.
-- `DataOutputDestinationExistsError` is caught before the generic sink failure
-  branch and translated to 409. Its public text is constructed from
-  `resolve_data_output_path`'s display path, never the absolute resolved path.
-- Unsupported create-only publication is returned with a safe actionable
-  detail. A post-publication directory-sync failure has its own safe response
-  explicitly stating that the artifact was published but durability could not
-  be confirmed.
-- `ApiInputSchemaError` opts into the stable public-contract adapter and maps to
-  422 across preview/write execution; JSON cache routes retain their existing
-  schema-error discriminator envelope.
-- `browse_files(extensions: str | None = None)` resolves omitted extensions
-  through the registry and delegates enumeration through
-  `run_in_threadpool`.
-- `get_schema` catches `UnsupportedSourceFormatError` and
-  `polars.exceptions.PolarsError` as expected 400-class input failures with
-  static safe details. It retains the generic sanitised `ValueError` and 500
-  branches, including `exc_info=True`.
 
 ## Approved change contract — canonical-only API payloads
 

--- a/docs/specs/server-api/low-level.md
+++ b/docs/specs/server-api/low-level.md
@@ -210,9 +210,10 @@ crash. Every filesystem event batches into `pending_changes`; a 300ms debounce t
 4. Classifies each remaining `.py`/`.json` change: `config/*.json` → re-parse every
    discovered pipeline; `modules/*.py` → re-parse only pipelines importing that module stem
    (case-insensitively, via `_module_dep_key`); any other `.py` (excluding `utility/` and
-   dunder-prefixed files) → re-parse that pipeline directly. Only this direct-source class
-   invalidates the pipeline name→path index before discovery; module and config changes do
-   not discard an otherwise valid index.
+   dunder-prefixed files) → re-parse that pipeline directly when added/modified. Any direct
+   pipeline `.py` addition, modification, or deletion invalidates the pipeline name→path
+   index before discovery; a deletion is not reparsed. Module and config changes (including
+   deletion) do not discard an otherwise valid pipeline index.
 5. For each changed pipeline: hash raw bytes first (cheap) and skip the parse entirely if the
    byte hash is unchanged *and* the change wasn't dependency-triggered (a module/config
    change always re-parses even if this pipeline's own bytes are unchanged, since its
@@ -221,9 +222,11 @@ crash. Every filesystem event batches into `pending_changes`; a 300ms debounce t
    `parse.error` and evict the stale fingerprint so the next successful parse re-broadcasts
    even if the bytes happen to match a previous good state.
 6. If the flush body itself raises, the *entire* processed batch is requeued and `_flush`
-   retries it in the same task at most three times with exponential backoff. Exhaustion logs
-   `file_watcher_flush_abandoned` and leaves the paths in `pending_changes` for the next
-   filesystem event; it does not recursively schedule another flush task.
+   retries it in the same task at most three times with exponential backoff. Cancellation
+   after snapshotting also requeues the batch. On exhaustion, `_flush` removes that batch
+   from `pending_changes`, tries each change once in isolation so healthy paths still
+   broadcast, and logs/drops each still-failing event. A later event for a dropped path is a
+   fresh attempt; no retry task is recursively scheduled.
 
 **Pipeline save (`SavePipelineService.save`)**, run inside the process-wide `save_lock` (an
 `asyncio.Lock`, so it serialises against concurrent submodel create/dissolve as well as
@@ -336,11 +339,13 @@ until the worker actually exits.
   other out of order. Each send (and each stalled-client close) has a hard 1-second timeout;
   a timeout marks the client dead and discards it rather than blocking the whole fan-out.
 - **The pipeline index has three lifecycle mutation points**: startup priming, watcher
-  invalidation for a direct pipeline `.py` change, and invalidation after a successful save.
+  invalidation for a direct pipeline `.py` add/modify/delete, and invalidation after a
+  successful save.
   `_ensure_pipeline_index()` uses double-checked locking so concurrent cold-cache readers
-  never scan twice. The module-dependency twin uses the same lock and publishes its complete
-  map only while holding it, so an invalidator that arrives during a build cannot be
-  overwritten by that stale build.
+  never scan twice. The module-dependency twin uses a dedicated single-builder lock and
+  snapshots the pipeline-index generation; it publishes only if that generation is still
+  current, otherwise it rescans. Invalidators therefore remain short and a stale in-flight
+  dependency scan cannot overwrite them.
 - **Module-dependency keys are casefolded** (`_module_dep_key`) because the build side
   derives a module stem from a `pipeline.submodel("modules/<name>.py")` *source literal*
   while the watcher derives it from an *on-disk filename* — on case-insensitive filesystems

--- a/src/haute/_json_shred.py
+++ b/src/haute/_json_shred.py
@@ -848,7 +848,10 @@ def shred_to_buffers(
         # shape — but COUNT it (W2 item 2.7): a mixed array loses that element's
         # row for this table, and the loss must be surfaced, never silent.
         for label, col_specs in tables_by_pos.get(pos, []):
-            is_scalar_table = any(leaf == _SCALAR_VALUE_LEAF for _n, leaf, _t, _d in col_specs)
+            is_scalar_table = any(
+                leaf == _SCALAR_VALUE_LEAF and source_depth == depth
+                for _n, leaf, _t, source_depth in col_specs
+            )
             shape_matches = is_scalar if is_scalar_table else is_dict
             if not shape_matches:
                 _count_row_skip(label)
@@ -881,7 +884,10 @@ def shred_to_buffers(
                 # $value resolves to None; ancestor columns still distribute), a
                 # non-record for an object table (counted as a dropped row).
                 for label, col_specs in tables_by_pos.get(pos, []):
-                    if any(leaf == _SCALAR_VALUE_LEAF for _n, leaf, _t, _d in col_specs):
+                    if any(
+                        leaf == _SCALAR_VALUE_LEAF and source_depth == depth
+                        for _n, leaf, _t, source_depth in col_specs
+                    ):
                         buffers[label].append(_emit_row(col_specs, None, ancestors, depth))
                     else:
                         _count_row_skip(label)
@@ -1221,12 +1227,11 @@ def build_per_port_cache(
     dp = Path(data_path)
     cd = Path(cache_dir)
 
-    table_specs = _emitting_table_specs(v2_config)
-    # A build has one source identity. Reuse this exact, double-stat-verified
-    # signature for the no-op decision and for a possible new meta.json.
-    data_file_sig = _data_file_signature(dp)
-
     with _build_lock_for(cd):
+        table_specs = _emitting_table_specs(v2_config)
+        # A build has one source identity. Reuse this exact, double-stat-
+        # verified signature for the no-op decision and a possible new meta.json.
+        data_file_sig = _data_file_signature(dp)
         # No-op trapdoor: if the existing meta.json's fingerprint matches the
         # current v2 schema, the recorded source signature still matches, and
         # every expected parquet matches its signed manifest entry and footer

--- a/src/haute/_node_apply.py
+++ b/src/haute/_node_apply.py
@@ -356,6 +356,7 @@ def assemble_output_from_config(
     from haute._output_assembler import (
         OutputMappingSchemaError,
         assemble_output_from_mapping,
+        is_active_mapping_entry,
     )
 
     if mapping is None:
@@ -368,7 +369,7 @@ def assemble_output_from_config(
     names = list(source_names) if source_names is not None else []
     frames: dict[str, _Frame] = dict(zip(names, positional, strict=False))
     frames.update(named)
-    referenced_ports = {e["source_port"] for e in mapping if e["enabled"]}
+    referenced_ports = {e["source_port"] for e in mapping if is_active_mapping_entry(e)}
     incoming = positional + list(named.values())
     if len(incoming) == 1 and referenced_ports:
         frames = {port: incoming[0] for port in referenced_ports}

--- a/src/haute/_output_assembler.py
+++ b/src/haute/_output_assembler.py
@@ -602,7 +602,14 @@ def is_active_mapping_entry(entry: dict[str, Any]) -> bool:
     """
     if not entry["enabled"]:
         return False
-    return bool(entry["source_column"].strip()) and bool(entry["output_path"].strip())
+    source_column = entry.get("source_column", "")
+    output_path = entry.get("output_path", "")
+    return (
+        isinstance(source_column, str)
+        and isinstance(output_path, str)
+        and bool(source_column.strip())
+        and bool(output_path.strip())
+    )
 
 
 def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
@@ -625,11 +632,10 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
     """
     by_port: dict[str, list[tuple[str, str]]] = {}
     parsed_by_path: dict[str, _ParsedPath] = {}
-    parse_output_path = _parse_output_path
 
     def _cached_parse(path: str) -> _ParsedPath:
         if path not in parsed_by_path:
-            parsed_by_path[path] = parse_output_path(path)
+            parsed_by_path[path] = _parse_output_path(path)
         return parsed_by_path[path]
 
     for entry in mapping:
@@ -652,11 +658,11 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
 
         distinct = sorted(
             dict.fromkeys(path for _, path in entries),
-            key=lambda path: parsed_by_path[path].segments,
+            key=lambda path: _cached_parse(path).segments,
         )
         for a, b in zip(distinct, distinct[1:], strict=False):
-            a_segments = parsed_by_path[a].segments
-            b_segments = parsed_by_path[b].segments
+            a_segments = _cached_parse(a).segments
+            b_segments = _cached_parse(b).segments
             if a_segments == b_segments[: len(a_segments)]:
                 raise OutputMappingSchemaError(
                     "output paths within a source frame must be pairwise "
@@ -665,7 +671,7 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
                     output_path=f"{a} vs {b}",
                 )
 
-        prefixes = [(path, _array_prefix(parsed_by_path[path])) for path in distinct]
+        prefixes = [(path, _array_prefix(_cached_parse(path))) for path in distinct]
         prefixes.sort(key=lambda item: item[1])
         for (a, a_prefix), (b, b_prefix) in zip(prefixes, prefixes[1:], strict=False):
             if not (a_prefix[: len(b_prefix)] == b_prefix or b_prefix[: len(a_prefix)] == a_prefix):

--- a/src/haute/_output_assembler.py
+++ b/src/haute/_output_assembler.py
@@ -24,7 +24,6 @@ Vocabulary (kept to tables / fields / join-constraints throughout):
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from itertools import combinations
 from typing import Any
 
 import polars as pl
@@ -446,7 +445,7 @@ def _assemble_document(field_frames: dict[str, pl.LazyFrame]) -> list[Any]:
             for port in parent_ports + child_ports:
                 for row in rows_by_port[port]:
                     for key in relation_keys:
-                        if row.get(key) is None:
+                        if key in row and row[key] is None:
                             raise OutputNestingKeyError(
                                 "a parent-to-child nesting key cannot be null",
                                 frame=port,
@@ -590,19 +589,6 @@ def _execute_plan(
 # ---------------------------------------------------------------------------
 
 
-def _prefix_comparable(a: str, b: str) -> bool:
-    """True if one output path's segments are a prefix of the other's (or equal).
-
-    Prefix-comparable paths put a value both *at* a slot and *inside* it — the
-    one would be a leaf, the other its enveloping container — which is not
-    acceptable JSON (§1.1). Within one source frame that is rejected (B1).
-    """
-    sa = _parse_output_path(a).segments
-    sb = _parse_output_path(b).segments
-    n = min(len(sa), len(sb))
-    return sa[:n] == sb[:n]
-
-
 def is_active_mapping_entry(entry: dict[str, Any]) -> bool:
     """Whether a mapping entry contributes — enabled AND fully filled in.
 
@@ -629,18 +615,28 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
     * **injectivity** — within one source frame, no two *different* columns map to
       the same path (§1.2);
     * **pairwise prefix-incomparability** — within one source frame, no two
-      distinct paths are prefix-comparable (B1, :func:`_prefix_comparable`).
+      distinct paths are prefix-comparable (B1);
+    * **one output branch per frame** — every path for one source frame has a
+      prefix-comparable array prefix.
 
     Type-consistency across a shared path (§1.3) is **not** checked here — it
     needs the input frames' column types, which the caller supplies separately at
     assemble/save time.
     """
     by_port: dict[str, list[tuple[str, str]]] = {}
+    parsed_by_path: dict[str, _ParsedPath] = {}
+    parse_output_path = _parse_output_path
+
+    def _cached_parse(path: str) -> _ParsedPath:
+        if path not in parsed_by_path:
+            parsed_by_path[path] = parse_output_path(path)
+        return parsed_by_path[path]
+
     for entry in mapping:
         if not is_active_mapping_entry(entry):
             continue
         path = entry["output_path"]
-        _parse_output_path(path)  # grammar — raises on a rejected selector
+        _cached_parse(path)  # grammar — raises on a rejected selector
         by_port.setdefault(entry["source_port"], []).append((entry["source_column"], path))
 
     for port, entries in by_port.items():
@@ -654,9 +650,14 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
                 )
             path_to_col[path] = col
 
-        distinct = list(dict.fromkeys(path for _, path in entries))
-        for a, b in combinations(distinct, 2):
-            if _prefix_comparable(a, b):
+        distinct = sorted(
+            dict.fromkeys(path for _, path in entries),
+            key=lambda path: parsed_by_path[path].segments,
+        )
+        for a, b in zip(distinct, distinct[1:], strict=False):
+            a_segments = parsed_by_path[a].segments
+            b_segments = parsed_by_path[b].segments
+            if a_segments == b_segments[: len(a_segments)]:
                 raise OutputMappingSchemaError(
                     "output paths within a source frame must be pairwise "
                     "prefix-incomparable (a leaf cannot also be a container)",
@@ -664,8 +665,9 @@ def validate_v2_output_mapping(mapping: list[dict[str, Any]]) -> None:
                     output_path=f"{a} vs {b}",
                 )
 
-        prefixes = [(path, _array_prefix(_parse_output_path(path))) for path in distinct]
-        for (a, a_prefix), (b, b_prefix) in combinations(prefixes, 2):
+        prefixes = [(path, _array_prefix(parsed_by_path[path])) for path in distinct]
+        prefixes.sort(key=lambda item: item[1])
+        for (a, a_prefix), (b, b_prefix) in zip(prefixes, prefixes[1:], strict=False):
             if not (a_prefix[: len(b_prefix)] == b_prefix or b_prefix[: len(a_prefix)] == a_prefix):
                 raise OutputMappingSchemaError(
                     "one source frame cannot emit into divergent array branches",

--- a/src/haute/routes/_helpers.py
+++ b/src/haute/routes/_helpers.py
@@ -558,11 +558,11 @@ async def broadcast(data: dict[str, Any]) -> None:
 # Lightweight index: pipeline_name → file_path.
 #
 # Lifecycle:
-#   1. Populated at server startup by ``haute.server._lifespan``.
-#   2. Rebuilt on file-watcher events by ``haute.server._file_watcher``, which
-#      is the *only* production caller of ``invalidate_pipeline_index``.
-# No other production code path is allowed to clear or rebuild the index —
-# doing so reintroduces the "two sources of truth" race the review flagged.
+#   1. Primed at server startup by ``haute.server._lifespan``.
+#   2. Invalidated by the file watcher for direct pipeline-source changes.
+#   3. Invalidated after ``SavePipelineService`` commits a successful save.
+# Other production code paths must treat the cache as read-only; adding an
+# uncoordinated writer would reintroduce the race the review flagged.
 #
 # The lock below serialises the rebuild path so two concurrent readers that
 # both observe a cold cache cannot scan the filesystem twice.  The swap at
@@ -576,11 +576,10 @@ _pipeline_index_lock = threading.Lock()
 def invalidate_pipeline_index() -> None:
     """Clear the cached pipeline name→path index.
 
-    Intended to be called **only** from the file-watcher in
-    ``haute.server._file_watcher``.  All other production code paths must
-    treat the cache as read-only — startup + watcher are the two — and only
-    two — legitimate writers.  Test suites are free to poke this directly
-    to set up fresh state between tests.
+    Production callers are the file watcher (for direct source changes) and
+    ``SavePipelineService`` after a successful commit. All other production
+    code paths must treat the cache as read-only. Test suites may call this
+    directly to establish fresh state.
     """
     global _pipeline_index, _module_deps
     with _pipeline_index_lock:
@@ -673,30 +672,38 @@ def _ensure_module_deps() -> dict[str, set[Path]]:
 
     Scans each pipeline source for ``pipeline.submodel("...")`` calls and
     maps the module file stem to the set of pipeline files that reference it.
+    The shared index lock serialises this builder with invalidation so a stale
+    in-flight scan cannot republish itself after a watcher event clears it.
     """
     global _module_deps
-    if _module_deps is not None:
-        return _module_deps
+    cached = _module_deps
+    if cached is not None:
+        return cached
 
     import ast
 
-    deps: dict[str, set[Path]] = {}
-    for f in discover_pipelines():
-        try:
-            source = read_user_text(f)
-            tree = ast.parse(source)
-        except Exception as exc:
-            logger.warning("module_deps_parse_failed", file=f.name, error=str(exc))
-            continue
+    with _pipeline_index_lock:
+        cached = _module_deps
+        if cached is not None:
+            return cached
 
-        from haute._parser_submodels import extract_submodel_calls
+        deps: dict[str, set[Path]] = {}
+        for f in discover_pipelines():
+            try:
+                source = read_user_text(f)
+                tree = ast.parse(source)
+            except Exception as exc:
+                logger.warning("module_deps_parse_failed", file=f.name, error=str(exc))
+                continue
 
-        for rel_path in extract_submodel_calls(tree):
-            module_stem = Path(rel_path).stem
-            deps.setdefault(_module_dep_key(module_stem), set()).add(f)
+            from haute._parser_submodels import extract_submodel_calls
 
-    _module_deps = deps
-    return _module_deps
+            for rel_path in extract_submodel_calls(tree):
+                module_stem = Path(rel_path).stem
+                deps.setdefault(_module_dep_key(module_stem), set()).add(f)
+
+        _module_deps = deps
+        return deps
 
 
 def pipelines_importing_module(module_stem: str) -> list[Path]:

--- a/src/haute/routes/_helpers.py
+++ b/src/haute/routes/_helpers.py
@@ -559,7 +559,7 @@ async def broadcast(data: dict[str, Any]) -> None:
 #
 # Lifecycle:
 #   1. Primed at server startup by ``haute.server._lifespan``.
-#   2. Invalidated by the file watcher for direct pipeline-source changes.
+#   2. Invalidated by the file watcher for direct pipeline-source add/modify/delete.
 #   3. Invalidated after ``SavePipelineService`` commits a successful save.
 # Other production code paths must treat the cache as read-only; adding an
 # uncoordinated writer would reintroduce the race the review flagged.
@@ -571,20 +571,22 @@ async def broadcast(data: dict[str, Any]) -> None:
 # the previous dict or the new dict, never a half-populated one.
 _pipeline_index: dict[str, Path] | None = None
 _pipeline_index_lock = threading.Lock()
+_pipeline_index_generation = 0
 
 
 def invalidate_pipeline_index() -> None:
     """Clear the cached pipeline name→path index.
 
-    Production callers are the file watcher (for direct source changes) and
-    ``SavePipelineService`` after a successful commit. All other production
-    code paths must treat the cache as read-only. Test suites may call this
-    directly to establish fresh state.
+    Production callers are the file watcher (for direct source additions,
+    modifications, and deletions) and ``SavePipelineService`` after a successful
+    commit. All other production code paths must treat the cache as read-only.
+    Test suites may call this directly to establish fresh state.
     """
-    global _pipeline_index, _module_deps
+    global _pipeline_index, _pipeline_index_generation, _module_deps
     with _pipeline_index_lock:
         _pipeline_index = None
         _module_deps = None
+        _pipeline_index_generation += 1
 
 
 def _ensure_pipeline_index() -> dict[str, Path]:
@@ -652,6 +654,7 @@ def discover_pipelines() -> list[Path]:
 # Module dependency map: module_stem → set of pipeline Paths that import it
 # ---------------------------------------------------------------------------
 _module_deps: dict[str, set[Path]] | None = None
+_module_deps_lock = threading.Lock()
 
 
 def _module_dep_key(module_stem: str) -> str:
@@ -672,8 +675,9 @@ def _ensure_module_deps() -> dict[str, set[Path]]:
 
     Scans each pipeline source for ``pipeline.submodel("...")`` calls and
     maps the module file stem to the set of pipeline files that reference it.
-    The shared index lock serialises this builder with invalidation so a stale
-    in-flight scan cannot republish itself after a watcher event clears it.
+    A dedicated build lock coalesces concurrent scans without blocking pipeline
+    index invalidation. The builder snapshots the index generation and publishes
+    only if it is unchanged; otherwise it rescans before returning.
     """
     global _module_deps
     cached = _module_deps
@@ -682,28 +686,39 @@ def _ensure_module_deps() -> dict[str, set[Path]]:
 
     import ast
 
-    with _pipeline_index_lock:
-        cached = _module_deps
-        if cached is not None:
-            return cached
+    with _module_deps_lock:
+        while True:
+            with _pipeline_index_lock:
+                cached = _module_deps
+                if cached is not None:
+                    return cached
+                build_generation = _pipeline_index_generation
 
-        deps: dict[str, set[Path]] = {}
-        for f in discover_pipelines():
-            try:
-                source = read_user_text(f)
-                tree = ast.parse(source)
-            except Exception as exc:
-                logger.warning("module_deps_parse_failed", file=f.name, error=str(exc))
-                continue
+            deps: dict[str, set[Path]] = {}
+            for f in discover_pipelines():
+                try:
+                    source = read_user_text(f)
+                    tree = ast.parse(source)
+                except Exception as exc:
+                    logger.warning("module_deps_parse_failed", file=f.name, error=str(exc))
+                    continue
 
-            from haute._parser_submodels import extract_submodel_calls
+                from haute._parser_submodels import extract_submodel_calls
 
-            for rel_path in extract_submodel_calls(tree):
-                module_stem = Path(rel_path).stem
-                deps.setdefault(_module_dep_key(module_stem), set()).add(f)
+                for rel_path in extract_submodel_calls(tree):
+                    module_stem = Path(rel_path).stem
+                    deps.setdefault(_module_dep_key(module_stem), set()).add(f)
 
-        _module_deps = deps
-        return deps
+            with _pipeline_index_lock:
+                if build_generation != _pipeline_index_generation:
+                    logger.debug(
+                        "module_deps_rebuild_restarted",
+                        build_generation=build_generation,
+                        current_generation=_pipeline_index_generation,
+                    )
+                    continue
+                _module_deps = deps
+                return deps
 
 
 def pipelines_importing_module(module_stem: str) -> list[Path]:

--- a/src/haute/routes/_supersession.py
+++ b/src/haute/routes/_supersession.py
@@ -121,6 +121,15 @@ class SupersessionCoordinator:
                             cancel_active,
                         )
 
+                if worker_error is not None:
+                    # A timeout that leaves blocking work running carries the
+                    # background future which owns the route's deferred
+                    # execution-context cleanup. Never replace that exception
+                    # with a 409: the route must see it to keep cache leases and
+                    # admission held until the worker really exits.
+                    if deferred_limiter_release is not None:
+                        raise worker_error
+
                 async with state.condition:
                     if generation != state.latest_generation:
                         raise SupersededRequestError(message)

--- a/src/haute/routes/output_assemble.py
+++ b/src/haute/routes/output_assemble.py
@@ -116,6 +116,7 @@ async def output_assemble_dry_run(
             operation="output_assemble_dry_run",
             profile=ExecutionProfile.PREVIEW_EAGER,
         )
+        admitted_context = context
 
         def _run() -> dict[str, Any]:
             return execute_graph(
@@ -124,7 +125,7 @@ async def output_assemble_dry_run(
                 row_limit=body.row_limit,
                 source=body.source,
                 target_preview_only=True,
-                execution_context=context,
+                execution_context=admitted_context,
             )
 
         results = await run_blocking_with_response_timeout(

--- a/src/haute/routes/output_assemble.py
+++ b/src/haute/routes/output_assemble.py
@@ -41,7 +41,7 @@ from haute.routes._timeouts import (
     BlockingWorkTimeoutError,
     run_blocking_with_response_timeout,
 )
-from haute.routes.pipeline import _validate_runtime_input_paths
+from haute.routes.pipeline import _memory_limit_http_exception, _validate_runtime_input_paths
 from haute.schemas import Graph
 
 logger = get_logger(component="server.output_assemble")
@@ -110,28 +110,35 @@ async def output_assemble_dry_run(
 
     # 3. Run up to the OUTPUT node. The render points prune the assembled frame,
     #    so ``preview`` is the response document.
-    context = create_admitted_execution_context(
-        operation="output_assemble_dry_run",
-        profile=ExecutionProfile.PREVIEW_EAGER,
-    )
-
-    def _run() -> dict[str, Any]:
-        return execute_graph(
-            graph,
-            target_node_id=body.node_id,
-            row_limit=body.row_limit,
-            source=body.source,
-            target_preview_only=True,
-            execution_context=context,
+    context = None
+    try:
+        context = create_admitted_execution_context(
+            operation="output_assemble_dry_run",
+            profile=ExecutionProfile.PREVIEW_EAGER,
         )
 
-    try:
+        def _run() -> dict[str, Any]:
+            return execute_graph(
+                graph,
+                target_node_id=body.node_id,
+                row_limit=body.row_limit,
+                source=body.source,
+                target_preview_only=True,
+                execution_context=context,
+            )
+
         results = await run_blocking_with_response_timeout(
             _run,
             timeout=_dry_run_timeout(),
             operation="output_assemble_dry_run",
         )
     except BlockingWorkTimeoutError as exc:
+        if context is not None:
+            timed_out_context = context
+            exc.background_task.add_done_callback(
+                lambda _future: timed_out_context.release_admission()
+            )
+            context = None
         raise HTTPException(status_code=504, detail="Output dry-run timed out") from exc
     except PUBLIC_CONTRACT_ERROR_TYPES as exc:
         raise contract_error_http_exception(exc) from None
@@ -141,20 +148,24 @@ async def output_assemble_dry_run(
     except (ConfigError, ContractMismatchError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except ExecutionAdmissionError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise _memory_limit_http_exception(exc) from None
     except HTTPException:
         raise
     except Exception:
         logger.exception("output_assemble_dry_run failed")
         raise HTTPException(status_code=500, detail=_INTERNAL_ERROR_DETAIL) from None
 
-    node_result = results.get(body.node_id)
-    if node_result is None or node_result.status != "ok":
-        detail = (node_result.error if node_result else None) or "Assembly failed"
-        return OutputAssembleDryRunResponse(status="error", error=detail)
+    else:
+        node_result = results.get(body.node_id)
+        if node_result is None or node_result.status != "ok":
+            detail = (node_result.error if node_result else None) or "Assembly failed"
+            return OutputAssembleDryRunResponse(status="error", error=detail)
 
-    return OutputAssembleDryRunResponse(
-        status="ok",
-        document=node_result.preview,
-        row_count=node_result.row_count,
-    )
+        return OutputAssembleDryRunResponse(
+            status="ok",
+            document=node_result.preview,
+            row_count=node_result.row_count,
+        )
+    finally:
+        if context is not None:
+            context.release_admission(preserve_primary_error=True)

--- a/src/haute/routes/pipeline.py
+++ b/src/haute/routes/pipeline.py
@@ -427,22 +427,29 @@ async def get_first_pipeline() -> PipelineGraph:
     """
     cwd = Path.cwd()
 
-    def _find_first() -> PipelineGraph:
+    def _find_first() -> tuple[PipelineGraph | None, str | None]:
         best: PipelineGraph | None = None
+        first_parse_error: str | None = None
         for f in discover_pipelines():
             try:
                 graph = parse_pipeline_to_graph(f)
                 graph.source_file = str(f.relative_to(cwd))
                 if graph.nodes:
-                    return graph
+                    return graph, None
                 if best is None:
                     best = graph
             except Exception as e:
                 logger.warning("parse_failed", file=f.name, error=str(e))
-                continue
-        return best or PipelineGraph()
+                if first_parse_error is None:
+                    first_parse_error = str(e)
+        return best, first_parse_error
 
-    return await asyncio.to_thread(_find_first)
+    graph, parse_error = await asyncio.to_thread(_find_first)
+    if graph is not None:
+        return graph
+    if parse_error is not None:
+        raise HTTPException(status_code=422, detail=parse_error)
+    return PipelineGraph()
 
 
 @router.post("/pipeline/save", response_model=SavePipelineResponse)

--- a/src/haute/server.py
+++ b/src/haute/server.py
@@ -674,16 +674,28 @@ async def _file_watcher() -> None:
     debounce_task: asyncio.Task[None] | None = None
     completed_normally = False
 
-    async def _flush_once() -> None:
-        """Parse and broadcast one pending watcher batch."""
-        to_process: set[tuple[Change, str]] = set()
-        try:
-            # Snapshot and clear before processing so new events can queue
-            # independently. If a higher-level flush failure happens below,
-            # we requeue this batch and schedule a retry.
-            to_process = set(pending_changes)
-            pending_changes.clear()
+    class _FlushBatchError(Exception):
+        """One watcher batch failed before it could be processed."""
 
+        def __init__(
+            self,
+            cause: Exception,
+            changes: set[tuple[Change, str]],
+        ) -> None:
+            super().__init__(str(cause))
+            self.cause = cause
+            self.changes = changes
+
+    async def _flush_once(
+        changes: set[tuple[Change, str]] | None = None,
+        *,
+        requeue_on_error: bool = True,
+    ) -> None:
+        """Parse and broadcast one pending watcher batch."""
+        to_process = set(pending_changes) if changes is None else set(changes)
+        if changes is None:
+            pending_changes.clear()
+        try:
             # S30: drop everything that arrived while a haute-initiated git op
             # holds the watcher pause. A move/checkout replaces the tree
             # wholesale, so those events are not user edits and must not be
@@ -696,6 +708,7 @@ async def _file_watcher() -> None:
             # Collect changed files from pending set
             changed_files: dict[str, tuple[Path, bool]] = {}
             direct_py_changes: list[Path] = []
+            direct_index_changed = False
             module_stems: list[str] = []
             config_changed = False
             self_write_keys: set[str] = set()
@@ -706,7 +719,7 @@ async def _file_watcher() -> None:
                     self_write_keys.add(key)
                     logger.debug("file_watcher_skipped_self_write", file=str(p))
                     continue
-                if change_type not in (Change.modified, Change.added):
+                if change_type not in (Change.modified, Change.added, Change.deleted):
                     continue
                 # JSON config files in config/ directory
                 if p.suffix == ".json" and config_dir.is_dir() and p.is_relative_to(config_dir):
@@ -721,13 +734,19 @@ async def _file_watcher() -> None:
                 if modules_dir.is_dir() and p.is_relative_to(modules_dir):
                     module_stems.append(p.stem)
                 else:
-                    direct_py_changes.append(p)
+                    # Deletions must invalidate the name→path index but must not
+                    # be reparsed. A rename is normally a deleted+added pair:
+                    # the added path below is the only one broadcast.
+                    direct_index_changed = True
+                    if change_type != Change.deleted:
+                        direct_py_changes.append(p)
 
             known_pipelines: dict[str, Path] = {}
             if direct_py_changes:
-                # Only direct pipeline-source edits can add, remove, or rename
-                # an indexed pipeline or change its module dependencies.
                 known_pipelines = _known_pipeline_paths()
+            if direct_index_changed:
+                # Direct pipeline-source additions, modifications, deletions,
+                # and renames can change index membership or dependencies.
                 invalidate_pipeline_index()
 
             discovered_pipelines: dict[str, Path] | None = None
@@ -810,9 +829,14 @@ async def _file_watcher() -> None:
                             "source_file": _wire_source_file(p),
                         },
                     )
-        except Exception:  # noqa: BLE001
-            pending_changes.update(to_process)
+        except asyncio.CancelledError:
+            if requeue_on_error:
+                pending_changes.update(to_process)
             raise
+        except Exception as exc:  # noqa: BLE001
+            if requeue_on_error:
+                pending_changes.update(to_process)
+            raise _FlushBatchError(exc, to_process) from exc
 
     async def _flush() -> None:
         """Debounce, then retry one batch with a bounded exponential backoff."""
@@ -823,19 +847,50 @@ async def _file_watcher() -> None:
                 return
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:  # noqa: BLE001
+            except _FlushBatchError as exc:
                 logger.error(
                     "file_watcher_flush_failed",
-                    error=str(exc),
+                    error=str(exc.cause),
                     traceback=traceback.format_exc(),
-                    requeued_changes=len(pending_changes),
+                    requeued_changes=len(exc.changes),
                     attempt=attempt + 1,
                 )
                 if attempt >= _WATCHER_FLUSH_MAX_RETRIES:
+                    # Do not retain a poisoned batch forever. Isolate it once
+                    # so healthy siblings still reach the canvas, then log and
+                    # drop only the changes that remain broken. A later event
+                    # for a dropped path is a fresh attempt.
+                    pending_changes.difference_update(exc.changes)
+                    ordered_changes = sorted(
+                        exc.changes,
+                        key=lambda item: (str(item[1]), str(item[0])),
+                    )
+                    recovered_changes = 0
+                    quarantined_changes = 0
+                    for index, change in enumerate(ordered_changes):
+                        try:
+                            await _flush_once({change}, requeue_on_error=False)
+                        except asyncio.CancelledError:
+                            pending_changes.update(ordered_changes[index:])
+                            raise
+                        except _FlushBatchError as isolated_exc:
+                            quarantined_changes += 1
+                            change_type, changed_path = change
+                            logger.error(
+                                "file_watcher_change_quarantined",
+                                file=changed_path,
+                                change_type=getattr(change_type, "name", str(change_type)),
+                                error=str(isolated_exc.cause),
+                                traceback=traceback.format_exc(),
+                            )
+                        else:
+                            recovered_changes += 1
                     logger.error(
                         "file_watcher_flush_abandoned",
                         attempts=attempt + 1,
-                        pending_changes=len(pending_changes),
+                        batch_changes=len(exc.changes),
+                        recovered_changes=recovered_changes,
+                        quarantined_changes=quarantined_changes,
                     )
                     return
                 retry_delay = _WATCHER_FLUSH_RETRY_BASE_SECONDS * (2**attempt)

--- a/src/haute/server.py
+++ b/src/haute/server.py
@@ -106,6 +106,8 @@ logger = get_logger(component="server")
 _watcher_task: asyncio.Task | None = None
 _optimiser_reaper_task: asyncio.Task[None] | None = None
 _WATCHER_RESTART_DELAY_SECONDS = 0.1
+_WATCHER_FLUSH_MAX_RETRIES = 3
+_WATCHER_FLUSH_RETRY_BASE_SECONDS = 0.1
 WS_FRAME_GRAPH_UPDATE = "graph_update"
 WS_FRAME_PARSE_ERROR = "parse_error"
 
@@ -672,11 +674,8 @@ async def _file_watcher() -> None:
     debounce_task: asyncio.Task[None] | None = None
     completed_normally = False
 
-    async def _flush() -> None:
-        """Parse and broadcast after debounce window expires."""
-        nonlocal debounce_task
-        await asyncio.sleep(_DEBOUNCE_SECONDS)
-
+    async def _flush_once() -> None:
+        """Parse and broadcast one pending watcher batch."""
         to_process: set[tuple[Change, str]] = set()
         try:
             # Snapshot and clear before processing so new events can queue
@@ -724,9 +723,12 @@ async def _file_watcher() -> None:
                 else:
                     direct_py_changes.append(p)
 
-            known_pipelines = _known_pipeline_paths() if direct_py_changes else {}
-
-            invalidate_pipeline_index()
+            known_pipelines: dict[str, Path] = {}
+            if direct_py_changes:
+                # Only direct pipeline-source edits can add, remove, or rename
+                # an indexed pipeline or change its module dependencies.
+                known_pipelines = _known_pipeline_paths()
+                invalidate_pipeline_index()
 
             discovered_pipelines: dict[str, Path] | None = None
 
@@ -808,15 +810,42 @@ async def _file_watcher() -> None:
                             "source_file": _wire_source_file(p),
                         },
                     )
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             pending_changes.update(to_process)
-            logger.error(
-                "file_watcher_flush_failed",
-                error=str(exc),
-                traceback=traceback.format_exc(),
-                requeued_changes=len(to_process),
-            )
-            debounce_task = asyncio.create_task(_flush())
+            raise
+
+    async def _flush() -> None:
+        """Debounce, then retry one batch with a bounded exponential backoff."""
+        await asyncio.sleep(_DEBOUNCE_SECONDS)
+        for attempt in range(_WATCHER_FLUSH_MAX_RETRIES + 1):
+            try:
+                await _flush_once()
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "file_watcher_flush_failed",
+                    error=str(exc),
+                    traceback=traceback.format_exc(),
+                    requeued_changes=len(pending_changes),
+                    attempt=attempt + 1,
+                )
+                if attempt >= _WATCHER_FLUSH_MAX_RETRIES:
+                    logger.error(
+                        "file_watcher_flush_abandoned",
+                        attempts=attempt + 1,
+                        pending_changes=len(pending_changes),
+                    )
+                    return
+                retry_delay = _WATCHER_FLUSH_RETRY_BASE_SECONDS * (2**attempt)
+                logger.warning(
+                    "file_watcher_flush_retry_scheduled",
+                    retry=attempt + 1,
+                    max_retries=_WATCHER_FLUSH_MAX_RETRIES,
+                    retry_delay_s=retry_delay,
+                )
+                await asyncio.sleep(retry_delay)
 
     try:
         async for changes in awatch(*watch_dirs, recursive=True):

--- a/tests/docs_accuracy_baseline.txt
+++ b/tests/docs_accuracy_baseline.txt
@@ -212,10 +212,14 @@ docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	useWebS
 docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	utils/__tests__/chartHelpers.test.ts
 docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	utils/__tests__/formatTime.test.ts
 docs/specs/git-integration/low-level.md	missing-module-map-symbol	_git
-docs/specs/json-shredding/high-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
-docs/specs/json-shredding/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
-docs/specs/json-shredding/low-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
-docs/specs/json-shredding/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
+docs/specs/io-layer/high-level.md	ambiguous-repo-reference	__init__.py -> rating/utility/__init__.py, src/haute/__init__.py, src/haute/assistant/__init__.py, src/haute/cli/__init__.py, src/haute/deploy/__init__.py, src/haute/modelling/__init__.py, src/haute/routes/__init__.py, tests/__init__.py
+docs/specs/io-layer/high-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
+docs/specs/io-layer/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
+docs/specs/io-layer/low-level.md	broken-link-anchor	high-level.md#approved-change-contract-070-data-io-convergence
+docs/specs/io-layer/low-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
+docs/specs/io-layer/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
+docs/specs/io-layer/low-level.md	missing-module-map-symbol	hive_schema
+docs/specs/io-layer/low-level.md	missing-module-map-symbol	schema_overrides
 docs/specs/mlflow-model-registry/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
 docs/specs/mlflow-model-registry/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
 docs/specs/modelling/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
@@ -247,8 +251,6 @@ docs/specs/reference-pipeline/low-level.md	missing-module-map-symbol	my_pipeline
 docs/specs/reference-pipeline/low-level.md	missing-repo-reference	rating/config/expander/premium.json
 docs/specs/reference-pipeline/low-level.md	missing-repo-reference	rating/data/quotes/nest_example.json
 docs/specs/sandbox-security/low-level.md	missing-module-map-symbol	exec()
-docs/specs/server-api/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
-docs/specs/server-api/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
 docs/specs/server-api/low-level.md	missing-module-map-symbol	contract_error
 docs/specs/submodels/low-level.md	missing-module-map-symbol	SUBMODEL
 docs/specs/tracing/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)

--- a/tests/docs_accuracy_baseline.txt
+++ b/tests/docs_accuracy_baseline.txt
@@ -212,14 +212,6 @@ docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	useWebS
 docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	utils/__tests__/chartHelpers.test.ts
 docs/specs/frontend-shared/low-level.md	non-root-relative-test-reference	utils/__tests__/formatTime.test.ts
 docs/specs/git-integration/low-level.md	missing-module-map-symbol	_git
-docs/specs/io-layer/high-level.md	ambiguous-repo-reference	__init__.py -> rating/utility/__init__.py, src/haute/__init__.py, src/haute/assistant/__init__.py, src/haute/cli/__init__.py, src/haute/deploy/__init__.py, src/haute/modelling/__init__.py, src/haute/routes/__init__.py, tests/__init__.py
-docs/specs/io-layer/high-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
-docs/specs/io-layer/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
-docs/specs/io-layer/low-level.md	broken-link-anchor	high-level.md#approved-change-contract-070-data-io-convergence
-docs/specs/io-layer/low-level.md	empty-roadmap-pointer	../../roadmap/io-layer.md
-docs/specs/io-layer/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
-docs/specs/io-layer/low-level.md	missing-module-map-symbol	hive_schema
-docs/specs/io-layer/low-level.md	missing-module-map-symbol	schema_overrides
 docs/specs/mlflow-model-registry/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
 docs/specs/mlflow-model-registry/low-level.md	legacy-contract-section	Polars backend contracts (0.6.0)
 docs/specs/modelling/high-level.md	legacy-contract-section	Polars backend contracts (0.6.0)

--- a/tests/test_output_assemble_routes.py
+++ b/tests/test_output_assemble_routes.py
@@ -10,7 +10,7 @@ canonical data-model example so the route's assembled output matches the
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -233,14 +233,24 @@ def test_dry_run_releases_admission_after_success(project) -> None:
 async def test_dry_run_timeout_defers_admission_release_until_worker_finishes(project) -> None:
     _, data_path = project
     release_calls: list[bool] = []
+    execution_contexts: list[object | None] = []
+    queued_work: list[Callable[[], dict[str, Any]]] = []
     background_task: asyncio.Future[object] = asyncio.get_running_loop().create_future()
 
     class _Context:
         def release_admission(self, *, preserve_primary_error: bool = False) -> None:
             release_calls.append(preserve_primary_error)
 
-    async def _raise_timeout(*args, **kwargs):
+    context = _Context()
+
+    def _execute_graph(*args, execution_context=None, **kwargs):
         del args, kwargs
+        execution_contexts.append(execution_context)
+        return {}
+
+    async def _raise_timeout(work, **kwargs):
+        del kwargs
+        queued_work.append(work)
         raise BlockingWorkTimeoutError(
             "output_assemble_dry_run",
             1,
@@ -252,8 +262,9 @@ async def test_dry_run_timeout_defers_admission_release_until_worker_finishes(pr
     with (
         patch(
             "haute.routes.output_assemble.create_admitted_execution_context",
-            return_value=_Context(),
+            return_value=context,
         ),
+        patch("haute.routes.output_assemble.execute_graph", _execute_graph),
         patch(
             "haute.routes.output_assemble.run_blocking_with_response_timeout",
             _raise_timeout,
@@ -270,8 +281,12 @@ async def test_dry_run_timeout_defers_admission_release_until_worker_finishes(pr
                 },
             )
 
-    assert resp.status_code == 504
-    assert release_calls == []
+        assert resp.status_code == 504
+        assert release_calls == []
+        assert len(queued_work) == 1
+
+        queued_work[0]()
+        assert execution_contexts == [context]
 
     background_task.set_result(None)
     await asyncio.sleep(0)

--- a/tests/test_output_assemble_routes.py
+++ b/tests/test_output_assemble_routes.py
@@ -9,18 +9,25 @@ canonical data-model example so the route's assembled output matches the
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from haute._execution_admission import ExecutionAdmissionError
+from haute._execution_context import ExecutionProfile
 from haute._json_flatten import _json_cache_dir
 from haute._json_shred import build_per_port_cache
 from haute._sandbox import _get_project_root, set_project_root
 from haute._types import NodeType
 from haute.executor import _preview_cache
+from haute.routes._timeouts import BlockingWorkTimeoutError
+from haute.schemas import NodeResult
 from tests.test_output_nested_roundtrip import (
     _FIXTURE,
     _api_input_config,
@@ -162,3 +169,110 @@ def test_dry_run_non_output_node_returns_400(project) -> None:
         },
     )
     assert resp.status_code == 400, resp.text
+
+
+def test_dry_run_admission_refusal_returns_structured_507(project) -> None:
+    client, data_path = project
+    error = ExecutionAdmissionError(
+        "output_assemble_dry_run",
+        profile=ExecutionProfile.PREVIEW_EAGER,
+        memory_limit_bytes=1024,
+        rss_at_admission_bytes=2048,
+        reason="memory budget exhausted",
+    )
+
+    with patch(
+        "haute.routes.output_assemble.create_admitted_execution_context",
+        side_effect=error,
+    ):
+        resp = client.post(
+            "/api/output-assemble/dry-run",
+            json={
+                "graph": _graph_json(_api_input_config(data_path)),
+                "node_id": "out",
+                "output_mapping": [],
+            },
+        )
+
+    assert resp.status_code == 507
+    assert resp.json() == {"detail": error.to_payload()}
+
+
+def test_dry_run_releases_admission_after_success(project) -> None:
+    client, data_path = project
+    release_calls: list[bool] = []
+
+    class _Context:
+        def release_admission(self, *, preserve_primary_error: bool = False) -> None:
+            release_calls.append(preserve_primary_error)
+
+    with (
+        patch(
+            "haute.routes.output_assemble.create_admitted_execution_context",
+            return_value=_Context(),
+        ),
+        patch(
+            "haute.routes.output_assemble.execute_graph",
+            return_value={"out": NodeResult(status="ok", preview=[], row_count=0)},
+        ),
+    ):
+        resp = client.post(
+            "/api/output-assemble/dry-run",
+            json={
+                "graph": _graph_json(_api_input_config(data_path)),
+                "node_id": "out",
+                "output_mapping": [],
+            },
+        )
+
+    assert resp.status_code == 200
+    assert release_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_timeout_defers_admission_release_until_worker_finishes(project) -> None:
+    _, data_path = project
+    release_calls: list[bool] = []
+    background_task: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+
+    class _Context:
+        def release_admission(self, *, preserve_primary_error: bool = False) -> None:
+            release_calls.append(preserve_primary_error)
+
+    async def _raise_timeout(*args, **kwargs):
+        del args, kwargs
+        raise BlockingWorkTimeoutError(
+            "output_assemble_dry_run",
+            1,
+            background_task,
+        )
+
+    from haute.server import app
+
+    with (
+        patch(
+            "haute.routes.output_assemble.create_admitted_execution_context",
+            return_value=_Context(),
+        ),
+        patch(
+            "haute.routes.output_assemble.run_blocking_with_response_timeout",
+            _raise_timeout,
+        ),
+    ):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            resp = await client.post(
+                "/api/output-assemble/dry-run",
+                json={
+                    "graph": _graph_json(_api_input_config(data_path)),
+                    "node_id": "out",
+                    "output_mapping": [],
+                },
+            )
+
+    assert resp.status_code == 504
+    assert release_calls == []
+
+    background_task.set_result(None)
+    await asyncio.sleep(0)
+    assert release_calls == [False]

--- a/tests/test_output_assembler.py
+++ b/tests/test_output_assembler.py
@@ -17,6 +17,7 @@ import polars as pl
 import pytest
 
 from haute._jsonpath import _Seg
+from haute._node_apply import assemble_output_from_config
 from haute._output_assembler import (
     OutputMappingSchemaError,
     OutputNestingKeyError,
@@ -768,6 +769,27 @@ def test_validate_accepts_a_well_formed_mapping() -> None:
     )
 
 
+def test_validate_parses_each_distinct_active_path_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    import haute._output_assembler as assembler
+
+    original = assembler._parse_output_path
+    calls: list[str] = []
+
+    def spy(path: str):
+        calls.append(path)
+        return original(path)
+
+    monkeypatch.setattr(assembler, "_parse_output_path", spy)
+    mapping = [
+        _entry("p", f"value_{index}", f"$[:].items[:].value_{index}") for index in range(200)
+    ]
+    mapping.extend([_entry("q", "same", "$[:].items[:].value_0") for _ in range(50)])
+
+    assembler.validate_v2_output_mapping(mapping)
+
+    assert len(calls) == 200
+
+
 def test_validate_rejects_prefix_comparable_paths_within_a_port() -> None:
     # $[:].a is a strict prefix of $[:].a.b — a would be both a leaf and the
     # container of b. Rejected within one port (B1).
@@ -875,6 +897,43 @@ def test_assemble_allows_null_scalar_payload_that_is_not_a_nesting_key() -> None
         "child": pl.LazyFrame({"$[:].id": [1], "$[:].items[:].value": ["v"]}),
     }
     assert _assemble_document(frames) == [{"id": 1, "items": [{"value": "v"}]}]
+
+
+def test_assemble_ignores_absent_nesting_key_in_partial_frame() -> None:
+    frames = {
+        "a": pl.LazyFrame(
+            {
+                "$[:].quote_id": [1],
+                "$[:].drivers[:].name": ["Ann"],
+            }
+        ),
+        "b": pl.LazyFrame({"$[:].drivers[:].age": [42]}),
+    }
+
+    assert _assemble_document(frames) == [
+        {"quote_id": 1, "drivers": [{"name": "Ann"}]},
+        {"drivers": [{"age": 42}]},
+    ]
+
+
+def test_config_assembly_ignores_incomplete_enabled_mapping_port() -> None:
+    result = assemble_output_from_config(
+        pl.DataFrame({"value": [1]}),
+        pl.DataFrame({"other": [2]}),
+        config={
+            "outputMapping": [
+                {
+                    "source_port": "phantom",
+                    "source_column": "",
+                    "output_path": "",
+                    "enabled": True,
+                }
+            ]
+        },
+        source_names=["real", "other"],
+    )
+
+    assert result.collect().to_dicts() == []
 
 
 def test_assemble_indexes_child_rows_once_per_relation_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_output_assembler.py
+++ b/tests/test_output_assembler.py
@@ -968,6 +968,7 @@ def test_is_active_mapping_entry() -> None:
     assert is_active_mapping_entry(_entry("p", "", "$[:].x")) is False  # blank source_column
     assert is_active_mapping_entry(_entry("p", "x", "")) is False  # blank output_path
     assert is_active_mapping_entry(_entry("p", "x", "$[:].x", enabled=False)) is False
+    assert is_active_mapping_entry({"enabled": True}) is False
     assert (
         is_active_mapping_entry(
             {"source_port": "p", "source_column": "  ", "output_path": "$[:].x", "enabled": True}

--- a/tests/test_output_assembler.py
+++ b/tests/test_output_assembler.py
@@ -12,6 +12,7 @@ Fields are single capital letters as in the doc; ``K`` is a common parent key,
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import FrozenInstanceError
 
 import polars as pl
 import pytest
@@ -22,6 +23,7 @@ from haute._output_assembler import (
     OutputMappingSchemaError,
     OutputNestingKeyError,
     _assemble_document,
+    _Core,
     _CutPlan,
     _execute_plan,
     _gyo_residue,
@@ -53,6 +55,16 @@ def test_output_mapping_error_is_haute_error() -> None:
     assert isinstance(err, HauteError)
     assert "bad mapping" in str(err)
     assert "output_path=$.a" in str(err)
+
+
+def test_output_nesting_key_error_requires_keyword_context() -> None:
+    with pytest.raises(TypeError):
+        OutputNestingKeyError(  # type: ignore[misc]
+            "bad nesting key",
+            "frame",
+            "$[:].id",
+            "$[:].id",
+        )
 
 
 # ─── GYO core detection — α-acyclic cases (no core, nothing cut) ───
@@ -803,6 +815,15 @@ def test_validate_rejects_two_columns_on_one_path() -> None:
         validate_v2_output_mapping([_entry("p", "x", "$[:].v"), _entry("p", "y", "$[:].v")])
 
 
+def test_validate_allows_equal_nonidentical_column_names_on_one_path() -> None:
+    first = b"same_column".decode()
+    second = b"same_column".decode()
+    assert first == second
+    assert first is not second
+
+    validate_v2_output_mapping([_entry("p", first, "$[:].v"), _entry("p", second, "$[:].v")])
+
+
 def test_validate_rejects_unsupported_selector() -> None:
     with pytest.raises(OutputMappingSchemaError):
         validate_v2_output_mapping([_entry("p", "x", "$[:].drivers[0].name")])
@@ -829,6 +850,17 @@ def test_validate_rejects_divergent_array_branches_in_descending_order() -> None
     mapping = [
         _entry("p", "right_id", "$[:].right[:].id"),
         _entry("p", "left_id", "$[:].left[:].id"),
+    ]
+
+    with pytest.raises(OutputMappingSchemaError, match="divergent"):
+        validate_v2_output_mapping(mapping)
+
+
+def test_validate_checks_divergent_branches_separated_by_a_root_leaf() -> None:
+    mapping = [
+        _entry("p", "left", "$[:].aaa[:].value"),
+        _entry("p", "middle", "$[:].middle"),
+        _entry("p", "right", "$[:].zzz[:].value"),
     ]
 
     with pytest.raises(OutputMappingSchemaError, match="divergent"):
@@ -897,6 +929,54 @@ def test_assemble_allows_null_scalar_payload_that_is_not_a_nesting_key() -> None
         "child": pl.LazyFrame({"$[:].id": [1], "$[:].items[:].value": ["v"]}),
     }
     assert _assemble_document(frames) == [{"id": 1, "items": [{"value": "v"}]}]
+
+
+def test_assemble_allows_null_scalar_payload_at_a_leaf_array_level() -> None:
+    frames = {
+        "item": pl.LazyFrame(
+            {
+                "$[:].items[:].id": [1],
+                "$[:].items[:].optional": [None],
+            }
+        )
+    }
+
+    assert _assemble_document(frames) == [{"items": [{"id": 1}]}]
+
+
+@pytest.mark.parametrize(
+    ("parent_item_id", "child_item_id", "expected_frame"),
+    [(None, 7, "item"), (7, None, "detail")],
+)
+def test_assemble_rejects_null_key_across_a_synthesised_child_level(
+    parent_item_id: int | None,
+    child_item_id: int | None,
+    expected_frame: str,
+) -> None:
+    frames = {
+        "detail": pl.LazyFrame(
+            {
+                "$[:].root_id": [1],
+                "$[:].items[:].item_id": [child_item_id],
+                "$[:].items[:].subitems[:].details[:].value": ["v"],
+            }
+        ),
+        "item": pl.LazyFrame(
+            {
+                "$[:].root_id": [1],
+                "$[:].items[:].item_id": [parent_item_id],
+            }
+        ),
+    }
+
+    with pytest.raises(OutputNestingKeyError) as exc_info:
+        _assemble_document(frames)
+
+    assert exc_info.value.context == {
+        "frame": expected_frame,
+        "output_path": "$[:].items[:].item_id",
+        "key": "$[:].items[:].item_id",
+    }
 
 
 def test_assemble_ignores_absent_nesting_key_in_partial_frame() -> None:
@@ -1018,6 +1098,32 @@ def test_output_contract_excludes_blank_source_column() -> None:
 # the mutation, not merely "it still runs".
 
 
+@pytest.mark.parametrize(
+    ("record", "attribute"),
+    [
+        (
+            _Core(
+                tables=frozenset({"T"}),
+                parent_keys=frozenset(),
+                carriers=frozenset(),
+            ),
+            "tables",
+        ),
+        (
+            _CutPlan(
+                cores=(),
+                cuts=frozenset(),
+                merge_residue={"T": frozenset()},
+            ),
+            "cuts",
+        ),
+    ],
+)
+def test_cut_plan_records_are_immutable(record: object, attribute: str) -> None:
+    with pytest.raises(FrozenInstanceError):
+        setattr(record, attribute, None)
+
+
 # _merge_groups union-find — find() must reach the true root regardless of the
 # alphabetical relation between a node and its parent pointer (the '!=' loop
 # bound must not become '<' or '>'). Two single-field merges with the carriers
@@ -1122,6 +1228,62 @@ def test_assemble_synthesised_level_with_own_key_excludes_siblings() -> None:
             "other": [{"ko": "o1", "sub": [{"vo": "ov"}]}],
         }
     ]
+
+
+def test_assemble_synthesised_siblings_scope_each_root_independently() -> None:
+    field_frames = {
+        "parent": pl.LazyFrame(
+            {
+                "$[:].a_key": [101, 102],
+                "$[:].z_key": [201, 202],
+                "$[:].name": ["first", "second"],
+            }
+        ),
+        "aaa": pl.LazyFrame(
+            {
+                "$[:].a_key": [101, 102],
+                "$[:].aaa[:].sub[:].value": ["a1", "a2"],
+            }
+        ),
+        "zzz": pl.LazyFrame(
+            {
+                "$[:].z_key": [201, 202],
+                "$[:].zzz[:].sub[:].value": ["z1", "z2"],
+            }
+        ),
+    }
+
+    assert _assemble_document(field_frames) == [
+        {
+            "a_key": 101,
+            "z_key": 201,
+            "name": "first",
+            "aaa": [{"sub": [{"value": "a1"}]}],
+            "zzz": [{"sub": [{"value": "z1"}]}],
+        },
+        {
+            "a_key": 102,
+            "z_key": 202,
+            "name": "second",
+            "aaa": [{"sub": [{"value": "a2"}]}],
+            "zzz": [{"sub": [{"value": "z2"}]}],
+        },
+    ]
+
+
+def test_assemble_allows_null_payload_owned_only_by_a_child() -> None:
+    field_frames = {
+        "parent": pl.LazyFrame({"$[:].id": [1]}),
+        "child": pl.LazyFrame(
+            {
+                "$[:].id": [1],
+                "$[:].items[:].name": ["item"],
+                "$[:].items[:].optional": [None],
+            }
+        ),
+    }
+
+    assert _assemble_document(field_frames) == [{"id": 1, "items": [{"name": "item"}]}]
 
 
 # _prune loop control — the empty-collection skips are `continue`, not `break`,

--- a/tests/test_pipeline_index_cache.py
+++ b/tests/test_pipeline_index_cache.py
@@ -521,6 +521,51 @@ class TestConcurrentReadsDoNotRace:
         # Sanity: the agreed-upon contents must be the expected two pipelines.
         assert set(results[0].keys()) == {"pipeline_a", "pipeline_b"}
 
+    def test_module_dependency_invalidation_wins_over_inflight_build(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An invalidator must not be overwritten by a stale dependency-map publish."""
+        import haute.routes._helpers as helpers
+
+        pipeline_file = tmp_path / "pipeline.py"
+        build_started = threading.Event()
+        allow_build_to_finish = threading.Event()
+        invalidation_finished = threading.Event()
+        results: list[dict[str, set[Path]]] = []
+
+        monkeypatch.setattr(helpers, "discover_pipelines", lambda: [pipeline_file])
+
+        def _slow_read(_path: Path) -> str:
+            build_started.set()
+            assert allow_build_to_finish.wait(2)
+            return 'pipeline.submodel("modules/shared.py")\n'
+
+        monkeypatch.setattr(helpers, "read_user_text", _slow_read)
+
+        builder = threading.Thread(target=lambda: results.append(helpers._ensure_module_deps()))
+        builder.start()
+        assert build_started.wait(2)
+
+        def _invalidate() -> None:
+            helpers.invalidate_pipeline_index()
+            invalidation_finished.set()
+
+        invalidator = threading.Thread(target=_invalidate)
+        invalidator.start()
+
+        assert not invalidation_finished.wait(0.05)
+        allow_build_to_finish.set()
+        builder.join(timeout=2)
+        invalidator.join(timeout=2)
+
+        assert not builder.is_alive()
+        assert not invalidator.is_alive()
+        assert invalidation_finished.is_set()
+        assert results == [{"shared": {pipeline_file}}]
+        assert helpers._module_deps is None
+
     def test_reader_during_rebuild_never_sees_none(
         self,
         pipeline_project: Path,

--- a/tests/test_pipeline_index_cache.py
+++ b/tests/test_pipeline_index_cache.py
@@ -521,26 +521,35 @@ class TestConcurrentReadsDoNotRace:
         # Sanity: the agreed-upon contents must be the expected two pipelines.
         assert set(results[0].keys()) == {"pipeline_a", "pipeline_b"}
 
-    def test_module_dependency_invalidation_wins_over_inflight_build(
+    def test_module_dependency_invalidation_does_not_block_and_forces_fresh_scan(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """An invalidator must not be overwritten by a stale dependency-map publish."""
+        """Invalidation stays short and a stale dependency scan is rebuilt before publish."""
         import haute.routes._helpers as helpers
 
         pipeline_file = tmp_path / "pipeline.py"
         build_started = threading.Event()
         allow_build_to_finish = threading.Event()
+        invalidation_started = threading.Event()
         invalidation_finished = threading.Event()
         results: list[dict[str, set[Path]]] = []
+        read_count = 0
 
         monkeypatch.setattr(helpers, "discover_pipelines", lambda: [pipeline_file])
+        monkeypatch.setattr(helpers, "_pipeline_index", helpers._pipeline_index)
+        monkeypatch.setattr(helpers, "_module_deps", None)
+        monkeypatch.setattr(helpers, "_pipeline_index_generation", 0)
 
         def _slow_read(_path: Path) -> str:
-            build_started.set()
-            assert allow_build_to_finish.wait(2)
-            return 'pipeline.submodel("modules/shared.py")\n'
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                build_started.set()
+                assert allow_build_to_finish.wait(2)
+                return 'pipeline.submodel("modules/stale.py")\n'
+            return 'pipeline.submodel("modules/fresh.py")\n'
 
         monkeypatch.setattr(helpers, "read_user_text", _slow_read)
 
@@ -549,13 +558,15 @@ class TestConcurrentReadsDoNotRace:
         assert build_started.wait(2)
 
         def _invalidate() -> None:
+            invalidation_started.set()
             helpers.invalidate_pipeline_index()
             invalidation_finished.set()
 
         invalidator = threading.Thread(target=_invalidate)
         invalidator.start()
 
-        assert not invalidation_finished.wait(0.05)
+        assert invalidation_started.wait(1)
+        invalidation_did_not_wait = invalidation_finished.wait(0.5)
         allow_build_to_finish.set()
         builder.join(timeout=2)
         invalidator.join(timeout=2)
@@ -563,8 +574,10 @@ class TestConcurrentReadsDoNotRace:
         assert not builder.is_alive()
         assert not invalidator.is_alive()
         assert invalidation_finished.is_set()
-        assert results == [{"shared": {pipeline_file}}]
-        assert helpers._module_deps is None
+        assert invalidation_did_not_wait
+        assert read_count == 2
+        assert results == [{"fresh": {pipeline_file}}]
+        assert helpers._module_deps == {"fresh": {pipeline_file}}
 
     def test_reader_during_rebuild_never_sees_none(
         self,

--- a/tests/test_pipeline_route_supersession.py
+++ b/tests/test_pipeline_route_supersession.py
@@ -1041,7 +1041,7 @@ async def test_timed_out_same_key_preview_stays_active_until_worker_finishes(
 async def test_superseded_timed_out_preview_holds_slot_until_worker_finishes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Supersession must not drop the cap for an old timed-out worker."""
+    """Supersession must preserve timeout ownership until the old worker exits."""
     import haute.routes.pipeline as route_mod
     from haute.server import app
 
@@ -1058,6 +1058,21 @@ async def test_superseded_timed_out_preview_holds_slot_until_worker_finishes(
     call_count = 0
     active = 0
     max_active = 0
+    contexts: list[_TrackedExecutionContext] = []
+
+    class _TrackedExecutionContext:
+        def __init__(self) -> None:
+            self.release_calls = 0
+
+        def release_admission(self, *, preserve_primary_error: bool = False) -> None:
+            del preserve_primary_error
+            self.release_calls += 1
+
+    def _create_context(**kwargs) -> _TrackedExecutionContext:
+        del kwargs
+        context = _TrackedExecutionContext()
+        contexts.append(context)
+        return context
 
     def slow_preview(*args, **kwargs) -> dict[str, NodeResult]:
         nonlocal active, call_count, max_active
@@ -1084,6 +1099,7 @@ async def test_superseded_timed_out_preview_holds_slot_until_worker_finishes(
             finished[call_number].set()
 
     monkeypatch.setattr(route_mod, "execute_graph", slow_preview)
+    monkeypatch.setattr(route_mod, "create_admitted_execution_context", _create_context)
 
     transport = httpx.ASGITransport(app=app)
     try:
@@ -1105,21 +1121,33 @@ async def test_superseded_timed_out_preview_holds_slot_until_worker_finishes(
                 "second same-key preview to enter supersession queue",
             )
             first_response = await first
-            assert first_response.status_code == 409
+            assert first_response.status_code == 504
+            assert contexts[0].release_calls == 0
             assert not await _thread_event_was_set(started[2], 0.05)
             with state_lock:
                 assert active == 1
 
             release[1].set()
             await _wait_for_thread_event(started[2], "second same-key preview worker")
+            for _ in range(100):
+                if contexts[0].release_calls == 1:
+                    break
+                await asyncio.sleep(0.005)
+            assert contexts[0].release_calls == 1
 
             second_response = await second
             assert second_response.status_code == 504
+            assert contexts[1].release_calls == 0
             with state_lock:
                 assert active == 1
 
             release[2].set()
             await _wait_for_thread_event(finished[2], "second preview completion")
+            for _ in range(100):
+                if contexts[1].release_calls == 1:
+                    break
+                await asyncio.sleep(0.005)
+            assert contexts[1].release_calls == 1
 
         await _wait_for_coordinator_snapshot(
             coordinator,

--- a/tests/test_request_supersession.py
+++ b/tests/test_request_supersession.py
@@ -11,6 +11,7 @@ from haute.routes._supersession import (
     SupersessionCoordinator,
     _SupersessionState,
 )
+from haute.routes._timeouts import BlockingWorkTimeoutError
 
 
 @pytest.mark.asyncio
@@ -101,6 +102,51 @@ async def test_superseded_running_worker_error_returns_superseded() -> None:
 
     with pytest.raises(SupersededRequestError):
         await first
+    assert await second == "latest"
+
+
+@pytest.mark.asyncio
+async def test_superseded_background_timeout_is_not_masked() -> None:
+    """The route must receive the timeout so it can defer context release."""
+    coordinator = SupersessionCoordinator()
+    key = ("preview", "graph")
+    started_first = asyncio.Event()
+    raise_timeout = asyncio.Event()
+    background_task: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+
+    async def first_work() -> str:
+        started_first.set()
+        await raise_timeout.wait()
+        raise BlockingWorkTimeoutError("preview", 1, background_task)
+
+    async def second_work() -> str:
+        return "latest"
+
+    first = asyncio.create_task(
+        coordinator.run_latest(
+            key,
+            first_work,
+            superseded_message="superseded",
+        )
+    )
+    await started_first.wait()
+
+    second = asyncio.create_task(
+        coordinator.run_latest(
+            key,
+            second_work,
+            superseded_message="superseded",
+        )
+    )
+    await asyncio.sleep(0)
+    raise_timeout.set()
+
+    with pytest.raises(BlockingWorkTimeoutError) as exc_info:
+        await first
+    assert exc_info.value.background_task is background_task
+    assert not second.done()
+
+    background_task.set_result(None)
     assert await second == "latest"
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -197,6 +197,33 @@ class TestGetFirstPipeline:
         assert graph["source_file"] == "main.py"
         assert graph["pipeline_name"] == "my_project"
 
+    def test_parse_failure_returns_422_instead_of_blank_canvas(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A broken discovered pipeline must never look like a new empty project."""
+        broken = tmp_path / "broken.py"
+        broken.write_text("this is not a valid Haute pipeline")
+        monkeypatch.chdir(tmp_path)
+
+        from haute.server import app
+
+        with (
+            patch(
+                "haute.routes.pipeline.discover_pipelines",
+                return_value=[broken],
+            ),
+            patch(
+                "haute.routes.pipeline.parse_pipeline_to_graph",
+                side_effect=ValueError("pipeline structure is invalid"),
+            ),
+        ):
+            resp = TestClient(app).get("/api/pipeline")
+
+        assert resp.status_code == 422
+        assert resp.json() == {"detail": "pipeline structure is invalid"}
+
 
 # ---------------------------------------------------------------------------
 # GET /api/pipeline/{name}
@@ -3457,6 +3484,67 @@ class TestFileWatcherRecovery:
         asyncio.run(_run())
 
         assert any(event == "graph.update" for event, _ in published)
+
+    def test_module_only_flush_does_not_invalidate_pipeline_index(
+        self,
+        pipeline_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A dependency edit changes graphs, not the pipeline name-to-path index."""
+        from haute.server import _file_watcher
+
+        monkeypatch.chdir(pipeline_dir)
+        modules_dir = pipeline_dir / "modules"
+        modules_dir.mkdir()
+        module_file = modules_dir / "shared.py"
+        module_file.write_text("VALUE = 2\n")
+
+        async def _single_module_change(*dirs, **kw):
+            yield [(Change.modified, str(module_file))]
+
+        async def _run() -> None:
+            with (
+                patch("watchfiles.awatch", _single_module_change),
+                patch("haute.server.is_self_write", return_value=False),
+                patch("haute.server.pipelines_importing_module", return_value=[]),
+                patch("haute.server.invalidate_pipeline_index") as invalidate,
+                patch("haute.server._DEBOUNCE_SECONDS", 0),
+            ):
+                await _file_watcher()
+                assert invalidate.call_count == 0
+
+        asyncio.run(_run())
+
+    def test_persistently_failing_flush_stops_after_bounded_retries(
+        self,
+        pipeline_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A poisoned batch must not create an infinite chain of retry tasks."""
+        from haute.server import _file_watcher
+
+        monkeypatch.chdir(pipeline_dir)
+        py_file = str(pipeline_dir / "test_pipeline.py")
+
+        async def _single_change(*dirs, **kw):
+            yield [(Change.modified, py_file)]
+
+        async def _run() -> int:
+            with (
+                patch("watchfiles.awatch", _single_change),
+                patch("haute.server.is_self_write", return_value=False),
+                patch(
+                    "haute.server.invalidate_pipeline_index",
+                    side_effect=RuntimeError("persistent cache failure"),
+                ) as invalidate,
+                patch("haute.server._DEBOUNCE_SECONDS", 0),
+                patch("haute.server._WATCHER_FLUSH_RETRY_BASE_SECONDS", 0),
+                patch("haute.server._WATCHER_FLUSH_MAX_RETRIES", 2),
+            ):
+                await _file_watcher()
+                return invalidate.call_count
+
+        assert asyncio.run(_run()) == 3
 
     def test_flush_error_recovery_allows_later_change(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3515,12 +3515,109 @@ class TestFileWatcherRecovery:
 
         asyncio.run(_run())
 
+    def test_deleted_pipeline_invalidates_index_without_reparse(
+        self,
+        pipeline_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A deleted pipeline must invalidate the index without a parse attempt."""
+        from haute.server import _file_watcher
+
+        monkeypatch.chdir(pipeline_dir)
+        deleted_file = pipeline_dir / "deleted_pipeline.py"
+
+        async def _single_deletion(*dirs, **kw):
+            yield [(Change.deleted, str(deleted_file))]
+
+        async def _run() -> None:
+            with (
+                patch("watchfiles.awatch", _single_deletion),
+                patch("haute.server.is_self_write", return_value=False),
+                patch("haute.server._known_pipeline_paths", return_value={}),
+                patch("haute.server.invalidate_pipeline_index") as invalidate,
+                patch("haute.server.parse_pipeline_to_graph") as parse,
+                patch("haute.server._DEBOUNCE_SECONDS", 0),
+            ):
+                await _file_watcher()
+                invalidate.assert_called_once_with()
+                parse.assert_not_called()
+
+        asyncio.run(_run())
+
+    def test_cancelled_flush_requeues_snapshotted_batch(
+        self,
+        pipeline_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cancellation after snapshotting must not discard the interrupted change."""
+        from haute.server import _file_watcher
+
+        monkeypatch.chdir(pipeline_dir)
+        interrupted_file = pipeline_dir / "interrupted.py"
+        later_file = pipeline_dir / "later.py"
+        interrupted_file.write_text("interrupted = True\n")
+        later_file.write_text("later = True\n")
+        known = {
+            str(interrupted_file.resolve()): interrupted_file,
+            str(later_file.resolve()): later_file,
+        }
+
+        class _FakeGraph:
+            nodes: list[object] = []
+
+            def model_dump(self) -> dict[str, object]:
+                return {"nodes": [], "edges": []}
+
+        class _BusStub:
+            def publish(self, event: str, payload: dict[str, object]) -> None:
+                del event, payload
+
+        async def _run() -> list[Path]:
+            cancellation_injected = asyncio.Event()
+            original_read_bytes = Path.read_bytes
+            interrupted_reads = 0
+
+            def _read_bytes(path: Path) -> bytes:
+                nonlocal interrupted_reads
+                if path.resolve() == interrupted_file.resolve():
+                    interrupted_reads += 1
+                    if interrupted_reads == 1:
+                        cancellation_injected.set()
+                        raise asyncio.CancelledError
+                return original_read_bytes(path)
+
+            async def _two_changes(*dirs, **kw):
+                del dirs, kw
+                yield [(Change.modified, str(interrupted_file))]
+                await cancellation_injected.wait()
+                await asyncio.sleep(0)
+                yield [(Change.modified, str(later_file))]
+
+            with (
+                patch("watchfiles.awatch", _two_changes),
+                patch.object(Path, "read_bytes", _read_bytes),
+                patch("haute.server.is_self_write", return_value=False),
+                patch("haute.server._known_pipeline_paths", return_value=known),
+                patch("haute.server._discovered_pipeline_paths", return_value=known),
+                patch("haute.server.invalidate_pipeline_index"),
+                patch(
+                    "haute.server.parse_pipeline_to_graph",
+                    return_value=_FakeGraph(),
+                ) as parse,
+                patch("haute.server.default_bus", _BusStub()),
+                patch("haute.server._DEBOUNCE_SECONDS", 0),
+            ):
+                await _file_watcher()
+                return [call.args[0] for call in parse.call_args_list]
+
+        assert set(asyncio.run(_run())) == {interrupted_file, later_file}
+
     def test_persistently_failing_flush_stops_after_bounded_retries(
         self,
         pipeline_dir: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A poisoned batch must not create an infinite chain of retry tasks."""
+        """A poisoned change gets bounded batch retries plus one isolated attempt."""
         from haute.server import _file_watcher
 
         monkeypatch.chdir(pipeline_dir)
@@ -3544,7 +3641,66 @@ class TestFileWatcherRecovery:
                 await _file_watcher()
                 return invalidate.call_count
 
-        assert asyncio.run(_run()) == 3
+        assert asyncio.run(_run()) == 4
+
+    def test_retry_exhaustion_isolates_poisoned_change_and_processes_healthy_change(
+        self,
+        pipeline_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One bad event must not remain queued or suppress a healthy sibling forever."""
+        from haute.server import _file_watcher
+
+        monkeypatch.chdir(pipeline_dir)
+        healthy_file = pipeline_dir / "test_pipeline.py"
+        poisoned_file = pipeline_dir / "poisoned.py"
+        published: list[tuple[str, dict[str, object]]] = []
+
+        class _FakeGraph:
+            nodes: list[object] = []
+
+            def model_dump(self) -> dict[str, object]:
+                return {"nodes": [], "edges": []}
+
+        class _BusStub:
+            def publish(self, event: str, payload: dict[str, object]) -> None:
+                published.append((event, payload))
+
+        def _self_write(path: Path, *, consume: bool) -> bool:
+            del consume
+            if path.name == poisoned_file.name:
+                raise RuntimeError("poisoned watcher event")
+            return False
+
+        async def _mixed_batch(*dirs, **kw):
+            yield [
+                (Change.modified, str(poisoned_file)),
+                (Change.modified, str(healthy_file)),
+            ]
+
+        known = {
+            str(poisoned_file.resolve()): poisoned_file,
+            str(healthy_file.resolve()): healthy_file,
+        }
+
+        async def _run() -> None:
+            with (
+                patch("watchfiles.awatch", _mixed_batch),
+                patch("haute.server.is_self_write", _self_write),
+                patch("haute.server._known_pipeline_paths", return_value=known),
+                patch("haute.server._discovered_pipeline_paths", return_value=known),
+                patch("haute.server.invalidate_pipeline_index"),
+                patch("haute.server.parse_pipeline_to_graph", return_value=_FakeGraph()),
+                patch("haute.server.default_bus", _BusStub()),
+                patch("haute.server._DEBOUNCE_SECONDS", 0),
+                patch("haute.server._WATCHER_FLUSH_RETRY_BASE_SECONDS", 0),
+                patch("haute.server._WATCHER_FLUSH_MAX_RETRIES", 1),
+            ):
+                await _file_watcher()
+
+        asyncio.run(_run())
+
+        assert [event for event, _ in published] == ["graph.update"]
 
     def test_flush_error_recovery_allows_later_change(
         self,

--- a/tests/test_v2_codec_and_shred.py
+++ b/tests/test_v2_codec_and_shred.py
@@ -926,3 +926,25 @@ def test_shred_scalar_array_table_distributes_ancestor_column() -> None:
         {"value": "comprehensive", "policy_id": 1},
         {"value": "TPO", "policy_id": 2},
     ]
+
+
+def test_shred_object_table_ignores_ancestor_scalar_value_column() -> None:
+    cfg = {
+        "path": "x.json",
+        "contract": "opaque",
+        "tables": [
+            {
+                "path": "$[:].items[:]",
+                "label": "items",
+                "emit": True,
+                "columns": [
+                    {"name": "name", "path": "$[:].items[:].name", "type": "str", "selected": True},
+                    {"name": "root_value", "path": "$[:].$value", "type": "str", "selected": True},
+                ],
+            },
+        ],
+    }
+
+    assert shred_to_buffers([{"items": [{"name": "kept"}]}], cfg) == {
+        "items": [{"name": "kept", "root_value": None}],
+    }


### PR DESCRIPTION
## Summary

- return a structured 422 when discovered pipeline files cannot be parsed, instead of presenting a destructive blank canvas
- preserve timeout/background-worker ownership through preview supersession and defer execution-context release until blocking work exits
- serialize module-dependency index rebuilds with invalidation, limit watcher flush retries, and avoid index invalidation for module/config-only events
- align OUTPUT dry-run admission failures with the structured 507 contract and close its admission-context lifecycle
- fix multi-frame absent-key handling, ancestor `$value` shredding, incomplete mapping rows, and repeated quadratic output-path parsing
- fold shipped server API and JSON shredding behavior into the canonical specs and record the explicit cross-stream deferrals

## Why

WS-04 collected several cases where runtime failures were masked as valid empty state, stale work could release shared execution resources early, and OUTPUT assembly could reject or lose otherwise valid multi-frame data. The canonical specifications also still described already-shipped behavior as future work and omitted live endpoints/error contracts.

## Impact

Pipeline load failures now remain visible and non-destructive. Timed-out same-key work cannot overlap its replacement or lose admission/cache ownership. Watcher recovery is bounded, and module dependency invalidation cannot be overwritten by an in-flight rebuild. OUTPUT assembly preserves valid partial frames while continuing to fail loudly for actual null relation keys and malformed mappings.

Cross-stream edits remain with their owners: projection-planner parity (WS-03), frontend load-failure presentation (WS-09), save/submodel/codegen guarantee wording (WS-05/WS-14), and the single version stamp (WS-01).

## Verification

- `uv run pytest tests/test_output_assembler.py tests/test_pipeline_index_cache.py tests/test_output_assemble_routes.py tests/test_v2_codec_and_shred.py -q` — 199 passed
- supersession/route targeted batch — 228 passed
- `uv run pytest tests/test_server.py -q` — 142 passed, 1 skipped
- `uv run pytest tests/test_docs_accuracy.py -q` — 21 passed
- Ruff lint and format checks — passed
- `scripts/preflight.ps1 -Quick` — passed (repository-wide Python/TypeScript checks; existing frontend warnings only)
