### PR TITLE
fix: pin Node webstorage off in vitest and add localStorage canary

### DIFF
--- a/docs/CI_MIRROR.md
+++ b/docs/CI_MIRROR.md
@@ -391,6 +391,60 @@ unit + coverage gates, optional-dep smokes, package build+install (incl.
 fresh-resolve yank detection), mutation config, e2e, docs build — is
 reproducible locally and should be run before every push per the runlist above.
 
+## Environment drift: pin the behaviour, not the platform
+
+Local-vs-CI divergence is not always a *missing* local gate — sometimes the
+platforms themselves quietly disagree. When a platform default drifts under a
+tool, the durable defence is **not** to enforce a platform version everywhere
+(that just re-breaks on the next upgrade, and local machines float ahead of
+CI's pins anyway). Node in particular has no global "behave like version X"
+compat switch, so version-pinning is the only *platform-level* lever — and it
+is the wrong one. Instead:
+
+1. **Pin each drifting behaviour explicitly, at the tool-config layer.** Turn
+   the specific experimental/default-flipped behaviour off with its own
+   `--no-experimental-*` flag (or equivalent config knob) in the config of the
+   tool that cares — `test.execArgv` in `frontend/vitest.config.ts` for the
+   vitest workers, `NODE_OPTIONS` for other Node-invoking scripts. The
+   behaviour is then identical on every Node version that recognises the flag,
+   and the platform version is free to float.
+2. **Add a cheap canary assertion that names the invariant.** One or two lines
+   in a setup file (e.g. `frontend/src/setupTests.ts`) that assert the pinned
+   behaviour actually holds, throwing a message that names the cause and
+   points at the pin. The next silent drift then fails loudly in one
+   self-explaining place, instead of producing dozens of baffling downstream
+   failures.
+
+**Worked example — the Node 25 localStorage shadowing (29 July 2026).** The
+frontend vitest suite broke locally-only: Node ≥ 22.4 ships experimental
+web-storage globals, default-on from Node 25, and Node's file-less
+`localStorage` stub (no `.clear`) landed on `globalThis` before jsdom set up.
+Vitest's jsdom environment skips window keys already present on `globalThis`,
+so the stub silently shadowed jsdom's real `Storage` and every test touching
+`localStorage.clear` failed with no obvious cause. CI stayed green because its
+Node is pinned to 22.14.0. The fix is
+`test.execArgv: ["--no-experimental-webstorage"]` in
+`frontend/vitest.config.ts` — pinning the behaviour off on every Node ≥ 22.4
+rather than demanding a particular Node locally — plus the canary in
+`frontend/src/setupTests.ts` asserting `localStorage` is a real, functioning
+`Storage`.
+
+**Sibling drift classes already seen in this repo** (same class — the local
+cache or environment diverges from CI's clean one — different tools):
+
+- **Stale `tsc` `.tsbuildinfo` false-negatives**: a local `npm run typecheck`
+  (`tsc -b`) can pass on a stale incremental cache where CI's clean build
+  fails. Mirror CI by clearing the incremental state when a type-sensitive
+  change misbehaves.
+- **mypy cache false-negatives**: same shape — local mypy can miss type errors
+  CI's clean environment catches; clear `.mypy_cache` for type-sensitive
+  changes.
+
+These two drift in the opposite direction (local-green/CI-red, versus the
+localStorage incident's local-red/CI-green), but the defence generalises: make
+the invariant explicit where the tool is configured, and prefer a loud, named
+failure over a silent divergence.
+
 ## Review history
 
 The first revision of this procedure was challenged by an adversarial Opus

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,18 +1,23 @@
 import "@testing-library/jest-dom/vitest"
 
-// Canary: the test environment's localStorage must be jsdom's real Storage.
-// Node >= 22.4 can inject its own file-less localStorage stub (no .clear) onto
-// globalThis (default-on from Node 25), and the jsdom environment skips window
-// keys already present there — so the stub silently shadows the real thing.
-// Guarded by `test.execArgv: ["--no-experimental-webstorage"]` in
-// vitest.config.ts; if this throws, that pin (or its successor) has stopped
-// holding.
-if (typeof localStorage.clear !== "function") {
-  throw new Error(
-    "localStorage is not a real Storage (no .clear) — Node's experimental " +
-      "web-storage stub is shadowing jsdom's. Check the " +
-      '`--no-experimental-webstorage` pin in vitest.config.ts test.execArgv.',
-  )
+// Canary: the test environment's web storage must be jsdom's real Storage.
+// Node >= 22.4 can inject its own file-less localStorage/sessionStorage stubs
+// onto globalThis (default-on from Node 25), and the jsdom environment skips
+// window keys already present there — so the stubs silently shadow the real
+// thing. `instanceof Storage` is the provenance check: jsdom always restores
+// the `Storage` class itself, so only jsdom-created storages pass, even if a
+// future Node stub grows a working `.clear`. Guarded by
+// `test.execArgv: ["--no-experimental-webstorage"]` in vitest.config.ts; if
+// this throws, that pin (or its successor) has stopped holding.
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  const storage = globalThis[name]
+  if (!(storage instanceof Storage) || typeof storage.clear !== "function") {
+    throw new Error(
+      `${name} is not jsdom's real Storage — Node's experimental web-storage ` +
+        "stub is shadowing it. Check the `--no-experimental-webstorage` pin " +
+        "in vitest.config.ts test.execArgv.",
+    )
+  }
 }
 localStorage.setItem("__storage_canary__", "ok")
 if (localStorage.getItem("__storage_canary__") !== "ok") {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,5 +1,29 @@
 import "@testing-library/jest-dom/vitest"
 
+// Canary: the test environment's localStorage must be jsdom's real Storage.
+// Node >= 22.4 can inject its own file-less localStorage stub (no .clear) onto
+// globalThis (default-on from Node 25), and the jsdom environment skips window
+// keys already present there — so the stub silently shadows the real thing.
+// Guarded by `test.execArgv: ["--no-experimental-webstorage"]` in
+// vitest.config.ts; if this throws, that pin (or its successor) has stopped
+// holding.
+if (typeof localStorage.clear !== "function") {
+  throw new Error(
+    "localStorage is not a real Storage (no .clear) — Node's experimental " +
+      "web-storage stub is shadowing jsdom's. Check the " +
+      '`--no-experimental-webstorage` pin in vitest.config.ts test.execArgv.',
+  )
+}
+localStorage.setItem("__storage_canary__", "ok")
+if (localStorage.getItem("__storage_canary__") !== "ok") {
+  throw new Error(
+    "localStorage set/get round-trip failed — the test environment's Storage " +
+      "is not functional. Check the `--no-experimental-webstorage` pin in " +
+      "vitest.config.ts test.execArgv.",
+  )
+}
+localStorage.removeItem("__storage_canary__")
+
 Object.defineProperty(globalThis, "__APP_VERSION__", {
   configurable: true,
   value: "999.0.0-test",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "jsdom",
+    // Node >= 22.4 ships experimental web-storage globals (on by default from
+    // Node 25). Node's file-less localStorage stub (no .clear) would shadow
+    // jsdom's real Storage, because the jsdom environment skips window keys
+    // already present on globalThis. Pin the behaviour off on every Node
+    // rather than pinning a Node version; setupTests.ts carries the canary.
+    execArgv: ["--no-experimental-webstorage"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
     setupFiles: ["./src/setupTests.ts"],
     allowOnly: false,


### PR DESCRIPTION
## Summary

On 29 July 2026 the frontend vitest suite broke locally-only under Node 25: Node ≥ 22.4 ships experimental web-storage globals (default-on from 25), and Node's file-less `localStorage` stub (no `.clear`) landed on `globalThis` before jsdom set up. Vitest's jsdom environment skips window keys already present on `globalThis`, so the stub silently shadowed jsdom's real `Storage`. CI stayed green (Node pinned 22.14.0).

Rather than enforcing a Node version, this pins the behaviour and adds a tripwire:

- **`frontend/vitest.config.ts`** — `test.execArgv: ["--no-experimental-webstorage"]` pins the behaviour off on every Node that recognises the flag, letting the platform version float.
- **`frontend/src/setupTests.ts`** — canary asserting `localStorage` and `sessionStorage` are jsdom's real `Storage` (`instanceof Storage` provenance check — jsdom always restores the `Storage` class itself — plus a working `.clear`), throwing a message that names the shadowing cause and points at the pin. The next silent drift fails loudly in one self-explaining place instead of dozens of baffling failures.
- **`docs/CI_MIRROR.md`** — new section "Environment drift: pin the behaviour, not the platform" documenting the pattern, this incident as the worked example, and the sibling stale-`tsc`-`.tsbuildinfo` and mypy-cache drift classes.

## Verification

On Node 25.6.1 (which reproduces the drift): target suite and full vitest suite (282 files, 5,531 tests) green with the pin; with the pin temporarily removed the canary fires with the named message. Typecheck (clean, incremental cache purged), lint, and `mkdocs build --strict` all green.

Reviewed via the cross-model fallback review (Codex unavailable on this machine): Opus primary + Sonnet assurance, both approved; Opus's two suggestions (provenance check, `sessionStorage` coverage) applied in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)