### PR TITLE
Add typography role token layer over Tailwind's font-mono

### DIFF
--- a/frontend/src/__tests__/cssColorTokenization.test.ts
+++ b/frontend/src/__tests__/cssColorTokenization.test.ts
@@ -48,7 +48,10 @@
  *      is worse here than in CSS: the declaration is invalid at
  *      computed-value time, so the property silently becomes its initial
  *      value — `transparent` backgrounds, `currentColor` borders — with
- *      no build error and no console warning.
+ *      no build error and no console warning.  Convention (review-policed,
+ *      not gate-policed): components prefer the index.css role token that
+ *      aliases a Tailwind token (e.g. --font-data) over the raw Tailwind
+ *      name — see the adoption pin below.
  *
  *   4. index.css must NOT redeclare a Tailwind theme token in its plain
  *      (unlayered) `:root` block.  Unlayered declarations outrank every
@@ -66,7 +69,8 @@
  *   `:root` block.  If the token is a Tailwind theme token the app
  *   genuinely uses, add it to TAILWIND_PROVIDED_TOKENS with the utility
  *   regex that keeps it emitted — do NOT declare it in :root (see the
- *   shadow rule below).  Only if the property is genuinely
+ *   shadow rule below) — and in ts/tsx prefer the index.css role token
+ *   that aliases it (e.g. --font-data).  Only if the property is genuinely
  *   caller-supplied (some JSX sets it via inline `style={{ ... }}`) add
  *   it to PARAMETERISED_TOKENS *and* give every reference an inline
  *   fallback.
@@ -372,9 +376,11 @@ const PARAMETERISED_TOKENS = new Set([
  * verify a token really appears in the built CSS before adding it.
  */
 const TAILWIND_PROVIDED_TOKENS = new Map<string, RegExp>([
-  // Trace detail components use var(--font-mono, monospace); the token
+  // The mono face behind the --font-data role token in index.css (trace
+  // value text goes through the role token, not this name).  The token
   // stays emitted because `.font-mono` utility classes are used
-  // throughout the app.
+  // throughout the app — and Tailwind's preflight references it
+  // unconditionally via --default-mono-font-family.
   ["--font-mono", /(?<![\w-])font-mono(?![\w-])/],
 ])
 
@@ -673,6 +679,65 @@ describe("index.css — design-token contract", () => {
   })
 })
 
