### PR TITLE
Add success-family role tokens over the intensity ladder

### DIFF
--- a/frontend/src/__tests__/cssColorTokenization.test.ts
+++ b/frontend/src/__tests__/cssColorTokenization.test.ts
@@ -172,6 +172,57 @@ function stripThemeBlocks(css: string): string {
   return out
 }
 
+// ---------------------------------------------------------------------------
+// Private primitive tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * Family PATTERNS for the graded ladder primitives that only the role
+ * tokens in index.css's :root block may reference.  A call site (ts/tsx,
+ * or a CSS rule body) that reaches for one directly bypasses the role
+ * layer — the role tokens exist so a shade retune touches one alias line
+ * per role instead of a grep across the tree.
+ *
+ * Patterns, not a hand-copied name list: the concrete tokens are derived
+ * from whatever the ladder currently declares, so a new ladder step is
+ * private from birth rather than silently public until someone remembers
+ * to update a list.  Extend family by family as the semantic layer rolls
+ * out (warning, danger, accent to follow).
+ */
+const PRIVATE_PRIMITIVE_PATTERNS = [
+  // Success family: the graded soft/border steps and the hover step.
+  // Deliberately NOT private: the base hue --success (still a direct
+  // anchor for ~25 sites) and --success-fill* (main's Commit button pair,
+  // unclassified until its own role token lands).
+  /--success-(?:soft|border|hover)[\w-]*/,
+]
+
+interface PrimitiveMention {
+  match: string
+  line: number
+}
+
+/**
+ * Every occurrence of a private-primitive IDENTIFIER in `text` — an
+ * identifier scan, not a var() parse, so Tailwind arbitrary-property
+ * shorthand (`bg-(--success-soft)`), dynamic template construction
+ * (`var(--success-soft-${tier})`, caught via its static prefix), and
+ * fallback-carrying references are all found.  A leading word/dash
+ * boundary stops `--x--success-soft`-style false joins.
+ */
+function findPrivatePrimitiveMentions(text: string): PrimitiveMention[] {
+  const hits: PrimitiveMention[] = []
+  for (const pattern of PRIVATE_PRIMITIVE_PATTERNS) {
+    const re = new RegExp(`(?<![-\\w])${pattern.source}`, "g")
+    let m: RegExpExecArray | null
+    while ((m = re.exec(text)) !== null) {
+      const line = text.slice(0, m.index).split("\n").length
+      hits.push({ match: m[0], line })
+    }
+  }
+  return hits.sort((a, b) => a.line - b.line)
+}
+
 function findRootBlockRange(css: string): { start: number; end: number } {
   const match = /:root\s*\{/.exec(css)
   if (!match) {
@@ -431,6 +482,22 @@ function findTokenDeclarations(css: string): Set<string> {
   return decls
 }
 
+/**
+ * Like findTokenDeclarations, but capturing each token's declared VALUE
+ * (whitespace collapsed, trailing `;` required).  Used by the
+ * behaviour-preservation pin to assert role-token → primitive aliases.
+ * Last declaration wins, matching the CSS cascade within one block.
+ */
+function findTokenDeclarationValues(css: string): Map<string, string> {
+  const values = new Map<string, string>()
+  const re = /(^|[\s{;])(--[a-zA-Z_][a-zA-Z0-9_-]*)\s*:\s*([^;}]+);/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(css)) !== null) {
+    values.set(m[2], m[3].trim().replace(/\s+/g, " "))
+  }
+  return values
+}
+
 // ---------------------------------------------------------------------------
 // TS/TSX source scanner (contract property 3)
 // ---------------------------------------------------------------------------
@@ -454,6 +521,26 @@ function collectSourceFiles(dir: string): string[] {
     if (!/\.(ts|tsx)$/.test(entry)) continue
     if (/\.(test|spec)\.(ts|tsx)$/.test(entry)) continue
     out.push(full)
+  }
+  return out
+}
+
+/**
+ * Enumerate `.css` stylesheets under `frontend/src` (skipping `__tests__/`).
+ * index.css is the only one today; scanning the tree keeps any future
+ * stylesheet inside the role-layer contract from the moment it is added
+ * rather than making the single-file scope a silent assumption.
+ */
+function collectStylesheets(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === "__tests__") continue
+      out.push(...collectStylesheets(full))
+      continue
+    }
+    if (/\.css$/.test(entry)) out.push(full)
   }
   return out
 }
@@ -677,6 +764,83 @@ describe("index.css — design-token contract", () => {
     const missing = required.filter((t) => !declared.has(t))
     expect(missing).toEqual([])
   })
