### PR TITLE
Key the pre-dispatch target gate on the effective metric set

### DIFF
--- a/specs/modelling/high-level.md
+++ b/specs/modelling/high-level.md
@@ -235,7 +235,11 @@ and those metrics are undefined on a continuous target, so that run is rejected
 pre-dispatch too rather than dying later at the metric stage. A binomial fit on a
 continuous proportion target stays legitimate and reachable — setting the reported
 metrics explicitly to regression metrics empties the effective set of classification
-metrics and the gate stands aside, which the rejection message itself points out. And because the fit runs in a spawn child, message
+metrics and the gate stands aside, which the rejection message itself points out —
+qualified to objectives that accept a continuous target (a binomial GLM family; a
+CatBoost Logloss/CrossEntropy loss never reaches this branch, since
+`resolve_loss_function` rejects it under a regression task at config time). And
+because the fit runs in a spawn child, message
 quality has to survive the process boundary: the child stamps every curated failure
 message on the failure payload's `user_message` field, and the parent supervisor
 surfaces that wording verbatim instead of re-wrapping it in worker jargon. This is the

--- a/specs/modelling/high-level.md
+++ b/specs/modelling/high-level.md
@@ -137,22 +137,32 @@ Invariants that always hold:
   exported: an unset loss/family, Tweedie variance power, Negative Binomial `theta`, GLM
   factor set, or elastic-net L1 ratio is rejected with an actionable message rather than
   silently defaulting.
