### PR TITLE
Migrate remaining monospace literals onto the typography role tokens

### DIFF
--- a/frontend/src/__tests__/cssColorTokenization.test.ts
+++ b/frontend/src/__tests__/cssColorTokenization.test.ts
@@ -1022,20 +1022,69 @@ describe("ts/tsx source — design-token contract", () => {
     expect(orphaned).toEqual([])
   })
 
-  it("the typography role tokens are adopted in live source (adoption pin)", () => {
-    // The trace sites migrated to var(--font-data) and ErrorBoundary's
+  it("every typography role token is adopted in live source (adoption pin)", () => {
+    // The trace sites' var(--font-data) and ErrorBoundary's
     // var(--font-code) are the role layer's seed adoption.  Nothing else
     // pins them: a revert to a raw font stack (or to
     // var(--font-mono, monospace)) would pass every resolution rule.
-    // Requiring at least one live reference per role keeps each token
-    // honest — a declared-but-unreferenced role token is a regression,
-    // not a tidy-up.
+    // The role list is DERIVED from the :root block's --font-*
+    // declarations rather than enumerated, so the pin is universal: a
+    // future role token declared but never referenced fails here instead
+    // of passing silently.  Tailwind-provided primitives are excluded on
+    // principle (they are faces, not roles) — though the shadow guard
+    // already keeps --font-mono out of :root.
+    const { start, end } = findRootBlockRange(CSS_CODE)
+    const roles = [...findTokenDeclarations(CSS_CODE.slice(start, end))].filter(
+      (name) => name.startsWith("--font-") && !TAILWIND_PROVIDED_TOKENS.has(name),
+    )
+    expect(roles.length, "no --font-* role tokens declared in index.css :root").toBeGreaterThan(0)
     const files = collectSourceFiles(SRC_ROOT)
-    const refs = files.flatMap((f) => findVarRefs(stripComments(readFileSync(f, "utf8"))))
-    for (const role of ["--font-data", "--font-code"]) {
+    const referenced = new Set(
+      files.flatMap((f) => findVarRefs(stripComments(readFileSync(f, "utf8"))).map((r) => r.name)),
+    )
+    const orphaned = roles.filter((role) => !referenced.has(role))
+    expect(
+      orphaned,
+      `typography role token(s) declared in index.css but never referenced from live ts/tsx source: ${orphaned.join(", ")}`,
+    ).toEqual([])
+  })
+
+  it("live source declares no raw monospace fontFamily (mono role-layer gate)", () => {
+    // The migration's end state — every mono surface routed through a
+    // --font-* role token — would otherwise be enforced by review
+    // discipline alone: nothing stopped a new `fontFamily: "monospace"`
+    // from quietly reopening the class.  Flag any fontFamily whose string
+    // value names a generic or concrete mono face directly.  Sole
+    // exemption: CodeMirrorEditor's deliberate custom stack inside
+    // EditorView.theme() (see the --font-code comment in index.css) — a
+    // recorded decision, not an oversight.
+    const EXEMPT = new Set(["panels/editors/CodeMirrorEditor.tsx"])
+    const MONO_FACE =
+      /fontFamily\s*:\s*["'`][^"'`]*(?:monospace|SFMono|SF Mono|Menlo|Consolas|Courier)/
+    const offenders: string[] = []
+    for (const file of collectSourceFiles(SRC_ROOT)) {
+      const rel = path.relative(SRC_ROOT, file).split(path.sep).join(path.posix.sep)
+      if (EXEMPT.has(rel)) continue
+      const lines = stripComments(readFileSync(file, "utf8")).split("\n")
+      lines.forEach((line, i) => {
+        if (MONO_FACE.test(line)) offenders.push(`  ${rel}:${i + 1}  ${line.trim()}`)
+      })
+    }
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found ${offenders.length} raw monospace fontFamily literal(s) in live source. ` +
+          `Route the surface through a --font-* role token from index.css (or add one) instead:\n` +
+          offenders.join("\n"),
+      )
+    }
+    expect(offenders).toEqual([])
+    // Exemption honesty: if the editor ever migrates onto a role token,
+    // the exemption must be deleted rather than linger as a silent hole.
+    for (const rel of EXEMPT) {
+      const text = stripComments(readFileSync(path.join(SRC_ROOT, rel), "utf8"))
       expect(
-        refs.some((r) => r.name === role),
-        `no live ts/tsx source references var(${role})`,
+        MONO_FACE.test(text),
+        `${rel} is exempted but no longer contains a raw mono fontFamily — remove the exemption`,
       ).toBe(true)
     }
   })

--- a/frontend/src/__tests__/cssColorTokenization.test.ts
+++ b/frontend/src/__tests__/cssColorTokenization.test.ts
@@ -1022,18 +1022,22 @@ describe("ts/tsx source — design-token contract", () => {
     expect(orphaned).toEqual([])
   })
 
-  it("the typography role token is adopted in live source (adoption pin)", () => {
-    // The three trace-detail sites migrated to var(--font-data) are the
-    // role layer's seed adoption.  Nothing else pins them: a revert to a
-    // raw font stack (or to var(--font-mono, monospace)) would pass every
-    // resolution rule.  Requiring at least one live reference keeps the
-    // role token honest — a declared-but-unreferenced role token is a
-    // regression, not a tidy-up.
+  it("the typography role tokens are adopted in live source (adoption pin)", () => {
+    // The trace sites migrated to var(--font-data) and ErrorBoundary's
+    // var(--font-code) are the role layer's seed adoption.  Nothing else
+    // pins them: a revert to a raw font stack (or to
+    // var(--font-mono, monospace)) would pass every resolution rule.
+    // Requiring at least one live reference per role keeps each token
+    // honest — a declared-but-unreferenced role token is a regression,
+    // not a tidy-up.
     const files = collectSourceFiles(SRC_ROOT)
-    const referenced = files.some((f) =>
-      findVarRefs(stripComments(readFileSync(f, "utf8"))).some((r) => r.name === "--font-data"),
-    )
-    expect(referenced, "no live ts/tsx source references var(--font-data)").toBe(true)
+    const refs = files.flatMap((f) => findVarRefs(stripComments(readFileSync(f, "utf8"))))
+    for (const role of ["--font-data", "--font-code"]) {
+      expect(
+        refs.some((r) => r.name === role),
+        `no live ts/tsx source references var(${role})`,
+      ).toBe(true)
+    }
   })
 
   it("live source does not mention private primitive tokens (role-layer gate)", () => {

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -46,7 +46,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <p style={{ margin: "0 0 8px", fontWeight: 600, color: "var(--text-primary)" }}>
             Something went wrong
           </p>
-          <p style={{ margin: "0 0 12px", fontFamily: "monospace", fontSize: "11px" }}>
+          <p style={{ margin: "0 0 12px", fontFamily: "var(--font-code)", fontSize: "11px" }}>
             {this.state.error?.message}
           </p>
           <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,6 +19,11 @@
      decision — distinct from the dead app-declared-alias fallbacks
      removed elsewhere, which could never fire. */
   --font-data: var(--font-mono, monospace);
+  /* Code-shaped diagnostic text (error messages, stack dumps) — a separate
+     role from --font-data even though the face is currently the same: the
+     two interfaces can diverge independently.  The CodeMirror editor keeps
+     its own custom stack and is deliberately not on this token. */
+  --font-code: var(--font-mono, monospace);
 
   /* Surfaces - blue-black */
   --bg-base: #0f1117;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,9 +19,9 @@
      decision — distinct from the dead app-declared-alias fallbacks
      removed elsewhere, which could never fire. */
   --font-data: var(--font-mono, monospace);
-  /* Code-shaped diagnostic text (error messages, stack dumps) — a separate
-     role from --font-data even though the face is currently the same: the
-     two interfaces can diverge independently.  The CodeMirror editor keeps
+  /* Code-shaped diagnostic text (error messages) — a separate role from
+     --font-data even though the face is currently the same: the two
+     interfaces can diverge independently.  The CodeMirror editor keeps
      its own custom stack and is deliberately not on this token. */
   --font-code: var(--font-mono, monospace);
 

--- a/frontend/src/trace/CalculationHero.tsx
+++ b/frontend/src/trace/CalculationHero.tsx
@@ -215,7 +215,7 @@ const CalculationHero: React.FC<CalculationHeroProps> = (props) => {
         <span
           style={{
             color: "var(--text-primary)",
-            fontFamily: "monospace",
+            fontFamily: "var(--font-data)",
             fontWeight: 600,
           }}
         >
@@ -242,7 +242,7 @@ const CalculationHero: React.FC<CalculationHeroProps> = (props) => {
         padding: "10px 12px",
         marginTop: 8,
         border: "1px solid rgba(255,255,255,.03)",
-        fontFamily: "monospace",
+        fontFamily: "var(--font-data)",
         fontSize: 12,
       }}>
         {/* Input/intermediate entries — top-down */}
@@ -328,7 +328,7 @@ const CalculationHero: React.FC<CalculationHeroProps> = (props) => {
         padding: "10px 12px",
         marginTop: 8,
         border: "1px solid rgba(255,255,255,.03)",
-        fontFamily: "monospace",
+        fontFamily: "var(--font-data)",
         fontSize: 12,
       }}>
         {entries.map((entry) => (


### PR DESCRIPTION
## Summary
Migrates the last hardcoded `fontFamily: "monospace"` literals onto the typography role-token layer introduced by #160:
- `CalculationHero.tsx` — the three trace-data sites (source-node name, both unified calculation boxes) move to `var(--font-data)`, matching the idiom #160 established in TraceDetail/LiveSwitchDetail/RatingStepDetail.
- `ErrorBoundary.tsx` — the error-message dump moves to a NEW role token `--font-code: var(--font-mono, monospace)`, declared in `index.css` `:root` beside `--font-data` with the same live-fallback convention. Separate role for a separate interface per the role-naming principle, even though the face is identical today.
- Gate: the typography adoption pin in `cssColorTokenization.test.ts` is generalised to require a live reference for BOTH role tokens (`--font-data`, `--font-code`), so a declared-but-unreferenced role token fails the gate. No pinning-table entry was needed — those tables are colour-specific; the adoption pin is the typography equivalent.
- `--font-mono` is NOT redeclared in `:root` (shadow guard holds); the new alias adds a second compiler-visible usage for the emission guards.

## Intended face change (reviewer note)
This is not a pure refactor at the four migrated sites: they move from the CSS generic `monospace` keyword (browser default fixed-width face) to Tailwind's concrete stack via `--font-mono` (`ui-monospace, SFMono-Regular, …`) — the same deliberate change #160 made in the other trace views. CalculationHero lays out numeric columns in mono, so advance widths shift slightly; worth an eyeball on the trace calculation panel.

## Out of scope
`CodeMirrorEditor.tsx:23` keeps its deliberate custom mono stack (differs from Tailwind's, lives inside `EditorView.theme()`); it is now the only remaining hardcoded mono family — a follow-up decision, noted in the `--font-code` comment.

## Verification (at 615d09be)
- `vitest run src/__tests__/cssColorTokenization.test.ts src/trace` — 134 passed (merged gate incl. compiled-emission, shadow, adoption pins); token gate re-run green at final SHA (23 passed).
- `npm run typecheck` — clean; `npm run lint` — 0 errors (27 pre-existing warnings).
- Full `vitest run` — 5776/5778 passed; the 2 failures (App.integration apiInput edge-reconciliation timeout; DataOutputEditor provider dropdown) are load-sensitive local flakes: failure set varies run-to-run (6→2→1→0 across four runs, both pass in isolation), no mechanism from a font-token diff, and main CI + the scheduled Frontend Shuffle lane are green. PR CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
