### PR TITLE
fix: pin Node webstorage off in vitest workers + storage canary

### DIFF
--- a/docs/CI_MIRROR.md
+++ b/docs/CI_MIRROR.md
@@ -391,6 +391,60 @@ unit + coverage gates, optional-dep smokes, package build+install (incl.
 fresh-resolve yank detection), mutation config, e2e, docs build — is
 reproducible locally and should be run before every push per the runlist above.
 
+## Environment drift: pin the behaviour, not the platform
+
+Local-vs-CI divergence is not always a *missing* local gate — sometimes the
+platforms themselves quietly disagree. When a platform default drifts under a
+tool, the durable defence is **not** to enforce a platform version everywhere
+(that just re-breaks on the next upgrade, and local machines float ahead of
+CI's pins anyway). Node in particular has no global "behave like version X"
+compat switch, so version-pinning is the only *platform-level* lever — and it
+is the wrong one. Instead:
+
+1. **Pin each drifting behaviour explicitly, at the tool-config layer.** Turn
+   the specific experimental/default-flipped behaviour off with its own
+   `--no-experimental-*` flag (or equivalent config knob) in the config of the
+   tool that cares — `test.execArgv` in `frontend/vitest.config.ts` for the
+   vitest workers, `NODE_OPTIONS` for other Node-invoking scripts. The
+   behaviour is then identical on every Node version that recognises the flag,
+   and the platform version is free to float.
+2. **Add a cheap canary assertion that names the invariant.** One or two lines
+   in a setup file (e.g. `frontend/src/setupTests.ts`) that assert the pinned
+   behaviour actually holds, throwing a message that names the cause and
+   points at the pin. The next silent drift then fails loudly in one
+   self-explaining place, instead of producing dozens of baffling downstream
+   failures.
+
+**Worked example — the Node 25 localStorage shadowing (29 July 2026).** The
+frontend vitest suite broke locally-only: Node ≥ 22.4 ships experimental
+web-storage globals, default-on from Node 25, and Node's file-less
+`localStorage` stub (no `.clear`) landed on `globalThis` before jsdom set up.
+Vitest's jsdom environment skips window keys already present on `globalThis`,
+so the stub silently shadowed jsdom's real `Storage` and every test touching
+`localStorage.clear` failed with no obvious cause. CI stayed green because its
+Node is pinned to 22.14.0. The fix is
+`test.execArgv: ["--no-experimental-webstorage"]` in
+`frontend/vitest.config.ts` — pinning the behaviour off on every Node ≥ 22.4
+rather than demanding a particular Node locally — plus the canary in
+`frontend/src/setupTests.ts` asserting `localStorage` is a real, functioning
+`Storage`.
+
+**Sibling drift classes already seen in this repo** (same class — the local
+cache or environment diverges from CI's clean one — different tools):
+
+- **Stale `tsc` `.tsbuildinfo` false-negatives**: a local `npm run typecheck`
+  (`tsc -b`) can pass on a stale incremental cache where CI's clean build
+  fails. Mirror CI by clearing the incremental state when a type-sensitive
+  change misbehaves.
+- **mypy cache false-negatives**: same shape — local mypy can miss type errors
+  CI's clean environment catches; clear `.mypy_cache` for type-sensitive
+  changes.
+
+These two drift in the opposite direction (local-green/CI-red, versus the
+localStorage incident's local-red/CI-green), but the defence generalises: make
+the invariant explicit where the tool is configured, and prefer a loud, named
+failure over a silent divergence.
+
 ## Review history
 
 The first revision of this procedure was challenged by an adversarial Opus

--- a/docs/CI_MIRROR.md
+++ b/docs/CI_MIRROR.md
@@ -386,7 +386,9 @@ uv run python scripts/run_mutation_suite.py --output-dir mutation-artifacts --ch
 
 Even with every mirrorable gate green locally, a PR can still fail CI on: (1)
 the Windows leg, (2) a Linux-x86-64-only behaviour, (3) a PyPI state change in
-the resolve window. These are bounded and named. Everything else — lint, types,
+the resolve window, or (4) a stale local cache or drifted local platform
+masking what CI's clean environment will catch — see §Environment drift below
+for that class. These are bounded and named. Everything else — lint, types,
 unit + coverage gates, optional-dep smokes, package build+install (incl.
 fresh-resolve yank detection), mutation config, e2e, docs build — is
 reproducible locally and should be run before every push per the runlist above.
@@ -418,9 +420,11 @@ is the wrong one. Instead:
 **Worked example — the Node 25 localStorage shadowing (29 July 2026).** The
 frontend vitest suite broke locally-only: Node ≥ 22.4 ships experimental
 web-storage globals, default-on from Node 25, and Node's file-less
-`localStorage` stub (no `.clear`) landed on `globalThis` before jsdom set up.
-Vitest's jsdom environment skips window keys already present on `globalThis`,
-so the stub silently shadowed jsdom's real `Storage` and every test touching
+`localStorage` landed on `globalThis` before jsdom set up (its shape varies by
+Node version — an inert stub with no `.clear` on 25, an `undefined`-returning
+accessor from 26; the shadowing needs only the key's presence). Vitest's jsdom
+environment skips window keys already present on `globalThis`, so Node's
+global silently shadowed jsdom's real `Storage` and every test touching
 `localStorage.clear` failed with no obvious cause. CI stayed green because its
 Node is pinned to 22.14.0. The fix is
 `test.execArgv: ["--no-experimental-webstorage"]` in

--- a/docs/CI_MIRROR.md
+++ b/docs/CI_MIRROR.md
@@ -386,9 +386,10 @@ uv run python scripts/run_mutation_suite.py --output-dir mutation-artifacts --ch
 
 Even with every mirrorable gate green locally, a PR can still fail CI on: (1)
 the Windows leg, (2) a Linux-x86-64-only behaviour, (3) a PyPI state change in
-the resolve window, or (4) a stale local cache or drifted local platform
-masking what CI's clean environment will catch — see §Environment drift below
-for that class. These are bounded and named. Everything else — lint, types,
+the resolve window, or (4) a stale local cache (incremental `tsc`/`mypy`
+state) masking what CI's clean environment will catch — see §Environment
+drift below, which also covers the inverse class (platform drift producing
+local-only failures CI never sees). These are bounded and named. Everything else — lint, types,
 unit + coverage gates, optional-dep smokes, package build+install (incl.
 fresh-resolve yank detection), mutation config, e2e, docs build — is
 reproducible locally and should be run before every push per the runlist above.
@@ -411,7 +412,7 @@ is the wrong one. Instead:
    behaviour is then identical on every Node version that recognises the flag,
    and the platform version is free to float.
 2. **Add a cheap canary assertion that names the invariant.** One or two lines
-   in a setup file (e.g. `frontend/src/setupTests.ts`) that assert the pinned
+   in a setup file (e.g. `frontend/src/setupStorageCanary.ts`) that assert the pinned
    behaviour actually holds, throwing a message that names the cause and
    points at the pin. The next silent drift then fails loudly in one
    self-explaining place, instead of producing dozens of baffling downstream
@@ -426,11 +427,29 @@ accessor from 26; the shadowing needs only the key's presence). Vitest's jsdom
 environment skips window keys already present on `globalThis`, so Node's
 global silently shadowed jsdom's real `Storage` and every test touching
 `localStorage.clear` failed with no obvious cause. CI stayed green because its
-Node is pinned to 22.14.0. The fix is
+Node is pinned to 22.14.0.
+
+The pin itself has two distinct failure modes, with different symptoms:
+
+- **Pin ignored / behaviour drifts anyway** (vitest stops passing the flag,
+  or a future Node moves the behaviour beyond the flag's reach): the canary
+  in `frontend/src/setupStorageCanary.ts` throws its named, self-explaining
+  error at the top of every test file.
+- **Pin rejected** (Node < 22.4, which predates the flag, or a future Node
+  dropping the `--no-experimental-webstorage` legacy alias — from Node 25
+  the canonical spelling is `--webstorage`): the workers crash **at spawn**
+  on an unrecognised option (`node: bad option` /
+  `ERR_WORKER_INVALID_EXEC_ARGV`), before any setup file or test output.
+  The canary never gets to speak; recognise that crash as the pin and
+  update the flag spelling in `frontend/vitest.config.ts`.
+
+A meta-test (`frontend/src/__tests__/webstoragePin.meta.test.ts`) gates the
+pin's presence in the config, because on CI's default-off Node deleting the
+`execArgv` line would otherwise go unnoticed. The fix is
 `test.execArgv: ["--no-experimental-webstorage"]` in
 `frontend/vitest.config.ts` — pinning the behaviour off on every Node ≥ 22.4
 rather than demanding a particular Node locally — plus the canary in
-`frontend/src/setupTests.ts` asserting `localStorage` is a real, functioning
+`frontend/src/setupStorageCanary.ts` asserting `localStorage` is a real, functioning
 `Storage`.
 
 **Sibling drift classes already seen in this repo** (same class — the local

--- a/frontend/src/__tests__/webstoragePin.meta.test.ts
+++ b/frontend/src/__tests__/webstoragePin.meta.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Meta-test: the Node webstorage pin must stay in vitest.config.ts.
+ *
+ * CI runs a Node where the experimental web-storage globals are off by
+ * default, so deleting `--no-experimental-webstorage` from test.execArgv
+ * keeps CI green while the protection silently vanishes for every dev on
+ * Node >= 25 (where the runtime canary in setupStorageCanary.ts is the
+ * only other line of defence — and it never runs on CI's Node). This test
+ * makes the pin's PRESENCE a CI-gated fact, mirroring the repo pattern of
+ * asserting on config/workflow content (tests/test_performance_docs.py).
+ * Asserts on the config source text: importing the config module here
+ * would pull `vitest/config` (and esbuild) into the jsdom environment,
+ * which esbuild refuses.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+// Vitest workers run with cwd at the project root (frontend/); import.meta.url
+// is an http: URL under the jsdom transform, so resolve from cwd instead.
+const configText = readFileSync(join(process.cwd(), "vitest.config.ts"), "utf8")
+
+describe("webstorage pin meta-test", () => {
+  it("keeps --no-experimental-webstorage in test.execArgv", () => {
+    expect(configText).toMatch(
+      /execArgv:\s*\[[^\]]*"--no-experimental-webstorage"/,
+    )
+  })
+
+  it("runs the storage canary first in setupFiles", () => {
+    expect(configText).toMatch(
+      /setupFiles:\s*\[\s*"\.\/src\/setupStorageCanary\.ts"/,
+    )
+  })
+})

--- a/frontend/src/setupStorageCanary.ts
+++ b/frontend/src/setupStorageCanary.ts
@@ -1,0 +1,59 @@
+// Canary: the test environment's web storage must be jsdom's real Storage.
+//
+// Node >= 22.4 can register its own web-storage keys on globalThis
+// (default-on from Node 25; shape varies — a file-less localStorage stub on
+// 25, an undefined-returning accessor from 26, and a real but process-global
+// sessionStorage that leaks state across test files). Vitest's jsdom
+// environment skips window keys already present on globalThis, so the key's
+// mere presence silently shadows the real thing.
+//
+// `instanceof Storage` is the provenance check: vitest (4.x) installs
+// jsdom's `Storage` class itself onto the global (it is in vitest's KEYS
+// list, so jsdom's class wins even if Node defines one), meaning only
+// jsdom-created storages pass. That is a vitest behaviour, not a jsdom
+// guarantee — hence the `typeof Storage` guard, so a changed vitest fails
+// with the named error below rather than an opaque "instanceof is not
+// callable" TypeError.
+//
+// Guarded by `test.execArgv: ["--no-experimental-webstorage"]` in
+// vitest.config.ts; if this file throws, that pin (or its successor) has
+// stopped holding. (If Node instead REJECTS the flag one day — e.g. a
+// future major drops the legacy alias — workers crash at spawn on an
+// unrecognised option before any setup file runs; recognise that as the
+// pin too.)
+//
+// This file MUST stay import-free and listed FIRST in setupFiles: ESM
+// hoisting evaluates imports before top-level code, so any imported module
+// reading storage at module scope would run before the canary.
+
+const pinHint =
+  "Check the `--no-experimental-webstorage` pin in vitest.config.ts " +
+  "test.execArgv."
+
+if (typeof Storage !== "function") {
+  throw new Error(
+    "global Storage is not jsdom's Storage class — vitest's jsdom global " +
+      `population has changed, or Node's web-storage global displaced it. ${pinHint}`,
+  )
+}
+
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  const storage = globalThis[name]
+  if (!(storage instanceof Storage) || typeof storage.clear !== "function") {
+    throw new Error(
+      `${name} is not jsdom's real Storage — Node's experimental ` +
+        "web-storage global is shadowing it, or vitest's global population " +
+        `changed. ${pinHint}`,
+    )
+  }
+  storage.setItem("__storage_canary__", "ok")
+  if (storage.getItem("__storage_canary__") !== "ok") {
+    throw new Error(
+      `${name} set/get round-trip failed — the test environment's Storage ` +
+        `is not functional. ${pinHint}`,
+    )
+  }
+  storage.removeItem("__storage_canary__")
+}
+
+export {}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,18 +1,23 @@
 import "@testing-library/jest-dom/vitest"
 
-// Canary: the test environment's localStorage must be jsdom's real Storage.
-// Node >= 22.4 can inject its own file-less localStorage stub (no .clear) onto
-// globalThis (default-on from Node 25), and the jsdom environment skips window
-// keys already present there — so the stub silently shadows the real thing.
-// Guarded by `test.execArgv: ["--no-experimental-webstorage"]` in
-// vitest.config.ts; if this throws, that pin (or its successor) has stopped
-// holding.
-if (typeof localStorage.clear !== "function") {
-  throw new Error(
-    "localStorage is not a real Storage (no .clear) — Node's experimental " +
-      "web-storage stub is shadowing jsdom's. Check the " +
-      '`--no-experimental-webstorage` pin in vitest.config.ts test.execArgv.',
-  )
+// Canary: the test environment's web storage must be jsdom's real Storage.
+// Node >= 22.4 can inject its own file-less localStorage/sessionStorage stubs
+// onto globalThis (default-on from Node 25), and the jsdom environment skips
+// window keys already present there — so the stubs silently shadow the real
+// thing. `instanceof Storage` is the provenance check: jsdom always restores
+// the `Storage` class itself, so only jsdom-created storages pass, even if a
+// future Node stub grows a working `.clear`. Guarded by
+// `test.execArgv: ["--no-experimental-webstorage"]` in vitest.config.ts; if
+// this throws, that pin (or its successor) has stopped holding.
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  const storage = globalThis[name]
+  if (!(storage instanceof Storage) || typeof storage.clear !== "function") {
+    throw new Error(
+      `${name} is not jsdom's real Storage — Node's experimental web-storage ` +
+        "stub is shadowing it. Check the `--no-experimental-webstorage` pin " +
+        "in vitest.config.ts test.execArgv.",
+    )
+  }
 }
 localStorage.setItem("__storage_canary__", "ok")
 if (localStorage.getItem("__storage_canary__") !== "ok") {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,10 +1,12 @@
 import "@testing-library/jest-dom/vitest"
 
 // Canary: the test environment's web storage must be jsdom's real Storage.
-// Node >= 22.4 can inject its own file-less localStorage/sessionStorage stubs
-// onto globalThis (default-on from Node 25), and the jsdom environment skips
-// window keys already present there — so the stubs silently shadow the real
-// thing. `instanceof Storage` is the provenance check: jsdom always restores
+// Node >= 22.4 can inject its own web-storage globals onto globalThis
+// (default-on from Node 25): an inert file-less localStorage stub, and a
+// real but process-global sessionStorage that leaks state across test files.
+// The jsdom environment skips window keys already present there, so both
+// silently shadow the real thing. `instanceof Storage` is the provenance
+// check: jsdom always restores
 // the `Storage` class itself, so only jsdom-created storages pass, even if a
 // future Node stub grows a working `.clear`. Guarded by
 // `test.execArgv: ["--no-experimental-webstorage"]` in vitest.config.ts; if

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,40 +1,5 @@
 import "@testing-library/jest-dom/vitest"
 
-// Canary: the test environment's web storage must be jsdom's real Storage.
-// Node >= 22.4 can register its own web-storage keys on globalThis
-// (default-on from Node 25; shape varies — a file-less localStorage stub on
-// 25, an undefined-returning accessor from 26, and a real but process-global
-// sessionStorage that leaks state across test files). The jsdom environment
-// skips window keys already present there, so the key's mere presence
-// silently shadows the real thing. `instanceof Storage` is the provenance
-// check: vitest (4.x) installs jsdom's `Storage` class itself onto the
-// global, so only jsdom-created storages pass — note that is a vitest
-// behaviour, not a jsdom guarantee. Guarded by
-// `test.execArgv: ["--no-experimental-webstorage"]` in vitest.config.ts; if
-// this throws, that pin (or its successor) has stopped holding. (If Node
-// instead REJECTS the flag one day, workers crash at spawn before this file
-// runs.) Keep this file's imports free of module-scope storage reads — ESM
-// hoisting evaluates them before the canary.
-for (const name of ["localStorage", "sessionStorage"] as const) {
-  const storage = globalThis[name]
-  if (!(storage instanceof Storage) || typeof storage.clear !== "function") {
-    throw new Error(
-      `${name} is not jsdom's real Storage — Node's experimental web-storage ` +
-        "global is shadowing it. Check the `--no-experimental-webstorage` " +
-        "pin in vitest.config.ts test.execArgv.",
-    )
-  }
-}
-localStorage.setItem("__storage_canary__", "ok")
-if (localStorage.getItem("__storage_canary__") !== "ok") {
-  throw new Error(
-    "localStorage set/get round-trip failed — the test environment's Storage " +
-      "is not functional. Check the `--no-experimental-webstorage` pin in " +
-      "vitest.config.ts test.execArgv.",
-  )
-}
-localStorage.removeItem("__storage_canary__")
-
 Object.defineProperty(globalThis, "__APP_VERSION__", {
   configurable: true,
   value: "999.0.0-test",

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,23 +1,27 @@
 import "@testing-library/jest-dom/vitest"
 
 // Canary: the test environment's web storage must be jsdom's real Storage.
-// Node >= 22.4 can inject its own web-storage globals onto globalThis
-// (default-on from Node 25): an inert file-less localStorage stub, and a
-// real but process-global sessionStorage that leaks state across test files.
-// The jsdom environment skips window keys already present there, so both
-// silently shadow the real thing. `instanceof Storage` is the provenance
-// check: jsdom always restores
-// the `Storage` class itself, so only jsdom-created storages pass, even if a
-// future Node stub grows a working `.clear`. Guarded by
+// Node >= 22.4 can register its own web-storage keys on globalThis
+// (default-on from Node 25; shape varies — a file-less localStorage stub on
+// 25, an undefined-returning accessor from 26, and a real but process-global
+// sessionStorage that leaks state across test files). The jsdom environment
+// skips window keys already present there, so the key's mere presence
+// silently shadows the real thing. `instanceof Storage` is the provenance
+// check: vitest (4.x) installs jsdom's `Storage` class itself onto the
+// global, so only jsdom-created storages pass — note that is a vitest
+// behaviour, not a jsdom guarantee. Guarded by
 // `test.execArgv: ["--no-experimental-webstorage"]` in vitest.config.ts; if
-// this throws, that pin (or its successor) has stopped holding.
+// this throws, that pin (or its successor) has stopped holding. (If Node
+// instead REJECTS the flag one day, workers crash at spawn before this file
+// runs.) Keep this file's imports free of module-scope storage reads — ESM
+// hoisting evaluates them before the canary.
 for (const name of ["localStorage", "sessionStorage"] as const) {
   const storage = globalThis[name]
   if (!(storage instanceof Storage) || typeof storage.clear !== "function") {
     throw new Error(
       `${name} is not jsdom's real Storage — Node's experimental web-storage ` +
-        "stub is shadowing it. Check the `--no-experimental-webstorage` pin " +
-        "in vitest.config.ts test.execArgv.",
+        "global is shadowing it. Check the `--no-experimental-webstorage` " +
+        "pin in vitest.config.ts test.execArgv.",
     )
   }
 }

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,5 +1,29 @@
 import "@testing-library/jest-dom/vitest"
 
+// Canary: the test environment's localStorage must be jsdom's real Storage.
+// Node >= 22.4 can inject its own file-less localStorage stub (no .clear) onto
+// globalThis (default-on from Node 25), and the jsdom environment skips window
+// keys already present there — so the stub silently shadows the real thing.
+// Guarded by `test.execArgv: ["--no-experimental-webstorage"]` in
+// vitest.config.ts; if this throws, that pin (or its successor) has stopped
+// holding.
+if (typeof localStorage.clear !== "function") {
+  throw new Error(
+    "localStorage is not a real Storage (no .clear) — Node's experimental " +
+      "web-storage stub is shadowing jsdom's. Check the " +
+      '`--no-experimental-webstorage` pin in vitest.config.ts test.execArgv.',
+  )
+}
+localStorage.setItem("__storage_canary__", "ok")
+if (localStorage.getItem("__storage_canary__") !== "ok") {
+  throw new Error(
+    "localStorage set/get round-trip failed — the test environment's Storage " +
+      "is not functional. Check the `--no-experimental-webstorage` pin in " +
+      "vitest.config.ts test.execArgv.",
+  )
+}
+localStorage.removeItem("__storage_canary__")
+
 Object.defineProperty(globalThis, "__APP_VERSION__", {
   configurable: true,
   value: "999.0.0-test",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "jsdom",
+    // Node >= 22.4 ships experimental web-storage globals (on by default from
+    // Node 25). Node's file-less localStorage stub (no .clear) would shadow
+    // jsdom's real Storage, because the jsdom environment skips window keys
+    // already present on globalThis. Pin the behaviour off on every Node
+    // rather than pinning a Node version; setupTests.ts carries the canary.
+    execArgv: ["--no-experimental-webstorage"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
     setupFiles: ["./src/setupTests.ts"],
     allowOnly: false,

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,10 +4,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     // Node >= 22.4 ships experimental web-storage globals (on by default from
-    // Node 25). Node's file-less localStorage stub (no .clear) would shadow
-    // jsdom's real Storage, because the jsdom environment skips window keys
-    // already present on globalThis. Pin the behaviour off on every Node
-    // rather than pinning a Node version; setupTests.ts carries the canary.
+    // Node 25), and the jsdom environment skips window keys already present
+    // on globalThis, so Node's globals shadow jsdom's: localStorage as an
+    // inert file-less stub (no .clear), sessionStorage as a real but
+    // process-global Storage that silently leaks state across test files.
+    // Pin the behaviour off on every Node rather than pinning a Node version;
+    // setupTests.ts carries the canary. Requires Node >= 22.4 (older Nodes
+    // reject the flag and crash the workers); from Node 25 this spelling is
+    // the legacy alias of --webstorage.
     execArgv: ["--no-experimental-webstorage"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
     setupFiles: ["./src/setupTests.ts"],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -11,14 +11,19 @@ export default defineConfig({
     // process-global Storage that leaks state across test files) — what
     // matters is the key's mere presence, which stops jsdom's real Storage
     // being installed. Pin the behaviour off on every Node rather than
-    // pinning a Node version; setupTests.ts carries the canary. Requires
+    // pinning a Node version; setupStorageCanary.ts (first in setupFiles)
+    // asserts the pin holds. Entries here are APPENDED to the worker argv
+    // vitest builds (which inherits only profiling flags from the parent
+    // process, by vitest design) — they replace nothing. Requires
     // Node >= 22.4 (older Nodes reject the flag and crash the workers at
     // spawn); from Node 25 this spelling is the legacy alias of --webstorage,
     // and if a future Node drops the alias the symptom is that same
     // worker-spawn crash on an unrecognised option, not a canary message.
+    // The webstoragePin meta-test gates this entry's presence, since on
+    // CI's default-off Node deleting it would go unnoticed.
     execArgv: ["--no-experimental-webstorage"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
-    setupFiles: ["./src/setupTests.ts"],
+    setupFiles: ["./src/setupStorageCanary.ts", "./src/setupTests.ts"],
     allowOnly: false,
     testTimeout: 30000,
     coverage: {
@@ -27,6 +32,7 @@ export default defineConfig({
       exclude: [
         "src/**/__tests__/**",
         "src/setupTests.ts",
+        "src/setupStorageCanary.ts",
         "src/main.tsx",
         "src/vite-env.d.ts",
       ],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -5,13 +5,17 @@ export default defineConfig({
     environment: "jsdom",
     // Node >= 22.4 ships experimental web-storage globals (on by default from
     // Node 25), and the jsdom environment skips window keys already present
-    // on globalThis, so Node's globals shadow jsdom's: localStorage as an
-    // inert file-less stub (no .clear), sessionStorage as a real but
-    // process-global Storage that silently leaks state across test files.
-    // Pin the behaviour off on every Node rather than pinning a Node version;
-    // setupTests.ts carries the canary. Requires Node >= 22.4 (older Nodes
-    // reject the flag and crash the workers); from Node 25 this spelling is
-    // the legacy alias of --webstorage.
+    // on globalThis, so Node's globals shadow jsdom's. The shapes vary by
+    // Node version (25: localStorage = inert file-less stub with no .clear;
+    // 26: an accessor returning undefined; sessionStorage: a real but
+    // process-global Storage that leaks state across test files) — what
+    // matters is the key's mere presence, which stops jsdom's real Storage
+    // being installed. Pin the behaviour off on every Node rather than
+    // pinning a Node version; setupTests.ts carries the canary. Requires
+    // Node >= 22.4 (older Nodes reject the flag and crash the workers at
+    // spawn); from Node 25 this spelling is the legacy alias of --webstorage,
+    // and if a future Node drops the alias the symptom is that same
+    // worker-spawn crash on an unrecognised option, not a canary message.
     execArgv: ["--no-experimental-webstorage"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}", "e2e/__tests__/**/*.test.ts"],
     setupFiles: ["./src/setupTests.ts"],

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -30,6 +30,9 @@ _INPUT_MANIFEST_NAME = "haute-build-inputs.json"
 _OUTPUT_MANIFEST_NAME = "manifest.json"
 _INPUT_MANIFEST_VERSION = 1
 _SOURCE_TEST_ONLY_DIRS = frozenset({"__tests__", "test-utils", "testSupport"})
+# Vitest setup files are verification-system support, not production inputs;
+# mirrored in tests/test_docs_accuracy.py's frontend-source classification.
+_SOURCE_VITEST_SETUP_FILES = frozenset({"setupTests.ts", "setupStorageCanary.ts"})
 _SOURCE_TEST_FILE = re.compile(r"[.](?:test|spec)[.][^.]+$")
 
 
@@ -369,7 +372,7 @@ class FrontendBuildHook(BuildHookInterface):
         relative = path.relative_to(source_root)
         if any(part in _SOURCE_TEST_ONLY_DIRS for part in relative.parts):
             return False
-        if path.name == "setupTests.ts":
+        if path.name in _SOURCE_VITEST_SETUP_FILES:
             return False
         return _SOURCE_TEST_FILE.search(path.name) is None
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -151,8 +151,9 @@ The component specs cover maintained behaviour, not just the importable runtime:
   map. Generated `src/haute/static/` assets are covered as a build output rather than one component
   per hashed file; `src/haute/py.typed` is a distribution marker.
 - Every production `.ts`, `.tsx`, and `.css` source under `frontend/src/` is named in a frontend
-  component's low-level module map. Test-only directories and `setupTests.ts` belong to the
-  verification system rather than the shipped application.
+  component's low-level module map. Test-only directories and the vitest setup files
+  (`setupTests.ts`, `setupStorageCanary.ts`) belong to the verification system rather than the
+  shipped application.
 - Packaging, dependency locks, frontend compilation, static-asset bundling, and documentation-site
   publication are owned by [build-and-distribution](build-and-distribution/high-level.md).
 - CI workflows, lint/type/coverage gates, repository scripts, mutation testing, browser E2E, and

--- a/specs/build-and-distribution/low-level.md
+++ b/specs/build-and-distribution/low-level.md
@@ -50,7 +50,8 @@ package input validated by `hatch_build.py`, not hand-edited source.
   `frontend/.npmrc`, `index.html`, package/lock metadata and Vite config; every
   recursively referenced TypeScript config; all regular files below
   `frontend/public/`; and production files below `frontend/src/`. Test files,
-  test-only directories, test support, and `setupTests.ts` are excluded.
+  test-only directories, test support, and the vitest setup files
+  (`setupTests.ts`, `setupStorageCanary.ts`) are excluded.
 - **Static output graph** is the Vite output rooted at
   `src/haute/static/`: regular `index.html`, non-empty `manifest.json` with at
   least one entry, every declared file/CSS/asset and import/dynamic-import key,

--- a/tests/test_docs_accuracy.py
+++ b/tests/test_docs_accuracy.py
@@ -55,6 +55,10 @@ _LEVEL_TWO_HEADING = re.compile(r"^##(?!#)\s+\S.*$", flags=re.MULTILINE)
 _MODULE_MAP_ROW = re.compile(r"^\s*\|\s*(.*?)\s*\|", flags=re.MULTILINE)
 _FRONTEND_SOURCE_SUFFIXES = frozenset({".css", ".ts", ".tsx"})
 _FRONTEND_TEST_ONLY_DIRS = frozenset({"__tests__", "test-utils", "testSupport"})
+# Vitest setup files belong to the verification system, not the shipped
+# application (specs/README.md §component coverage); mirrored in
+# hatch_build.py's production-input manifest exclusions.
+_FRONTEND_VITEST_SETUP_FILES = frozenset({"setupTests.ts", "setupStorageCanary.ts"})
 _BACKEND_BEHAVIOUR_ASSETS = frozenset(
     {
         "_polars_io_arguments.json",
@@ -1303,7 +1307,7 @@ def _is_frontend_production_source(path: Path) -> bool:
         return False
     if any(part in _FRONTEND_TEST_ONLY_DIRS for part in relative.parts):
         return False
-    if path.name == "setupTests.ts":
+    if path.name in _FRONTEND_VITEST_SETUP_FILES:
         return False
     return re.search(r"[.](?:test|spec)[.](?:css|ts|tsx)$", path.name) is None
 


### PR DESCRIPTION
## Summary

On Node >= 25, Node's default-on experimental web-storage globals shadow jsdom's in the vitest environment (vitest's jsdom env skips window keys already present on `globalThis`): `localStorage` becomes an inert file-less stub (no `.clear`) — breaking all 39 tests in `useAssistantStore.test.ts` locally — and `sessionStorage` becomes a real but *process-global* Storage that silently leaks state across test files. CI (Node pinned 22.14.0) never sees either.

Rather than enforcing a Node version, this pins the behaviour off wherever the tests run:

- `frontend/vitest.config.ts`: `test.execArgv: ["--no-experimental-webstorage"]` — valid and a no-op on CI's 22.14 (flag exists since 22.4; verified worker-permitted against Node source)
- `frontend/src/setupTests.ts`: canary asserting both storages are jsdom's (`instanceof Storage` provenance check + round-trip), so any future drift fails loudly with a named cause instead of dozens of baffling failures
- `docs/CI_MIRROR.md`: new section documenting the pattern — pin the behaviour, not the platform, plus the canary tripwire

Supersedes the unraised `claude/elastic-bassi-ac709e` branch (its two commits are cherry-picked here onto current main, plus a comment-accuracy follow-up).

## Review

Cross-model reviewed per repo policy (Codex CLI unavailable on this machine → agreed Claude fallback): Opus primary review verified the flag semantics against Node 22.3/22.4/22.14/24/25 sources and vitest 4.1.9 dist internals; Sonnet second pass verified config-type validity, flag spelling, and CI workflow pins. Findings (sessionStorage mischaracterisation, Node >= 22.4 floor, Node 25 alias) folded into the final commit.

## Verification

- `useAssistantStore.test.ts`: 39/39 failing → passing on Node 25.6.1
- Full frontend unit suite on merged-forward main: 5593 passed; `tsc -b` clean; eslint clean
- Flag exercised under threads pool, forks pool, and coverage runs without `ERR_WORKER_INVALID_EXEC_ARGV`

## Note

`tests/test_docs_accuracy.py::test_docs_accuracy_ratchet` currently fails on origin/main itself (`specs/roadmap/assistant.md` references `src/haute/assistant/_project_knowledge.py` and `tests/test_assistant_project_knowledge.py`, which don't exist yet — PR #153 fallout, unrelated to this diff). Expect that failure in this PR's backend lane until fixed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)