+
+  it("stylesheets do not mention private primitive tokens outside index.css's :root (role-layer gate, CSS side)", () => {
+    // :root is where the ladder is declared and where the role-token
+    // aliases live; everything else — index.css rule bodies and any other
+    // stylesheet under src/ — must go through the role tokens.  Identifier
+    // scan, same as the ts/tsx side.
+    const offenders: string[] = []
+    const { start, end } = findRootBlockRange(CSS_CODE)
+    for (const hit of findPrivatePrimitiveMentions(CSS_CODE.slice(0, start) + CSS_CODE.slice(end))) {
+      // Line numbers are meaningless on the spliced text; name the region.
+      offenders.push(`  index.css (outside :root)  ${hit.match}`)
+    }
+    for (const file of collectStylesheets(SRC_ROOT)) {
+      if (path.resolve(file) === CSS_PATH) continue
+      const rel = path.relative(SRC_ROOT, file).split(path.sep).join(path.posix.sep)
+      for (const hit of findPrivatePrimitiveMentions(stripComments(readFileSync(file, "utf8")))) {
+        offenders.push(`  ${rel}:${hit.line}  ${hit.match}`)
+      }
+    }
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found ${offenders.length} mention(s) of private primitive tokens outside index.css's :root. ` +
+          `Reference the role token that aliases the primitive instead:\n` +
+          offenders.join("\n"),
+      )
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it("success role tokens alias their expected primitives (behaviour-preservation pin)", () => {
+    // The role layer is a pure re-labelling: each role token must resolve
+    // to exactly the primitive its call sites rendered with before the
+    // migration.  This map IS the review surface for shade changes — a
+    // retune must edit it, visibly.  (The near-miss this pins against: a
+    // draft of this PR silently normalised three banner shades and broke
+    // intra-component tone parity.)
+    const expected: Record<string, string> = {
+      "--trace-added-text": "var(--color-added, var(--success-hover))",
+      "--trace-added-bg": "var(--success-soft-mid)",
+      "--trace-chip-matched-text": "var(--success-hover)",
+      "--trace-chip-matched-bg": "var(--success-soft-mid)",
+      "--delta-positive-text": "var(--success-hover)",
+      "--flash-success-text": "var(--success-hover)",
+      "--banner-success-bg": "var(--success-soft)",
+      "--banner-success-border": "var(--success-border)",
+      "--banner-success-text": "var(--success)",
+      "--banner-success-data": "var(--success-hover)",
+      "--banner-success-action": "var(--success-hover)",
+      "--editor-status-success-bg": "var(--success-soft-subtle)",
+      "--editor-status-success-border": "var(--success-border)",
+      "--editor-status-success-text": "var(--success)",
+      "--train-summary-success-bg": "var(--success-soft-subtle)",
+      "--train-summary-success-border": "var(--success-soft-strong)",
+      "--train-summary-success-text": "var(--success)",
+      "--train-complete-bg": "var(--success-soft-faint)",
+      "--train-complete-border": "var(--success-border)",
+      "--train-complete-text": "var(--success)",
+      "--add-pill-text": "var(--success)",
+      "--add-pill-border": "var(--success-border)",
+      "--add-pill-bg": "var(--success-soft)",
+      "--column-confirm-text": "var(--success)",
+      "--column-confirm-border": "var(--success-border)",
+      "--column-origin-manual-text": "var(--success)",
+      "--column-origin-manual-bg": "var(--success-soft)",
+      "--cache-ready-text": "var(--success)",
+      "--cache-ready-border": "var(--success-border-strong)",
+      "--cache-ready-bg": "var(--success-soft)",
+      "--branch-restore-text": "var(--success)",
+      "--branch-restore-hover-bg": "var(--success-soft)",
+      "--diff-added-soft": "var(--success-soft)",
+    }
+    const declared = findTokenDeclarationValues(CSS_CODE)
+    const mismatches = Object.entries(expected)
+      .filter(([name, value]) => declared.get(name) !== value)
+      .map(([name, value]) => `  ${name}: expected "${value}", declared "${declared.get(name) ?? "(missing)"}"`)
+    expect(mismatches).toEqual([])
+  })
 })
 
 describe("Tailwind-provided tokens", () => {
@@ -870,6 +1034,36 @@ describe("ts/tsx source — design-token contract", () => {
       findVarRefs(stripComments(readFileSync(f, "utf8"))).some((r) => r.name === "--font-data"),
     )
     expect(referenced, "no live ts/tsx source references var(--font-data)").toBe(true)
+  })
+
+  it("live source does not mention private primitive tokens (role-layer gate)", () => {
+    // Without this rule the "private primitives" comment in index.css is
+    // prose, not a contract: the first `var(--success-soft)` written at a
+    // call site would pass the resolution rule above (the token IS
+    // declared) and quietly re-open direct ladder access.  The scan
+    // matches the token IDENTIFIERS themselves, not parsed var() calls,
+    // so it also catches Tailwind v4 arbitrary-property shorthand
+    // (`bg-(--success-soft)`), template-interpolated names whose static
+    // prefix is a ladder step (`var(--success-soft-${tier})`), and
+    // fallback-carrying refs — routing through the role token is the
+    // point, not resolvability.
+    const offenders: string[] = []
+    for (const file of collectSourceFiles(SRC_ROOT)) {
+      const text = stripComments(readFileSync(file, "utf8"))
+      for (const hit of findPrivatePrimitiveMentions(text)) {
+        const rel = path.relative(SRC_ROOT, file).split(path.sep).join(path.posix.sep)
+        offenders.push(`  ${rel}:${hit.line}  ${hit.match}`)
+      }
+    }
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found ${offenders.length} mention(s) of private primitive tokens in ts/tsx source. ` +
+          `Reference the index.css role token that aliases the primitive (or add a new role ` +
+          `token there) instead of the ladder step:\n` +
+          offenders.join("\n"),
+      )
+    }
+    expect(offenders).toEqual([])
   })
 
   it("skips template-interpolated token names (dynamic refs like var(--diff-${status}))", () => {

--- a/frontend/src/components/BranchManager.tsx
+++ b/frontend/src/components/BranchManager.tsx
@@ -574,7 +574,7 @@ export default function BranchManager({ selectedBranch, onPeek, onSave }: Branch
                 className="flex items-center gap-1.5 px-3 py-1.5 w-full text-left hover:bg-[var(--bg-hover)] disabled:opacity-40"
                 style={{ color: "var(--text-primary)" }}
               >
-                <RotateCcw size={12} style={{ color: "var(--success)" }} /> Restore
+                <RotateCcw size={12} style={{ color: "var(--branch-restore-text)" }} /> Restore
               </button>
             )}
             <button
@@ -700,7 +700,7 @@ function BranchRow({
             data-testid="branch-manager-restore"
             onClick={onRestore}
             disabled={anyBusy}
-            className="p-1 rounded transition-colors text-[var(--text-muted)] hover:bg-[var(--success-soft)] hover:text-[var(--success)] disabled:opacity-40"
+            className="p-1 rounded transition-colors text-[var(--text-muted)] hover:bg-[var(--branch-restore-hover-bg)] hover:text-[var(--branch-restore-text)] disabled:opacity-40"
           >
             <RotateCcw size={12} />
           </button>

--- a/frontend/src/components/CacheFetchButton.tsx
+++ b/frontend/src/components/CacheFetchButton.tsx
@@ -227,9 +227,9 @@ export function CacheFetchButton<TStatus extends BaseCacheStatus>({
         title={externalDisabled ? disabledReason : undefined}
         className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-colors disabled:opacity-40"
         style={{
-          background: (building && cancelFetchFn) || hasStatusError ? 'var(--danger-soft)' : cache?.cached ? 'var(--success-soft)' : 'var(--accent-soft)',
-          border: (building && cancelFetchFn) || hasStatusError ? '1px solid var(--danger-border-strong)' : cache?.cached ? '1px solid var(--success-border-strong)' : '1px solid var(--accent)',
-          color: (building && cancelFetchFn) || hasStatusError ? 'var(--danger)' : cache?.cached ? 'var(--success)' : 'var(--accent)',
+          background: (building && cancelFetchFn) || hasStatusError ? 'var(--danger-soft)' : cache?.cached ? 'var(--cache-ready-bg)' : 'var(--accent-soft)',
+          border: (building && cancelFetchFn) || hasStatusError ? '1px solid var(--danger-border-strong)' : cache?.cached ? '1px solid var(--cache-ready-border)' : '1px solid var(--accent)',
+          color: (building && cancelFetchFn) || hasStatusError ? 'var(--danger)' : cache?.cached ? 'var(--cache-ready-text)' : 'var(--accent)',
         }}
       >
         {building ? (

--- a/frontend/src/components/ComparisonInspector.tsx
+++ b/frontend/src/components/ComparisonInspector.tsx
@@ -21,7 +21,7 @@ const STATUS_META: Record<
   ComparisonInspect["status"],
   { label: string; color: string; soft: string }
 > = {
-  added: { label: "Added", color: "var(--diff-added)", soft: "var(--success-soft)" },
+  added: { label: "Added", color: "var(--diff-added)", soft: "var(--diff-added-soft)" },
   removed: { label: "Removed", color: "var(--diff-removed)", soft: "var(--danger-soft)" },
   changed: { label: "Changed", color: "var(--diff-changed)", soft: "var(--warning-soft)" },
   unchanged: { label: "Unchanged", color: "var(--text-muted)", soft: "var(--bg-hover)" },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -111,9 +111,118 @@
   --danger-border: rgba(239,68,68,.20);
   --danger-border-strong: rgba(239,68,68,.30);
 
+  /* ── Success role tokens ──────────────────────────────────────────
+     Functional layer over the success intensity ladder above.  Call
+     sites reference these; the graded ladder steps (--success-soft*,
+     --success-border*, --success-hover) are private primitives (same
+     pattern as the --diff-* aliases below), enforced by the role-layer
+     gate in __tests__/cssColorTokenization.test.ts.  The base --success
+     hue is still referenced directly by numerous sites outside this
+     audit (e.g. status dots, git panel icons, toast accents, editor
+     state colours) — the hue anchor, to be role-tokenised as roles
+     emerge.
+     One token per interface element — elements that merely share a
+     shade today get separate tokens so their fates stay independent.
+     Components whose tones sit in a success/warning/danger map keep
+     per-component roles so the tones stay in alpha parity (the map's
+     real invariant) rather than being fused with lookalike elements
+     elsewhere. */
+
+  /* Trace step "added" marking: added-column tags, "+N added" counts,
+     added-row values (StepCard).  The text colour honours the
+     caller-overridable --color-added hook at the ALIAS layer, so every
+     call site inherits the override for free.  The hook's scope is
+     deliberately exactly this role: the matched chip and positive-delta
+     roles below used to sit behind it too and no longer do — an override
+     recolours added markings, nothing else.  (--color-modified, its
+     sibling for the "modified" marking, still lives at its StepCard call
+     site pending the warning-family PR.) */
+  --trace-added-text: var(--color-added, var(--success-hover));
+  --trace-added-bg: var(--success-soft-mid);
+
+  /* Trace detail chip, "matched" tone (TraceDetailChip's success tone,
+     whose only consumer is the matched rating-band status).  Same
+     shades as the added marking, deliberately separate role. */
+  --trace-chip-matched-text: var(--success-hover);
+  --trace-chip-matched-bg: var(--success-soft-mid);
+
+  /* Positive signed numeric delta text (model contributions, optimiser
+     lambda terms).  Call sites pair this with --danger-text for the
+     negative case until the danger family grows --delta-negative-text. */
+  --delta-positive-text: var(--success-hover);
+
+  /* Transient success flash line — inline confirmation text, no box
+     (e.g. "Trace copied as Markdown"). */
+  --flash-success-text: var(--success-hover);
+
+  /* Confirmation banner, success tone — icon + message in a tinted
+     rounded box: picker path confirmation, optimiser converged.  The
+     `success` qualifier is deliberate: banner-* is a TONE-QUALIFIED
+     family, and --banner-warning-* (e.g. the optimiser's did-not-
+     converge state) is expected to join it in the warning-family PR.
+     -data is the mono path/value text inside the banner; -action is an
+     inline banner control (the path picker's "change" button). */
+  --banner-success-bg: var(--success-soft);
+  --banner-success-border: var(--success-border);
+  --banner-success-text: var(--success);
+  --banner-success-data: var(--success-hover);
+  --banner-success-action: var(--success-hover);
+
+  /* Editor status badge (MlflowStatusBadge in editors/_shared), success
+     tone.  Its success/danger/warning tints deliberately share the .06
+     alpha tier so no tone shouts over the others — keep parity with the
+     danger/warning sides of the tone map when retuning. */
+  --editor-status-success-bg: var(--success-soft-subtle);
+  --editor-status-success-border: var(--success-border);
+  --editor-status-success-text: var(--success);
+
+  /* Training data-summary banner (modelling panel), ok state.  Pairs
+     with a warning state at the same .06 tint tier — keep parity. */
+  --train-summary-success-bg: var(--success-soft-subtle);
+  --train-summary-success-border: var(--success-soft-strong);
+  --train-summary-success-text: var(--success);
+
+  /* Training completion badge (modelling panel). */
+  --train-complete-bg: var(--success-soft-faint);
+  --train-complete-border: var(--success-border);
+  --train-complete-text: var(--success);
+
+  /* "Add mapping row" pill button (OutputEditor). */
+  --add-pill-text: var(--success);
+  --add-pill-border: var(--success-border);
+  --add-pill-bg: var(--success-soft);
+
+  /* Column-confirm affordances in ApiInputEditor: the per-column
+     confirm check and the "Confirm all" pill.  Column-scoped name so a
+     future unrelated confirm surface (e.g. a destructive confirm
+     dialog) cannot plausibly reach for it. */
+  --column-confirm-text: var(--success);
+  --column-confirm-border: var(--success-border);
+
+  /* ApiInput column-origin chip, "manual" variant.  "column-origin"
+     (the chip's domain term), not git-remote origin. */
+  --column-origin-manual-text: var(--success);
+  --column-origin-manual-bg: var(--success-soft);
+
+  /* Cache fetch button, cached state. */
+  --cache-ready-text: var(--success);
+  --cache-ready-border: var(--success-border-strong);
+  --cache-ready-bg: var(--success-soft);
+
+  /* Branch-restore affordance (BranchManager): icon/text colour at rest
+     and on hover, plus the icon-button hover fill.  Branch-scoped name —
+     "restore" alone would invite reuse by unrelated restore surfaces. */
+  --branch-restore-text: var(--success);
+  --branch-restore-hover-bg: var(--success-soft);
+
   /* Diff highlight (read-only comparison view, S11): added / removed / changed
-     components.  Aliased onto the semantic palette so they theme together. */
+     components.  Aliased onto the semantic palette so they theme together.
+     -soft is the added-state soft background behind comparison chips; the
+     family is intentionally partial — --diff-removed-soft and
+     --diff-changed-soft arrive with the danger and warning family PRs
+     (their call sites still use those families' primitives). */
   --diff-added: var(--success);
+  --diff-added-soft: var(--success-soft);
   --diff-removed: var(--danger);
   --diff-changed: var(--warning-strong);
   --diff-moved: var(--accent);

--- a/frontend/src/panels/OptimiserConfig.tsx
+++ b/frontend/src/panels/OptimiserConfig.tsx
@@ -1222,8 +1222,8 @@ export default function OptimiserConfig({
           )}
 
           {/* Convergence status */}
-          <div className="px-3 py-2 rounded-lg text-xs space-y-1" style={{ background: solveResult.converged ? "var(--success-soft)" : "var(--warning-soft-subtle)", border: `1px solid ${solveResult.converged ? "var(--success-border)" : "var(--warning-soft-selected)"}` }}>
-            <div style={{ color: solveResult.converged ? "var(--success)" : "var(--warning-strong)" }}>
+          <div className="px-3 py-2 rounded-lg text-xs space-y-1" style={{ background: solveResult.converged ? "var(--banner-success-bg)" : "var(--warning-soft-subtle)", border: `1px solid ${solveResult.converged ? "var(--banner-success-border)" : "var(--warning-soft-selected)"}` }}>
+            <div style={{ color: solveResult.converged ? "var(--banner-success-text)" : "var(--warning-strong)" }}>
               {solveResult.converged ? "Converged" : "Did not converge"}
               {solveIterationSummary ? ` in ${solveIterationSummary.long}` : ""}
               {solveResult.n_quotes != null && solveResult.n_steps != null && (

--- a/frontend/src/panels/TracePanel.tsx
+++ b/frontend/src/panels/TracePanel.tsx
@@ -298,7 +298,7 @@ export default function TracePanel({ trace, onClose }: TracePanelProps) {
         style={{ background: "var(--bg-panel)" }}
       >
         {exportStatus === "copied" && (
-          <div role="status" className="text-[11px]" style={{ color: "var(--success-hover)" }}>
+          <div role="status" className="text-[11px]" style={{ color: "var(--flash-success-text)" }}>
             Trace copied as Markdown.
           </div>
         )}

--- a/frontend/src/panels/editors/ApiInputEditor.tsx
+++ b/frontend/src/panels/editors/ApiInputEditor.tsx
@@ -1070,7 +1070,7 @@ function TableBlock({
             onClick={onConfirmAll}
             title="Confirm every not-yet-confirmed column (confirmed columns survive a re-infer)"
             className="text-[10px] font-semibold px-1.5 py-0.5 rounded flex items-center gap-1"
-            style={{ color: "var(--success)", border: "1px solid var(--success-border)" }}
+            style={{ color: "var(--column-confirm-text)", border: "1px solid var(--column-confirm-border)" }}
           >
             <Check size={9} />
             Confirm all
@@ -1228,7 +1228,7 @@ function OriginChip({
   const palette: Record<ColumnOrigin, { color: string; background: string }> = {
     inferred: { color: "var(--text-muted)", background: "var(--bg-input)" },
     inherited: { color: "var(--accent)", background: "var(--accent-soft)" },
-    manual: { color: "var(--success)", background: "var(--success-soft)" },
+    manual: { color: "var(--column-origin-manual-text)", background: "var(--column-origin-manual-bg)" },
   }
   return (
     <span
@@ -1372,7 +1372,7 @@ function ColumnRow({
           onClick={() => onUpdate({ status: "Confirmed" })}
           title="Confirm this column (a confirmed column survives a re-infer)"
         >
-          <Check size={10} style={{ color: "var(--success)" }} />
+          <Check size={10} style={{ color: "var(--column-confirm-text)" }} />
         </button>
       )}
       <button data-testid={`${testIdPrefix}-remove`} onClick={onRemove}>

--- a/frontend/src/panels/editors/OutputEditor.tsx
+++ b/frontend/src/panels/editors/OutputEditor.tsx
@@ -1153,9 +1153,9 @@ function FrameBlock({
                 onClick={onAddRow}
                 className="text-[11px] font-semibold px-2 py-0.5 rounded flex items-center gap-1"
                 style={{
-                  color: "var(--success)",
-                  border: "1px solid var(--success-border)",
-                  background: "var(--success-soft)",
+                  color: "var(--add-pill-text)",
+                  border: "1px solid var(--add-pill-border)",
+                  background: "var(--add-pill-bg)",
                 }}
                 title="Add an empty mapping row"
               >

--- a/frontend/src/panels/editors/_shared.tsx
+++ b/frontend/src/panels/editors/_shared.tsx
@@ -117,21 +117,21 @@ export function MlflowStatusBadge() {
         ? "warning"
         : "neutral"
   const background = tone === "success"
-    ? "var(--success-soft-subtle)"
+    ? "var(--editor-status-success-bg)"
     : tone === "danger"
       ? "var(--danger-soft-faint)"
       : tone === "warning"
         ? "var(--warning-soft-subtle)"
         : "var(--bg-panel)"
   const border = tone === "success"
-    ? "var(--success-border)"
+    ? "var(--editor-status-success-border)"
     : tone === "danger"
       ? "var(--danger-border)"
       : tone === "warning"
         ? "var(--warning-border)"
         : "var(--border)"
   const iconColor = tone === "success"
-    ? "var(--success)"
+    ? "var(--editor-status-success-text)"
     : tone === "danger"
       ? "var(--danger)"
       : tone === "warning"
@@ -249,9 +249,9 @@ export function FileBrowser({
   return (
     <div>
       {showSelectionSummary && selectedPath && (
-        <div className="mb-2 px-2.5 py-2 rounded-lg flex items-center gap-2" style={{ background: 'var(--success-soft)', border: '1px solid var(--success-border)' }}>
-          <Check size={14} style={{ color: 'var(--success)' }} className="shrink-0" />
-          <span className="text-xs font-mono truncate" style={{ color: 'var(--success-hover)' }}>{selectedPath}</span>
+        <div className="mb-2 px-2.5 py-2 rounded-lg flex items-center gap-2" style={{ background: 'var(--banner-success-bg)', border: '1px solid var(--banner-success-border)' }}>
+          <Check size={14} style={{ color: 'var(--banner-success-text)' }} className="shrink-0" />
+          <span className="text-xs font-mono truncate" style={{ color: 'var(--banner-success-data)' }}>{selectedPath}</span>
         </div>
       )}
 

--- a/frontend/src/panels/editors/shared/PathPickerField.tsx
+++ b/frontend/src/panels/editors/shared/PathPickerField.tsx
@@ -33,10 +33,10 @@ export default function PathPickerField({
       {value && (
         <div
           className="px-2.5 py-2 rounded-lg flex items-center gap-2"
-          style={{ background: "var(--success-soft)", border: "1px solid var(--success-border)" }}
+          style={{ background: "var(--banner-success-bg)", border: "1px solid var(--banner-success-border)" }}
         >
-          <Check size={14} style={{ color: "var(--success)" }} className="shrink-0" />
-          <span className="text-xs font-mono truncate flex-1" style={{ color: "var(--success-hover)" }}>
+          <Check size={14} style={{ color: "var(--banner-success-text)" }} className="shrink-0" />
+          <span className="text-xs font-mono truncate flex-1" style={{ color: "var(--banner-success-data)" }}>
             {value}
           </span>
           <button
@@ -44,7 +44,7 @@ export default function PathPickerField({
             data-testid="file-change-btn"
             onClick={() => setExpanded(!expanded)}
             className="shrink-0 text-[11px] font-semibold px-2 py-0.5 rounded transition-colors"
-            style={{ color: "var(--success-hover)" }}
+            style={{ color: "var(--banner-success-action)" }}
           >
             {expanded ? "close" : "change"}
           </button>

--- a/frontend/src/panels/modelling/TrainingActionsAndResults.tsx
+++ b/frontend/src/panels/modelling/TrainingActionsAndResults.tsx
@@ -140,12 +140,12 @@ export function TrainingActionsAndResults({
       )}
       {ramEstimate && !ramEstimateLoading && adjusted && (
         <div className="px-3 py-2.5 rounded-lg text-xs space-y-1.5" style={{
-          background: adjusted.wasDownsampled ? "var(--warning-soft-subtle)" : "var(--success-soft-subtle)",
-          border: `1px solid ${adjusted.wasDownsampled ? "var(--warning-border)" : "var(--success-soft-strong)"}`,
+          background: adjusted.wasDownsampled ? "var(--warning-soft-subtle)" : "var(--train-summary-success-bg)",
+          border: `1px solid ${adjusted.wasDownsampled ? "var(--warning-border)" : "var(--train-summary-success-border)"}`,
         }}>
           <div className="flex items-center gap-2">
             {adjusted.wasDownsampled && <AlertTriangle size={12} className="shrink-0" style={{ color: "var(--warning-strong)" }} />}
-            <span className="font-medium" style={{ color: adjusted.wasDownsampled ? "var(--warning)" : "var(--success)" }}>
+            <span className="font-medium" style={{ color: adjusted.wasDownsampled ? "var(--warning)" : "var(--train-summary-success-text)" }}>
               {adjusted.wasDownsampled ? "Will downsample" : "Dataset fits in memory"}
             </span>
           </div>
@@ -248,9 +248,9 @@ export function TrainingActionsAndResults({
 
       {/* Completion badge — results are in the preview panel below */}
       {trainResult && trainResult.status !== "error" && !training && !submitting && (
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs" style={{ background: "var(--success-soft-faint)", border: "1px solid var(--success-border)" }}>
-          <CheckCircle2 size={12} style={{ color: "var(--success)" }} className="shrink-0" />
-          <span style={{ color: "var(--success)" }}>
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs" style={{ background: "var(--train-complete-bg)", border: "1px solid var(--train-complete-border)" }}>
+          <CheckCircle2 size={12} style={{ color: "var(--train-complete-text)" }} className="shrink-0" />
+          <span style={{ color: "var(--train-complete-text)" }}>
             Model trained — results in preview panel below
           </span>
         </div>

--- a/frontend/src/trace/ModelScoreDetail.tsx
+++ b/frontend/src/trace/ModelScoreDetail.tsx
@@ -146,7 +146,7 @@ export function ModelScoreDetailBlock({ detail }: {
                 <span style={{ overflowWrap: "anywhere", color: "var(--text-muted)" }}>
                   {featureValue.hasValue ? formatValue(featureValue.value) : "not provided"}
                 </span>
-                <span className="text-right" style={{ color: value >= 0 ? "var(--success-hover)" : "var(--danger-text)" }}>
+                <span className="text-right" style={{ color: value >= 0 ? "var(--delta-positive-text)" : "var(--danger-text)" }}>
                   {formatSignedValue(value)}
                 </span>
                 <span className="text-right" style={{ color: "var(--text-primary)" }}>
@@ -194,7 +194,7 @@ export function ModelScoreDetailBlock({ detail }: {
                 <span style={{ color: "var(--text-muted)" }}>
                   {contribution.feature_value !== undefined ? formatValue(contribution.feature_value) : ""}
                 </span>
-                <span style={{ color: value == null || value >= 0 ? "var(--success-hover)" : "var(--danger-text)" }}>
+                <span style={{ color: value == null || value >= 0 ? "var(--delta-positive-text)" : "var(--danger-text)" }}>
                   {signedValue}
                 </span>
               </div>

--- a/frontend/src/trace/OptimiserApplyDetail.tsx
+++ b/frontend/src/trace/OptimiserApplyDetail.tsx
@@ -83,7 +83,7 @@ export function OptimiserOnlineDetail({ detail }: {
               <span key={name} className="inline-flex min-w-0 items-center gap-1">
                 <span style={{ color: "var(--text-muted)" }}>+</span>
                 <span style={{ color: "var(--text-muted)", overflowWrap: "anywhere" }}>lambda {name}</span>
-                <span style={{ color: value >= 0 ? "var(--color-added, var(--success-hover))" : "var(--danger-text)" }}>
+                <span style={{ color: value >= 0 ? "var(--delta-positive-text)" : "var(--danger-text)" }}>
                   {formatSignedValue(value)}
                 </span>
               </span>

--- a/frontend/src/trace/StepCard.tsx
+++ b/frontend/src/trace/StepCard.tsx
@@ -80,7 +80,7 @@ export function StepCard({
   }
 
   const tagColors = {
-    added: { bg: "var(--success-soft-mid)", color: "var(--color-added, var(--success-hover))", label: "+" },
+    added: { bg: "var(--trace-added-bg)", color: "var(--trace-added-text)", label: "+" },
     modified: { bg: "var(--warning-bright-soft)", color: "var(--color-modified, var(--warning))", label: "~" },
     value: { bg: "rgba(255,255,255,.06)", color: "var(--text-secondary)", label: "=" },
   }
@@ -298,7 +298,7 @@ export function StepCard({
           {/* Schema changes summary */}
           <div className="flex flex-wrap gap-2 py-2 text-[10px]">
             {columns_added.length > 0 && (
-              <span style={{ color: "var(--color-added, var(--success-hover))" }}>+{columns_added.length} added</span>
+              <span style={{ color: "var(--trace-added-text)" }}>+{columns_added.length} added</span>
             )}
             {columns_modified.length > 0 && (
               <span style={{ color: "var(--color-modified, var(--warning))" }}>~{columns_modified.length} modified</span>
@@ -326,7 +326,7 @@ export function StepCard({
               let rowColor = "var(--text-secondary)"
               let prefix = ""
               if (isAdded) {
-                rowColor = "var(--color-added, var(--success-hover))"
+                rowColor = "var(--trace-added-text)"
                 prefix = "+"
               } else if (isModified) {
                 rowColor = "var(--color-modified, var(--warning))"

--- a/frontend/src/trace/TraceDetail.tsx
+++ b/frontend/src/trace/TraceDetail.tsx
@@ -7,7 +7,7 @@ function toneStyle(tone: Tone): CSSProperties {
     return { color: "var(--accent)", background: "var(--accent-soft)" }
   }
   if (tone === "success") {
-    return { color: "var(--color-added, var(--success-hover))", background: "var(--success-soft-mid)" }
+    return { color: "var(--trace-chip-matched-text)", background: "var(--trace-chip-matched-bg)" }
   }
   if (tone === "warning") {
     return { color: "var(--warning)", background: "var(--warning-bright-soft-strong)" }


### PR DESCRIPTION
Tier 2 of the design-token improvements, first family: a semantic role-token layer over the **success** intensity ladder. Stacked on #160 (base is `claude/typography-role-tokens`); retarget to `main` after #160 merges. **Fully behaviour-preserving** — every migrated site resolves to the identical computed colour.

## What

The `--success-*` ladder steps graded opacity of a hue rather than naming a role. They become **private primitives** — now enforced by a role-layer gate rule (ts/tsx and CSS rule bodies may not reference them; only `:root` aliases may) — and every live call site references a functional token (the `--diff-added: var(--success)` pattern):

| Role token(s) | Interface element | Call sites |
|---|---|---|
| `--trace-added-text/-bg` | trace "added" marking (tags, +N counts, added rows) | `StepCard` |
| `--trace-chip-matched-text/-bg` | trace detail chip, matched rating band | `TraceDetail` via `RatingStepDetail` |
| `--delta-positive-text` | positive signed numeric deltas | `ModelScoreDetail`, `OptimiserApplyDetail` |
| `--flash-success-text` | transient inline success confirmation line | `TracePanel` |
| `--banner-success-bg/-border/-text/-data/-action` | success confirmation banner | `PathPickerField`, `_shared` selection summary, `OptimiserConfig` converged |
| `--editor-status-success-*` | editor status badge (MLflow), success tone — kept at the .06 tier in parity with its danger/warning siblings | `_shared` tone map |
| `--train-summary-success-*` / `--train-complete-*` | training summary banner / completion badge | `TrainingActionsAndResults` |
| `--add-pill-*` | "Add mapping row" pill | `OutputEditor` |
| `--column-confirm-text/-border` | column-confirm affordances (per-column check + "Confirm all") | `ApiInputEditor` |
| `--column-origin-manual-*` | column-origin chip, manual variant | `ApiInputEditor` |
| `--cache-ready-*` | cache fetch button, cached state | `CacheFetchButton` |
| `--branch-restore-text` + `--branch-restore-hover-bg` | branch-restore affordance (menu icon + icon-button hover) | `BranchManager` |
| `--diff-added-soft` | comparison-view added soft background | `ComparisonInspector` |

The `--color-added` override hook (declared as a trace-panel alias by PR #157; previously an unset caller hook) previously fused three deliberately-separated roles behind one override. It now lives **at the alias layer**, scoped to exactly the added-marking role: `--trace-added-text: var(--color-added, var(--success-hover))`. Overriding it recolours added markings only — the matched chip and positive-delta roles no longer sit behind it. Its sibling `--color-modified` stays at its StepCard call site pending the warning-family PR.

## Review provenance

Raised after the standard cross-model pass (no Codex on this machine → Opus + Sonnet), then reworked in a deep second-pass review (Opus code review + Opus AGENTS.md contract check). Key reversals from that pass:

- An earlier draft normalised three banner shades (.06/.08 → .10). The deep review showed those shades were **intra-component tone parity** with danger/warning siblings, not drift — normalising only the success side inverted the urgency hierarchy, worst for red-green colour-blind users. The normalisation is dropped; per-component roles preserve the tiers, with parity called out in the token comments. Cross-component shade unification, if wanted, is DESIGN's call.
- The private-primitives claim was prose; it is now a gate rule.
- Naming: `--status-banner-*` → `--banner-*` (avoids colliding with the node-execution `--status-running`/`--status-info` family), `--origin-*` → `--column-origin-*` (avoids git-remote reading), `--trace-chip-success-*` → `--trace-chip-matched-*` (named for what it is for).

## Verification

- Tokenization gate 18/18 (incl. the pattern-derived role-layer rules, a behaviour-preservation alias pin, and the compiled-emission guard); trace-area vitest 111; full frontend suite 5,563 passing — the only failing file is `useAssistantStore.test.ts` (39), identical on the clean baseline (known Node-webstorage drift, PRs #156/#158). `tsc -b --noEmit` clean.
- Grep-verified: zero live-source references to any `--success-*` ladder step; the gate now keeps it that way.

## Follow-ups (later family PRs)

- Warning (~150 refs, incl. `--color-modified` hook removal), danger (~91, incl. `--delta-negative` to pair with `--delta-positive-text`), accent-soft + text-accent (~40, incl. deleting unreferenced `--accent-soft-whisper`); completing the per-family sides of `OriginChip` (inferred/inherited) and `ComparisonInspector` (removed/changed) belongs to those PRs.
- Base `--success` hue keeps ~25 direct sites (hue anchor) pending roles; `theme/colors.ts` harmonisation with the role layer is a DESIGN-level decision (spec `frontend-shared/high-level.md` names it the token layer).
- `--success-fill/-fill-hover` (main's Commit-button pair, direct-referenced from `Toolbar.tsx`) are deliberately **excluded** from the private-primitive patterns — their classification (primitive behind a role token vs documented exception) is an open call for Nick, recorded in the pattern's comment.

## Cross-vendor review round (7 Aug)

Applied from the Kimi K3 / GLM-5.2 / GPT-5.6 trio run by the orchestration session: the `--color-added` hook is restored **at the alias layer**, scoped to exactly the StepCard added-marking role (the unanimous finding — removal left an asymmetry with `--color-modified`); the private-primitives gate is now pattern-derived and scans token **identifiers** across ts/tsx and all `src` stylesheets, catching `bg-(--success-soft)` shorthand and `var(--success-soft-${tier})` interpolation; a behaviour-preservation pin asserts every role token's exact primitive alias; and the collision/destructive-reuse renames above (`--delta-positive-text`, `--column-confirm-*`, `--branch-restore-*`). `--banner-success-*` is documented as a tone-qualified family that `--banner-warning-*` will join; `--diff-*-soft` is documented as intentionally partial until the danger/warning PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