-- A classification task never trains against a continuous target. Once training data is
-  materialised, the target column's values are checked against the task — in the train
-  route before the fit worker is dispatched, and again inside `TrainingJob` itself so
-  the CLI and exported-script paths share the same gate. A float or decimal target with
-  fractional values (or a target whose type cannot serve as class labels) under
-  `task="classification"` is rejected with a message naming the target column and task
-  and directing the user to choose a discrete target or switch the task to regression,
-  instead of failing later inside a metrics library with a context-free error. The gate
-  keys on the configured task only — a classification-flavoured objective under a
-  regression task (e.g. a binomial GLM defaulting to AUC/log-loss metrics) is not
-  gated, because a binomial target may legitimately be a continuous proportion; that
-  path is covered by the metric-stage context wrap below. Non-finite float values
-  are deliberately excluded from the fractional scan: NaN is treated as missing
-  (null-target handling and the metric stage's non-finite filtering own it), so an
-  all-NaN or infinite-valued target passes the gate and fails downstream inside the
-  wrapped metric stage with its own bounded message.
+- A classification task never trains against a continuous target, and classification
+  metrics are never computed against one. Once training data is materialised, the
+  target column's values are checked against the task and the effective metric set —
+  in the train route before the fit worker is dispatched, and again inside
+  `TrainingJob` itself so the CLI and exported-script paths share the same gate. A
+  float or decimal target with fractional values (or a target whose type cannot serve
+  as class labels) under `task="classification"` is rejected with a message naming
+  the target column and task and directing the user to choose a discrete target or
+  switch the task to regression, instead of failing later inside a metrics library
+  with a context-free error. The gate originally keyed on the configured task only —
+  a classification-flavoured objective under a regression task (e.g. a binomial GLM
+  defaulting to AUC/log-loss metrics) was left to the metric-stage context wrap,
+  because a binomial target may legitimately be a continuous proportion. But that run
+  still dies once AUC/log loss are computed, only later and with less context, so the
+  gate now keys on the effective metric set as well: a fractional target whose
+  effective metrics (explicit config metrics, or the objective-implied defaults —
+  the same derivation the job builder uses) include AUC/log loss is rejected
+  pre-dispatch with the metrics named and the escape hatch stated. The legitimate
+  continuous-proportion binomial fit remains reachable by setting the reported
+  metrics explicitly to regression metrics, which removes every classification
+  metric from the effective set. On this metric-keyed branch, non-float target types
+  defer to the fit's own validation. Non-finite float values are deliberately
+  excluded from the fractional scan: NaN is treated as missing (null-target handling
+  and the metric stage's non-finite filtering own it), so an all-NaN or
+  infinite-valued target passes the gate and fails downstream inside the wrapped
+  metric stage with its own bounded message.
 - Every trained model is saved together with a feature contract pinning its exact
   feature order, dtypes, categorical domains, target, and offset column. Any drift
   detected later (train vs. score) raises rather than producing a plausible-looking
@@ -212,12 +222,20 @@ trainable, plausible-looking model — just not the one the user intended.
 route's upfront validation, so the two paths cannot drift apart on what counts as
 "complete."
 
-The same posture extends to the target/task pairing and to the worker error boundary.
-A continuous target under a classification task used to train all the way to the
-metric stage and surface sklearn's bare "continuous format is not supported" — no
-target column, no task, no fix — so `_target_check.training_target_task_issue` gates
-the pairing with the objects the user can act on (target column, task), at both the
-route and `TrainingJob` layers. And because the fit runs in a spawn child, message
+The same posture extends to the target/task/metric pairing and to the worker error
+boundary. A continuous target under a classification task used to train all the way
+to the metric stage and surface sklearn's bare "continuous format is not supported" —
+no target column, no task, no fix — so `_target_check.training_target_task_issue`
+gates the pairing with the objects the user can act on (target column, task,
+metrics), at both the route and `TrainingJob` layers. The gate keys on the EFFECTIVE
+metric set (explicit config metrics or the objective-implied defaults from
+`effective_metrics`), not the declared task alone: a binomial family or
+Logloss/CrossEntropy loss under `task="regression"` implies AUC/log loss by default,
+and those metrics are undefined on a continuous target, so that run is rejected
+pre-dispatch too rather than dying later at the metric stage. A binomial fit on a
+continuous proportion target stays legitimate and reachable — setting the reported
+metrics explicitly to regression metrics empties the effective set of classification
+metrics and the gate stands aside, which the rejection message itself points out. And because the fit runs in a spawn child, message
 quality has to survive the process boundary: the child stamps every curated failure
 message on the failure payload's `user_message` field, and the parent supervisor
 surfaces that wording verbatim instead of re-wrapping it in worker jargon. This is the
@@ -328,11 +346,13 @@ browser without a server or JS bundle.
   HTTP classification (`http_status_code` 422 for missing required columns or
   bounded-streaming unsupported; 500 for a generic failure) on the terminal status,
   and the job transitions to `contract_error`/`error` accordingly.
-- A target column whose values cannot serve the configured task (a continuous target
-  under classification) is rejected after materialisation but before the fit worker is
-  dispatched: the job transitions to `contract_error` with a message naming the target
-  column and task and directing the user to choose a discrete target or switch the
-  task to regression.
+- A target column whose values cannot serve the configured task or effective metric
+  set (a continuous target under classification, or under AUC/log-loss metrics
+  implied by a classification-flavoured objective with `task="regression"`) is
+  rejected after materialisation but before the fit worker is dispatched: the job
+  transitions to `contract_error` with a message naming the target column, task, and
+  (on the metric-keyed branch) the metrics, directing the user to choose a discrete
+  target, switch the task, or set regression metrics explicitly.
 - Failures that cross the training/dispersion worker boundary surface the child's
   wording, not worker jargon — but only when that wording is deliberately curated.
   The child's failure mapper marks haute-authored messages (the gates, the metric
@@ -353,8 +373,11 @@ browser without a server or JS bundle.
   evaluation plan's public `development`/`final test` labels on that pipeline),
   target column, task, and requested metrics around the underlying library error,
   with the instruction to fix the target/task/metric pairing — a bare library
-  message cannot reach the UI from the metric stage. This wrap covers every
-  mandatory metric site: the evaluation plan's validation fits (the first metrics
+  message cannot reach the UI from the metric stage. With the pre-dispatch gate
+  keyed on the effective metric set, this wrap is the residual net for the
+  target/metric mismatches the gate's one fractional-values scan cannot see (e.g.
+  binary AUC over a multi-class integer target) and for every other metric-stage
+  failure. It covers every mandatory metric site: the evaluation plan's validation fits (the first metrics
   computed on the live route), the final fit's diagnostics-partition metrics, and
   the separate validation re-read. It catches the failure classes pure metric
   computation produces (`ValueError`, `TypeError`, arithmetic errors — never

--- a/specs/modelling/low-level.md
+++ b/specs/modelling/low-level.md
@@ -10,8 +10,8 @@
 | `src/haute/modelling/_training_job.py` | `TrainingJob` orchestrator — prepare one eligible source, persist/reload its evaluation plan, run selection or tuning fits, perform one deployable final fit, compute diagnostics, stage artifacts, and optionally log once to MLflow; also defines `TrainResult` and intermediate stage types. |
 | `src/haute/modelling/_evaluation.py` | Strict version-1 evaluation config, exact development/final-test and validation-fit plan generation, plan/result/report codecs, digest linkage, strategy summaries, and validation-row-weighted aggregation. |
 | `src/haute/modelling/_tuning.py` | Strict bounded CatBoost tuning config/search-space validation, seeded trial resolution, winner/tree-count selection, and tuning plan/trials/report codecs. |
-| `src/haute/modelling/_train_config.py` | Single source of truth for modelling-node config → training-job kwargs (`build_training_job_kwargs`, `build_train_params`, `parse_evaluation_config`, `parse_tuning_config`, `training_objective_issue`, `default_metrics`). |
-| `src/haute/modelling/_target_check.py` | `training_target_task_issue()` — data-dependent target-column vs task gate returning an actionable message (or nothing when the pairing is valid), shared by the train route's pre-dispatch validation and `TrainingJob._prepare_data`. |
+| `src/haute/modelling/_train_config.py` | Single source of truth for modelling-node config → training-job kwargs (`build_training_job_kwargs`, `build_train_params`, `parse_evaluation_config`, `parse_tuning_config`, `training_objective_issue`, `default_metrics`, `effective_metrics`). |
+| `src/haute/modelling/_target_check.py` | `training_target_task_issue()` — data-dependent target-column vs task/metric gate returning an actionable message (or nothing when the pairing is valid), keyed on the effective reported-metric set (explicit config metrics or the objective-implied defaults), shared by the train route's pre-dispatch validation and `TrainingJob._prepare_data`. |
 | `src/haute/modelling/_split.py` | Internal partition-mask execution used by a final or selection fit. Its `SplitConfig` is a private test seam for direct callers exercising the shared partition/fit machinery; it is not a public modelling-node config contract and is not exported. |
 | `src/haute/modelling/_metrics.py` | Primary metric functions and diagnostic data computation (double lift, AvE, residuals, actual-vs-predicted, Lorenz, PDP). |
 | `src/haute/modelling/_feature_contract.py` | `FeatureContract` build/save/load/cache, contract comparison, and categorical-level normalisation/validation. |
@@ -194,10 +194,14 @@
    when a stale `exclude` entry also names them, and streams the result to a temp parquet with
    `bounded_sink`;
    `training_target_task_issue` (`_target_check.py`) then validates the sunk parquet's
-   target column against the configured task — a classification task pointed at a
-   continuous (or otherwise non-classifiable) target removes the temp parquet and
-   rejects HTTP 422/`contract_error` with a message naming the target column and task,
-   before any fit worker is spawned;
+   target column against the configured task and the effective metric set
+   (`effective_metrics` — explicit config metrics or the objective-implied defaults,
+   the same derivation `build_training_job_kwargs` uses) — a classification task
+   pointed at a continuous (or otherwise non-classifiable) target, or a continuous
+   target whose effective metrics include AUC/log loss (implied by a binomial family
+   or Logloss/CrossEntropy loss even under `task="regression"`), removes the temp
+   parquet and rejects HTTP 422/`contract_error` with a message naming the target
+   column, task, and metrics, before any fit worker is spawned;
    `_launch_background` builds the `TrainingJob` via `build_training_job_kwargs`
    (`params` overridden by the GPU-adjusted `train_params`), creates a same-filesystem
    staging root, and starts a daemon supervisor thread around a spawn child.
@@ -245,11 +249,13 @@ live modelling-node and exported-script call. Direct/test callers that deliberat
 omit it retain the constructor-only legacy split/CV pipeline described above.
 
 1. **Prepare one eligible source** — `_prepare_data` reuses an already-sunk parquet or
-   materialises a supplied frame, validates required columns and the target/task
-   pairing (`training_target_task_issue` — a continuous or non-classifiable target
-   under `task="classification"` raises the same actionable message the route gate
-   surfaces, here as a `ValueError`, covering the CLI and exported-script paths;
-   internal evaluation clones skip the re-scan), removes null-target rows,
+   materialises a supplied frame, validates required columns and the
+   target/task/metric pairing (`training_target_task_issue` over the job's effective
+   metrics — a continuous or non-classifiable target under `task="classification"`,
+   or a continuous target with AUC/log loss in the effective metric set, raises the
+   same actionable message the route gate surfaces, here as a `ValueError`, covering
+   the CLI and exported-script paths; internal evaluation clones skip the re-scan),
+   removes null-target rows,
    derives the final feature set and schema snapshot, and applies GLM term narrowing
    and monotonicity validation once before planning.
 2. **Plan once** — `_build_evaluation_plan` reads only the target or strategy key
@@ -268,7 +274,7 @@ omit it retain the constructor-only legacy split/CV pipeline described above.
    first metrics computed on the live route, so the wrap must fire here too), and
    returns `EvaluationFitResult`; it never saves a deployable model,
    feature contract, MLflow run, SHAP/PDP, or full diagnostics. No-validation performs
-   zero selection fits. Internal clones skip `_prepare_data`'s target/task re-scan —
+   zero selection fits. Internal clones skip `_prepare_data`'s target/task/metric re-scan —
    the outer job already gated the shared prepared source.
 4. **Run bounded tuning when configured** — `_run_tuning_trials` writes/reloads the
    tuning plan, uses one seeded Optuna `TPESampler` through sequential ask/tell, runs
@@ -563,7 +569,7 @@ rows/features) and retry.
   block via `_record_diag_error`; recorded in `diagnostics_errors`, never propagates to
   fail the whole run.
 - **`ValueError`** — the dominant validation error across the package: invalid