+describe("Tailwind-provided tokens", () => {
+  it("the shadow guard's declaration scan covers non-:root blocks", () => {
+    // Pin the whole-file property the shadow guards rely on: a token
+    // declared in an `html, body { ... }` block (or any other unlayered
+    // block) is found by findTokenDeclarations exactly like a :root
+    // declaration.  Without this canary, a refactor that narrowed the
+    // scan to the first :root block would silently re-open the html/body
+    // shadow hole.
+    const decls = findTokenDeclarations("html, body, #root { --font-mono: x; }")
+    expect(decls.has("--font-mono")).toBe(true)
+  })
+
+  it("each mapped token survives into the app's compiled output (compiled-emission guard)", async () => {
+    // The input-side emission guard above pins the PREMISE of emission
+    // (theme.css declaration + live utility usage).  This one pins the
+    // OUTPUT: a Tailwind upgrade could keep theme.css textually intact yet
+    // stop emitting the custom property (e.g. moving the font block to
+    // `@theme inline`, whose values are substituted at build time and
+    // never emitted).  The input guard would pass while every
+    // var(--font-mono) — and so --font-data — silently became invalid at
+    // computed-value time.
+    //
+    // The compilation target is the APP's real entry (src/index.css), not
+    // Tailwind's package entry — the invariant is "our build emits the
+    // token", and an index.css edit that dropped the default theme must
+    // fail here too.  No utility candidates are passed: emission must hold
+    // even for a page that uses no Tailwind utilities, via index.css's own
+    // var() reference (or, for --font-mono, Tailwind's preflight).  The
+    // assertion runs on comment-stripped output and anchors the token name
+    // so neither a stray comment nor a longer token (--font-mono-x) can
+    // satisfy it.
+    let compile: typeof import("tailwindcss").compile
+    try {
+      ;({ compile } = await import("tailwindcss"))
+    } catch {
+      throw new Error("Cannot import tailwindcss — is frontend/node_modules installed? (npm ci --prefix frontend)")
+    }
+    const twEntry = path.resolve(HERE, "..", "..", "node_modules", "tailwindcss", "index.css")
+    const compiled = await compile(CSS, {
+      base: path.dirname(CSS_PATH),
+      async loadStylesheet(id: string, base: string) {
+        // `@import "tailwindcss"` resolves to the package entry; the
+        // package's internal imports (theme/preflight/utilities.css)
+        // resolve relative to the importing file.
+        const file = id === "tailwindcss" ? twEntry : path.resolve(base, id)
+        return { path: file, base: path.dirname(file), content: readFileSync(file, "utf8") }
+      },
+    })
+    const output = stripComments(compiled.build([]))
+    for (const token of TAILWIND_PROVIDED_TOKENS.keys()) {
+      const declRe = new RegExp(`(^|[^-\\w])${token}\\s*:`, "m")
+      expect(
+        declRe.test(output),
+        `${token} is not emitted by the app's compiled CSS — the TAILWIND_PROVIDED_TOKENS premise no longer holds`,
+      ).toBe(true)
+    }
+  })
+})
+
 describe("ts/tsx source — design-token contract", () => {
   it("every var(--name) in live source resolves to an index.css token (or is an allowlisted parameterised token with a fallback)", () => {
     // Regression guard for the bug class where a component references a
@@ -791,6 +856,20 @@ describe("ts/tsx source — design-token contract", () => {
       return !texts.some((t) => setterRe.test(t))
     })
     expect(orphaned).toEqual([])
+  })
+
+  it("the typography role token is adopted in live source (adoption pin)", () => {
+    // The three trace-detail sites migrated to var(--font-data) are the
+    // role layer's seed adoption.  Nothing else pins them: a revert to a
+    // raw font stack (or to var(--font-mono, monospace)) would pass every
+    // resolution rule.  Requiring at least one live reference keeps the
+    // role token honest — a declared-but-unreferenced role token is a
+    // regression, not a tidy-up.
+    const files = collectSourceFiles(SRC_ROOT)
+    const referenced = files.some((f) =>
+      findVarRefs(stripComments(readFileSync(f, "utf8"))).some((r) => r.name === "--font-data"),
+    )
+    expect(referenced, "no live ts/tsx source references var(--font-data)").toBe(true)
   })
 
   it("skips template-interpolated token names (dynamic refs like var(--diff-${status}))", () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,23 @@
 :root {
   color-scheme: dark;
 
+  /* Typography roles.  The mono face itself is Tailwind v4's --font-mono
+     theme token (node_modules/tailwindcss/theme.css, emitted into
+     @layer theme).  Never redeclare --font-mono here: this :root block is
+     unlayered, so a redeclaration would outrank @layer theme and shadow
+     Tailwind's value (pinned by the shadow guard in
+     __tests__/cssColorTokenization.test.ts; a deliberate face override
+     belongs in an @theme block, which the guard exempts).  Role tokens
+     alias the face so call sites name what the text is for, not how it
+     looks.
+     The `monospace` fallback here is LIVE, not speculative: the primitive
+     is Tailwind-emitted, so under real drift (an @theme-inline style
+     upgrade, or a build that never ran the gate) call sites degrade to
+     the generic mono face instead of silently inheriting sans.  Recorded
+     decision — distinct from the dead app-declared-alias fallbacks
+     removed elsewhere, which could never fire. */
+  --font-data: var(--font-mono, monospace);
+
   /* Surfaces - blue-black */
   --bg-base: #0f1117;
   --bg-canvas: #131620;

--- a/frontend/src/trace/LiveSwitchDetail.tsx
+++ b/frontend/src/trace/LiveSwitchDetail.tsx
@@ -8,7 +8,7 @@ import {
 const traceDetailValueStyle = {
   color: "var(--text-secondary)",
   fontSize: 11,
-  fontFamily: "var(--font-mono, monospace)",
+  fontFamily: "var(--font-data)",
 }
 
 export function LiveSwitchDetailBlock({ detail }: {

--- a/frontend/src/trace/RatingStepDetail.tsx
+++ b/frontend/src/trace/RatingStepDetail.tsx
@@ -17,7 +17,7 @@ const formatValue = formatTraceValue
 const traceDetailValueStyle = {
   color: "var(--text-secondary)",
   fontSize: 11,
-  fontFamily: "var(--font-mono, monospace)",
+  fontFamily: "var(--font-data)",
 }
 
 export function RatingStepDetailBlock({

--- a/frontend/src/trace/TraceDetail.tsx
+++ b/frontend/src/trace/TraceDetail.tsx
@@ -79,7 +79,7 @@ export function TraceCalculationFrame({
             title={resultTitle}
             style={{
               minWidth: 0,
-              fontFamily: "var(--font-mono, monospace)",
+              fontFamily: "var(--font-data)",
               fontSize: 13,
               fontWeight: 600,
               fontVariantNumeric: "tabular-nums",

--- a/specs/frontend-shared/low-level.md
+++ b/specs/frontend-shared/low-level.md
@@ -43,7 +43,7 @@
 | `frontend/src/hooks/useMlflowBrowser.ts` | Lazy-loads MLflow experiments/runs/models/versions for dropdown UIs; shared by `ModelScoreEditor` and `OptimiserApplyEditor` (node-editors). |
 | `frontend/src/hooks/useSchemaFetch.ts` | Fetch-schema-on-mount-and-on-path-change pattern used by `frontend/src/panels/editors/ApiInputEditor.tsx` and `frontend/src/panels/editors/DataInputEditor.tsx` (node-editors). |
 | `frontend/src/hooks/useStaleConfigEstimate.ts` | Generic "estimate endpoint keyed by config hash + source + structural version, refetch when any of the three changes" pattern, built on `hashConfig`. Takes a required `context: {source, structuralVersion}` argument alongside the cached result. |
-| `frontend/src/index.css` | Global Tailwind import and dark-theme CSS-variable contract: root sizing/type, native-control and scrollbar defaults, React Flow interaction overrides, and canonical semantic surface/status/chart/git-node tokens consumed directly by the theme module and components. Also owns the `.toolbar-btn` action-button surface (resting/hover/pressed fills, engaged `aria-pressed` toggle, and a flat unavailable state that keeps its label readable) and the `.toolbar-number-input` spinner suppression. |
+| `frontend/src/index.css` | Global Tailwind import and dark-theme CSS-variable contract: root sizing/type, native-control and scrollbar defaults, React Flow interaction overrides, canonical semantic surface/status/chart/git-node tokens consumed directly by the theme module and components, and typography role tokens (`--font-data`) that alias Tailwind theme tokens rather than redeclaring them (no Tailwind theme token may be redeclared in the file's plain blocks — they are unlayered and would shadow `@layer theme`; a deliberate override belongs in an `@theme` block, which the gate exempts automatically; and components conventionally reference the role token rather than the raw Tailwind name — adoption and emission both pinned by `__tests__/cssColorTokenization.test.ts`). Also owns the `.toolbar-btn` action-button surface (resting/hover/pressed fills, engaged `aria-pressed` toggle, and a flat unavailable state that keeps its label readable) and the `.toolbar-number-input` spinner suppression. |
 | `frontend/src/utils/chartHelpers.ts` | Small pure chart leaf helpers: compact K/M/scientific axis labels and inclusive evenly spaced Y ticks (a degenerate range yields one tick). |
 | `frontend/src/utils/formatTrace.ts` | Cross-surface trace-value/expression/calculation/schema-summary presentation formatting: retains date-shaped strings, represents non-finite numbers explicitly, quotes ordinary strings, escapes column names before substitution, and uses longest names first to avoid partial replacement. |
 | `frontend/src/utils/mlflowOptimiser.ts` | Pure MLflow run/model metadata classifier: the canonical `params.mode` value selects ratebook versus online; absent or invalid values yield the empty mode. |
@@ -459,10 +459,13 @@ no-op blur, external-value draft reset, and form-label/control semantics.
 `frontend/src/utils/__tests__/formatTrace.test.ts` respectively pin numeric
 ticks/formatting and trace substitutions/non-finite display.
 `frontend/src/components/NodeTypeIcon.tsx`,
-`frontend/src/components/form/index.ts`, `frontend/src/index.css`, and
+`frontend/src/components/form/index.ts`, and
 `frontend/src/utils/mlflowOptimiser.ts` currently have no dedicated test file; the
-icon/form/CSS files are simple presentation or re-export surfaces, while the optimiser
-classifier is an uncovered pure helper.
+icon/form files are simple presentation or re-export surfaces, while the optimiser
+classifier is an uncovered pure helper.  `frontend/src/index.css` is pinned by
+`frontend/src/__tests__/cssColorTokenization.test.ts` (design-token contract: no hex
+outside `:root`, no dangling `var()` references, Tailwind-provided-token emission and
+shadow guards).
 
 Known gaps: `frontend/src/components/Toolbar.tsx`'s inline timing/memory formatting helpers
 (`formatTiming`/`formatMemory`, distinct from and not delegating to


### PR DESCRIPTION
Tier 1 of the design-token improvements: introduce a typography role-token layer.

## What

- New role token in `frontend/src/index.css` `:root`: `--font-data: var(--font-mono)` — the mono face for data values. `--font-mono` itself is Tailwind v4's theme token (declared in `node_modules/tailwindcss/theme.css`, emitted into `@layer theme`) and is deliberately **not** redeclared in our unlayered `:root`, which would outrank `@layer theme` and shadow it.
- Migrated the three `var(--font-mono, monospace)` call sites — the trace-detail value text in `TraceDetail.tsx`, `LiveSwitchDetail.tsx`, `RatingStepDetail.tsx` — to `var(--font-data)`. The inline fallbacks go because the gate now guarantees resolution end-to-end; note the honest trade-off: if Tailwind ever stopped emitting `--font-mono`, the failure mode is the inherited sans face rather than the old hard `monospace` — which is exactly what the guards below exist to make impossible to miss.
- Taught the tokenization gate (`cssColorTokenization.test.ts`) about Tailwind-provided tokens:
  - After the rebase over #157's gate hardening, the resolution rules follow main's allowlist design: each `TAILWIND_PROVIDED_TOKENS` entry carries a usage-regex **emission guard** pinning the utility that keeps it in the tree-shaken bundle. The role-token convention for components is review-policed plus an **adoption pin** (some live source must reference `var(--font-data)` — a wholesale revert to raw stacks fails).
  - This PR's surviving additions on top of #157's mechanisms: a **compiled-emission guard** — compiles the app's real `index.css` entry with no utility candidates and asserts the token survives into the output CSS (comment-stripped, name-anchored), closing the hole where an upgrade keeps `theme.css` textually intact but stops emitting the variable (e.g. `@theme inline`) — and a **non-`:root` canary** pinning that the shadow scan covers `html, body, #root`-style unlayered blocks. #157's `stripThemeBlocks` @theme exemption, `CSS_CODE` naming, and broad `TAILWIND_DECLARED` shadow guard are adopted as-is (my parallel copies deduped).
- Spec upkeep: the two `index.css` rows in `specs/frontend-shared/low-level.md` (one predating this PR) now describe the typography layer and the gate.

## Verification

- Tokenization gate: 12/12. Trace-area vitest: 111/111. `tsc -b --noEmit` clean.
- Negative tests: a `:root` redeclaration of `--font-mono` fails the shadow guard; a bare `var(--font-mono)` in a ts file fails the source rule.
- Reviewer verified (in `tailwindcss` 4.1.18): a declaration-value `var()` reference marks a theme variable used, and preflight keeps `--font-mono` alive regardless; the compiled-emission guard pins the built output either way.

## Review

No Codex CLI on this machine, so the agreed cross-model fallback ran twice: Opus + Sonnet at raise time, then a deep second pass (Opus code review + Opus contract check) during the CI incident window — the second commit applies its findings (ts/tsx strictness, whole-file shadow guard, compiled-emission guard, corrected emission-mechanism comment, spec rows).

Noted residuals (deliberately out of scope):

- `fontFamily: "monospace"` literals in `trace/CalculationHero.tsx` (×3) and `components/ErrorBoundary.tsx` — handled by the separate mono-literal branch stacked on this PR (raised separately).
- `CodeMirrorEditor.tsx` keeps its custom mono stack — a deliberate follow-up decision.
- `--font-code` arrives with the first code-face call site; the text-size scale (~818 hardcoded `text-[13px]` utilities) remains the optional large follow-up.
- Reviewer nit for the record: `--font-data` could read as "font for data nodes" in this repo's vocabulary; rename to `--font-value` is cheap now if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Cross-vendor review round (7 Aug)

Applied from the Kimi K3 / GLM-5.2 / GPT-5.6 trio run by the orchestration session: the compiled-emission guard now compiles the **application's** `index.css` entry (an app edit that dropped the default theme fails too), asserting on comment-stripped output with the token name anchored; all gate scans share one comment-stripped CSS source; a canary pins that the shadow scan covers non-`:root` blocks, and a broad guard rejects shadowing **any** of Tailwind's ~375 theme tokens; an adoption pin requires live source to reference `var(--font-data)`. `--font-data` carries a recorded **live** runtime fallback (`var(--font-mono, monospace)`) so drift degrades to generic mono rather than silently inheriting sans — distinct from the dead app-declared-alias fallbacks removed elsewhere. One description correction: relative to `main`, the ts/tsx rule's strictness is *preserved*, not tightened (an intermediate commit had loosened it; the net diff does not).
