### PR TITLE
docs+test: preflight doc accuracy and persisted-fingerprint format pin

### DIFF
--- a/docs/COMMIT_STANDARDS.md
+++ b/docs/COMMIT_STANDARDS.md
@@ -183,8 +183,8 @@ if not str(target).startswith(str(base)):
 
 - Each commit is atomic: one logical change per commit.
 - Commit messages follow conventional format: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`.
-  *Note: whether this prefix rule is struck or actively enforced is an open decision, tracked
-  separately from this document — do not treat it as settled either way.*
+  *Note: this rule currently stands — follow it. Whether it is eventually struck or
+  actively enforced is an open decision tracked separately from this document.*
 - No generated files (`node_modules/`, `__pycache__/`, build output) in commits.
 
 ## 18. Design Before Code
@@ -444,7 +444,7 @@ The script runs these checks in order and reports every selected failure:
 | `ruff format --check .` | Python formatting | 1s |
 | `mypy src/haute/` | Python type errors | 5s |
 | `pytest tests/ --collect-only -q` | Broken test imports/collection | 10s |
-| `pytest tests/ -n 4 --cov=src/haute --cov-fail-under=90` + `scripts/check_critical_coverage.py` | Python test failures, global coverage < 90%, per-file critical coverage | 4 min |
+| `pytest tests/ -n 4 --cov=src/haute --cov-branch --cov-fail-under=90` + `scripts/check_critical_coverage.py` | Python test failures, global line+branch coverage < 90%, per-file critical coverage (60s per-test timeout) | 4 min |
 | `HAUTE_BUILD_FRONTEND=1 uv build` | Package build failures | 1 min |
 | `npm run typecheck` (frontend, `tsc -b --noEmit`) | TypeScript type errors | 5s |
 | `npm run lint` (frontend, `eslint .`) | JS/TS lint errors (no-explicit-any, unused vars, React hooks rules) | 3s |
@@ -453,9 +453,12 @@ The script runs these checks in order and reports every selected failure:
 | `npm run test:benchmark:pr` (frontend) | Render/hash performance regressions | 30s |
 | `npm run test:coverage` (frontend) | Frontend test failures, coverage thresholds, per-file critical coverage | 1 min |
 
-`--quick` runs only the lint and type rows. `--backend-only` / `--frontend-only` run the
-corresponding half of the table, including the test, build, and budget gates — a
-frontend-only run is *not* just typecheck + lint + tests.
+`--quick` runs only the lint, format, and type rows — it skips every test, build, and
+budget gate, and composes with the `-only` flags. `--backend-only` / `--frontend-only`
+run the corresponding half of the table: a full frontend-only run includes the build,
+bundle-budget, benchmark, and coverage gates — *not* just typecheck + lint + tests.
+Opt-in extras: `--perf` adds the backend perf suite, and `--init-smoke` runs the
+fresh-install wheel smoke on its own.
 
 Use `--quick` during active development (catches ~80% of CI failures in 15 seconds). Run the full version before opening a PR. Set `PYTEST_WORKERS=<n>` to tune the backend test worker count for unusually small or large machines.
 
@@ -480,9 +483,13 @@ Hooks do **not** run tests (too slow for commit-time). Run tests via the preflig
 For opt-in performance, benchmark, bundle, and memory smoke lanes, see
 [Local Performance Checks](PERFORMANCE_CHECKS.md).
 
-If you only touched backend Python:
+If you only touched backend Python, run the backend half of preflight:
 ```bash
-uv run ruff check src/ && uv run mypy src/haute/ && uv run pytest tests/ -q
+./scripts/preflight.sh --backend-only
+```
+For a faster inner loop while iterating (not a substitute for the full backend gate):
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run mypy src/haute/ && uv run pytest tests/ -q
 ```
 
 If you only touched frontend TypeScript, run the frontend half of preflight — it is the

