### PR TITLE
Fix within-file order dependence behind nightly shuffle failures

### DIFF
--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -70,6 +70,12 @@ function connectionEndState({
 const mouseUpEvent = { clientX: 200, clientY: 150 } as MouseEvent
 
 describe("useEdgeHandlers", () => {
+  beforeEach(() => {
+    // Toast assertions read the global store; without this, error toasts from
+    // whichever tests shuffle ran earlier leak into exact-match expectations.
+    useToastStore.setState({ toasts: [], _toastCounter: 0 })
+  })
+
   afterEach(() => {
     cleanup()
     vi.useRealTimers()

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -458,7 +458,6 @@ describe("useEdgeHandlers", () => {
   })
 
   it("onConnectEnd honours React Flow rejection after reverse-direction validation passes", () => {
-    useToastStore.setState({ toasts: [], _toastCounter: 0 })
     const params = makeParams()
     params.validateConnection = vi.fn(() => ({ ok: true as const }))
     const { result } = renderHook(() => useEdgeHandlers(params))

--- a/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore from "../../stores/useGitStore"
+import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
 import type { GitWorkingBranchResponse } from "../../api/types"
 
 // Perf behaviours of the Version Control panel:
@@ -127,6 +127,9 @@ describe("GitPanel session cache + unchanged-payload short-circuit", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     clearGitPanelCaches()
+    // (e)/(e2) hold getWorkingBranch open forever; without this the stuck
+    // single-flight starves loadStatus() in every test shuffled after them.
+    resetGitStatusRequestForTests()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
     useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)

--- a/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
@@ -131,7 +131,7 @@ describe("GitPanel session cache + unchanged-payload short-circuit", () => {
     // single-flight starves loadStatus() in every test shuffled after them.
     resetGitStatusRequestForTests()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockSetWorkingBranch.mockResolvedValue({})
     // Fresh, deep-equal object per call: proves the short-circuit works on

--- a/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
@@ -144,7 +144,10 @@ describe("GitPanel session cache + unchanged-payload short-circuit", () => {
     mockGetGitGraph.mockImplementation(() => Promise.resolve(structuredClone(graphTwoBranch)))
   })
 
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    resetGitStatusRequestForTests()
+  })
 
   it("(a) a byte-identical refresh applies no state: rail layout untouched, row nodes stable", async () => {
     render(<GitPanel {...defaultProps} />)

--- a/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
@@ -62,7 +62,7 @@ describe("GitPanel — uncovered fork/view/peek paths", () => {
     // The panel's session caches are module-level (they survive remounts by
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
-    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestones.mockResolvedValue(milestones)
     mockGetPendingSaves.mockResolvedValue({ saves: [] })

--- a/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore from "../../stores/useGitStore"
+import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
 
 // Mirror of GitPanel.test.tsx's client mock — the panel reads working-branch
 // status from useGitStore and fetches milestone/ledger history directly.
@@ -62,6 +62,7 @@ describe("GitPanel — uncovered fork/view/peek paths", () => {
     // The panel's session caches are module-level (they survive remounts by
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
+    resetGitStatusRequestForTests()
     useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestones.mockResolvedValue(milestones)
@@ -71,7 +72,10 @@ describe("GitPanel — uncovered fork/view/peek paths", () => {
     mockGetWorkingBranches.mockResolvedValue({ current: "pricing-dev", branches: [] })
   })
 
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    resetGitStatusRequestForTests()
+  })
 
   it("reloads the page after a fork that switches the working branch", async () => {
     // A fork whose creation switches the active working branch forces a full

--- a/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches, readBranchHistory } from "../gitPanelCache"
-import useGitStore from "../../stores/useGitStore"
+import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
 
 // Regression pin for the refresh() generation guard: a refresh captured for
 // the PREVIOUS branch (its fetches still in flight when a peek retargets the
@@ -82,6 +82,7 @@ describe("GitPanel stale refresh (generation guard)", () => {
     vi.clearAllMocks()
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    resetGitStatusRequestForTests()
     useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestoneSaves.mockResolvedValue({ saves: [] })
@@ -89,7 +90,10 @@ describe("GitPanel stale refresh (generation guard)", () => {
     mockGetGitGraph.mockResolvedValue(emptyGraph)
   })
 
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    resetGitStatusRequestForTests()
+  })
 
   it("peeking triggers one refresh without replaying active nonce effects", async () => {
     useGitStore.setState({ historyNonce: 1, commitNonce: 1 })

--- a/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
@@ -82,7 +82,7 @@ describe("GitPanel stale refresh (generation guard)", () => {
     vi.clearAllMocks()
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestoneSaves.mockResolvedValue({ saves: [] })
     mockGetWorkingBranches.mockResolvedValue({ current: "pricing-dev", branches: [] })

--- a/frontend/src/panels/__tests__/GitPanel.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore from "../../stores/useGitStore"
+import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
 import useGraphStore from "../../stores/useGraphStore"
 import useToastStore from "../../stores/useToastStore"
 
@@ -124,6 +124,7 @@ describe("GitPanel", () => {
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+    resetGitStatusRequestForTests()
     useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     // Switches record undoable VC entries on the graph store's history stacks.
     useGraphStore.setState({ dirty: false, undoStack: [], redoStack: [], vcBusy: false })
@@ -137,7 +138,10 @@ describe("GitPanel", () => {
     mockGetGitGraph.mockResolvedValue(emptyGraph)
   })
 
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    resetGitStatusRequestForTests()
+  })
 
   it("renders the panel", async () => {
     render(<GitPanel {...defaultProps} />)

--- a/frontend/src/panels/__tests__/GitPanel.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.test.tsx
@@ -124,7 +124,7 @@ describe("GitPanel", () => {
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    useGitStore.setState({ status: null, loading: false, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     // Switches record undoable VC entries on the graph store's history stacks.
     useGraphStore.setState({ dirty: false, undoStack: [], redoStack: [], vcBusy: false })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)

--- a/frontend/src/stores/__tests__/useGitStore.test.ts
+++ b/frontend/src/stores/__tests__/useGitStore.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../api/client", () => ({
   retryGitStorageSync: vi.fn(),
 }))
 
-import useGitStore from "../useGitStore"
+import useGitStore, { resetGitStatusRequestForTests } from "../useGitStore"
 import {
   acknowledgeGitBind,
   bindGitStorage,
@@ -43,6 +43,7 @@ describe("useGitStore", () => {
       branchesLoading: false, branchesError: null, modal: null, pendingAction: null,
     })
     vi.clearAllMocks()
+    resetGitStatusRequestForTests()
   })
   afterEach(() => {
     useGitStore.setState({
@@ -77,6 +78,37 @@ describe("useGitStore", () => {
     expect(getWorkingBranch).toHaveBeenCalledOnce()
     resolve(READY)
     await expect(Promise.all([first, second])).resolves.toEqual([READY, READY])
+  })
+
+  it("a request settling after a single-flight reset neither publishes state nor clobbers the newer request", async () => {
+    // First load is detached mid-flight (what a test's beforeEach reset does).
+    let resolveFirst!: (value: GitWorkingBranchResponse) => void
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(
+      new Promise((done) => { resolveFirst = done }),
+    )
+    const first = useGitStore.getState().loadStatus()
+    resetGitStatusRequestForTests()
+
+    // Second load starts a genuinely new request in the freed slot.
+    let resolveSecond!: (value: GitWorkingBranchResponse) => void
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(
+      new Promise((done) => { resolveSecond = done }),
+    )
+    const second = useGitStore.getState().loadStatus()
+    expect(getWorkingBranch).toHaveBeenCalledTimes(2)
+
+    // The detached request settles late: no state write, and the newer
+    // request keeps its single-flight slot (a third call still coalesces
+    // instead of spawning a duplicate fetch).
+    resolveFirst({ ...READY, working_branch: "stale" })
+    await first
+    expect(useGitStore.getState().status).toBeNull()
+    expect(useGitStore.getState().loadStatus()).toBe(second)
+    expect(getWorkingBranch).toHaveBeenCalledTimes(2)
+
+    resolveSecond(READY)
+    await expect(second).resolves.toEqual(READY)
+    expect(useGitStore.getState().status).toEqual(READY)
   })
 
   it("de-duplicates concurrent branch loads and publishes the shared listing", async () => {

--- a/frontend/src/stores/__tests__/useGitStore.test.ts
+++ b/frontend/src/stores/__tests__/useGitStore.test.ts
@@ -46,6 +46,7 @@ describe("useGitStore", () => {
     resetGitStatusRequestForTests()
   })
   afterEach(() => {
+    resetGitStatusRequestForTests()
     useGitStore.setState({
       status: null, loading: false, statusError: null, branches: [], branchesLoaded: false,
       branchesLoading: false, branchesError: null, modal: null, pendingAction: null,
@@ -204,6 +205,7 @@ describe("useGitStore durable-storage actions", () => {
   }
 
   beforeEach(() => {
+    resetGitStatusRequestForTests()
     useGitStore.setState({ status: null, loading: false, statusError: null })
     vi.clearAllMocks()
   })
@@ -293,6 +295,7 @@ describe("useGitStore reopens the storage dialog when a background bind fails", 
   })
 
   beforeEach(() => {
+    resetGitStatusRequestForTests()
     useGitStore.setState({ status: null, modal: null, loading: false, statusError: null })
     vi.clearAllMocks()
   })

--- a/frontend/src/stores/__tests__/useGitStore.test.ts
+++ b/frontend/src/stores/__tests__/useGitStore.test.ts
@@ -112,6 +112,49 @@ describe("useGitStore", () => {
     expect(useGitStore.getState().status).toEqual(READY)
   })
 
+  it("a detached request rejecting cannot write an error over the newer request's state", async () => {
+    let rejectFirst!: (error: Error) => void
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(
+      new Promise((_done, fail) => { rejectFirst = fail }),
+    )
+    const first = useGitStore.getState().loadStatus()
+    resetGitStatusRequestForTests()
+
+    let resolveSecond!: (value: GitWorkingBranchResponse) => void
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(
+      new Promise((done) => { resolveSecond = done }),
+    )
+    const second = useGitStore.getState().loadStatus()
+
+    rejectFirst(new Error("stale failure"))
+    await expect(first).resolves.toBeNull()
+    expect(useGitStore.getState().statusError).toBeNull()
+    expect(useGitStore.getState().loadStatus()).toBe(second)
+
+    resolveSecond(READY)
+    await expect(second).resolves.toEqual(READY)
+    expect(useGitStore.getState().statusError).toBeNull()
+  })
+
+  it("a request detached while resolving its error message does not publish the error", async () => {
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(
+      Promise.reject(new Error("boom")),
+    )
+    const first = useGitStore.getState().loadStatus()
+    // Two microtask ticks let the rejection reach the catch handler, which
+    // passes its first identity check and suspends at the dynamic gitError
+    // import; the reset then detaches the request before it resumes. (If an
+    // engine drains differently the reset simply lands before the handler's
+    // first check instead — the assertions hold on either path.)
+    await Promise.resolve()
+    await Promise.resolve()
+    resetGitStatusRequestForTests()
+
+    await expect(first).resolves.toBeNull()
+    expect(useGitStore.getState().statusError).toBeNull()
+    expect(useGitStore.getState().loading).toBe(true)
+  })
+
   it("de-duplicates concurrent branch loads and publishes the shared listing", async () => {
     const branches: GitManagedBranch[] = [{
       name: "dev", is_current: true, is_archived: false, has_unmerged_saves: false,

--- a/frontend/src/stores/__tests__/useGraphStore.consolidation.test.ts
+++ b/frontend/src/stores/__tests__/useGraphStore.consolidation.test.ts
@@ -179,6 +179,7 @@ function reset() {
     nodes: [],
     edges: [],
     preamble: "",
+    submodels: {},
     lastSavedSnapshot: null,
     undoStack: [],
     redoStack: [],

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -24,6 +24,12 @@ import type { GitBindStorageResponse, GitFastForwardResponse, GitForkStorageResp
 
 let statusInFlight: Promise<GitWorkingBranchResponse | null> | null = null
 
+/** Tests that hold a mocked getWorkingBranch open forever leave the
+ *  single-flight stuck, starving every later loadStatus() in the same file. */
+export const resetGitStatusRequestForTests = () => {
+  statusInFlight = null
+}
+
 /** Which modal is open. */
 export type GitModalMode =
   | "select"

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -150,8 +150,12 @@ const useGitStore = create<GitState>()((set, get) => ({
   loadStatus: () => {
     if (statusInFlight) return statusInFlight
     set({ loading: true, statusError: null })
-    statusInFlight = getWorkingBranch()
+    // Identity-guarded settle: after resetGitStatusRequestForTests() (or any
+    // future invalidation) detaches this request, a late settle must neither
+    // publish state nor null out a NEWER request's single-flight slot.
+    const request: Promise<GitWorkingBranchResponse | null> = getWorkingBranch()
       .then((status) => {
+        if (statusInFlight !== request) return status
         set({ status, loading: false, statusError: null })
         // Binding runs in the background, so its dialog is closed by the time
         // a failure lands. Bring it back — the user asked for durable storage
@@ -163,6 +167,7 @@ const useGitStore = create<GitState>()((set, get) => ({
         return status
       })
       .catch(async (error: unknown) => {
+        if (statusInFlight !== request) return null
         // Readiness is best-effort editor chrome. Keep the last successful
         // state for gating, but expose this failure for an explicit retry.
         const { gitErrorMessage } = await import("../utils/gitError")
@@ -173,9 +178,10 @@ const useGitStore = create<GitState>()((set, get) => ({
         return null
       })
       .finally(() => {
-        statusInFlight = null
+        if (statusInFlight === request) statusInFlight = null
       })
-    return statusInFlight
+    statusInFlight = request
+    return request
   },
 
   loadBranches: (options) =>

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -149,21 +149,28 @@ const useGitStore = create<GitState>()((set, get) => ({
 
   loadStatus: () => {
     if (statusInFlight) return statusInFlight
-    set({ loading: true, statusError: null })
     // Identity-guarded settle: after resetGitStatusRequestForTests() (or any
     // future invalidation) detaches this request, a late settle must neither
-    // publish state nor null out a NEWER request's single-flight slot.
+    // publish state nor null out a NEWER request's single-flight slot. The
+    // guard is re-checked before EVERY set() — any yield point (the await
+    // below) or synchronous subscriber reacting to a set() could have
+    // detached this request in the meantime — and each settle path performs
+    // a single set() so a passed check can't go stale mid-handler.
     const request: Promise<GitWorkingBranchResponse | null> = getWorkingBranch()
       .then((status) => {
         if (statusInFlight !== request) return status
-        set({ status, loading: false, statusError: null })
         // Binding runs in the background, so its dialog is closed by the time
         // a failure lands. Bring it back — the user asked for durable storage
         // and must find out they haven't got it. Never steals focus from
         // another open modal.
-        if (status?.storage_bind?.state === "failed" && get().modal === null) {
-          set({ modal: "storage" })
-        }
+        const surfaceBindFailure =
+          status?.storage_bind?.state === "failed" && get().modal === null
+        set({
+          status,
+          loading: false,
+          statusError: null,
+          ...(surfaceBindFailure ? { modal: "storage" as const } : {}),
+        })
         return status
       })
       .catch(async (error: unknown) => {
@@ -171,6 +178,7 @@ const useGitStore = create<GitState>()((set, get) => ({
         // Readiness is best-effort editor chrome. Keep the last successful
         // state for gating, but expose this failure for an explicit retry.
         const { gitErrorMessage } = await import("../utils/gitError")
+        if (statusInFlight !== request) return null
         set({
           loading: false,
           statusError: gitErrorMessage(error, "Unable to check Git status"),
@@ -181,6 +189,10 @@ const useGitStore = create<GitState>()((set, get) => ({
         if (statusInFlight === request) statusInFlight = null
       })
     statusInFlight = request
+    // Set loading only after the slot is owned: a synchronous subscriber
+    // reacting to this set() by calling loadStatus() coalesces onto this
+    // request instead of racing a second one into the slot.
+    set({ loading: true, statusError: null })
     return request
   },
 


### PR DESCRIPTION
## Summary

The nightly **Frontend Shuffle** lane had been red every night since 22 July (issue #115). Every failure was within-file test-order dependence exposed by `--sequence.shuffle`; three leaks across nine red nights:

- **`useEdgeHandlers.test.ts`** — a test asserted the exact contents of the global toast store without resetting it, so error toasts from earlier-shuffled tests accumulated. Reset `useToastStore` in the describe-level `beforeEach` (and drop the per-test reset that made redundant).
- **`GitPanel.cache.test.tsx`** — tests (e)/(e2) hold the mocked `getWorkingBranch` open forever; `useGitStore.loadStatus()` single-flights through a module-level `statusInFlight` promise, which stayed stuck, starving status in every later-shuffled test (the git-graph rail never rendered). Added `resetGitStatusRequestForTests()` (following the `resetIoCapabilitiesCacheForTests` / `resetOutputWriteStoreForTests` precedent) and call it in `beforeEach`; also completed the store reset there (it omitted `statusError`/`branches*` keys — the same partial-reset class).
- **`useGraphStore.consolidation.test.ts`** — the `reset()` helper omitted `submodels`, which `isDirty()` serialises, so a leaked value made an empty graph read dirty.

Not a product bug: at runtime `getWorkingBranch` always settles (API-client timeout + bounded retries), so the single-flight always releases — the stuck promise is purely a never-settling test mock.

## Verification

- Green GitHub shuffle run on this branch under last night's exact failing seed: [run 30533329973](https://github.com/PricingFrontier/haute/actions/runs/30533329973) (`workflow_dispatch`, seed `1785381160095`, 5,593 tests).
- Local shuffle sweeps over the touched files: CI seed + ten random seeds, all green; `tsc -b` and eslint clean.
- Cross-model review (Codex unavailable): Opus primary + Sonnet second pass, both APPROVED; their in-scope suggestions applied in the second commit, remaining hygiene suggestions tracked separately.

Closes #115 once tonight's scheduled run confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)