### PR TITLE
Spec test-only reset seams beside the invariants they reset

### DIFF
--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -91,6 +91,12 @@ the key scenarios covered, and known coverage gaps.
   acceptance test as `test-path::test_symbol`, so the retirement guard has positive evidence.
   Cite a pre-existing symbol that will be modified as a bare path until a new acceptance symbol
   proves the changed behaviour.
+- When a specced invariant guards module-level state that a test-only reset helper clears
+  (a `*ForTests` export or equivalent), note that seam in one standalone sentence beside
+  the invariant guarding the state it resets, prefixed `Test seam:` — not folded into the
+  invariant sentence as a parenthetical. The seam is part of the module's contract — the
+  invariant must hold across a reset — and an unspecced test-only export otherwise reads
+  as drift. This is a low-level.md concern; high-level.md never mentions test seams.
 - Every file named in `## Testing` resolves unambiguously in the repository. Frontend unit and
   browser references are additionally repository-root-relative and start with `frontend/`; a
   frontend basename or path relative only to `frontend/src/` is invalid even when it happens to

--- a/specs/frontend-git-ui/low-level.md
+++ b/specs/frontend-git-ui/low-level.md
@@ -71,6 +71,11 @@ list. Notable invariants:
 - `closeModal` always clears `pendingAction` — a dismissed modal must never leave a queued
   action to fire on a later, unrelated confirmation.
 
+Test seam: `resetGitStoreForTests()` is the family reset — one awaited call restores every
+`GitState` data field to its initial value (the data half is spread from one
+required-fields object, so a new field cannot silently survive a reset) and clears the two
+single-flight seams above.
+
 **`RowDescriptor`** (`gitgraph/layout.ts`) — `{ kind: "pending-save" | "milestone" | "save"
 | "placeholder"; sha; expanded?; milestoneSha? }`. Mirrors `GitPanel`'s render order
 exactly (`GitPanel.railRowData`): pending saves first, then milestones newest-first, each

--- a/specs/frontend-git-ui/low-level.md
+++ b/specs/frontend-git-ui/low-level.md
@@ -54,10 +54,17 @@ list. Notable invariants:
 - `statusError` is transport/server failure text, never a synonym for a successful
   `state: "no-repository"` response. `loadStatus()` retains the last successful status,
   clears `statusError` on success, and exposes retry by simply being callable again.
+  Concurrent `loadStatus()` calls share one module-level in-flight promise. Test seam:
+  `resetGitStatusRequestForTests()` clears that promise so a never-settling mocked
+  request cannot starve later loads in the same test file.
 - `branches` has one store owner. Concurrent `loadBranches()` calls share the same in-flight
   promise; a completed mutation/save/commit schedules at most one new endpoint call.
   `loadBranches()` delegates to the lazy `gitBranchLoader.ts` coordinator, while
   `useGitStore` remains the sole publisher and consumer-facing owner of the result.
+  The coordinator's settle paths are identity-guarded: a request detached by a newer
+  queued refresh (or a reset) neither publishes state nor clobbers a newer request's
+  slot. Test seam: `resetGitBranchLoaderForTests()` clears the coordinator's
+  in-flight/queued promises.
 - `historyNonce` and `commitNonce` both trigger `GitPanel.refresh()` but only `commitNonce`
   additionally selects the newly-committed milestone, and only when the panel is not
   peeking (`peekingRef.current` false at the time the refresh resolves).

--- a/specs/frontend-graph-canvas/low-level.md
+++ b/specs/frontend-graph-canvas/low-level.md
@@ -187,6 +187,9 @@ newer overlapping transform.
   fingerprints to that snapshot, clears both history stacks, recomputes the
   structural and panel-context fingerprints, and increments both versions
   exactly once in one Zustand transition.
+  Test seam: `resetGraphStoreForTests()` restores the full initial state and throws
+  while a VC undo/redo is in flight (`vcBusy`) — that entry's completion handlers
+  `set()` unconditionally and would overwrite the fresh reset with stale VC state.
 - **`HauteNodeData`** (`types/node.ts`) — base node data shape:
   `label`, `nodeType`, `description?`, `config?`, `code?`, `func_name?`, plus
   underscore-prefixed *transient* fields that are runtime-only and never

--- a/specs/frontend-node-editors/low-level.md
+++ b/specs/frontend-node-editors/low-level.md
@@ -118,7 +118,10 @@
 guarded `/api/io-capabilities` client returns ordered groups, fields,
 directional formats/modes/arguments/engines, snapshot build class and schema
 requirements, writer class, and publication modes; each mount refreshes it and