--- a/docs/COMMIT_STANDARDS.md
+++ b/docs/COMMIT_STANDARDS.md
@@ -183,6 +183,8 @@ if not str(target).startswith(str(base)):
 
 - Each commit is atomic: one logical change per commit.
 - Commit messages follow conventional format: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`.
+  *Note: whether this prefix rule is struck or actively enforced is an open decision, tracked
+  separately from this document — do not treat it as settled either way.*
 - No generated files (`node_modules/`, `__pycache__/`, build output) in commits.
 
 ## 18. Design Before Code
@@ -438,13 +440,22 @@ The script runs these checks in order and reports every selected failure:
 
 | Check | What it catches | Approximate time |
 |-------|----------------|-----------------|
-| `ruff check src/` | Python lint errors | 1s |
-| `ruff format --check src/ tests/` | Python formatting | 1s |
+| `ruff check .` | Python lint errors | 1s |
+| `ruff format --check .` | Python formatting | 1s |
 | `mypy src/haute/` | Python type errors | 5s |
-| `tsc -b --noEmit` (frontend) | TypeScript type errors | 5s |
-| `eslint .` (frontend) | JS/TS lint errors (no-explicit-any, unused vars, React hooks rules) | 3s |
-| `pytest tests/ -n 4 --cov=src/haute` | Python test failures, coverage < 90% | 4 min |
-| `npm test` (frontend) | Frontend test failures | 20s |
+| `pytest tests/ --collect-only -q` | Broken test imports/collection | 10s |
+| `pytest tests/ -n 4 --cov=src/haute --cov-fail-under=90` + `scripts/check_critical_coverage.py` | Python test failures, global coverage < 90%, per-file critical coverage | 4 min |
+| `HAUTE_BUILD_FRONTEND=1 uv build` | Package build failures | 1 min |
+| `npm run typecheck` (frontend, `tsc -b --noEmit`) | TypeScript type errors | 5s |
+| `npm run lint` (frontend, `eslint .`) | JS/TS lint errors (no-explicit-any, unused vars, React hooks rules) | 3s |
+| `npm run build` (frontend) | Production build failures | 30s |
+| `npm run check:bundle` (frontend) | Bundle budget and UI dependency violations | 1s |
+| `npm run test:benchmark:pr` (frontend) | Render/hash performance regressions | 30s |
+| `npm run test:coverage` (frontend) | Frontend test failures, coverage thresholds, per-file critical coverage | 1 min |
+
+`--quick` runs only the lint and type rows. `--backend-only` / `--frontend-only` run the
+corresponding half of the table, including the test, build, and budget gates — a
+frontend-only run is *not* just typecheck + lint + tests.
 
 Use `--quick` during active development (catches ~80% of CI failures in 15 seconds). Run the full version before opening a PR. Set `PYTEST_WORKERS=<n>` to tune the backend test worker count for unusually small or large machines.
 
@@ -474,7 +485,13 @@ If you only touched backend Python:
 uv run ruff check src/ && uv run mypy src/haute/ && uv run pytest tests/ -q
 ```
 
-If you only touched frontend TypeScript:
+If you only touched frontend TypeScript, run the frontend half of preflight — it is the
+same gate CI applies (typecheck, lint, build, bundle budget, PR benchmark gate, and
+coverage-gated tests):
+```bash
+./scripts/preflight.sh --frontend-only
+```
+For a faster inner loop while iterating (not a substitute for the full frontend gate):
 ```bash
 cd frontend && npm run typecheck && npm run lint && npm test
 ```

--- a/frontend/src/utils/__tests__/graphSnapshot.test.ts
+++ b/frontend/src/utils/__tests__/graphSnapshot.test.ts
@@ -1,7 +1,7 @@
 /**
  * Format pin for the serialized persisted-fingerprint produced by the graph
- * snapshot path (`serializeSnapshot`, reached in the store via
- * `computePersistedFingerprint`).
+ * snapshot path (`serializeSnapshot`, which the graph store uses to derive
+ * `persistedFingerprint` on every mutation).
  *
  * The fingerprint string is compared verbatim against `savedPersistedFingerprint`
  * to derive the dirty flag, and any change to its serialized shape (key order,
@@ -19,9 +19,12 @@ import { serializeSnapshot, EMPTY_SNAPSHOT } from "../graphSnapshot"
 import useGraphStore from "../../stores/useGraphStore"
 
 // ---------------------------------------------------------------------------
-// Fixtures — deliberately include everything the serializer must strip:
-// React Flow UI fields (`selected`, `dragging`, `measured`), `_`-prefixed
-// transient node-data metadata, and the same shapes nested inside submodels.
+// Fixtures — between them the two nodes carry all six stripped React Flow UI
+// fields (`selected`, `dragging`, `positionAbsolute`, `measured`, `resizing`,
+// `computed`), `_`-prefixed transient node-data metadata, and a *nested*
+// `_`-prefixed key that must SURVIVE (the metadata strip is shallow by
+// design). The same shapes recur inside submodels. Node array order is
+// deliberately non-sorted ("n1" before "n0") to pin caller-order retention.
 // ---------------------------------------------------------------------------
 
 const NODE = {
@@ -34,11 +37,22 @@ const NODE = {
   measured: { width: 100, height: 40 },
 } as Node
 
+const NODE2 = {
+  id: "n0",
+  type: "dataInput",
+  position: { x: 0, y: 0 },
+  data: { label: "src", config: { _kept: true } },
+  positionAbsolute: { x: 0, y: 0 },
+  resizing: true,
+  computed: { width: 1 },
+  selected: false,
+} as unknown as Node
+
 const EDGE = {
   id: "e1",
   source: "n1",
   sourceHandle: "out",
-  target: "n2",
+  target: "n0",
   targetHandle: "in",
   sourcePort: null,
   selected: true,
@@ -54,6 +68,8 @@ const SUBMODELS: Record<string, unknown> = {
         position: { x: 0, y: 0 },
         data: { kind: "input", _meta: 1 },
         selected: true,
+        resizing: true,
+        positionAbsolute: { x: 1, y: 1 },
       },
     ],
     edges: [{ source: "s1", target: "s2", selected: true }],
@@ -62,12 +78,14 @@ const SUBMODELS: Record<string, unknown> = {
 
 /**
  * The pinned serialized format: JSON with alphabetically sorted keys at every
- * level, arrays in caller order, UI/transient fields stripped, `null` values
- * preserved.
+ * level, arrays in caller order (nodes are NOT sorted by id), UI/transient
+ * fields stripped (shallow for `_`-metadata — nested `_kept` survives),
+ * `null` values preserved.
  */
 const EXPECTED_FINGERPRINT =
