### PR TITLE
Correct frontend-shared spec's description of the design-token layer

### DIFF
--- a/specs/frontend-shared/high-level.md
+++ b/specs/frontend-shared/high-level.md
@@ -37,16 +37,18 @@ In scope:
   toast notifications (`useToastStore`), and layout/modal chrome
   (`useUIStore`).
 - The design-token layer, which lives in `index.css`: the CSS
-  custom-property primitives (surface/text/accent hues and the
-  success/warning/danger intensity ladders, chart and syntax colours)
-  plus the role tokens layered over them (`--font-data`, the
-  success-family roles, the `--diff-*` aliases), which name what an
-  element is for rather than its shade. Components consume these as
+  custom-property colour primitives (surface/text/accent hues and the
+  success/warning/danger intensity ladders, chart and syntax colours),
+  the colour role tokens layered over them (e.g. the success-family
+  roles and the `--diff-*` aliases), which name what an element is for
+  rather than its shade, and the typography role token `--font-data`,
+  which aliases Tailwind's `--font-mono` face for the same
+  purpose-not-appearance reason. Components consume these as
   `var(--...)` references directly, in stylesheets and inline styles
   alike. `theme/colors.ts` is a narrower TypeScript-side companion:
   grouped `var(--...)` string constants
   (structure/status/model/chart/syntax) for code that needs a token as a
-  JS value, plus the literal `NODE_GROUP_COLORS` palette — it is one
+  JS value, plus the literal `NODE_GROUP_COLORS` palette — it is a
   consumer-facing view of the token layer, not the layer itself.
 - Chrome widgets and app-shell surfaces: `ErrorBoundary`, `Toast`,
   `ModalShell`, `Tooltip`, `ContextMenu`, `KeyboardShortcuts`, `Toolbar`,
@@ -256,7 +258,7 @@ therefore fail at the caller, consistent with the application's fail-loud policy
   `index.css`, with role tokens aliasing the raw intensity-ladder
   primitives so call sites reference purpose, not shade; components use
   `var(--...)` rather than literal colours (the role-layer boundary is
-  enforced by the tokenization gate in
+  guarded by the tokenization gate in
   `__tests__/cssColorTokenization.test.ts`). `theme/colors.ts` follows
   the same rule where TypeScript needs a colour value, re-exporting
   `var(--...)` strings rather than hex — except for the small

--- a/specs/frontend-shared/high-level.md
+++ b/specs/frontend-shared/high-level.md
@@ -36,8 +36,18 @@ In scope:
   (`useNodeResultsStore`), app-wide settings/caches (`useSettingsStore`),
   toast notifications (`useToastStore`), and layout/modal chrome
   (`useUIStore`).
-- The design-token layer (`theme/colors.ts`) — CSS-variable-backed colour
-  constants used by every visual component.
+- The design-token layer, which lives in `index.css`: the CSS
+  custom-property primitives (surface/text/accent hues and the
+  success/warning/danger intensity ladders, chart and syntax colours)
+  plus the role tokens layered over them (`--font-data`, the
+  success-family roles, the `--diff-*` aliases), which name what an
+  element is for rather than its shade. Components consume these as
+  `var(--...)` references directly, in stylesheets and inline styles
+  alike. `theme/colors.ts` is a narrower TypeScript-side companion:
+  grouped `var(--...)` string constants
+  (structure/status/model/chart/syntax) for code that needs a token as a
+  JS value, plus the literal `NODE_GROUP_COLORS` palette — it is one
+  consumer-facing view of the token layer, not the layer itself.
 - Chrome widgets and app-shell surfaces: `ErrorBoundary`, `Toast`,
   `ModalShell`, `Tooltip`, `ContextMenu`, `KeyboardShortcuts`, `Toolbar`,
   `ImportsPanel`, `BackgroundJobPolling`, `NodeSearch`, `BreadcrumbBar`.
@@ -242,10 +252,16 @@ therefore fail at the caller, consistent with the application's fail-loud policy
   so that a component depending on "is the palette open" doesn't
   re-render on every MLflow poll tick.
 - **CSS variables, not hard-coded hex, for anything theme-sensitive.**
-  `theme/colors.ts` re-exports `var(--...)` tokens (light/dark themes swap
-  the underlying CSS custom properties) rather than literal colours,
-  except for the small `NODE_GROUP_COLORS` palette, which is
-  fixed-per-node-type branding rather than a theme concern.
+  Theme-sensitive colour is declared once as custom properties in
+  `index.css`, with role tokens aliasing the raw intensity-ladder
+  primitives so call sites reference purpose, not shade; components use
+  `var(--...)` rather than literal colours (the role-layer boundary is
+  enforced by the tokenization gate in
+  `__tests__/cssColorTokenization.test.ts`). `theme/colors.ts` follows
+  the same rule where TypeScript needs a colour value, re-exporting
+  `var(--...)` strings rather than hex — except for the small
+  `NODE_GROUP_COLORS` palette, which is fixed-per-node-type branding
+  rather than a theme concern.
 - **Endpoint modules split out of `api/client.ts` when their only
   consumer is lazy-loaded.** `api/dispersion.ts` exists as a separate file
   — not more exports on `client.ts` — specifically so its code isn't


### PR DESCRIPTION
## Summary
specs/frontend-shared/high-level.md claimed `theme/colors.ts` is "the design-token layer". Since the role-token work (PRs #160/#161) that no longer describes the codebase: the token layer lives in `frontend/src/index.css` — CSS custom-property primitives (surface/text/accent hues, the success/warning/danger intensity ladders, chart/syntax colours) plus the role tokens layered over them (`--font-data`, the success-family roles, the `--diff-*` aliases) — and components consume these directly as `var(--...)` references in stylesheets and inline styles. `theme/colors.ts` is a narrower TypeScript-side companion: grouped `var(--...)` string constants (structure/status/model/chart/syntax) for code needing a token as a JS value, plus the literal `NODE_GROUP_COLORS` palette.

Two passages corrected: the Scope bullet (the old line-39 claim) and the "CSS variables, not hard-coded hex" design-rationale bullet, which now anchors the rule in index.css and notes the role-layer boundary is enforced by the tokenization gate in `frontend/src/__tests__/cssColorTokenization.test.ts`.

Docs-accuracy only — no code change. The wider colors.ts-vs-role-layer harmonisation deliberately stays a DESIGN-session decision and is not written into the spec.

## Verification
- New prose checked against the current tree: role tokens and primitives confirmed in `frontend/src/index.css`; ~35 call sites consume `--success-*`/`--font-data` as raw `var()` strings without going through colors.ts; `theme/colors.ts` exports exactly the five grouped constant maps + `NODE_GROUP_COLORS`; the referenced gate file `__tests__/cssColorTokenization.test.ts` exists.
- Docs-only diff (1 file, +22/−6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