-  evaluation/tuning evidence, missing required columns, a target/task mismatch
+  evaluation/tuning evidence, missing required columns, a target/task/metric mismatch
   (`training_target_task_issue`), an empty training DataFrame, all-non-finite metric
   inputs, a missing offset column at predict time, or GLM terms referencing absent
   columns. A metric failure (`ValueError`, `TypeError`, or an arithmetic error —
@@ -700,11 +706,17 @@ Tests live in the flat `tests/` directory rather than mirroring the package layo
 - `test_target_task_gate.py` — `training_target_task_issue` unit coverage (discrete
   dtypes pass, integral floats pass, fractional floats and non-classifiable dtypes
   gate with messages naming the target column, task, and call to action; regression
-  task untouched), the `TrainingJob._prepare_data` gate on both the legacy and
-  evaluation-plan pipelines, the metric-stage `ValueError` context wrap on both the
-  final-fit and validation-fit sites, and the route-side pre-dispatch gate
+  task with regression metrics untouched; AUC/log loss in the effective metric set
+  gates a fractional target under any task, with explicit regression metrics as the
+  escape hatch and non-float targets deferred to the fit's own validation on that
+  branch), the `TrainingJob._prepare_data` gate on both the legacy and
+  evaluation-plan pipelines (including the objective-implied Logloss-under-regression
+  case), the metric-stage `ValueError` context wrap on both the final-fit and
+  validation-fit sites (via a multi-class integer target, which passes the gate but
+  breaks binary AUC), and the route-side pre-dispatch gate
   (`TestPreDispatchServiceGate`: 422 → `contract_error`, temp-parquet removal on the
-  issue and scan-failure paths, and the wiring test proving the gate precedes
+  issue and scan-failure paths, the binomial-family-under-regression rejection with
+  its explicit-regression-metrics pass, and the wiring test proving the gate precedes
   `_launch_background`). Its `TestWorkerBoundaryUserMessage` covers both supervisor
   sides of the curated-message contract.
 - Narrow, remediation-pinned regression suites: `test_training_memory_safety.py`,

--- a/specs/modelling/low-level.md
+++ b/specs/modelling/low-level.md
@@ -196,12 +196,15 @@
    `training_target_task_issue` (`_target_check.py`) then validates the sunk parquet's
    target column against the configured task and the effective metric set
    (`effective_metrics` — explicit config metrics or the objective-implied defaults,
-   the same derivation `build_training_job_kwargs` uses) — a classification task
-   pointed at a continuous (or otherwise non-classifiable) target, or a continuous
+   the same derivation `build_training_job_kwargs` uses; a malformed metrics config
+   maps to the same 422/`contract_error` with the parquet removed) — a classification
+   task pointed at a continuous (or otherwise non-classifiable) target gates
+   regardless of the metric set (the fit itself is undefined on it), and a continuous
    target whose effective metrics include AUC/log loss (implied by a binomial family
-   or Logloss/CrossEntropy loss even under `task="regression"`), removes the temp
-   parquet and rejects HTTP 422/`contract_error` with a message naming the target
-   column, task, and metrics, before any fit worker is spawned;
+   even under `task="regression"`, or set explicitly) gates on the metric-keyed
+   branch; either removes the temp parquet and rejects HTTP 422/`contract_error`
+   with a message naming the target column, task, and offending metrics, before any
+   fit worker is spawned;
    `_launch_background` builds the `TrainingJob` via `build_training_job_kwargs`
    (`params` overridden by the GPU-adjusted `train_params`), creates a same-filesystem
    staging root, and starts a daemon supervisor thread around a spawn child.

--- a/src/haute/modelling/_target_check.py
+++ b/src/haute/modelling/_target_check.py
@@ -25,6 +25,10 @@ import polars as pl
 # Reported metrics that are undefined without discrete class labels. A
 # continuous target reaching sklearn's roc_auc_score/log_loss with any of
 # these requested dies at the metric stage, so the gate rejects it up front.
+# This is the complete set of classification metrics in _metrics.py's
+# registry today (gini is a native Lorenz implementation, defined on
+# continuous targets); extend it alongside any new registry entry that
+# needs discrete labels.
 _DISCRETE_LABEL_METRICS = frozenset({"auc", "logloss"})
 
 
