### PR TITLE
Resolve the process's own cgroup for memory headroom, with ancestor-min semantics

### DIFF
--- a/specs/execution-engine/low-level.md
+++ b/specs/execution-engine/low-level.md
@@ -21,7 +21,7 @@
 | `src/haute/_graph_utils.py` | Pure-function graph helpers decoupled from the Pydantic models: `build_parents_of`, `upstream_node_ids`, `_sanitize_func_name`, `edge_input_name` (the single edge→input-name derivation: apiInput-frame edge → its frame label verbatim, else sanitised source-node label; consumed by the executor, codegen, projection, and the deploy scorer so all four agree byte-for-byte), `build_instance_mapping`, `resolve_orig_source_names`, and edge-id construction. |
 | `src/haute/_worker_isolation.py` | `run_isolated_worker()` — spawn a child process for one function call with an optional address-space resource cap, timeout, and cooperative stop-reason polling; typed error hierarchy for every terminal state. |
 | `src/haute/chunking.py` | `ChunkPlanRequest`/`chunk_plan()` (proves a graph suffix is chunk-safe, sizes chunks from projected target width, and rejects an over-budget single target row), `iter_chunked_frames()`/`run_chunked_reduce()`/`collect_chunked()` (the serial runner), the per-`NodeType` `ChunkCapability` registry, and the AST-based row-local user-code whitelist. |
-| `src/haute/_host_memory.py` | Host memory observation: `available_ram_bytes()` (per-platform probes behind one shared result contract, including Linux cgroup v2/v1 headroom clamping — each probe reports a real measurement or a recorded failure reason, never fabricated capacity) and `available_vram_bytes()` (the first GPU's total VRAM via nvidia-smi — the CatBoost single-device sizing basis — or nothing when no GPU is present; detection failures other than an absent binary are logged with a reason). Owns the nvidia-smi subprocess chokepoint. |
+| `src/haute/_host_memory.py` | Host memory observation: `available_ram_bytes()` (per-platform probes behind one shared result contract, including Linux cgroup v2/v1 headroom clamping resolved at the process's own cgroup with ancestor-min semantics — each probe reports a real measurement or a recorded failure reason, never fabricated capacity) and `available_vram_bytes()` (the first GPU's total VRAM via nvidia-smi — the CatBoost single-device sizing basis — or nothing when no GPU is present; detection failures other than an absent binary are logged with a reason). Owns the nvidia-smi subprocess chokepoint. |
 | `src/haute/_ram_estimate.py` | Workload-side estimation: `estimate_safe_training_rows()` (parquet-metadata-based peak-memory estimate and downsample decision), `estimate_gpu_vram_bytes()`, and the `MaterialisationEstimate` contract consumed by strategy planning. It imports graph models directly from `_types.py` so admission and route cold imports do not re-enter the execution facade. |
 
 ## Key types and data structures
@@ -111,7 +111,16 @@
   attempted-but-failed reason, or not-applicable-on-this-platform). The first
   observation wins and is clamped once to any finite Linux cgroup headroom:
   cgroup v2 `memory.max - memory.current`, else the v1
-  `memory.limit_in_bytes - memory.usage_in_bytes` pair. `max` and the v1
+  `memory.limit_in_bytes - memory.usage_in_bytes` pair. The controller files
+  are read at the process's **own** cgroup, resolved from `/proc/self/cgroup`
+  and `/proc/self/mountinfo` (v2 unified and v1 hybrid), not just the mount
+  root — a systemd service slice or a container sharing the host cgroup
+  namespace keeps its binding limits below `/sys/fs/cgroup`. Headroom is the
+  **minimum** across the process's cgroup and its ancestors up to the mount
+  point (a parent's limit binds its children; a level whose controller files
+  are absent contributes nothing). Any resolution failure — unreadable or
+  malformed proc files, no matching mount, a cgroup path outside the mount
+  root — degrades to the historical mount-root read. `max` and the v1
   unlimited sentinel do not clamp; negative headroom clamps to zero.
 - **Degraded-observation contract** — one policy governs every degraded memory
   state, split by whether the value is a capacity *source* or a best-effort

--- a/specs/execution-engine/low-level.md
+++ b/specs/execution-engine/low-level.md
@@ -120,7 +120,17 @@
   point (a parent's limit binds its children; a level whose controller files
   are absent contributes nothing). Any resolution failure — unreadable or
   malformed proc files, no matching mount, a cgroup path outside the mount
-  root — degrades to the historical mount-root read. `max` and the v1
+  root — degrades a step at a time: an unresolvable cgroup path still reads
+  at the **parsed** mount point, and only unusable proc files fall back to
+  the compiled-in default mount. With several mounts of one hierarchy the
+  mount whose root most specifically contains the cgroup path wins; a walk
+  deeper than the depth limit fails open rather than reporting a partial
+  chain as complete. mountinfo octal decoding is restricted to the kernel's
+  escape set (space/tab/newline/backslash) and decoded path fields are
+  rejected on traversal or NUL content, so a hostile mount record cannot
+  redirect controller reads. Known limitation, accepted: the proc files are
+  re-parsed per probe call (admission is per-execution, not per-row, and
+  caching would mis-locate a process migrated between cgroups). `max` and the v1
   unlimited sentinel do not clamp; negative headroom clamps to zero.
 - **Degraded-observation contract** — one policy governs every degraded memory
   state, split by whether the value is a capacity *source* or a best-effort

--- a/specs/execution-engine/low-level.md
+++ b/specs/execution-engine/low-level.md
@@ -118,20 +118,16 @@
   namespace keeps its binding limits below `/sys/fs/cgroup`. Headroom is the
   **minimum** across the process's cgroup and its ancestors up to the mount
   point (a parent's limit binds its children; a level whose controller files
-  are absent contributes nothing). Any resolution failure — unreadable or
-  malformed proc files, no matching mount, a cgroup path outside the mount
-  root — degrades a step at a time: an unresolvable cgroup path still reads
-  at the **parsed** mount point, and only unusable proc files fall back to
-  the compiled-in default mount. With several mounts of one hierarchy the
-  mount whose root most specifically contains the cgroup path wins; a walk
-  deeper than the depth limit fails open rather than reporting a partial
-  chain as complete. mountinfo octal decoding is restricted to the kernel's
-  escape set (space/tab/newline/backslash) and decoded path fields are
-  rejected on traversal or NUL content, so a hostile mount record cannot
-  redirect controller reads. Known limitation, accepted: the proc files are
-  re-parsed per probe call (admission is per-execution, not per-row, and
-  caching would mis-locate a process migrated between cgroups). `max` and the v1
-  unlimited sentinel do not clamp; negative headroom clamps to zero.
+  are absent contributes nothing). With several mounts of one hierarchy the
+  mount whose root most specifically contains the cgroup path wins. mountinfo
+  octal decoding is restricted to the kernel's escape set
+  (space/tab/newline/backslash) and decoded path fields are rejected on
+  traversal or NUL content, so a hostile mount record cannot redirect
+  controller reads. Known limitation, accepted: the proc files are re-parsed
+  per probe call (admission is per-execution, not per-row, and caching would
+  mis-locate a process migrated between cgroups). `max` and the v1 unlimited
+  sentinel do not clamp; negative headroom clamps to zero. Resolution and
+  read failures degrade per the Degraded-observation contract below.
 - **Degraded-observation contract** — one policy governs every degraded memory
   state, split by whether the value is a capacity *source* or a best-effort
   *refinement* of an independent observation:
@@ -140,6 +136,14 @@
     observed; a controller whose files are missing, unreadable, or
     non-numeric is logged (`cgroup_memory_state_incomplete` /
     `cgroup_memory_state_malformed`) and leaves the host value unchanged.
+    Self-cgroup resolution failures degrade a step at a time before reaching
+    that fail-open floor: an unresolvable cgroup path still reads at the
+    **parsed** mount point (`cgroup_self_path_unresolved`), and only unusable
+    proc files fall back to the compiled-in default mount
+    (`cgroup_self_state_unreadable`). An ancestor walk deeper than the depth
+    limit fails open outright (`cgroup_ancestor_walk_truncated`) — a partial
+    chain must never pass for a complete observation, because the dropped
+    levels nearest the mount point hold the broadest limits.
     Failing closed would refuse all adaptive admission on any host with an
     odd cgroup mount for a harm that is conditional (a real limit must exist
     *and* be smaller than the estimate), while the runtime defence-in-depth

--- a/src/haute/_host_memory.py
+++ b/src/haute/_host_memory.py
@@ -92,10 +92,17 @@ _CGROUP_WALK_DEPTH_LIMIT = 64
 
 
 def _read_cgroup_memory_file(path: str) -> str | None:
-    """Read one cgroup control file, returning ``None`` when absent."""
+    """Read one cgroup control file, returning ``None`` when absent.
+
+    Decoded with ``errors="replace"``: controller files are ASCII, but
+    ``/proc/self/cgroup`` carries raw kernel dentry names which may hold any
+    non-``/`` byte — a sibling's non-UTF-8 cgroup name must degrade to an
+    unresolvable path, not crash the probe with ``UnicodeDecodeError``.
+    """
     try:
-        return Path(path).read_text(encoding="utf-8").strip()
-    except OSError:
+        return Path(path).read_bytes().decode("utf-8", errors="replace").strip()
+    except (OSError, ValueError):
+        # ValueError: an embedded NUL in the path is rejected at open time.
         return None
 
 
@@ -137,17 +144,25 @@ def _parse_proc_self_cgroup(text: str) -> tuple[str | None, str | None]:
     return v2_path, v1_path
 
 
+# The only octal escapes the kernel emits in mountinfo paths (show_path in
+# fs/proc_namespace.c escapes space, tab, newline, and backslash).  Decoding
+# is restricted to exactly this set: a permissive all-octal decoder would let
+# a hostile name smuggle ``\057`` (``/``) or ``\056`` (``.``) past any
+# validation done on the raw string.
+_MOUNTINFO_OCTAL_ESCAPES = {"040": " ", "011": "\t", "012": "\n", "134": "\\"}
+
+
 def _unescape_mountinfo_field(field: str) -> str:
-    """Decode the octal escapes (``\\040`` etc.) mountinfo uses in paths."""
+    """Decode the kernel's mountinfo octal escapes; other sequences pass through."""
     if "\\" not in field:
         return field
     out: list[str] = []
     index = 0
     while index < len(field):
         char = field[index]
-        octal = field[index + 1 : index + 4]
-        if char == "\\" and len(octal) == 3 and all(digit in "01234567" for digit in octal):
-            out.append(chr(int(octal, 8)))
+        decoded = _MOUNTINFO_OCTAL_ESCAPES.get(field[index + 1 : index + 4])
+        if char == "\\" and decoded is not None:
+            out.append(decoded)
             index += 4
         else:
             out.append(char)
@@ -155,37 +170,50 @@ def _unescape_mountinfo_field(field: str) -> str:
     return "".join(out)
 
 
+def _usable_mount_path(field: str) -> bool:
+    """True when a decoded mountinfo path field is safe to build read paths from.
+
+    Kernel-generated fields are absolute and cannot contain ``..`` components
+    or NUL bytes; anything else indicates a malformed or hostile record and
+    the line is skipped rather than allowed to redirect controller reads.
+    """
+    return field.startswith("/") and "\x00" not in field and ".." not in field.split("/")
+
+
 def _parse_proc_self_mountinfo(
     text: str,
-) -> tuple[tuple[str, str] | None, tuple[str, str] | None]:
-    """Return (root, mount point) for the cgroup2 and v1-memory mounts.
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return every (root, mount point) for the cgroup2 and v1-memory mounts.
 
-    mountinfo fields: ``ID parent major:minor root mount-point options
-    [optional...] - fstype source super-options``.  Malformed lines are
-    skipped; the first matching mount per hierarchy wins.
+    mountinfo fields: ``ID parent major:minor root mount-point mount-options
+    [optional...] - fstype source super-options``.  The separator can appear
+    no earlier than index 6 (six mandatory fields precede it); shorter records
+    are malformed and skipped, as is any record whose decoded path fields are
+    unusable — a bad line must never redirect controller reads.  All matches
+    are returned; the caller selects among multiple mounts per hierarchy.
     """
-    v2_mount: tuple[str, str] | None = None
-    v1_mount: tuple[str, str] | None = None
+    v2_mounts: list[tuple[str, str]] = []
+    v1_mounts: list[tuple[str, str]] = []
     for line in text.splitlines():
         fields = line.split(" ")
         try:
             separator = fields.index("-")
         except ValueError:
             continue
-        if separator < 5 or separator + 1 >= len(fields):
+        if separator < 6 or separator + 1 >= len(fields):
             continue
         root = _unescape_mountinfo_field(fields[3])
         mount_point = _unescape_mountinfo_field(fields[4])
         fs_type = fields[separator + 1]
-        if not root.startswith("/") or not mount_point.startswith("/"):
+        if not _usable_mount_path(root) or not _usable_mount_path(mount_point):
             continue
         if fs_type == "cgroup2":
-            v2_mount = v2_mount if v2_mount is not None else (root, mount_point)
+            v2_mounts.append((root, mount_point))
         elif fs_type == "cgroup" and separator + 3 < len(fields):
             super_options = fields[separator + 3]
             if "memory" in super_options.split(","):
-                v1_mount = v1_mount if v1_mount is not None else (root, mount_point)
-    return v2_mount, v1_mount
+                v1_mounts.append((root, mount_point))
+    return v2_mounts, v1_mounts
 
 
 def _resolve_cgroup_directory(cgroup_path: str, mount_root: str, mount_point: str) -> str | None:
@@ -195,6 +223,11 @@ def _resolve_cgroup_directory(cgroup_path: str, mount_root: str, mount_point: st
     directory is the mount point plus the cgroup path's remainder below that
     root.  Returns ``None`` when the path is not under the mount root (a
     cross-namespace view this process cannot read through this mount).
+
+    The ``..`` check is not input sanitisation — every field here is
+    kernel-generated — it recognises the literal ``/../..`` shape the kernel
+    reports for a cgroup outside the reader's cgroup-namespace root, which
+    cannot be mapped through any mount.
     """
     if ".." in cgroup_path.split("/"):
         return None
@@ -210,49 +243,96 @@ def _resolve_cgroup_directory(cgroup_path: str, mount_root: str, mount_point: st
     return f"{mount}/{suffix}" if mount != "/" else f"/{suffix}"
 
 
+def _resolve_hierarchy_location(
+    version: str,
+    default_mount: str,
+    cgroup_path: str | None,
+    mounts: list[tuple[str, str]],
+) -> _CgroupLocation:
+    """Resolve one hierarchy's walk location, degrading a step at a time.
+
+    A parsed mount always beats the compiled-in default mount point (the
+    hierarchy may be mounted elsewhere, e.g. ``/sys/fs/cgroup/unified``);
+    the process's own directory then refines it when the cgroup path maps
+    under a mount's root.  With several mounts of the hierarchy (user
+    namespaces, nspawn), the one whose root most specifically contains the
+    cgroup path wins — the binding limit may only be reachable through a
+    subtree mount a broader first-match would shadow.
+    """
+    if not mounts:
+        return _CgroupLocation(default_mount, default_mount)
+    best: _CgroupLocation | None = None
+    best_root_depth = -1
+    if cgroup_path is not None:
+        for mount_root, mount_point in mounts:
+            directory = _resolve_cgroup_directory(cgroup_path, mount_root, mount_point)
+            if directory is None:
+                continue
+            root_depth = len((mount_root.rstrip("/") or "/").split("/"))
+            if root_depth > best_root_depth:
+                best = _CgroupLocation(directory, mount_point)
+                best_root_depth = root_depth
+        if best is not None:
+            return best
+        logger.warning(
+            "cgroup_self_path_unresolved",
+            version=version,
+            cgroup_path=cgroup_path,
+            candidate_mounts=len(mounts),
+            mount_root=mounts[0][0],
+            mount_point=mounts[0][1],
+        )
+    return _CgroupLocation(mounts[0][1], mounts[0][1])
+
+
 def _resolve_cgroup_locations() -> tuple[_CgroupLocation, _CgroupLocation]:
-    """Resolve the v2 and v1 walk locations, defaulting to the mount roots."""
-    v2_location = _CgroupLocation(_CGROUP_V2_DEFAULT_MOUNT, _CGROUP_V2_DEFAULT_MOUNT)
-    v1_location = _CgroupLocation(_CGROUP_V1_MEMORY_DEFAULT_MOUNT, _CGROUP_V1_MEMORY_DEFAULT_MOUNT)
+    """Resolve the v2 and v1 walk locations, defaulting to the mount roots.
+
+    Re-parses ``/proc/self/mountinfo`` on every probe call rather than caching
+    the resolution: admission checks are per-execution, not per-row, and a
+    stale cache would mis-locate a process migrated between cgroups.
+    """
+    v2_path: str | None = None
+    v1_path: str | None = None
+    v2_mounts: list[tuple[str, str]] = []
+    v1_mounts: list[tuple[str, str]] = []
     cgroup_text = _read_cgroup_memory_file(_PROC_SELF_CGROUP)
     mountinfo_text = _read_cgroup_memory_file(_PROC_SELF_MOUNTINFO)
     if cgroup_text is None or mountinfo_text is None:
-        return v2_location, v1_location
-    v2_path, v1_path = _parse_proc_self_cgroup(cgroup_text)
-    v2_mount, v1_mount = _parse_proc_self_mountinfo(mountinfo_text)
-    if v2_path is not None and v2_mount is not None:
-        directory = _resolve_cgroup_directory(v2_path, *v2_mount)
-        if directory is not None:
-            v2_location = _CgroupLocation(directory, v2_mount[1])
-        else:
-            logger.warning(
-                "cgroup_self_path_unresolved",
-                version="v2",
-                cgroup_path=v2_path,
-                mount_root=v2_mount[0],
-                mount_point=v2_mount[1],
-            )
-    if v1_path is not None and v1_mount is not None:
-        directory = _resolve_cgroup_directory(v1_path, *v1_mount)
-        if directory is not None:
-            v1_location = _CgroupLocation(directory, v1_mount[1])
-        else:
-            logger.warning(
-                "cgroup_self_path_unresolved",
-                version="v1",
-                cgroup_path=v1_path,
-                mount_root=v1_mount[0],
-                mount_point=v1_mount[1],
-            )
-    return v2_location, v1_location
+        logger.warning(
+            "cgroup_self_state_unreadable",
+            cgroup_readable=cgroup_text is not None,
+            mountinfo_readable=mountinfo_text is not None,
+        )
+    else:
+        v2_path, v1_path = _parse_proc_self_cgroup(cgroup_text)
+        v2_mounts, v1_mounts = _parse_proc_self_mountinfo(mountinfo_text)
+    return (
+        _resolve_hierarchy_location("v2", _CGROUP_V2_DEFAULT_MOUNT, v2_path, v2_mounts),
+        _resolve_hierarchy_location("v1", _CGROUP_V1_MEMORY_DEFAULT_MOUNT, v1_path, v1_mounts),
+    )
 
 
-def _cgroup_ancestor_chain(location: _CgroupLocation) -> list[str]:
-    """Directories from the process's cgroup up to the mount point, inclusive."""
+def _cgroup_ancestor_chain(location: _CgroupLocation) -> list[str] | None:
+    """Directories from the process's cgroup up to the mount point, inclusive.
+
+    Returns ``None`` when the walk would exceed the depth limit: a truncated
+    chain must not pass for a complete one — the levels nearest the mount
+    point are the broadest limits, and silently dropping them would let a
+    loose leaf limit mask a binding ancestor (over-admission).
+    """
     top = location.mount_point.rstrip("/") or "/"
     current = location.directory.rstrip("/") or "/"
     chain: list[str] = []
-    while len(chain) < _CGROUP_WALK_DEPTH_LIMIT:
+    while True:
+        if len(chain) >= _CGROUP_WALK_DEPTH_LIMIT:
+            logger.warning(
+                "cgroup_ancestor_walk_truncated",
+                directory=location.directory,
+                mount_point=location.mount_point,
+                depth_limit=_CGROUP_WALK_DEPTH_LIMIT,
+            )
+            return None
         chain.append(current)
         if current == top or "/" not in current or current == "/":
             break