-only concurrent pending requests coalesce. `_IoFormatEditor` renders one
+only concurrent pending requests coalesce. Test seam:
+`resetIoCapabilitiesCacheForTests()` clears the in-flight coalescing promise —
+the module's only state; despite the name, no result cache exists to clear.
+`_IoFormatEditor` renders one
 selected group/direction, while dedicated provider sections cover file,
 database, lakehouse, Databricks, and inline fields. `OnReplaceConfig` constructs
 and commits one fresh active branch for a provider change. Data Input provider
@@ -142,7 +145,8 @@ selected capability requires a bounded schema, merging detected dtypes into
 `arguments.schema` without discarding other arguments. `DataOutputEditor` has
 no code panel. Its per-node Zustand entry carries request id, semantic request
 identity, phase, and structured result/error; request-id checks reject late
-results. Destination preview comes from `/api/pipeline/output-destination`,
+results. Test seam: `resetOutputWriteStoreForTests()` clears every per-node
+write entry and the request-id counter. Destination preview comes from `/api/pipeline/output-destination`,
 and write identity is projected from the semantic flattened graph, output
 node, execution source, and streaming settings. A 409 becomes
 `confirm_overwrite`; only that action retries with `overwrite=true`.

--- a/specs/hosted-project-storage/low-level.md
+++ b/specs/hosted-project-storage/low-level.md
@@ -16,7 +16,7 @@
 | `frontend/src/components/BranchIndicator.tsx` | Owned by [frontend-git-ui](../frontend-git-ui/low-level.md); this component adds the chips it hosts. The storage/sync chip beside the branch indicator. |
 | `frontend/src/components/StorageBindModal.tsx` | The bind dialog, including the distinct restart-required state. |
 | `frontend/src/components/IdentityPromptModal.tsx` | Asks for a git name and email when a save committed but version capture could not, and retries the save once one is recorded — a restored clone carries no identity. |
-| `frontend/src/stores/identityPrompt.ts` | Per-browser-session dismissal for that prompt, so waving it away does not silence the accompanying warning on later saves. |
+| `frontend/src/stores/identityPrompt.ts` | Per-browser-session dismissal for that prompt, so waving it away does not silence the accompanying warning on later saves. Test seam: `resetIdentityPromptForTests()` clears the module-level dismissal flag between tests. |
 | `frontend/src/types/guards.ts`, `frontend/src/api/{types,client}.ts`, `frontend/src/stores/useGitStore.ts` | Parsing, API calls, and store actions for the above. Guards are owned by [frontend-shared](../frontend-shared/low-level.md) and the git store by [frontend-git-ui](../frontend-git-ui/low-level.md); this component adds the storage fields and actions. |
 | `tests/test_project_storage.py` | Module tests, including the container-death survival scenario against a `file://` bare repo. |
 | `tests/test_storage_routes.py` | HTTP-surface tests, including the no-raw-stderr regression. |


### PR DESCRIPTION
## Summary
PR #164's contract review flagged that `resetGitBranchLoaderForTests` (added by PR #168) and the pre-existing frontend `ForTests` helpers were absent from the low-level specs. Decision, applied once and uniformly: a test-only reset helper that clears specced module-level state is part of the module's contract — the invariant must hold across a reset — so each gets a one-line `Test seam:` note beside the invariant it resets in the owning low-level spec. The convention is recorded once in `specs/TEMPLATE.md`'s Writing rules, worded rename-tolerantly ("a `*ForTests` export or equivalent") so it survives in-flight helper additions/renames. Prose-only; no code changes.

A sweep found five helpers (not the three originally flagged); all are covered:

- `specs/TEMPLATE.md` — convention added to Writing rules (low-level-only; high-level never mentions test seams)
- `specs/frontend-git-ui/low-level.md` — `resetGitBranchLoaderForTests()` (global from `setupTests.ts`; identity-guarded settle paths) and `resetGitStatusRequestForTests()`, beside the `GitState` single-flight invariants
- `specs/frontend-node-editors/low-level.md` — `resetIoCapabilitiesCacheForTests()` beside the capabilities request-coalescing prose; `resetOutputWriteStoreForTests()` beside the per-node request-identity prose
- `specs/hosted-project-storage/low-level.md` — `resetIdentityPromptForTests()` on the `identityPrompt.ts` module-map row (the only place its dismissal invariant is specced)

## Verification
`uv run pytest tests/test_docs_accuracy.py -q` — 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