@@ -88,7 +92,7 @@ def training_target_task_issue(
     through their own (streaming, execution-context-aware) collector; the
     default collects through Polars' streaming engine.
     """
-    classification_task = str(task) == "classification"
+    classification_task = str(task).lower() == "classification"
     label_metrics = sorted({str(metric).lower() for metric in metrics} & _DISCRETE_LABEL_METRICS)
     if not classification_task and not label_metrics:
         return None
@@ -132,13 +136,14 @@ def training_target_task_issue(
             )
         return (
             f"Target column '{target}' contains continuous values, but the reported "
-            f"metrics ({', '.join(metrics)}) include classification metrics — AUC and "
-            f"log loss need a discrete 0/1 target. The training task is {task}, so "
+            f"metrics include classification metrics ({', '.join(label_metrics)}), "
+            f"which need a discrete 0/1 target. The training task is {task}, so "
             "these metrics are either set explicitly or implied by a "
             "classification-flavoured objective (e.g. a binomial family). Choose a "
-            "discrete target column (e.g. a 0/1 claim flag), or set the reported "
-            "metrics explicitly to regression metrics (e.g. gini, rmse) to keep the "
-            "continuous target."
+            "discrete target column (e.g. a 0/1 claim flag), or — for objectives "
+            "that accept a continuous target, such as a binomial GLM family — set "
+            "the reported metrics explicitly to regression metrics (e.g. gini, "
+            "rmse) to keep the continuous target."
         )
     if not classification_task:
         return None

--- a/src/haute/modelling/_target_check.py
+++ b/src/haute/modelling/_target_check.py
@@ -1,24 +1,31 @@
-"""Data-dependent target-column vs task gate for model training.
+"""Data-dependent target vs task/metric gate for model training.
 
 ``training_target_task_issue`` mirrors ``training_objective_issue``
 (`_train_config.py`): return an actionable, user-facing message — naming the
-user-model objects involved (target column, task) and what to do next — or
-``None`` when the pairing is valid. It is shared by the train route's
-pre-dispatch validation (over the sunk training parquet) and
+user-model objects involved (target column, task, metrics) and what to do
+next — or ``None`` when the pairing is valid. It is shared by the train
+route's pre-dispatch validation (over the sunk training parquet) and
 ``TrainingJob._prepare_data`` (which also covers the CLI and exported-script
 paths), so the two gates can never drift.
 
-The motivating failure: a continuous target under ``task="classification"``
-trained all the way to the metric stage and surfaced sklearn's bare
-"ValueError: continuous format is not supported" — no target column, no task,
-no fix.
+The motivating failures: a continuous target under ``task="classification"``
+— and a continuous target whose *effective* metric set includes AUC/log loss
+(the defaults implied by a binomial family or Logloss/CrossEntropy loss even
+under ``task="regression"``) — trained all the way to the metric stage and
+surfaced sklearn's bare "ValueError: continuous format is not supported" —
+no target column, no task, no fix.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 import polars as pl
+
+# Reported metrics that are undefined without discrete class labels. A
+# continuous target reaching sklearn's roc_auc_score/log_loss with any of
+# these requested dies at the metric stage, so the gate rejects it up front.
+_DISCRETE_LABEL_METRICS = frozenset({"auc", "logloss"})
 
 
 def _has_fractional_values(
@@ -51,25 +58,39 @@ def training_target_task_issue(
     *,
     target: str,
     task: str,
+    metrics: Sequence[str],
     collect: Callable[[pl.LazyFrame], pl.DataFrame] | None = None,
 ) -> str | None:
-    """Return an actionable message when the target's values cannot serve the task.
+    """Return an actionable message when the target's values cannot serve the run.
 
-    A classification task needs a target holding discrete class labels:
-    boolean, integer, string/categorical/enum, or a float/decimal column
-    whose finite values are all integral (a materialised 0/1 flag). A
-    float/decimal target with fractional values — or a target whose type
-    cannot act as class labels at all — must gate here, with the target
-    column and task named, rather than fall through to a library error
-    stripped of that context. The gate keys on the configured task only; a
-    classification-flavoured objective under a regression task is covered by
-    the metric-stage context wrap in ``TrainingJob._compute_metrics``.
+    ``metrics`` is the EFFECTIVE reported-metric set — explicit config metrics
+    or the objective-implied defaults (``effective_metrics`` /
+    ``TrainingJob.metrics``), which is what the metric stage will actually
+    compute. The gate fires in two situations:
+
+    - ``task="classification"``: the target must hold discrete class labels —
+      boolean, integer, string/categorical/enum, or a float/decimal column
+      whose finite values are all integral (a materialised 0/1 flag). A
+      fractional float/decimal target, or a type that cannot act as class
+      labels at all, gates regardless of the metric set: the classification
+      fit itself is undefined on it.
+    - Any other task whose effective metrics include AUC/log loss (implied by
+      a binomial family or Logloss/CrossEntropy loss under
+      ``task="regression"``, or set explicitly): a fractional float/decimal
+      target gates, because those metrics need discrete class labels and the
+      run would only die later at the metric stage, stripped of this context.
+      A binomial fit on a continuous proportion target stays legitimate and
+      reachable — set the reported metrics explicitly to regression metrics
+      and no classification metric is ever computed. Non-float targets defer
+      to the fit's own validation on this branch.
 
     ``collect`` lets callers route the one boolean fractional-values scan
     through their own (streaming, execution-context-aware) collector; the
     default collects through Polars' streaming engine.
     """
-    if str(task) != "classification":
+    classification_task = str(task) == "classification"
+    label_metrics = sorted({str(metric).lower() for metric in metrics} & _DISCRETE_LABEL_METRICS)
+    if not classification_task and not label_metrics:
         return None
     schema = data.collect_schema()
     if target not in schema:
@@ -86,6 +107,8 @@ def training_target_task_issue(
     if base_type == pl.Boolean or dtype.is_integer():
         return None
     if base_type in (pl.String, pl.Categorical, pl.Enum):
+        # Class labels for classification; under any other task a string
+        # target is a target/task problem the fit's own validation owns.
         return None
     if dtype.is_float() or base_type == pl.Decimal:
         if collect is None:
@@ -99,13 +122,26 @@ def training_target_task_issue(
             decimal=base_type == pl.Decimal,
         ):
             return None
+        if classification_task:
+            return (
+                f"Target column '{target}' contains continuous values, but the training "
+                "task is classification. A classification target must hold discrete class "
+                "labels (e.g. a 0/1 claim flag) — classification training and its metrics "
+                "(AUC, log loss) are undefined on a continuous target. Choose a discrete "
+                "target column, or set the task to regression to model a continuous target."
+            )
         return (
-            f"Target column '{target}' contains continuous values, but the training "
-            "task is classification. A classification target must hold discrete class "
-            "labels (e.g. a 0/1 claim flag) — classification training and its metrics "
-            "(AUC, log loss) are undefined on a continuous target. Choose a discrete "
-            "target column, or set the task to regression to model a continuous target."
+            f"Target column '{target}' contains continuous values, but the reported "
+            f"metrics ({', '.join(metrics)}) include classification metrics — AUC and "
+            f"log loss need a discrete 0/1 target. The training task is {task}, so "
+            "these metrics are either set explicitly or implied by a "
+            "classification-flavoured objective (e.g. a binomial family). Choose a "
+            "discrete target column (e.g. a 0/1 claim flag), or set the reported "
+            "metrics explicitly to regression metrics (e.g. gini, rmse) to keep the "
+            "continuous target."
         )
+    if not classification_task:
+        return None
     return (
         f"Target column '{target}' has type {dtype}, which cannot be used as "
         "classification class labels. Choose a target column with discrete class "

--- a/src/haute/modelling/_train_config.py
+++ b/src/haute/modelling/_train_config.py
@@ -105,6 +105,36 @@ def default_metrics(
     return ["gini", "rmse"]
 
 
+def effective_metrics(config: Mapping[str, Any]) -> list[str]:
+    """The reported-metric list training will actually use for this config.
+
+    Explicit ``config["metrics"]`` wins; otherwise the objective-implied
+    defaults from :func:`default_metrics` apply — notably, a
+    classification-flavoured objective (binomial family, Logloss/CrossEntropy
+    loss) implies AUC/log loss even under ``task="regression"``. Shared by
+    ``build_training_job_kwargs`` and the train route's pre-dispatch
+    target/task/metric gate so the two derivations can never drift.
+    """
+    algorithm = str(config.get("algorithm", "catboost")).lower()
+    task = str(config.get("task", "regression"))
+    if algorithm == "glm":
+        family = config.get("family")
+        loss_function = None
+    else:
+        family = None
+        loss_function = config.get("loss_function")
+    metrics = config.get("metrics") or default_metrics(
+        task,
+        loss_function=loss_function,
+        family=family,
+    )
+    if not isinstance(metrics, list) or not all(
+        isinstance(metric, str) and metric for metric in metrics
+    ):
+        raise TrainingConfigError("Configured metrics must be a non-empty string list.")
+    return list(metrics)
+
+
 def training_objective_issue(config: Mapping[str, Any]) -> str | None:
     """Return an actionable message when the training objective is incomplete.
 
@@ -233,8 +263,6 @@ def build_training_job_kwargs(
     params = build_train_params(config)
     algorithm = str(config.get("algorithm", "catboost")).lower()
     task = str(config.get("task", "regression"))
-    family = params.get("family") if algorithm == "glm" else None
-    loss_function = None if algorithm == "glm" else config.get("loss_function")
     variance_power = config.get("var_power") if algorithm == "glm" else config.get("variance_power")
     legacy_fields = [key for key in ("split", "cross_validation") if key in config]
     if legacy_fields:
@@ -243,15 +271,7 @@ def build_training_job_kwargs(
             "were replaced by the canonical versioned evaluation object."
         )
     evaluation = parse_evaluation_config(config.get("evaluation"))
-    metrics = config.get("metrics") or default_metrics(
-        task,
-        loss_function=loss_function,
-        family=family,
-    )
-    if not isinstance(metrics, list) or not all(
-        isinstance(metric, str) and metric for metric in metrics
-    ):
-        raise TrainingConfigError("Configured metrics must be a non-empty string list.")
+    metrics = effective_metrics(config)
     tuning = parse_tuning_config(
         config.get("tuning"),
         algorithm=algorithm,

--- a/src/haute/modelling/_training_job.py
+++ b/src/haute/modelling/_training_job.py
@@ -1503,10 +1503,12 @@ class TrainingJob:
             )
             self._validate_columns(schema_df)
 
-            # The target's values must be able to serve the configured task.
-            # The train route runs the same gate before dispatching the fit
-            # worker; repeating it here covers the CLI and exported-script
-            # paths, and the shared function keeps the two from drifting.
+            # The target's values must be able to serve the configured task
+            # and the effective metric set (objective-implied defaults
+            # included). The train route runs the same gate before dispatching
+            # the fit worker; repeating it here covers the CLI and
+            # exported-script paths, and the shared function keeps the two
+            # from drifting.
             # Internal evaluation clones (selection, tuning, and the final
             # fit — all constructed with evaluation_plan set) re-read a
             # prepared source the outer job already gated, so they skip the
@@ -1518,6 +1520,7 @@ class TrainingJob:
                     pl.scan_parquet(data_path),
                     target=self.target,
                     task=self.task,
+                    metrics=self.metrics,
                     collect=lambda lf: _training_streaming_collect(
                         lf,
                         stage_name="training_target_task_check",

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -1999,23 +1999,30 @@ class TrainService:
         *,
         execution_context: ExecutionContext,
     ) -> None:
-        """Gate a target whose materialised values cannot serve the configured task.
+        """Gate a target whose materialised values cannot serve the task/metrics.
 
         Runs on the sunk training parquet, after materialisation but before
-        the fit worker is dispatched, so a config/data mismatch (the
-        motivating case: a continuous target under a classification task)
-        fails with the target column and task named instead of surfacing a
-        context-free library error from inside the child. Removes the temp
-        parquet before raising — no later owner exists for it on this path.
+        the fit worker is dispatched, so a config/data mismatch (a continuous
+        target under a classification task, or under objective-implied
+        AUC/log-loss defaults — e.g. a binomial family with
+        ``task="regression"``) fails with the target column, task, and metrics
+        named instead of surfacing a context-free library error from inside
+        the child. The gate keys on the effective metric set
+        (``effective_metrics`` — explicit config metrics or the
+        objective-implied defaults), the same derivation
+        ``build_training_job_kwargs`` uses. Removes the temp parquet before
+        raising — no later owner exists for it on this path.
         """
         from haute._polars_utils import streaming_collect
         from haute.modelling._target_check import training_target_task_issue
+        from haute.modelling._train_config import effective_metrics
 
         try:
             issue = training_target_task_issue(
                 pl.scan_parquet(tmp_parquet),
                 target=str(config.get("target", "")),
                 task=str(config.get("task", "regression")),
+                metrics=effective_metrics(config),
                 collect=lambda lf: streaming_collect(lf, execution_context=execution_context),
             )
         except BaseException:

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -2015,14 +2015,24 @@ class TrainService:
         """
         from haute._polars_utils import streaming_collect
         from haute.modelling._target_check import training_target_task_issue
-        from haute.modelling._train_config import effective_metrics
+        from haute.modelling._train_config import TrainingConfigError, effective_metrics
 
+        # Derive the effective metrics before the data scan: it is a pure
+        # config computation, and a malformed metrics config (normally caught
+        # by the route's upfront validation) must map to the same
+        # 422/contract_error taxonomy as the gate itself, not fall through
+        # the scan-failure path below.
+        try:
+            metrics = effective_metrics(config)
+        except TrainingConfigError as exc:
+            _remove_gated_temp_parquet(tmp_parquet)
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         try:
             issue = training_target_task_issue(
                 pl.scan_parquet(tmp_parquet),
                 target=str(config.get("target", "")),
                 task=str(config.get("task", "regression")),
-                metrics=effective_metrics(config),
+                metrics=metrics,
                 collect=lambda lf: streaming_collect(lf, execution_context=execution_context),
             )
         except BaseException:

--- a/tests/test_target_task_gate.py
+++ b/tests/test_target_task_gate.py
@@ -148,6 +148,28 @@ class TestTrainingTargetTaskIssue:
         issue = training_target_task_issue(data, target="prop", task="regression", metrics=["AUC"])
         assert issue is not None
         assert "'prop'" in issue
+        # The message names the normalised offending metric, not the raw list.
+        assert "(auc)" in issue
+
+    def test_task_is_matched_case_insensitively(self) -> None:
+        """A creatively-cased task must not skip the gate entirely."""
+        data = pl.LazyFrame({"sev": [123.45, 0.0, 1.0]})
+        issue = training_target_task_issue(
+            data, target="sev", task="Classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
+        assert issue is not None
+        assert "'sev'" in issue
+
+    def test_message_names_only_the_offending_metrics(self) -> None:
+        """gini/rmse ride alongside auc in a mixed explicit list — the
+        message must indict only the discrete-label metrics."""
+        data = pl.LazyFrame({"prop": [0.25, 0.5]})
+        issue = training_target_task_issue(
+            data, target="prop", task="regression", metrics=["gini", "auc", "rmse"]
+        )
+        assert issue is not None
+        assert "(auc)" in issue
+        assert "(gini" not in issue
 
     def test_regression_task_with_classification_metrics_passes_integral_flag(self) -> None:
         data = pl.LazyFrame({"flag": [0.0, 1.0, None, 1.0]})
@@ -371,6 +393,43 @@ class TestTrainingJobGate:
         prepared = job._prepare_data(lambda message, fraction: None)
         assert prepared is not None
 
+    def test_escape_hatch_trains_a_binomial_glm_on_proportions_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact scenario the rejection message prescribes must work:
+        config-built binomial GLM, continuous proportion target, explicit
+        regression metrics — through the builder, the gate, the fit, and the
+        metric stage to a completed result."""
+        from haute.modelling._train_config import build_training_job_kwargs
+
+        rng = np.random.RandomState(42)
+        n = 80
+        x1 = rng.randn(n)
+        prop = 1.0 / (1.0 + np.exp(-(0.8 * x1 + rng.randn(n) * 0.3)))
+        data_path = tmp_path / "proportions.parquet"
+        pl.DataFrame({"x1": x1, "prop": prop}).write_parquet(data_path)
+        config = {
+            "name": "hatch_binomial_model",
+            "target": "prop",
+            "task": "regression",
+            "algorithm": "glm",
+            "family": "binomial",
+            "terms": {"x1": {"type": "linear"}},
+            "metrics": ["gini", "rmse"],
+            "evaluation": {
+                "schema_version": 1,
+                "strategy": "random",
+                "seed": 42,
+                "validation": {"method": "single", "size": 0.2},
+            },
+            "output_dir": str(tmp_path),
+        }
+        kwargs = build_training_job_kwargs(config, data=str(data_path))
+        assert kwargs["metrics"] == ["gini", "rmse"]
+        result = TrainingJob(**kwargs).run()
+        assert "gini" in result.metrics
+        assert "rmse" in result.metrics
+
 
 class TestMetricStageContext:
     def test_metric_failure_names_target_task_and_metrics(self, tmp_path: Path) -> None:
@@ -413,7 +472,10 @@ class TestMetricStageContext:
         assert "'sev'" in message
         assert "'regression'" in message
         assert "auc" in message
-        assert "multi_class" in message  # the chained sklearn detail survives
+        # The library detail is chained last (truncation-safe) without
+        # coupling to sklearn's exact wording.
+        assert "Underlying error:" in message
+        assert isinstance(excinfo.value.__cause__, ValueError)
 
     def test_metric_failure_is_wrapped_on_the_evaluation_plan_path(self, tmp_path: Path) -> None:
         """The canonical evaluation-plan pipeline wraps its validation-fit metrics.
@@ -458,7 +520,8 @@ class TestMetricStageContext:
         assert "'sev'" in message
         assert "'regression'" in message
         assert "auc" in message
-        assert "multi_class" in message
+        assert "Underlying error:" in message
+        assert isinstance(excinfo.value.__cause__, ValueError)
 
 
 class TestPreDispatchServiceGate:
@@ -550,6 +613,28 @@ class TestPreDispatchServiceGate:
             execution_context=context,
         )
         assert tmp_parquet.exists()
+
+    def test_validate_target_task_pairing_maps_malformed_metrics_to_422(
+        self, tmp_path: Path
+    ) -> None:
+        """A malformed metrics config (normally rejected by the route's
+        upfront validation) is a config problem, not a scan failure — it must
+        map to 422/contract_error and still not orphan the temp parquet."""
+        tmp_parquet = tmp_path / "train_input.parquet"
+        pl.DataFrame({"x1": [0.1, 0.2], "sev": [123.45, 6.7]}).write_parquet(tmp_parquet)
+        context = ExecutionContext(
+            operation="training_pipeline",
+            profile=ExecutionProfile.TRAINING_PREP,
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            TrainService._validate_target_task_pairing(
+                str(tmp_parquet),
+                {"target": "sev", "task": "regression", "metrics": "auc"},
+                execution_context=context,
+            )
+        assert excinfo.value.status_code == 422
+        assert "non-empty string list" in str(excinfo.value.detail)
+        assert not tmp_parquet.exists()
 
     def test_validate_target_task_pairing_removes_parquet_when_the_scan_fails(
         self, tmp_path: Path

--- a/tests/test_target_task_gate.py
+++ b/tests/test_target_task_gate.py
@@ -1,14 +1,16 @@
-"""Target/task pairing gate and worker-boundary message contract.
+"""Target/task/metric pairing gate and worker-boundary message contract.
 
 Pins the fix for the motivating low-context error surface: a continuous
-target under ``task="classification"`` used to train to the metric stage and
-surface sklearn's bare "ValueError: continuous format is not supported" with
-no target column, no task, and no call to action. The gate
-(`haute.modelling._target_check.training_target_task_issue`) now rejects the
-pairing before dispatch with the user-model objects named; the metric stage
-wraps any remaining library error with the same context; and the failure
-payload's ``user_message`` field carries curated wording verbatim across the
-worker boundary.
+target under ``task="classification"`` — or under objective-implied AUC/log
+loss defaults with ``task="regression"`` (e.g. a binomial family) — used to
+train to the metric stage and surface sklearn's bare "ValueError: continuous
+format is not supported" with no target column, no task, and no call to
+action. The gate (`haute.modelling._target_check.training_target_task_issue`)
+now keys on the EFFECTIVE metric set and rejects the pairing before dispatch
+with the user-model objects named; the metric stage wraps any remaining
+library error with the same context; and the failure payload's
+``user_message`` field carries curated wording verbatim across the worker
+boundary.
 """
 
 from __future__ import annotations
@@ -60,10 +62,19 @@ def _curated_failure_worker(runtime: object, request: object) -> WorkerFailurePa
     )
 
 
+_CLASSIFICATION_DEFAULT_METRICS = ["auc", "logloss"]
+_REGRESSION_DEFAULT_METRICS = ["gini", "rmse"]
+
+
 class TestTrainingTargetTaskIssue:
-    def test_regression_task_never_gates(self) -> None:
+    def test_regression_task_with_regression_metrics_never_gates(self) -> None:
         data = pl.LazyFrame({"sev": [1.5, 2.25, 3.75]})
-        assert training_target_task_issue(data, target="sev", task="regression") is None
+        assert (
+            training_target_task_issue(
+                data, target="sev", task="regression", metrics=_REGRESSION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     @pytest.mark.parametrize(
         "values",
@@ -77,15 +88,27 @@ class TestTrainingTargetTaskIssue:
     )
     def test_discrete_targets_pass_classification(self, values: pl.Series) -> None:
         data = pl.LazyFrame([values])
-        assert training_target_task_issue(data, target="flag", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_integral_float_flag_passes_classification(self) -> None:
         data = pl.LazyFrame({"flag": [0.0, 1.0, None, 1.0, float("nan")]})
-        assert training_target_task_issue(data, target="flag", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_continuous_float_gates_classification(self) -> None:
         data = pl.LazyFrame({"sev": [123.45, 0.0, 1.0]})
-        issue = training_target_task_issue(data, target="sev", task="classification")
+        issue = training_target_task_issue(
+            data, target="sev", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
         assert issue is not None
         # The message must name the user-model objects and a call to action.
         assert "'sev'" in issue
@@ -93,33 +116,105 @@ class TestTrainingTargetTaskIssue:
         assert "regression" in issue
         assert "Choose a discrete target column" in issue
 
+    def test_classification_task_gates_even_with_regression_metrics(self) -> None:
+        """The classification FIT is undefined on a continuous target — the
+        gate cannot be escaped by requesting regression metrics."""
+        data = pl.LazyFrame({"sev": [123.45, 0.0, 1.0]})
+        issue = training_target_task_issue(
+            data, target="sev", task="classification", metrics=_REGRESSION_DEFAULT_METRICS
+        )
+        assert issue is not None
+        assert "'sev'" in issue
+        assert "classification" in issue
+
+    def test_regression_task_with_classification_metrics_gates_continuous_target(self) -> None:
+        """The binomial-family bypass: objective-implied AUC/log loss under
+        ``task="regression"`` must gate pre-dispatch, naming the metrics."""
+        data = pl.LazyFrame({"prop": [0.25, 0.5, 0.75]})
+        issue = training_target_task_issue(
+            data, target="prop", task="regression", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
+        assert issue is not None
+        assert "'prop'" in issue
+        assert "regression" in issue
+        assert "auc, logloss" in issue
+        assert "Choose a discrete target column" in issue
+        # The escape hatch for a legitimate continuous-proportion binomial
+        # fit must be named: set regression metrics explicitly.
+        assert "set the reported metrics explicitly to regression metrics" in issue
+
+    def test_metric_names_are_matched_case_insensitively(self) -> None:
+        data = pl.LazyFrame({"prop": [0.25, 0.5]})
+        issue = training_target_task_issue(data, target="prop", task="regression", metrics=["AUC"])
+        assert issue is not None
+        assert "'prop'" in issue
+
+    def test_regression_task_with_classification_metrics_passes_integral_flag(self) -> None:
+        data = pl.LazyFrame({"flag": [0.0, 1.0, None, 1.0]})
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="regression", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
+
+    def test_regression_task_with_classification_metrics_defers_non_float_targets(self) -> None:
+        """On the metric-keyed branch only fractional float/decimal targets
+        gate; other dtypes stay owned by the fit's own target validation."""
+        data = pl.LazyFrame({"when": pl.Series([1, 2]).cast(pl.Date)})
+        assert (
+            training_target_task_issue(
+                data, target="when", task="regression", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
+
     def test_non_classifiable_dtype_gates_classification(self) -> None:
         data = pl.LazyFrame({"when": pl.Series([1, 2]).cast(pl.Date)})
-        issue = training_target_task_issue(data, target="when", task="classification")
+        issue = training_target_task_issue(
+            data, target="when", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
         assert issue is not None
         assert "'when'" in issue
         assert "regression" in issue
 
     def test_missing_target_column_is_not_this_gates_job(self) -> None:
         data = pl.LazyFrame({"other": [1.5]})
-        assert training_target_task_issue(data, target="sev", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="sev", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_all_null_target_defers_to_the_null_count_gate(self) -> None:
         """A Null-typed column is a null-count problem, not a type problem."""
         data = pl.LazyFrame({"flag": [None, None]})
-        assert training_target_task_issue(data, target="flag", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_integral_decimal_flag_passes_classification(self) -> None:
         data = pl.LazyFrame(
             {"flag": pl.Series([Decimal("0"), Decimal("1")], dtype=pl.Decimal(3, 0))}
         )
-        assert training_target_task_issue(data, target="flag", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_fractional_decimal_gates_classification(self) -> None:
         data = pl.LazyFrame(
             {"sev": pl.Series([Decimal("123.45"), Decimal("6.70")], dtype=pl.Decimal(10, 2))}
         )
-        issue = training_target_task_issue(data, target="sev", task="classification")
+        issue = training_target_task_issue(
+            data, target="sev", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
         assert issue is not None
         assert "'sev'" in issue
         assert "continuous values" in issue
@@ -133,7 +228,9 @@ class TestTrainingTargetTaskIssue:
         data = pl.LazyFrame(
             {"sev": pl.Series([Decimal("12345678901234567890.5")], dtype=pl.Decimal(38, 2))}
         )
-        issue = training_target_task_issue(data, target="sev", task="classification")
+        issue = training_target_task_issue(
+            data, target="sev", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+        )
         assert issue is not None
         assert "'sev'" in issue
 
@@ -141,7 +238,12 @@ class TestTrainingTargetTaskIssue:
         data = pl.LazyFrame(
             {"flag": pl.Series([Decimal("0.00"), Decimal("1.00"), None], dtype=pl.Decimal(38, 2))}
         )
-        assert training_target_task_issue(data, target="flag", task="classification") is None
+        assert (
+            training_target_task_issue(
+                data, target="flag", task="classification", metrics=_CLASSIFICATION_DEFAULT_METRICS
+            )
+            is None
+        )
 
     def test_custom_collector_is_used_for_the_fractional_scan(self) -> None:
         data = pl.LazyFrame({"sev": [123.45]})
@@ -152,7 +254,11 @@ class TestTrainingTargetTaskIssue:
             return lf.collect()
 
         issue = training_target_task_issue(
-            data, target="sev", task="classification", collect=collect
+            data,
+            target="sev",
+            task="classification",
+            metrics=_CLASSIFICATION_DEFAULT_METRICS,
+            collect=collect,
         )
         assert issue is not None
         assert len(collected) == 1
@@ -213,14 +319,67 @@ class TestTrainingJobGate:
         assert "'sev'" in message
         assert "set the task to regression" in message
 
+    def test_prepare_data_gates_objective_implied_metrics_under_regression(
+        self, tmp_path: Path
+    ) -> None:
+        """The binomial-family bypass closed: a Logloss objective under
+        ``task="regression"`` defaults the metrics to AUC/log loss, so a
+        continuous target must gate at prepare time, not the metric stage."""
+        data = pl.DataFrame(
+            {
+                "x1": [0.1, 0.2, 0.3, 0.4],
+                "prop": [0.25, 0.5, 0.75, 0.1],
+            }
+        )
+        job = TrainingJob(
+            name="gate_implied_metrics_model",
+            data=data,
+            target="prop",
+            task="regression",
+            loss_function="Logloss",
+            output_dir=str(tmp_path),
+        )
+        assert job.metrics == ["auc", "logloss"]  # the objective-implied defaults
+        with pytest.raises(ValueError, match="continuous values") as excinfo:
+            job.run()
+        message = str(excinfo.value)
+        assert "'prop'" in message
+        assert "auc, logloss" in message
+        assert "set the reported metrics explicitly to regression metrics" in message
+
+    def test_prepare_data_passes_explicit_regression_metrics_over_proportions(
+        self, tmp_path: Path
+    ) -> None:
+        """The escape hatch: explicit regression metrics keep a legitimate
+        continuous-proportion fit trainable — the gate must not fire, so the
+        run proceeds past _prepare_data (here into the fit itself)."""
+        data = pl.DataFrame(
+            {
+                "x1": [0.1, 0.2, 0.3, 0.4],
+                "prop": [0.25, 0.5, 0.75, 0.1],
+            }
+        )
+        job = TrainingJob(
+            name="gate_escape_hatch_model",
+            data=data,
+            target="prop",
+            task="regression",
+            loss_function="Logloss",
+            metrics=["gini", "rmse"],
+            output_dir=str(tmp_path),
+        )
+        prepared = job._prepare_data(lambda message, fraction: None)
+        assert prepared is not None
+
 
 class TestMetricStageContext:
     def test_metric_failure_names_target_task_and_metrics(self, tmp_path: Path) -> None:
         """A metric/task mismatch the gate cannot catch still surfaces with context.
 
-        Regression task passes the target gate, but AUC over a continuous
-        target raises inside sklearn; the wrap must name the evaluation set,
-        target, task, and metric list around the library error.
+        A multi-class integer target passes the gate (integers are discrete
+        labels), but binary AUC over it raises inside sklearn; the wrap must
+        name the evaluation set, target, task, and metric list around the
+        library error.
         """
         rng = np.random.RandomState(42)
         n = 60
@@ -229,7 +388,7 @@ class TestMetricStageContext:
             {
                 "x1": x1,
                 "x2": rng.randn(n),
-                "sev": (x1 + rng.randn(n) * 0.5) + 5.0,
+                "sev": rng.randint(0, 3, n),
             }
         )
         with (
@@ -254,7 +413,7 @@ class TestMetricStageContext:
         assert "'sev'" in message
         assert "'regression'" in message
         assert "auc" in message
-        assert "continuous" in message  # the chained sklearn detail survives
+        assert "multi_class" in message  # the chained sklearn detail survives
 
     def test_metric_failure_is_wrapped_on_the_evaluation_plan_path(self, tmp_path: Path) -> None:
         """The canonical evaluation-plan pipeline wraps its validation-fit metrics.
@@ -262,7 +421,8 @@ class TestMetricStageContext:
         The live train route always supplies the canonical ``evaluation``
         object, so the first metric computation happens inside a validation
         fit — the wrap must fire there too, not only in the legacy
-        constructor-only pipeline's final-fit metric stage.
+        constructor-only pipeline's final-fit metric stage. The multi-class
+        integer target passes the pre-dispatch gate but breaks binary AUC.
         """
         rng = np.random.RandomState(42)
         n = 60
@@ -271,7 +431,7 @@ class TestMetricStageContext:
             {
                 "x1": x1,
                 "x2": rng.randn(n),
-                "sev": (x1 + rng.randn(n) * 0.5) + 5.0,
+                "sev": rng.randint(0, 3, n),
             }
         )
         job = TrainingJob(
@@ -298,7 +458,7 @@ class TestMetricStageContext:
         assert "'sev'" in message
         assert "'regression'" in message
         assert "auc" in message
-        assert "continuous" in message
+        assert "multi_class" in message
 
 
 class TestPreDispatchServiceGate:
@@ -330,6 +490,63 @@ class TestPreDispatchServiceGate:
         TrainService._validate_target_task_pairing(
             str(tmp_parquet),
             {"target": "sev", "task": "regression"},
+            execution_context=context,
+        )
+        assert tmp_parquet.exists()
+
+    def test_validate_target_task_pairing_rejects_binomial_family_under_regression(
+        self, tmp_path: Path
+    ) -> None:
+        """A binomial GLM under ``task="regression"`` implies AUC/log loss —
+        a continuous target must fail here pre-dispatch, not at the metric
+        stage inside the child."""
+        tmp_parquet = tmp_path / "train_input.parquet"
+        pl.DataFrame({"x1": [0.1, 0.2], "prop": [0.25, 0.75]}).write_parquet(tmp_parquet)
+        context = ExecutionContext(
+            operation="training_pipeline",
+            profile=ExecutionProfile.TRAINING_PREP,
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            TrainService._validate_target_task_pairing(
+                str(tmp_parquet),
+                {
+                    "target": "prop",
+                    "task": "regression",
+                    "algorithm": "glm",
+                    "family": "binomial",
+                    "terms": ["x1"],
+                },
+                execution_context=context,
+            )
+        assert excinfo.value.status_code == 422
+        detail = str(excinfo.value.detail)
+        assert "'prop'" in detail
+        assert "auc, logloss" in detail
+        assert "set the reported metrics explicitly to regression metrics" in detail
+        assert not tmp_parquet.exists()
+
+    def test_validate_target_task_pairing_honours_explicit_regression_metrics(
+        self, tmp_path: Path
+    ) -> None:
+        """Explicit regression metrics keep a continuous-proportion binomial
+        fit dispatchable — the effective metric set has no classification
+        metric, so the gate must not fire."""
+        tmp_parquet = tmp_path / "train_input.parquet"
+        pl.DataFrame({"x1": [0.1, 0.2], "prop": [0.25, 0.75]}).write_parquet(tmp_parquet)
+        context = ExecutionContext(
+            operation="training_pipeline",
+            profile=ExecutionProfile.TRAINING_PREP,
+        )
+        TrainService._validate_target_task_pairing(
+            str(tmp_parquet),
+            {
+                "target": "prop",
+                "task": "regression",
+                "algorithm": "glm",
+                "family": "binomial",
+                "terms": ["x1"],
+                "metrics": ["gini", "rmse"],
+            },
             execution_context=context,
         )
         assert tmp_parquet.exists()

--- a/tests/test_train_config_builder.py
+++ b/tests/test_train_config_builder.py
@@ -16,6 +16,7 @@ from haute.modelling._train_config import (
     build_train_params,
     build_training_job_kwargs,
     default_metrics,
+    effective_metrics,
 )
 
 # Minimal canonical evaluation object — every public modelling config must
@@ -433,6 +434,39 @@ class TestDefaultMetricsDerivation:
             "gini",
             "tweedie_deviance",
         ]
+
+    def test_effective_metrics_matches_the_builder_derivation(self):
+        """The pre-dispatch target/task/metric gate keys on this helper — it
+        must agree with what ``build_training_job_kwargs`` produces, explicit
+        metrics and objective-implied defaults alike."""
+        binomial_glm = {
+            "target": "y",
+            "task": "regression",
+            "algorithm": "glm",
+            "family": "binomial",
+            "all_factors": True,
+        }
+        assert effective_metrics(binomial_glm) == ["auc", "logloss"]
+        assert effective_metrics(
+            {"target": "y", "task": "regression", "loss_function": "Logloss"}
+        ) == ["auc", "logloss"]
+        assert effective_metrics(
+            {"target": "y", "task": "regression", "loss_function": "RMSE"}
+        ) == ["gini", "rmse"]
+        assert effective_metrics({**binomial_glm, "metrics": ["gini", "rmse"]}) == [
+            "gini",
+            "rmse",
+        ]
+        # A GLM config's loss_function (if a stray one appears) must not leak
+        # into the derivation, mirroring the builder.
+        assert effective_metrics({**binomial_glm, "loss_function": "Poisson"}) == [
+            "auc",
+            "logloss",
+        ]
+
+    def test_effective_metrics_rejects_malformed_explicit_metrics(self):
+        with pytest.raises(TrainingConfigError, match="non-empty string list"):
+            effective_metrics({"target": "y", "metrics": "auc"})
 
     def test_training_job_fallback_metrics_follow_loss(self):
         """TrainingJob is also constructed directly (not only via the

--- a/tests/test_train_config_builder.py
+++ b/tests/test_train_config_builder.py
@@ -463,6 +463,21 @@ class TestDefaultMetricsDerivation:
             "auc",
             "logloss",
         ]
+        # And the drift-prevention itself: the builder's kwargs carry exactly
+        # this helper's answer, for implied and explicit metrics alike.
+        for config in (
+            {**binomial_glm, "evaluation": MINIMAL_EVALUATION},
+            {**binomial_glm, "evaluation": MINIMAL_EVALUATION, "metrics": ["gini", "rmse"]},
+            {
+                "target": "y",
+                "task": "regression",
+                "loss_function": "Poisson",
+                "evaluation": MINIMAL_EVALUATION,
+            },
+        ):
+            assert build_training_job_kwargs(config, data="d")["metrics"] == effective_metrics(
+                config
+            )
 
     def test_effective_metrics_rejects_malformed_explicit_metrics(self):
         with pytest.raises(TrainingConfigError, match="non-empty string list"):


### PR DESCRIPTION
## What

PR #159's pre-dispatch target/task gate keyed on the declared task only, so objective-implied classification metrics under task="regression" — a binomial GLM family or Logloss/CrossEntropy loss defaulting the reported metrics to AUC/log loss — bypassed it and only failed downstream at the metric stage, a later and less specific failure than the gate could give.

`training_target_task_issue` now keys on the EFFECTIVE metric set (declared task + objective-implied defaults):

- New `effective_metrics()` in `_train_config.py` — explicit config metrics or the objective-implied `default_metrics` — is the single shared derivation: `build_training_job_kwargs` delegates to it and the train route's `_validate_target_task_pairing` passes it to the gate, so the builder and the gate can never drift. `TrainingJob._prepare_data` passes `self.metrics` (the job-side effective set).
- A fractional float/decimal target whose effective metrics include AUC/log loss is rejected pre-dispatch (HTTP 422/`contract_error` at the route; the same `ValueError` message in `TrainingJob` for the CLI/exported-script paths) with a curated message naming the target column, task, and metrics.
- #159's by-design bypass ("a binomial target may legitimately be a continuous proportion") is resolved, not just removed: that fit stays reachable by setting the reported metrics explicitly to regression metrics (which empties the effective set of classification metrics), and the rejection message states that escape hatch. Classification tasks still gate regardless of metrics — the fit itself is undefined on a continuous target. Non-float targets on the metric-keyed branch defer to the fit's own validation.
- The metric-stage context wrap remains the residual net for mismatches the gate's one fractional-values scan cannot see (its tests now pin a multi-class integer target, which passes the gate but breaks binary AUC).

Specs updated and folded present-tense: modelling high-level (posture + edge-case entries, including rewriting the recorded #159 deliberate-bypass note into its resolution) and low-level (module map, route step 3, canonical pipeline step 1, failure taxonomy, test map).

## Verification

- `tests/test_target_task_gate.py` + `tests/test_train_config_builder.py`: the new metric-keyed branch (gates fractional targets, passes integral flags, defers non-float dtypes, case-insensitive metric match), the classification branch unchanged, the escape hatch at unit/TrainingJob/route levels, the binomial-family-under-regression 422 with parquet removal, and `effective_metrics` agreement with the builder (explicit override, GLM family vs catboost loss, malformed-metrics rejection).
- Full batch green on the branch: target-gate, train-config-builder, worker isolation, training worker protocol, train-service coverage + helpers, modelling (402 passed, 2 skipped); docs-accuracy (44 passed); mypy clean on a cleared cache; ruff check + format clean.
- Not verified live: a full train through a running server (RAM-probe constraint, same as #159); the chain is pinned link-by-link including the route wiring test.

## Out-of-scope findings

- No per-file critical-coverage entry exists for `_target_check.py` (or `_train_service.py`) in pyproject's `[tool.haute.critical_coverage]` — adding one is a policy addition for Nick to call.
- Pre-existing, untouched: the fit-stage `_friendly_error` fallbacks and child-crash surface (already assigned to the error-curation session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
