### PR TITLE
Strip redundant inline fallbacks from trace-panel colour alias call sites

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -134,9 +134,9 @@
      call site inherits the override for free.  The hook's scope is
      deliberately exactly this role: the matched chip and positive-delta
      roles below used to sit behind it too and no longer do — an override
-     recolours added markings, nothing else.  (--color-modified, its
-     sibling for the "modified" marking, still lives at its StepCard call
-     site pending the warning-family PR.) */
+     recolours added markings, nothing else.  (The "modified" marking has
+     no role token yet — its call sites reference the --color-modified
+     alias in :root directly, pending the warning-family PR.) */
   --trace-added-text: var(--color-added, var(--success-hover));
   --trace-added-bg: var(--success-soft-mid);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -276,8 +276,11 @@
   --chart-negative: #f44336;
   --chart-neutral: #9e9e9e;
   /* Trace-panel semantic aliases (StepCard, TraceDetail, WaterfallChart,
-     OptimiserApplyDetail): column-diff and delta-sign colours.  Call sites
-     reference these with the alias target as inline fallback.  Note
+     OptimiserApplyDetail): column-diff and delta-sign colours.  Call
+     sites reference these bare — these declarations are the single
+     source of each value (no inline fallbacks duplicating the targets).
+     --color-added is consumed via --trace-added-text, where it stays a
+     caller-overridable hook.  Note
      --color-added tracks --success-hover, deliberately BRIGHTER than
      --diff-added's --success: these colour small (10-11px) trace text,
      kept exactly as the call sites shipped, whereas --diff-* tint the

--- a/frontend/src/trace/StepCard.tsx
+++ b/frontend/src/trace/StepCard.tsx
@@ -81,7 +81,7 @@ export function StepCard({
 
   const tagColors = {
     added: { bg: "var(--trace-added-bg)", color: "var(--trace-added-text)", label: "+" },
-    modified: { bg: "var(--warning-bright-soft)", color: "var(--color-modified, var(--warning))", label: "~" },
+    modified: { bg: "var(--warning-bright-soft)", color: "var(--color-modified)", label: "~" },
     value: { bg: "rgba(255,255,255,.06)", color: "var(--text-secondary)", label: "=" },
   }
 
@@ -301,10 +301,10 @@ export function StepCard({
               <span style={{ color: "var(--trace-added-text)" }}>+{columns_added.length} added</span>
             )}
             {columns_modified.length > 0 && (
-              <span style={{ color: "var(--color-modified, var(--warning))" }}>~{columns_modified.length} modified</span>
+              <span style={{ color: "var(--color-modified)" }}>~{columns_modified.length} modified</span>
             )}
             {columns_removed.length > 0 && (
-              <span style={{ color: "var(--color-removed, var(--danger-text))" }}>-{columns_removed.length} removed</span>
+              <span style={{ color: "var(--color-removed)" }}>-{columns_removed.length} removed</span>
             )}
             <span style={{ color: "var(--text-muted)" }}>
               {step.schema_diff.columns_passed.length} passed through
@@ -329,10 +329,10 @@ export function StepCard({
                 rowColor = "var(--trace-added-text)"
                 prefix = "+"
               } else if (isModified) {
-                rowColor = "var(--color-modified, var(--warning))"
+                rowColor = "var(--color-modified)"
                 prefix = "~"
               } else if (isRemoved) {
-                rowColor = "var(--color-removed, var(--danger-text))"
+                rowColor = "var(--color-removed)"
                 prefix = "-"
               }
 

--- a/frontend/src/trace/WaterfallChart.tsx
+++ b/frontend/src/trace/WaterfallChart.tsx
@@ -93,10 +93,10 @@ const WaterfallChart: React.FC<WaterfallChartProps> = ({ steps, resultValue }) =
                 width: animated ? `${barWidth}%` : "0%",
                 backgroundColor:
                   step.direction === "positive"
-                    ? "var(--color-positive, var(--chart-positive))"
+                    ? "var(--color-positive)"
                     : step.direction === "negative"
-                      ? "var(--color-negative, var(--chart-negative))"
-                      : "var(--color-neutral, var(--chart-neutral))",
+                      ? "var(--color-negative)"
+                      : "var(--color-neutral)",
                 borderRadius: 2,
                 minWidth: animated ? 2 : 0,
                 transition: `width 400ms cubic-bezier(0.22, 1, 0.36, 1)`,


### PR DESCRIPTION
## Summary
PR #157 declared the trace-panel semantic aliases (`--color-modified`, `--color-removed`, `--color-positive`, `--color-negative`, `--color-neutral`) in `index.css` `:root`, but the tsx call sites kept inline fallbacks of the shape `var(--color-modified, var(--warning))`. Each fallback silently duplicates the alias target with nothing pinning the pair in sync (AGENTS.md no-silent-fallbacks), and the tokenization gate already guarantees the tokens resolve. This strips the fallbacks so the `:root` declarations are the single source of each value.

- `StepCard.tsx`: modified-marking sites (tag colour map, "~N modified" summary, row colour) and removed-marking sites ("-N removed" summary, row colour) now reference `var(--color-modified)` / `var(--color-removed)` bare
- `WaterfallChart.tsx`: bar fills now reference `var(--color-positive)` / `var(--color-negative)` / `var(--color-neutral)` bare
- `index.css`: the alias-block comment no longer claims call sites carry inline fallbacks

Deliberately untouched: `--trace-added-text: var(--color-added, var(--success-hover))` — PR #161 restored `--color-added` as a caller-overridable hook at the alias layer, scoped to the StepCard added-marking role; the alias-pinning table in `cssColorTokenization.test.ts` pins that shape.

No gate changes: the semantic-pinning table pins alias-layer targets, not call-site fallbacks, and the `--color-*` family is `:root`-declared so the PARAMETERISED_TOKENS fallback requirement does not apply.

## Verification
- `cssColorTokenization.test.ts`: 23/23 pass
- Full frontend suite: 299 files / 5778 tests pass
- `eslint .`: 0 errors (27 pre-existing warnings)
- `tsc -b --noEmit`: clean, run with incremental cache cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)