-  '{"edges":[{"id":"e1","source":"n1","sourceHandle":"out","sourcePort":null,"target":"n2","targetHandle":"in"}],' +
-  '"nodes":[{"data":{"alpha":1,"label":"price"},"id":"n1","position":{"x":10,"y":20},"type":"expression"}],' +
+  '{"edges":[{"id":"e1","source":"n1","sourceHandle":"out","sourcePort":null,"target":"n0","targetHandle":"in"}],' +
+  '"nodes":[{"data":{"alpha":1,"label":"price"},"id":"n1","position":{"x":10,"y":20},"type":"expression"},' +
+  '{"data":{"config":{"_kept":true},"label":"src"},"id":"n0","position":{"x":0,"y":0},"type":"dataInput"}],' +
   '"preamble":"import polars as pl",' +
   '"submodels":{"sub1":{"edges":[{"source":"s1","target":"s2"}],"nodes":[{"data":{"kind":"input"},"id":"s1","position":{"x":0,"y":0}}]}}}'
 
@@ -81,7 +99,7 @@ describe("persisted-fingerprint serialized format", () => {
   it("pins the full serialized shape byte-for-byte", () => {
     expect(
       serializeSnapshot({
-        nodes: [NODE],
+        nodes: [NODE, NODE2],
         edges: [EDGE],
         preamble: PREAMBLE,
         submodels: SUBMODELS,
@@ -89,7 +107,7 @@ describe("persisted-fingerprint serialized format", () => {
     ).toBe(EXPECTED_FINGERPRINT)
   })
 
-  it("is insensitive to object key insertion order", () => {
+  it("is insensitive to object key insertion order at every level", () => {
     const reorderedNode = {
       measured: { width: 100, height: 40 },
       data: { _transient: "dropped", alpha: 1, label: "price" },
@@ -100,12 +118,38 @@ describe("persisted-fingerprint serialized format", () => {
       id: "n1",
     } as Node
 
+    const reorderedEdge = {
+      targetHandle: "in",
+      sourcePort: null,
+      target: "n0",
+      selected: true,
+      sourceHandle: "out",
+      source: "n1",
+      id: "e1",
+    } as PipelineEdge
+
+    const reorderedSubmodels: Record<string, unknown> = {
+      sub1: {
+        edges: [{ selected: true, target: "s2", source: "s1" }],
+        nodes: [
+          {
+            positionAbsolute: { x: 1, y: 1 },
+            resizing: true,
+            selected: true,
+            data: { _meta: 1, kind: "input" },
+            position: { y: 0, x: 0 },
+            id: "s1",
+          },
+        ],
+      },
+    }
+
     expect(
       serializeSnapshot({
-        nodes: [reorderedNode],
-        edges: [EDGE],
+        nodes: [reorderedNode, NODE2],
+        edges: [reorderedEdge],
         preamble: PREAMBLE,
-        submodels: SUBMODELS,
+        submodels: reorderedSubmodels,
       }),
     ).toBe(EXPECTED_FINGERPRINT)
   })
@@ -121,23 +165,39 @@ describe("graph store produces the pinned format", () => {
       lastSavedSnapshot: null,
       undoStack: [],
       redoStack: [],
-      persistedFingerprint: EMPTY_SNAPSHOT,
+      // Deliberately wrong: every assertion below proves the store's own
+      // mutation path RECOMPUTED the fingerprint, not that the reset seeded it.
+      persistedFingerprint: "STALE-SENTINEL",
       savedPersistedFingerprint: null,
       dirty: false,
     })
   })
 
-  it("initial-state fingerprint is the empty sentinel", () => {
-    expect(useGraphStore.getState().persistedFingerprint).toBe(EXPECTED_EMPTY)
-  })
-
-  it("store mutations recompute the fingerprint in the pinned format", () => {
+  it("every mutation recomputes the fingerprint in the pinned format", () => {
     const store = useGraphStore.getState()
-    store.setNodes([NODE])
-    store.setEdges([EDGE])
-    store.setPreamble(PREAMBLE)
-    store.setSubmodelsRaw(SUBMODELS)
+    const fingerprint = () => useGraphStore.getState().persistedFingerprint
 
-    expect(useGraphStore.getState().persistedFingerprint).toBe(EXPECTED_FINGERPRINT)
+    store.setNodes([NODE, NODE2])
+    expect(fingerprint()).toBe(
+      serializeSnapshot({ nodes: [NODE, NODE2], edges: [], preamble: "", submodels: {} }),
+    )
+
+    store.setEdges([EDGE])
+    expect(fingerprint()).toBe(
+      serializeSnapshot({ nodes: [NODE, NODE2], edges: [EDGE], preamble: "", submodels: {} }),
+    )
+
+    store.setPreamble(PREAMBLE)
+    expect(fingerprint()).toBe(
+      serializeSnapshot({
+        nodes: [NODE, NODE2],
+        edges: [EDGE],
+        preamble: PREAMBLE,
+        submodels: {},
+      }),
+    )
+
+    store.setSubmodelsRaw(SUBMODELS)
+    expect(fingerprint()).toBe(EXPECTED_FINGERPRINT)
   })
 })

--- a/frontend/src/utils/__tests__/graphSnapshot.test.ts
+++ b/frontend/src/utils/__tests__/graphSnapshot.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Format pin for the serialized persisted-fingerprint produced by the graph
+ * snapshot path (`serializeSnapshot`, reached in the store via
+ * `computePersistedFingerprint`).
+ *
+ * The fingerprint string is compared verbatim against `savedPersistedFingerprint`
+ * to derive the dirty flag, and any change to its serialized shape (key order,
+ * stripped fields, scope) invalidates every previously captured baseline. Today
+ * that surfaces only as spurious dirty flags / cache misses downstream — these
+ * tests make a format drift fail loudly here instead.
+ *
+ * If a change to this format is intentional, update the literals below and
+ * audit every holder of a previously serialized fingerprint.
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import type { Node } from "@xyflow/react"
+import type { PipelineEdge } from "../../types/node"
+import { serializeSnapshot, EMPTY_SNAPSHOT } from "../graphSnapshot"
+import useGraphStore from "../../stores/useGraphStore"
+
+// ---------------------------------------------------------------------------
+// Fixtures — deliberately include everything the serializer must strip:
+// React Flow UI fields (`selected`, `dragging`, `measured`), `_`-prefixed
+// transient node-data metadata, and the same shapes nested inside submodels.
+// ---------------------------------------------------------------------------
+
+const NODE = {
+  id: "n1",
+  type: "expression",
+  position: { x: 10, y: 20 },
+  data: { label: "price", alpha: 1, _transient: "dropped" },
+  selected: true,
+  dragging: true,
+  measured: { width: 100, height: 40 },
+} as Node
+
+const EDGE = {
+  id: "e1",
+  source: "n1",
+  sourceHandle: "out",
+  target: "n2",
+  targetHandle: "in",
+  sourcePort: null,
+  selected: true,
+} as PipelineEdge
+
+const PREAMBLE = "import polars as pl"
+
+const SUBMODELS: Record<string, unknown> = {
+  sub1: {
+    nodes: [
+      {
+        id: "s1",
+        position: { x: 0, y: 0 },
+        data: { kind: "input", _meta: 1 },
+        selected: true,
+      },
+    ],
+    edges: [{ source: "s1", target: "s2", selected: true }],
+  },
+}
+
+/**
+ * The pinned serialized format: JSON with alphabetically sorted keys at every
+ * level, arrays in caller order, UI/transient fields stripped, `null` values
+ * preserved.
+ */
+const EXPECTED_FINGERPRINT =
+  '{"edges":[{"id":"e1","source":"n1","sourceHandle":"out","sourcePort":null,"target":"n2","targetHandle":"in"}],' +
+  '"nodes":[{"data":{"alpha":1,"label":"price"},"id":"n1","position":{"x":10,"y":20},"type":"expression"}],' +
+  '"preamble":"import polars as pl",' +
+  '"submodels":{"sub1":{"edges":[{"source":"s1","target":"s2"}],"nodes":[{"data":{"kind":"input"},"id":"s1","position":{"x":0,"y":0}}]}}}'
+
+const EXPECTED_EMPTY = '{"edges":[],"nodes":[],"preamble":"","submodels":{}}'
+
+describe("persisted-fingerprint serialized format", () => {
+  it("pins the empty-workspace sentinel byte-for-byte", () => {
+    expect(EMPTY_SNAPSHOT).toBe(EXPECTED_EMPTY)
+  })
+
+  it("pins the full serialized shape byte-for-byte", () => {
+    expect(
+      serializeSnapshot({
+        nodes: [NODE],
+        edges: [EDGE],
+        preamble: PREAMBLE,
+        submodels: SUBMODELS,
+      }),
+    ).toBe(EXPECTED_FINGERPRINT)
+  })
+
+  it("is insensitive to object key insertion order", () => {
+    const reorderedNode = {
+      measured: { width: 100, height: 40 },
+      data: { _transient: "dropped", alpha: 1, label: "price" },
+      position: { y: 20, x: 10 },
+      type: "expression",
+      dragging: true,
+      selected: true,
+      id: "n1",
+    } as Node
+
+    expect(
+      serializeSnapshot({
+        nodes: [reorderedNode],
+        edges: [EDGE],
+        preamble: PREAMBLE,
+        submodels: SUBMODELS,
+      }),
+    ).toBe(EXPECTED_FINGERPRINT)
+  })
+})
+
+describe("graph store produces the pinned format", () => {
+  beforeEach(() => {
+    useGraphStore.setState({
+      nodes: [],
+      edges: [],
+      preamble: "",
+      submodels: {},
+      lastSavedSnapshot: null,
+      undoStack: [],
+      redoStack: [],
+      persistedFingerprint: EMPTY_SNAPSHOT,
+      savedPersistedFingerprint: null,
+      dirty: false,
+    })
+  })
+
+  it("initial-state fingerprint is the empty sentinel", () => {
+    expect(useGraphStore.getState().persistedFingerprint).toBe(EXPECTED_EMPTY)
+  })
+
+  it("store mutations recompute the fingerprint in the pinned format", () => {
+    const store = useGraphStore.getState()
+    store.setNodes([NODE])
+    store.setEdges([EDGE])
+    store.setPreamble(PREAMBLE)
+    store.setSubmodelsRaw(SUBMODELS)
+
+    expect(useGraphStore.getState().persistedFingerprint).toBe(EXPECTED_FINGERPRINT)
+  })
+})


### PR DESCRIPTION
## Summary
Two accuracy items from PR #168's AGENTS.md contract audit (standalone scope, independent of the merge queue):

1. **docs/COMMIT_STANDARDS.md — Local Verification (Preflight) accuracy.** The table and the touched-frontend recipe understated what `scripts/preflight.sh` actually runs. Rewritten from the script's real behaviour: adds test collection, the critical-coverage sub-gate, `uv build`, the frontend build, `check:bundle`, `test:benchmark:pr`, and the frontend coverage gates; the coverage row now states line+branch (`--cov-branch`); `--quick`/`--backend-only`/`--frontend-only`/`--perf`/`--init-smoke` semantics documented; both touched-only recipes now point at the corresponding preflight half with the manual chains demoted to inner-loop shortcuts. §17 carries a note that the conventional-commit prefix rule stands while strike-or-enforce remains an open tracked decision.

2. **frontend/src/utils/__tests__/graphSnapshot.test.ts — persisted-fingerprint format pin.** New test pinning byte-for-byte the serialized fingerprint produced by `serializeSnapshot` (the store's `persistedFingerprint` path), so format drift fails loudly instead of via spurious dirty flags / downstream cache misses. Pins: empty sentinel, full representative shape (all six stripped React Flow UI fields, shallow `_`-metadata strip incl. surviving nested key, `null` preservation, submodel recursion, caller-order retention), key-order insensitivity at every level, and per-setter recompute through the store (stale-sentinel reset so no assertion is tautological).

## Verification
- `uv run pytest tests/test_docs_accuracy.py` — 44 passed
- `vitest run src/utils/__tests__/graphSnapshot.test.ts` — 4 passed
- frontend `npm run typecheck` + `eslint` on the new file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