@@ -319,11 +399,16 @@ def _hierarchy_headroom(
     A level where the controller files are absent (controller not enabled
     there, or the hierarchy's true root) contributes nothing; a level with
     incomplete or malformed state fails the whole probe open, matching the
-    single-level behaviour this generalises.
+    single-level behaviour this generalises.  A depth-truncated walk also
+    fails open — a partial chain could report a looser limit than the one
+    that actually binds.
     """
+    chain = _cgroup_ancestor_chain(location)
+    if chain is None:
+        return True, None
     present = False
     minimum: int | None = None
-    for level in _cgroup_ancestor_chain(location):
+    for level in chain:
         prefix = level.rstrip("/")
         level_present, headroom, abort = _level_headroom(
             version,

--- a/src/haute/_host_memory.py
+++ b/src/haute/_host_memory.py
@@ -10,7 +10,9 @@ detection failures are logged with a reason.  Workload-side estimation (how
 much a job *needs*) lives in :mod:`haute._ram_estimate`.
 
 Available RAM is resolved by trying each platform source in order; the first
-observation wins and is clamped to any finite Linux cgroup memory headroom.
+observation wins and is clamped to any finite Linux cgroup memory headroom,
+resolved at the process's own cgroup (nested limits included) with
+ancestor-min semantics.
 When every source fails, one ``available_ram_unavailable`` warning reports
 each attempted source's failure reason.
 """
@@ -67,13 +69,26 @@ def require_positive_available_ram(available: object) -> int:
 # ---------------------------------------------------------------------------
 # Linux cgroup memory headroom
 # ---------------------------------------------------------------------------
+#
+# The memory limit that binds this process is not necessarily at the cgroup
+# mount root: under a systemd service slice, or in a container sharing the
+# host cgroup namespace, the process lives in a nested cgroup whose controller
+# files sit below the mount point.  The probe resolves the process's own
+# cgroup directory from ``/proc/self/cgroup`` + ``/proc/self/mountinfo``
+# (v2 unified and v1 hybrid) and takes the minimum headroom across that
+# cgroup and its ancestors up to the mount point — a parent's limit binds its
+# children, and the memory controller may only be enabled partway up.  When
+# resolution fails (unreadable or malformed proc files, no matching mount, a
+# path outside the mount root), the probe degrades to reading the mount-root
+# controller files, preserving the historical fail-open behaviour.
 
 
-_CGROUP_V2_MEMORY_MAX = "/sys/fs/cgroup/memory.max"
-_CGROUP_V2_MEMORY_CURRENT = "/sys/fs/cgroup/memory.current"
-_CGROUP_V1_MEMORY_LIMIT = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-_CGROUP_V1_MEMORY_USAGE = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+_PROC_SELF_CGROUP = "/proc/self/cgroup"
+_PROC_SELF_MOUNTINFO = "/proc/self/mountinfo"
+_CGROUP_V2_DEFAULT_MOUNT = "/sys/fs/cgroup"
+_CGROUP_V1_MEMORY_DEFAULT_MOUNT = "/sys/fs/cgroup/memory"
 _CGROUP_V1_UNLIMITED_SENTINEL = 1 << 60
+_CGROUP_WALK_DEPTH_LIMIT = 64
 
 
 def _read_cgroup_memory_file(path: str) -> str | None:
@@ -84,65 +99,263 @@ def _read_cgroup_memory_file(path: str) -> str | None:
         return None
 
 
+class _CgroupLocation(NamedTuple):
+    """Where one hierarchy's memory controller files live for this process.
+
+    ``directory`` is the process's own cgroup directory (the walk start) and
+    ``mount_point`` is the hierarchy's mount point (the walk end, inclusive).
+    The mount-root fallback is the degenerate case where both are the mount
+    point itself, which reads exactly the historical single-level paths.
+    """
+
+    directory: str
+    mount_point: str
+
+
+def _parse_proc_self_cgroup(text: str) -> tuple[str | None, str | None]:
+    """Return (v2 path, v1 memory-controller path) from ``/proc/self/cgroup``.
+
+    Lines look like ``0::/system.slice/haute.service`` (v2) or
+    ``4:memory:/docker/abc`` (v1).  Malformed lines are skipped; a hierarchy
+    with no well-formed line simply stays unresolved and falls back.
+    """
+    v2_path: str | None = None
+    v1_path: str | None = None
+    for line in text.splitlines():
+        parts = line.split(":", 2)
+        if len(parts) != 3:
+            continue
+        hierarchy_id, controllers, cgroup_path = parts
+        # A deleted cgroup is reported with a trailing marker; its controller
+        # files are gone, so resolution would only produce absent-file reads.
+        if not cgroup_path.startswith("/") or cgroup_path.endswith(" (deleted)"):
+            continue
+        if hierarchy_id == "0" and controllers == "":
+            v2_path = v2_path if v2_path is not None else cgroup_path
+        elif "memory" in controllers.split(","):
+            v1_path = v1_path if v1_path is not None else cgroup_path
+    return v2_path, v1_path
+
+
+def _unescape_mountinfo_field(field: str) -> str:
+    """Decode the octal escapes (``\\040`` etc.) mountinfo uses in paths."""
+    if "\\" not in field:
+        return field
+    out: list[str] = []
+    index = 0
+    while index < len(field):
+        char = field[index]
+        octal = field[index + 1 : index + 4]
+        if char == "\\" and len(octal) == 3 and all(digit in "01234567" for digit in octal):
+            out.append(chr(int(octal, 8)))
+            index += 4
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
+
+
+def _parse_proc_self_mountinfo(
+    text: str,
+) -> tuple[tuple[str, str] | None, tuple[str, str] | None]:
+    """Return (root, mount point) for the cgroup2 and v1-memory mounts.
+
+    mountinfo fields: ``ID parent major:minor root mount-point options
+    [optional...] - fstype source super-options``.  Malformed lines are
+    skipped; the first matching mount per hierarchy wins.
+    """
+    v2_mount: tuple[str, str] | None = None
+    v1_mount: tuple[str, str] | None = None
+    for line in text.splitlines():
+        fields = line.split(" ")
+        try:
+            separator = fields.index("-")
+        except ValueError:
+            continue
+        if separator < 5 or separator + 1 >= len(fields):
+            continue
+        root = _unescape_mountinfo_field(fields[3])
+        mount_point = _unescape_mountinfo_field(fields[4])
+        fs_type = fields[separator + 1]
+        if not root.startswith("/") or not mount_point.startswith("/"):
+            continue
+        if fs_type == "cgroup2":
+            v2_mount = v2_mount if v2_mount is not None else (root, mount_point)
+        elif fs_type == "cgroup" and separator + 3 < len(fields):
+            super_options = fields[separator + 3]
+            if "memory" in super_options.split(","):
+                v1_mount = v1_mount if v1_mount is not None else (root, mount_point)
+    return v2_mount, v1_mount
+
+
+def _resolve_cgroup_directory(cgroup_path: str, mount_root: str, mount_point: str) -> str | None:
+    """Map a ``/proc/self/cgroup`` path onto the filesystem via its mount.
+
+    The mount exposes the hierarchy subtree at ``mount_root``; the process's
+    directory is the mount point plus the cgroup path's remainder below that
+    root.  Returns ``None`` when the path is not under the mount root (a
+    cross-namespace view this process cannot read through this mount).
+    """
+    if ".." in cgroup_path.split("/"):
+        return None
+    root = mount_root.rstrip("/") or "/"
+    path = cgroup_path.rstrip("/") or "/"
+    mount = mount_point.rstrip("/") or "/"
+    if path == root:
+        return mount
+    prefix = "/" if root == "/" else root + "/"
+    if not path.startswith(prefix):
+        return None
+    suffix = path[len(prefix) :]
+    return f"{mount}/{suffix}" if mount != "/" else f"/{suffix}"
+
+
+def _resolve_cgroup_locations() -> tuple[_CgroupLocation, _CgroupLocation]:
+    """Resolve the v2 and v1 walk locations, defaulting to the mount roots."""
+    v2_location = _CgroupLocation(_CGROUP_V2_DEFAULT_MOUNT, _CGROUP_V2_DEFAULT_MOUNT)
+    v1_location = _CgroupLocation(_CGROUP_V1_MEMORY_DEFAULT_MOUNT, _CGROUP_V1_MEMORY_DEFAULT_MOUNT)
+    cgroup_text = _read_cgroup_memory_file(_PROC_SELF_CGROUP)
+    mountinfo_text = _read_cgroup_memory_file(_PROC_SELF_MOUNTINFO)
+    if cgroup_text is None or mountinfo_text is None:
+        return v2_location, v1_location
+    v2_path, v1_path = _parse_proc_self_cgroup(cgroup_text)
+    v2_mount, v1_mount = _parse_proc_self_mountinfo(mountinfo_text)
+    if v2_path is not None and v2_mount is not None:
+        directory = _resolve_cgroup_directory(v2_path, *v2_mount)
+        if directory is not None:
+            v2_location = _CgroupLocation(directory, v2_mount[1])
+        else:
+            logger.warning(
+                "cgroup_self_path_unresolved",
+                version="v2",
+                cgroup_path=v2_path,
+                mount_root=v2_mount[0],
+                mount_point=v2_mount[1],
+            )
+    if v1_path is not None and v1_mount is not None:
+        directory = _resolve_cgroup_directory(v1_path, *v1_mount)
+        if directory is not None:
+            v1_location = _CgroupLocation(directory, v1_mount[1])
+        else:
+            logger.warning(
+                "cgroup_self_path_unresolved",
+                version="v1",
+                cgroup_path=v1_path,
+                mount_root=v1_mount[0],
+                mount_point=v1_mount[1],
+            )
+    return v2_location, v1_location
+
+
+def _cgroup_ancestor_chain(location: _CgroupLocation) -> list[str]:
+    """Directories from the process's cgroup up to the mount point, inclusive."""
+    top = location.mount_point.rstrip("/") or "/"
+    current = location.directory.rstrip("/") or "/"
+    chain: list[str] = []
+    while len(chain) < _CGROUP_WALK_DEPTH_LIMIT:
+        chain.append(current)
+        if current == top or "/" not in current or current == "/":
+            break
+        current = current.rsplit("/", 1)[0] or "/"
+    return chain
+
+
+def _level_headroom(
+    version: str,
+    limit_path: str,
+    current_path: str,
+    *,
+    supports_max: bool,
+) -> tuple[bool, int | None, bool]:
+    """Read one cgroup level: (present, finite headroom, fail-open abort)."""
+    raw_limit = _read_cgroup_memory_file(limit_path)
+    raw_current = _read_cgroup_memory_file(current_path)
+    if raw_limit is None and raw_current is None:
+        return False, None, False
+    if raw_limit is None or raw_current is None:
+        logger.warning(
+            "cgroup_memory_state_incomplete",
+            version=version,
+            limit_path=limit_path,
+            current_path=current_path,
+        )
+        return True, None, True
+    if supports_max and raw_limit == "max":
+        return True, None, False
+    try:
+        limit = int(raw_limit)
+        current = int(raw_current)
+    except ValueError:
+        logger.warning(
+            "cgroup_memory_state_malformed",
+            version=version,
+            limit=raw_limit,
+            current=raw_current,
+        )
+        return True, None, True
+    if limit < 0 or current < 0:
+        logger.warning(
+            "cgroup_memory_state_malformed",
+            version=version,
+            limit=raw_limit,
+            current=raw_current,
+        )
+        return True, None, True
+    if not supports_max and limit >= _CGROUP_V1_UNLIMITED_SENTINEL:
+        return True, None, False
+    return True, max(limit - current, 0), False
+
+
+def _hierarchy_headroom(
+    version: str,
+    location: _CgroupLocation,
+    limit_name: str,
+    current_name: str,
+    *,
+    supports_max: bool,
+) -> tuple[bool, int | None]:
+    """Minimum finite headroom across the ancestor chain of *location*.
+
+    A level where the controller files are absent (controller not enabled
+    there, or the hierarchy's true root) contributes nothing; a level with
+    incomplete or malformed state fails the whole probe open, matching the
+    single-level behaviour this generalises.
+    """
+    present = False
+    minimum: int | None = None
+    for level in _cgroup_ancestor_chain(location):
+        prefix = level.rstrip("/")
+        level_present, headroom, abort = _level_headroom(
+            version,
+            f"{prefix}/{limit_name}",
+            f"{prefix}/{current_name}",
+            supports_max=supports_max,
+        )
+        present = present or level_present
+        if abort:
+            return present, None
+        if headroom is not None:
+            minimum = headroom if minimum is None else min(minimum, headroom)
+    return present, minimum
+
+
 def _cgroup_memory_headroom_bytes() -> int | None:
     """Return observable Linux cgroup memory headroom, if it is finite."""
-
-    def controller_headroom(
-        version: str,
-        limit_path: str,
-        current_path: str,
-        *,
-        supports_max: bool,
-    ) -> tuple[bool, int | None]:
-        raw_limit = _read_cgroup_memory_file(limit_path)
-        raw_current = _read_cgroup_memory_file(current_path)
-        if raw_limit is None and raw_current is None:
-            return False, None
-        if raw_limit is None or raw_current is None:
-            logger.warning(
-                "cgroup_memory_state_incomplete",
-                version=version,
-                limit_path=limit_path,
-                current_path=current_path,
-            )
-            return True, None
-        if supports_max and raw_limit == "max":
-            return True, None
-        try:
-            limit = int(raw_limit)
-            current = int(raw_current)
-        except ValueError:
-            logger.warning(
-                "cgroup_memory_state_malformed",
-                version=version,
-                limit=raw_limit,
-                current=raw_current,
-            )
-            return True, None
-        if limit < 0 or current < 0:
-            logger.warning(
-                "cgroup_memory_state_malformed",
-                version=version,
-                limit=raw_limit,
-                current=raw_current,
-            )
-            return True, None
-        if not supports_max and limit >= _CGROUP_V1_UNLIMITED_SENTINEL:
-            return True, None
-        return True, max(limit - current, 0)
-
-    v2_present, v2_headroom = controller_headroom(
+    v2_location, v1_location = _resolve_cgroup_locations()
+    v2_present, v2_headroom = _hierarchy_headroom(
         "v2",
-        _CGROUP_V2_MEMORY_MAX,
-        _CGROUP_V2_MEMORY_CURRENT,
+        v2_location,
+        "memory.max",
+        "memory.current",
         supports_max=True,
     )
     if v2_present:
         return v2_headroom
-    _v1_present, v1_headroom = controller_headroom(
+    _v1_present, v1_headroom = _hierarchy_headroom(
         "v1",
-        _CGROUP_V1_MEMORY_LIMIT,
-        _CGROUP_V1_MEMORY_USAGE,
+        v1_location,
+        "memory.limit_in_bytes",
+        "memory.usage_in_bytes",
         supports_max=False,
     )
     return v1_headroom

--- a/tests/test_host_memory.py
+++ b/tests/test_host_memory.py
@@ -425,6 +425,329 @@ class TestAvailableRamPlatformPaths:
 
 
 # ---------------------------------------------------------------------------
+# Linux cgroup — nested-cgroup path resolution
+# ---------------------------------------------------------------------------
+
+
+_V2_ROOT_MOUNTINFO = "35 24 0:30 / /sys/fs/cgroup rw,nosuid - cgroup2 cgroup2 rw\n"
+_V1_MEMORY_ROOT_MOUNTINFO = (
+    "36 24 0:31 / /sys/fs/cgroup/memory rw,nosuid - cgroup cgroup rw,memory\n"
+)
+
+
+def _probe(files: dict[str, str]) -> int | None:
+    """Run the cgroup headroom probe with all file reads answered from *files*."""
+    with patch("haute._host_memory._read_cgroup_memory_file", side_effect=files.get):
+        return _host_memory._cgroup_memory_headroom_bytes()
+
+
+class TestCgroupNestedResolution:
+    """The probe reads the process's own cgroup, not just the mount root.
+
+    A process in a systemd service slice or a shared-cgroup-namespace
+    container has its binding limits below ``/sys/fs/cgroup``; the probe must
+    resolve its directory via /proc/self/cgroup + /proc/self/mountinfo and
+    apply ancestor-min semantics, while every resolution failure degrades to
+    the historical mount-root read (fail-open).
+    """
+
+    def test_mount_root_process_reads_mount_root(self) -> None:
+        files = {
+            "/proc/self/cgroup": "0::/\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_nested_one_level_v2(self) -> None:
+        """Limits one level below the mount root bind the process."""
+        files = {
+            "/proc/self/cgroup": "0::/haute\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/haute/memory.max": "1000",
+            "/sys/fs/cgroup/haute/memory.current": "600",
+        }
+        assert _probe(files) == 400
+
+    def test_nested_systemd_slice_ancestor_min(self) -> None:
+        """A tighter slice-level limit wins over a looser service-level one."""
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/haute.service/memory.max": "10000",
+            "/sys/fs/cgroup/system.slice/haute.service/memory.current": "1000",
+            "/sys/fs/cgroup/system.slice/memory.max": "4000",
+            "/sys/fs/cgroup/system.slice/memory.current": "3500",
+        }
+        assert _probe(files) == 500
+
+    def test_leaf_tighter_than_ancestor(self) -> None:
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/haute.service/memory.max": "300",
+            "/sys/fs/cgroup/system.slice/haute.service/memory.current": "100",
+            "/sys/fs/cgroup/system.slice/memory.max": "100000",
+            "/sys/fs/cgroup/system.slice/memory.current": "2000",
+        }
+        assert _probe(files) == 200
+
+    def test_unlimited_leaf_finite_ancestor(self) -> None:
+        """``max`` at the leaf does not hide a finite ancestor limit."""
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/haute.service/memory.max": "max",
+            "/sys/fs/cgroup/system.slice/haute.service/memory.current": "100",
+            "/sys/fs/cgroup/system.slice/memory.max": "5000",
+            "/sys/fs/cgroup/system.slice/memory.current": "4000",
+        }
+        assert _probe(files) == 1000
+
+    def test_controller_enabled_only_at_ancestor(self) -> None:
+        """Absent leaf files (controller not enabled there) walk up to a limit."""
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/memory.max": "900",
+            "/sys/fs/cgroup/system.slice/memory.current": "150",
+        }
+        assert _probe(files) == 750
+
+    def test_v1_nested_docker_shared_namespace(self) -> None:
+        """A v1 memory hierarchy resolves the /docker/<id> path below its mount."""
+        files = {
+            "/proc/self/cgroup": "4:memory:/docker/abc123\n1:name=systemd:/\n",
+            "/proc/self/mountinfo": _V1_MEMORY_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory/docker/abc123/memory.limit_in_bytes": "1000",
+            "/sys/fs/cgroup/memory/docker/abc123/memory.usage_in_bytes": "400",
+        }
+        assert _probe(files) == 600
+
+    def test_v1_ancestor_min_and_unlimited_sentinel(self) -> None:
+        """v1 walks ancestors too, ignoring near-sentinel unlimited levels."""
+        files = {
+            "/proc/self/cgroup": "4:memory:/docker/abc123\n",
+            "/proc/self/mountinfo": _V1_MEMORY_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory/docker/abc123/memory.limit_in_bytes": str(1 << 60),
+            "/sys/fs/cgroup/memory/docker/abc123/memory.usage_in_bytes": "400",
+            "/sys/fs/cgroup/memory/docker/memory.limit_in_bytes": "700",
+            "/sys/fs/cgroup/memory/docker/memory.usage_in_bytes": "300",
+        }
+        assert _probe(files) == 400
+
+    def test_v1_mount_root_is_container_subtree(self) -> None:
+        """When the mount's root IS the container's cgroup, read the mount point."""
+        files = {
+            "/proc/self/cgroup": "4:memory:/docker/abc123\n",
+            "/proc/self/mountinfo": (
+                "36 24 0:31 /docker/abc123 /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n"
+            ),
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": "1000",
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_hybrid_v2_without_memory_falls_to_v1(self) -> None:
+        """On a hybrid host the v2 walk finds no memory files and v1 answers."""
+        files = {
+            "/proc/self/cgroup": "0::/user.slice\n4:memory:/docker/abc123\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 / /sys/fs/cgroup/unified rw - cgroup2 cgroup2 rw\n"
+                + _V1_MEMORY_ROOT_MOUNTINFO
+            ),
+            "/sys/fs/cgroup/memory/docker/abc123/memory.limit_in_bytes": "1000",
+            "/sys/fs/cgroup/memory/docker/abc123/memory.usage_in_bytes": "800",
+        }
+        assert _probe(files) == 200
+
+    def test_malformed_proc_self_cgroup_falls_back_to_mount_root(self) -> None:
+        """Unparseable /proc/self/cgroup lines degrade to the mount-root read."""
+        files = {
+            "/proc/self/cgroup": "not a cgroup line\n0:no-path-field\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_malformed_mountinfo_falls_back_to_mount_root(self) -> None:
+        """mountinfo lines without the options separator degrade gracefully."""
+        files = {
+            "/proc/self/cgroup": "0::/haute\n",
+            "/proc/self/mountinfo": "garbage line\n1 2 0:30 / /sys/fs/cgroup rw cgroup2\n",
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_missing_proc_files_fall_back_to_mount_root(self) -> None:
+        files = {
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_path_outside_mount_root_warns_and_falls_back(self) -> None:
+        """A cgroup path this mount cannot expose is logged, then fail-open."""
+        files = {
+            "/proc/self/cgroup": "0::/machine.slice/vm\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 /user.slice /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"
+            ),
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) == 750
+        assert any(entry["event"] == "cgroup_self_path_unresolved" for entry in logs)
+
+    def test_dot_dot_cgroup_path_is_rejected(self) -> None:
+        files = {
+            "/proc/self/cgroup": "0::/../escape\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) == 750
+        assert any(entry["event"] == "cgroup_self_path_unresolved" for entry in logs)
+
+    def test_malformed_nested_level_fails_open(self) -> None:
+        """A malformed ancestor value fails the whole probe open, not partial."""
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/haute.service/memory.max": "1000",
+            "/sys/fs/cgroup/system.slice/haute.service/memory.current": "250",
+            "/sys/fs/cgroup/system.slice/memory.max": "oops",
+            "/sys/fs/cgroup/system.slice/memory.current": "1",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) is None
+        assert any(entry["event"] == "cgroup_memory_state_malformed" for entry in logs)
+
+    def test_incomplete_nested_level_fails_open(self) -> None:
+        files = {
+            "/proc/self/cgroup": "0::/haute\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/haute/memory.max": "1000",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) is None
+        assert any(entry["event"] == "cgroup_memory_state_incomplete" for entry in logs)
+
+    def test_deleted_cgroup_line_is_ignored(self) -> None:
+        files = {
+            "/proc/self/cgroup": "0::/gone (deleted)\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_escaped_mount_point_is_decoded(self) -> None:
+        """Octal escapes in mountinfo paths (e.g. \\040 for space) are decoded."""
+        files = {
+            "/proc/self/cgroup": "0::/haute\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 / /sys/fs/my\\040cgroup rw - cgroup2 cgroup2 rw\n"
+            ),
+            "/sys/fs/my cgroup/haute/memory.max": "1000",
+            "/sys/fs/my cgroup/haute/memory.current": "100",
+        }
+        assert _probe(files) == 900
+
+    def test_nested_clamp_applies_end_to_end(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """available_ram_bytes clamps to the nested cgroup, not the host figure."""
+        monkeypatch.setattr("sys.platform", "linux")
+        files = {
+            "/proc/self/cgroup": "0::/system.slice/haute.service\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/system.slice/haute.service/memory.max": "700",
+            "/sys/fs/cgroup/system.slice/haute.service/memory.current": "200",
+        }
+        with (
+            patch("builtins.open", return_value=__import__("io").StringIO("MemAvailable: 2 kB\n")),
+            patch("haute._host_memory._read_cgroup_memory_file", side_effect=files.get),
+        ):
+            assert available_ram_bytes() == 500
+
+
+class TestCgroupParsers:
+    def test_unescape_mountinfo_field(self) -> None:
+        unescape = _host_memory._unescape_mountinfo_field
+        assert unescape("/plain/path") == "/plain/path"
+        assert unescape("/with\\040space") == "/with space"
+        assert unescape("/tab\\011here") == "/tab\there"
+        # A trailing or non-octal backslash sequence passes through untouched.
+        assert unescape("/odd\\") == "/odd\\"
+        assert unescape("/not\\09octal") == "/not\\09octal"
+
+    def test_parse_proc_self_cgroup_prefers_first_match(self) -> None:
+        v2, v1 = _host_memory._parse_proc_self_cgroup(
+            "0::/first\n0::/second\n5:cpu,memory:/one\n4:memory:/two\n"
+        )
+        assert v2 == "/first"
+        assert v1 == "/one"
+
+    def test_parse_proc_self_mountinfo_matches_fstype_and_super_options(self) -> None:
+        text = (
+            "30 24 0:26 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu\n"
+            "31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n"
+            "35 24 0:30 / /sys/fs/cgroup/unified rw shared:1 - cgroup2 cgroup2 rw\n"
+        )
+        v2_mount, v1_mount = _host_memory._parse_proc_self_mountinfo(text)
+        assert v2_mount == ("/", "/sys/fs/cgroup/unified")
+        assert v1_mount == ("/", "/sys/fs/cgroup/memory")
+
+    def test_parse_proc_self_mountinfo_skips_unusable_lines(self) -> None:
+        text = (
+            # Separator too early: no room for the mandatory leading fields.
+            "1 2 - cgroup2 cgroup2 rw\n"
+            # Relative root and mount point are not usable paths.
+            "30 24 0:26 rel /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"
+            # A v1 cgroup line with no super-options field cannot prove it
+            # carries the memory controller.
+            "31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup\n"
+        )
+        assert _host_memory._parse_proc_self_mountinfo(text) == (None, None)
+
+    def test_v1_path_outside_mount_root_warns_and_falls_back(self) -> None:
+        files = {
+            "/proc/self/cgroup": "4:memory:/other\n",
+            "/proc/self/mountinfo": (
+                "36 24 0:31 /docker/abc /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n"
+            ),
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": "1000",
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": "250",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) == 750
+        assert any(
+            entry["event"] == "cgroup_self_path_unresolved" and entry["version"] == "v1"
+            for entry in logs
+        )
+
+    def test_ancestor_chain_depth_limit_bounds_the_walk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_host_memory, "_CGROUP_WALK_DEPTH_LIMIT", 2)
+        chain = _host_memory._cgroup_ancestor_chain(_host_memory._CgroupLocation("/a/b/c/d", "/a"))
+        assert chain == ["/a/b/c/d", "/a/b/c"]
+
+    def test_resolve_cgroup_directory_shapes(self) -> None:
+        resolve = _host_memory._resolve_cgroup_directory
+        assert resolve("/", "/", "/sys/fs/cgroup") == "/sys/fs/cgroup"
+        assert resolve("/a/b", "/", "/sys/fs/cgroup") == "/sys/fs/cgroup/a/b"
+        assert resolve("/a/b", "/a", "/sys/fs/cgroup") == "/sys/fs/cgroup/b"
+        assert resolve("/a/b", "/a/b", "/sys/fs/cgroup") == "/sys/fs/cgroup"
+        assert resolve("/other", "/a", "/sys/fs/cgroup") is None
+        assert resolve("/a/../b", "/", "/sys/fs/cgroup") is None
+
+
+# ---------------------------------------------------------------------------
 # available_ram_bytes — macOS Mach VM counters
 # ---------------------------------------------------------------------------
 

--- a/tests/test_host_memory.py
+++ b/tests/test_host_memory.py
@@ -603,6 +603,130 @@ class TestCgroupNestedResolution:
             assert _probe(files) == 750
         assert any(entry["event"] == "cgroup_self_path_unresolved" for entry in logs)
 
+    def test_unresolvable_path_still_reads_the_parsed_mount_point(self) -> None:
+        """The fallback honours a non-default mount, not the compiled-in path.
+
+        On a host with cgroup2 mounted away from ``/sys/fs/cgroup``, an
+        unresolvable cgroup path must degrade to the parsed mount point —
+        falling back to the default location would silently observe nothing.
+        """
+        files = {
+            "/proc/self/cgroup": "0::/machine.slice/vm\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 /user.slice /sys/fs/cgroup/unified rw - cgroup2 cgroup2 rw\n"
+            ),
+            "/sys/fs/cgroup/unified/memory.max": "1000",
+            "/sys/fs/cgroup/unified/memory.current": "400",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) == 600
+        assert any(entry["event"] == "cgroup_self_path_unresolved" for entry in logs)
+
+    def test_mount_without_cgroup_line_reads_the_parsed_mount_point(self) -> None:
+        """A parsed mount beats the default even with no usable cgroup path."""
+        files = {
+            "/proc/self/cgroup": "not parseable\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 / /sys/fs/cgroup/unified rw - cgroup2 cgroup2 rw\n"
+            ),
+            "/sys/fs/cgroup/unified/memory.max": "1000",
+            "/sys/fs/cgroup/unified/memory.current": "250",
+        }
+        assert _probe(files) == 750
+
+    def test_unreadable_proc_files_warn_and_use_default_mounts(self) -> None:
+        files = {
+            "/sys/fs/cgroup/memory.max": "1000",
+            "/sys/fs/cgroup/memory.current": "250",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) == 750
+        unreadable = [e for e in logs if e["event"] == "cgroup_self_state_unreadable"]
+        assert unreadable
+        assert unreadable[0]["cgroup_readable"] is False
+        assert unreadable[0]["mountinfo_readable"] is False
+
+    def test_malformed_v2_dominates_a_healthy_v1(self) -> None:
+        """A present-but-broken v2 controller fails open without consulting v1.
+
+        Deliberate: a v2 hierarchy that answers at all is the authoritative
+        one, and falling through to v1 on a malformed read could substitute a
+        stale or unrelated limit for the broken authoritative state.
+        """
+        files = {
+            "/proc/self/cgroup": "0::/haute\n4:memory:/haute\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO + _V1_MEMORY_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/haute/memory.max": "oops",
+            "/sys/fs/cgroup/haute/memory.current": "1",
+            "/sys/fs/cgroup/memory/haute/memory.limit_in_bytes": "1000",
+            "/sys/fs/cgroup/memory/haute/memory.usage_in_bytes": "250",
+        }
+        assert _probe(files) is None
+
+    def test_depth_truncated_walk_fails_the_probe_open(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A too-deep cgroup fails open rather than reporting a partial walk.
+
+        The levels past the cutoff are the ones nearest the mount point — the
+        broadest limits — so a truncated walk that returned its finite leaf
+        headroom could over-admit against a tighter unseen ancestor.
+        """
+        monkeypatch.setattr(_host_memory, "_CGROUP_WALK_DEPTH_LIMIT", 2)
+        files = {
+            "/proc/self/cgroup": "0::/a/b/c\n",
+            "/proc/self/mountinfo": _V2_ROOT_MOUNTINFO,
+            "/sys/fs/cgroup/a/b/c/memory.max": "1000",
+            "/sys/fs/cgroup/a/b/c/memory.current": "250",
+        }
+        with capture_logs() as logs:
+            assert _probe(files) is None
+        assert any(entry["event"] == "cgroup_ancestor_walk_truncated" for entry in logs)
+
+    def test_most_specific_mount_root_wins_across_multiple_mounts(self) -> None:
+        """Among several cgroup2 mounts, the deepest containing root is used.
+
+        The binding limit may only be reachable through a subtree mount; a
+        first-match rule would resolve through the broad mount and read a
+        different (or absent) set of controller files.
+        """
+        files = {
+            "/proc/self/cgroup": "0::/docker/abc/task\n",
+            "/proc/self/mountinfo": (
+                "35 24 0:30 / /broad rw - cgroup2 cgroup2 rw\n"
+                "36 24 0:30 /docker/abc /narrow rw - cgroup2 cgroup2 rw\n"
+            ),
+            # Reachable through the broad mount too, but with no limits there;
+            # the binding limit lives under the subtree mount.
+            "/narrow/task/memory.max": "1000",
+            "/narrow/task/memory.current": "600",
+            "/narrow/memory.max": "2000",
+            "/narrow/memory.current": "1900",
+        }
+        assert _probe(files) == 100
+        # Mount order must not matter: the subtree root wins listed either way.
+        files["/proc/self/mountinfo"] = (
+            "36 24 0:30 /docker/abc /narrow rw - cgroup2 cgroup2 rw\n"
+            "35 24 0:30 / /broad rw - cgroup2 cgroup2 rw\n"
+        )
+        assert _probe(files) == 100
+
+    def test_reader_returns_none_for_nul_bearing_path(self) -> None:
+        """An embedded NUL raises ValueError at open; the reader absorbs it."""
+        assert _host_memory._read_cgroup_memory_file("/sys/fs/\x00bad") is None
+
+    def test_non_utf8_proc_content_degrades_instead_of_raising(self, haute_scratch: Path) -> None:
+        """Raw kernel dentry bytes must never crash the reader.
+
+        /proc/self/cgroup is not octal-escaped like mountinfo: a sibling
+        cgroup named with non-UTF-8 bytes appears verbatim, and the reader
+        must substitute rather than raise ``UnicodeDecodeError``.
+        """
+        proc_file = haute_scratch / "cgroup"
+        proc_file.write_bytes(b"0::/bad\xffname\n")
+        content = _host_memory._read_cgroup_memory_file(str(proc_file))
+        assert content == "0::/bad�name"
+
     def test_dot_dot_cgroup_path_is_rejected(self) -> None:
         files = {
             "/proc/self/cgroup": "0::/../escape\n",
@@ -684,6 +808,11 @@ class TestCgroupParsers:
         # A trailing or non-octal backslash sequence passes through untouched.
         assert unescape("/odd\\") == "/odd\\"
         assert unescape("/not\\09octal") == "/not\\09octal"
+        # Only the kernel's escape set decodes: \057 (/) and \056 (.) must
+        # NOT — a permissive decoder would let a hostile name synthesise
+        # traversal components after validation.
+        assert unescape("/a\\057\\056\\056\\057etc") == "/a\\057\\056\\056\\057etc"
+        assert unescape("/nul\\000byte") == "/nul\\000byte"
 
     def test_parse_proc_self_cgroup_prefers_first_match(self) -> None:
         v2, v1 = _host_memory._parse_proc_self_cgroup(
@@ -698,21 +827,35 @@ class TestCgroupParsers:
             "31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n"
             "35 24 0:30 / /sys/fs/cgroup/unified rw shared:1 - cgroup2 cgroup2 rw\n"
         )
-        v2_mount, v1_mount = _host_memory._parse_proc_self_mountinfo(text)
-        assert v2_mount == ("/", "/sys/fs/cgroup/unified")
-        assert v1_mount == ("/", "/sys/fs/cgroup/memory")
+        v2_mounts, v1_mounts = _host_memory._parse_proc_self_mountinfo(text)
+        assert v2_mounts == [("/", "/sys/fs/cgroup/unified")]
+        assert v1_mounts == [("/", "/sys/fs/cgroup/memory")]
 
     def test_parse_proc_self_mountinfo_skips_unusable_lines(self) -> None:
         text = (
             # Separator too early: no room for the mandatory leading fields.
             "1 2 - cgroup2 cgroup2 rw\n"
+            # Five fields before the separator is still short of the six
+            # mandatory ones — a missing field shifts the path positions.
+            "30 24 0:26 / /sys/fs/cgroup - cgroup2 cgroup2 rw\n"
             # Relative root and mount point are not usable paths.
             "30 24 0:26 rel /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"
+            # Traversal components in a decoded path field must not redirect
+            # controller reads outside the hierarchy.
+            "30 24 0:26 / /sys/fs/../etc rw - cgroup2 cgroup2 rw\n"
             # A v1 cgroup line with no super-options field cannot prove it
             # carries the memory controller.
             "31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup\n"
         )
-        assert _host_memory._parse_proc_self_mountinfo(text) == (None, None)
+        assert _host_memory._parse_proc_self_mountinfo(text) == ([], [])
+
+    def test_parse_proc_self_mountinfo_six_field_boundary(self) -> None:
+        """Exactly the six mandatory fields before the separator is accepted."""
+        text = "35 24 0:30 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"
+        assert _host_memory._parse_proc_self_mountinfo(text) == (
+            [("/", "/sys/fs/cgroup")],
+            [],
+        )
 
     def test_v1_path_outside_mount_root_warns_and_falls_back(self) -> None:
         files = {
@@ -734,8 +877,19 @@ class TestCgroupParsers:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(_host_memory, "_CGROUP_WALK_DEPTH_LIMIT", 2)
-        chain = _host_memory._cgroup_ancestor_chain(_host_memory._CgroupLocation("/a/b/c/d", "/a"))
-        assert chain == ["/a/b/c/d", "/a/b/c"]
+        with capture_logs() as logs:
+            chain = _host_memory._cgroup_ancestor_chain(
+                _host_memory._CgroupLocation("/a/b/c/d", "/a")
+            )
+        # A truncated walk is no walk at all: the dropped levels nearest the
+        # mount point hold the broadest limits, so a partial chain must not
+        # pass for a complete observation.
+        assert chain is None
+        assert any(entry["event"] == "cgroup_ancestor_walk_truncated" for entry in logs)
+        within_limit = _host_memory._cgroup_ancestor_chain(
+            _host_memory._CgroupLocation("/a/b", "/a")
+        )
+        assert within_limit == ["/a/b", "/a"]
 
     def test_resolve_cgroup_directory_shapes(self) -> None:
         resolve = _host_memory._resolve_cgroup_directory


### PR DESCRIPTION
## Summary
The Linux cgroup memory probe read only the mount-root controller files at /sys/fs/cgroup, so a process in a nested cgroup within the host namespace (a systemd service slice, a container sharing the host cgroup namespace) had its actual limits invisible and admission sized against host RAM.

The probe now resolves the process's own cgroup directory by parsing /proc/self/cgroup and /proc/self/mountinfo (cgroup v2 unified and v1 hybrid), reads the controller files at the resolved path, and takes the minimum headroom across the cgroup and its ancestors up to the mount point — a parent's limit binds its children, and the memory controller may only be enabled partway up. Any resolution failure (unreadable or malformed proc files, no matching mount, a cgroup path outside the mount root) degrades to the historical mount-root read, so the existing fail-open behaviour on unreadable state is unchanged (per the ruled Degraded-observation contract; see PR #178).

Test matrix covers mount-root, nested-one-level, nested-systemd-slice, docker shared-namespace v1, subtree-root mounts, hybrid v2+v1 hosts, malformed proc lines, unresolvable paths, and octal-escaped mount points.

## Verification
- Full `scripts/preflight.sh --backend-only` green — 14,983 passed, ruff/mypy clean
- `src/haute/_host_memory.py` at 100% statement / 100% branch coverage against its 98/94 critical-coverage gate
- `_execution_admission.py` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
