### PR TITLE
Curate the remaining worker-boundary error surfaces (fit fallback, crash, model-save OSError, memory limit)

### DIFF
--- a/specs/background-jobs/high-level.md
+++ b/specs/background-jobs/high-level.md
@@ -260,8 +260,9 @@ Depended on:
   terminal message; failures without one keep the typed wrapper text. The crash
   wrapper — the one surface that can only be parent-authored, since a crashed
   child left no payload to curate — is itself written as user-facing wording:
-  it distinguishes an out-of-memory kill from an unexpected stop and carries
-  the exit code.
+  a hedged may-have-run-out-of-memory phrasing when the exit code looks
+  memory-limited (the heuristic is indicative, not proof), an unexpected-stop
+  phrasing otherwise, each carrying the exit code when available.
   An unrecognised reason string coerces to `error` rather than raising, so the job
   still reaches a terminal state.
 

--- a/specs/background-jobs/high-level.md
+++ b/specs/background-jobs/high-level.md
@@ -257,7 +257,11 @@ Depended on:
   remote exceptions, `worker_exitcode` for crashes, `error_code` for memory limits).
   A child that curated a user-facing failure message marks it on the payload's
   `user_message` field, and the supervisor uses that curated wording as the job's
-  terminal message; failures without one keep the typed wrapper text.
+  terminal message; failures without one keep the typed wrapper text. The crash
+  wrapper — the one surface that can only be parent-authored, since a crashed
+  child left no payload to curate — is itself written as user-facing wording:
+  it distinguishes an out-of-memory kill from an unexpected stop and carries
+  the exit code.
   An unrecognised reason string coerces to `error` rather than raising, so the job
   still reaches a terminal state.
 

--- a/specs/execution-engine/low-level.md
+++ b/specs/execution-engine/low-level.md
@@ -565,7 +565,11 @@ timeout terminates, escalates to kill, joins, and verifies death; a surviving ch
   (child raised a Python exception; carries `remote_type`/`remote_message`/
   `remote_traceback`), `IsolatedWorkerCrashedError` (child exited without a result;
   reclassified to `terminal_reason="memory_limited"` when the exit code looks like
-  `SIGKILL`/`SIGABRT` under a configured cap), `IsolatedWorkerTimeoutError`,
+  `SIGKILL`/`SIGABRT` under a configured cap — its message is parent-authored
+  user-facing wording, since a crashed child left no payload to curate: an
+  out-of-memory phrasing for the reclassified case, an unexpected-stop phrasing
+  otherwise, each carrying the exit code, which also stays on the exception's
+  `exitcode` attribute), `IsolatedWorkerTimeoutError`,
   `IsolatedWorkerStoppedError` (parent-requested stop; raises `ValueError` if
   constructed with `terminal_reason="completed"`, which is not a valid stop reason),
   `IsolatedWorkerMemoryLimitUnsupportedError` (platform can't enforce the requested

--- a/specs/execution-engine/low-level.md
+++ b/specs/execution-engine/low-level.md
@@ -566,10 +566,11 @@ timeout terminates, escalates to kill, joins, and verifies death; a surviving ch
   `remote_traceback`), `IsolatedWorkerCrashedError` (child exited without a result;
   reclassified to `terminal_reason="memory_limited"` when the exit code looks like
   `SIGKILL`/`SIGABRT` under a configured cap — its message is parent-authored
-  user-facing wording, since a crashed child left no payload to curate: an
-  out-of-memory phrasing for the reclassified case, an unexpected-stop phrasing
-  otherwise, each carrying the exit code, which also stays on the exception's
-  `exitcode` attribute), `IsolatedWorkerTimeoutError`,
+  user-facing wording, since a crashed child left no payload to curate: a
+  hedged may-have-run-out-of-memory phrasing for the reclassified case (the
+  exit-code heuristic is indicative, not proof), an unexpected-stop phrasing
+  otherwise, each carrying the exit code when available; the code also stays on
+  the exception's `exitcode` attribute), `IsolatedWorkerTimeoutError`,
   `IsolatedWorkerStoppedError` (parent-requested stop; raises `ValueError` if
   constructed with `terminal_reason="completed"`, which is not a valid stop reason),
   `IsolatedWorkerMemoryLimitUnsupportedError` (platform can't enforce the requested

--- a/specs/modelling/high-level.md
+++ b/specs/modelling/high-level.md
@@ -360,19 +360,27 @@ browser without a server or JS bundle.
 - Failures that cross the training/dispersion worker boundary surface the child's
   wording, not worker jargon — but only when that wording is deliberately curated.
   The child's failure mapper marks haute-authored messages (the gates, the metric
-  wrap, validation `ValueError`s, and the recognised friendly-error shapes) on the
-  payload's `user_message` field, and the parent supervisor surfaces that message
-  verbatim as the job's terminal message — the internal
-  "Isolated worker raised {type}: …" wrapper text is never shown for those
-  failures. An unrecognised third-party exception's text is not vouched for: it
-  keeps the typed wrapper surface, as do failures that never produce a payload (a
-  child crash, a parent-side timeout). The field is a routing contract, not a
-  per-message content guarantee: message quality is enforced at the producing
-  sites (the gates and wraps in this component, pinned by their tests). Error
-  types and bounded tracebacks stay in diagnostic fields; the curated messages
-  carry domain context (target column, task, metrics) and never secrets or raw
-  tracebacks — a filesystem path appears only where the path itself is the
-  actionable object (a file-not-found or model-save failure).
+  wrap, validation `ValueError`s, and the friendly-error shapes — including an
+  unexpected-error fallback that names the target/objective and the exception
+  type but not the third-party message body, and a memory-limit message giving
+  used/allowed sizes with a call to action) on the payload's `user_message`
+  field, and the parent supervisor surfaces that message verbatim as the job's
+  terminal message — the internal "Isolated worker raised {type}: …" wrapper
+  text is never shown for those failures. An arbitrary third-party exception's
+  text is never vouched for as a terminal message: the fallback wraps it in a
+  haute-authored system-error shape (still a plain `error`, never relabelled as
+  `contract_error`) and keeps the raw text in diagnostic fields. Failures that
+  never produce a payload (a child crash, a parent-side timeout) keep the
+  parent-authored wrapper surface, whose crash wording is itself written for the
+  user (out-of-memory vs. unexpected-stop phrasing, with the exit code). The
+  field is a routing contract, not a per-message content guarantee: message
+  quality is enforced at the producing sites (the gates and wraps in this
+  component, pinned by their tests). Error types and bounded tracebacks stay in
+  diagnostic fields; the curated messages carry domain context (target column,
+  task, metrics) and never secrets or raw tracebacks — a filesystem path appears
+  only where the path itself is the actionable object (a file-not-found
+  failure); a model-save failure names the OS-level reason, not the internal
+  staging path.
 - A mandatory metric-evaluation failure names the evaluation set (using the
   evaluation plan's public `development`/`final test` labels on that pipeline),
   target column, task, and requested metrics around the underlying library error,

--- a/specs/modelling/high-level.md
+++ b/specs/modelling/high-level.md
@@ -372,15 +372,18 @@ browser without a server or JS bundle.
   `contract_error`) and keeps the raw text in diagnostic fields. Failures that
   never produce a payload (a child crash, a parent-side timeout) keep the
   parent-authored wrapper surface, whose crash wording is itself written for the
-  user (out-of-memory vs. unexpected-stop phrasing, with the exit code). The
+  user (a hedged may-have-run-out-of-memory phrasing when the exit code looks
+  memory-limited — the heuristic is indicative, not proof — vs. an
+  unexpected-stop phrasing, with the exit code when available). The
   field is a routing contract, not a per-message content guarantee: message
   quality is enforced at the producing sites (the gates and wraps in this
   component, pinned by their tests). Error types and bounded tracebacks stay in
   diagnostic fields; the curated messages carry domain context (target column,
-  task, metrics) and never secrets or raw tracebacks — a filesystem path appears
-  only where the path itself is the actionable object (a file-not-found
-  failure); a model-save failure names the OS-level reason, not the internal
-  staging path.
+  task, metrics) and never secrets, raw tracebacks, or filesystem paths — a
+  missing-file or save failure names the failure class and the errno-derived
+  OS reason, keeping the path itself diagnostic. The `ValueError` validation
+  channel travels verbatim by provenance convention (haute authors its
+  validation messages as `ValueError`s), not by enforcement.
 - A mandatory metric-evaluation failure names the evaluation set (using the
   evaluation plan's public `development`/`final test` labels on that pipeline),
   target column, task, and requested metrics around the underlying library error,

--- a/specs/modelling/low-level.md
+++ b/specs/modelling/low-level.md
@@ -595,14 +595,24 @@ rows/features) and retry.
 - **Generic `Exception`** catch-all in each process entrypoint maps to an `error`
   failure payload with the message produced by
   `_friendly_error(exc, operation_noun=..., context=...)` — a heuristic
-  translator whose every shape is haute-authored: `ValueError` messages verbatim
-  (the validation channel), `FileNotFoundError` prefixed (the missing path is the
-  actionable object), CatBoost-flavoured exceptions special-cased (NaN/Inf hint,
-  feature-count mismatch, and a generic shape naming the training context),
-  `OSError` rendered as a save failure naming only `exc.strerror` — never the
+  translator whose every shape is haute-authored, and which — apart from the
+  `ValueError` channel — never interpolates a third-party message body:
+  `ValueError` messages verbatim (the validation channel; provenance by
+  convention, not enforcement — a dependency's `ValueError` rides the same
+  channel, an accepted residual of the #159 design), `FileNotFoundError` as a
+  path-free could-not-find-a-file shape (a fit-stage missing file is typically
+  an internal staged asset, so this deliberately narrows #159's
+  path-as-actionable ruling — the path stays in the diagnostic fields and
+  traceback), CatBoost failures keyed on the exception TYPE name (never a
+  message substring, so a non-CatBoost error that mentions catboost in its text
+  cannot take these shapes) with a NaN/Inf hint, a body-free feature-mismatch
+  shape, and a body-free generic shape naming the type and training context,
+  `OSError` rendered as a save failure whose reason is re-derived from the
+  numeric errno via `os.strerror` (`exc.strerror` is constructor-supplied and
+  untrusted; no errno → a generic file-system-error wording) — never the
   internal temp/staging path embedded in `str(exc)` — and an unexpected-error
   fallback naming the operation, the target/objective context, and the exception
-  type but deliberately not the third-party message body. `context` is built by
+  type. `context` is built by
   `_training_context_phrase(job_kwargs)` (`target 'x' (objective 'y')`, falling
   back to `"the model"`); the entrypoints capture it right after parsing
   `job_kwargs` so a fit-stage failure names what was being trained. The fallback

--- a/specs/modelling/low-level.md
+++ b/specs/modelling/low-level.md
@@ -593,25 +593,37 @@ rows/features) and retry.
   (`memory_limited` for 507, `contract_error` for other 4xx, `error` otherwise) before
   re-raising, so the job store and the HTTP response can never disagree about outcome.
 - **Generic `Exception`** catch-all in each process entrypoint maps to an `error`
-  failure payload with the message produced by `_friendly_error(exc)` — a heuristic
-  translator that
-  returns `ValueError` messages verbatim, prefixes `FileNotFoundError`, special-cases
-  CatBoost-flavoured exceptions (NaN/Inf hint, feature-count mismatch), prefixes
-  `OSError` as a model-save failure, and otherwise falls back to
-  `f"Training failed ({exc_type}): {msg}"`.
+  failure payload with the message produced by
+  `_friendly_error(exc, operation_noun=..., context=...)` — a heuristic
+  translator whose every shape is haute-authored: `ValueError` messages verbatim
+  (the validation channel), `FileNotFoundError` prefixed (the missing path is the
+  actionable object), CatBoost-flavoured exceptions special-cased (NaN/Inf hint,
+  feature-count mismatch, and a generic shape naming the training context),
+  `OSError` rendered as a save failure naming only `exc.strerror` — never the
+  internal temp/staging path embedded in `str(exc)` — and an unexpected-error
+  fallback naming the operation, the target/objective context, and the exception
+  type but deliberately not the third-party message body. `context` is built by
+  `_training_context_phrase(job_kwargs)` (`target 'x' (objective 'y')`, falling
+  back to `"the model"`); the entrypoints capture it right after parsing
+  `job_kwargs` so a fit-stage failure names what was being trained. The fallback
+  stays a plain system `error` — a system fault is never relabelled as
+  `contract_error`.
 - **Curated failure surfacing** — `_worker_failure_payload` takes an explicit
   `user_facing` decision from every call site and stamps the payload's
   `user_message` field (`_worker_protocol.WORKER_USER_MESSAGE_FIELD`) only for
   deliberately curated, haute-authored wording: the cancelled/memory-limit/
-  contract-error/bounded-memory branches of `_known_training_worker_failure`, the
-  `ValueError` validation channel (which carries the gate and metric-wrap
-  messages), and the recognised shapes of `_classified_friendly_error`
-  (`_friendly_error`'s classifying twin). The unrecognised fallback
-  (`"Training failed ({exc_type}): {msg}"` — an arbitrary third-party
-  exception's text) and raw `MemoryError` text are NOT stamped and keep the
-  typed "Isolated worker raised {type}: {message}" wrapper surface. For stamped
-  failures the supervisor surfaces the field verbatim as the job's terminal
-  message; the wrapper text is retained in the diagnostic `error` field. See
+  contract-error/bounded-memory branches of `_known_training_worker_failure`
+  (the memory-limit branch authors its message from the exception's structured
+  attributes via `_memory_limit_user_message` — human-readable used/allowed
+  sizes plus a call to action, never the internal operation name, which stays
+  in the diagnostic `error` field), the `ValueError` validation channel (which
+  carries the gate and metric-wrap messages), and every `_friendly_error` shape
+  (all curated as above, so the entrypoints pass `user_facing=True` and thread
+  the raw `str(exc)` into `fields["error"]` explicitly). Raw `MemoryError` text
+  is NOT stamped and keeps the typed "Isolated worker raised {type}: {message}"
+  wrapper surface. For stamped failures the supervisor surfaces the field
+  verbatim as the job's terminal message; the wrapper text is retained in the
+  diagnostic `error` field. See
   [background-jobs](../background-jobs/low-level.md) for the supervisor side of
   the contract.
 - **`_record_diag_error`** is the single call site that converts an optional-diagnostic

--- a/src/haute/_worker_isolation.py
+++ b/src/haute/_worker_isolation.py
@@ -139,17 +139,31 @@ class IsolatedWorkerRemoteError(IsolatedWorkerError):
 
 
 class IsolatedWorkerCrashedError(IsolatedWorkerError):
-    """Raised when the child exits without returning a result payload."""
+    """Raised when the child exits without returning a result payload.
+
+    The message is parent-authored — a crashed child left no payload to
+    curate — so it is written directly for the user rather than in
+    supervisor jargon. The exit code stays on the exception (and in the
+    job's ``worker_exitcode`` field) for diagnostics.
+    """
 
     def __init__(self, *, exitcode: int | None, memory_limit_bytes: int | None) -> None:
-        terminal_reason: WorkerTerminalReason = (
-            "memory_limited"
-            if _exitcode_looks_memory_limited(exitcode, memory_limit_bytes)
-            else "error"
-        )
+        memory_limited = _exitcode_looks_memory_limited(exitcode, memory_limit_bytes)
+        exit_detail = "" if exitcode is None else f" (exit code {exitcode})"
+        if memory_limited:
+            message = (
+                f"The background process ran out of memory and was stopped{exit_detail}. "
+                "Reduce the data size, or run on a server with more memory, then try again."
+            )
+        else:
+            message = (
+                "The background process stopped unexpectedly before returning a result"
+                f"{exit_detail}. This usually means it crashed or was stopped by the "
+                "operating system — check the server logs, then try again."
+            )
         super().__init__(
-            f"Isolated worker exited without a result payload (exitcode={exitcode!r})",
-            terminal_reason=terminal_reason,
+            message,
+            terminal_reason="memory_limited" if memory_limited else "error",
         )
         self.exitcode = exitcode
 

--- a/src/haute/_worker_isolation.py
+++ b/src/haute/_worker_isolation.py
@@ -151,9 +151,13 @@ class IsolatedWorkerCrashedError(IsolatedWorkerError):
         memory_limited = _exitcode_looks_memory_limited(exitcode, memory_limit_bytes)
         exit_detail = "" if exitcode is None else f" (exit code {exitcode})"
         if memory_limited:
+            # The exit-code heuristic is indicative, not proof (a native abort
+            # or an external kill can look the same) — the wording hedges
+            # rather than asserting an out-of-memory condition as fact.
             message = (
-                f"The background process ran out of memory and was stopped{exit_detail}. "
-                "Reduce the data size, or run on a server with more memory, then try again."
+                f"The background process was stopped and may have run out of memory"
+                f"{exit_detail}. Reduce the data size, or run on a server with more "
+                "memory, then try again."
             )
         else:
             message = (

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -192,8 +192,10 @@ def _memory_limit_http_exception(
     detail = exc.to_payload()
     if isinstance(exc, ExecutionMemoryLimitExceededError):
         # str(exc) names the internal operation and raw byte counts; author
-        # the public message from the structured attributes instead.
-        detail.setdefault("message", _memory_limit_user_message(exc, operation_noun="Training"))
+        # the public message from the structured attributes instead. Assigned
+        # unconditionally: a payload-carried "message" must not win over the
+        # curated wording.
+        detail["message"] = _memory_limit_user_message(exc, operation_noun="Training")
     else:
         detail.setdefault("message", str(exc))
     return HTTPException(status_code=507, detail=detail)
@@ -623,42 +625,70 @@ def _friendly_error(
 
     Every returned shape is haute-authored and safe to promote verbatim as the
     job's terminal message; the raw exception text stays in the diagnostic
-    ``error`` field and the traceback. The unexpected-error fallback names the
-    target/objective context and the exception type but deliberately not the
-    third-party message body (which may carry internal paths), and it stays a
-    plain system ``error`` — a system fault is never relabelled as a
-    ``contract_error``.
+    ``error`` field and the traceback. Apart from the `ValueError` validation
+    channel, no shape interpolates a third-party message body (which may carry
+    internal paths or secrets) — third-party failures name the exception type
+    and the target/objective context only, and they stay a plain system
+    ``error`` — a system fault is never relabelled as a ``contract_error``.
     """
-    msg = str(exc)
-
     if isinstance(exc, ValueError):
         # ValueError is the package's deliberate validation channel: gates,
-        # column checks, and the metric-stage wrap all speak through it.
-        return msg
-
-    if isinstance(exc, FileNotFoundError):
-        # The missing path is itself the actionable object here.
-        return f"File not found: {msg}"
+        # column checks, and the metric-stage wrap all speak through it. This
+        # is provenance by convention, not enforcement — a dependency's
+        # ValueError rides the same channel.
+        return str(exc)
 
     exc_type = type(exc).__name__
-    if "CatBoost" in exc_type or "catboost" in msg.lower():
+
+    if isinstance(exc, FileNotFoundError):
+        # At the fit stage the missing path is typically an internal staged
+        # asset, so the message does not quote it; the path stays in the
+        # diagnostic fields and traceback.
+        return (
+            f"{operation_noun} could not find a file it needs. The full error, "
+            "including the path, is recorded in the job's error details."
+        )
+
+    # Keyed on the exception TYPE: a non-CatBoost error that merely mentions
+    # "catboost" in its text must not take a CatBoost-specific shape.
+    if "CatBoost" in exc_type:
+        msg = str(exc)
         if "nan" in msg.lower() or "inf" in msg.lower():
             return (
-                "Training failed: the data contains NaN or infinite values. "
-                "Add a polars node upstream to handle missing values "
+                f"{operation_noun} failed: the data contains NaN or infinite "
+                "values. Add a polars node upstream to handle missing values "
                 "(e.g. .fill_null() or .drop_nulls()) before training."
             )
         if "feature" in msg.lower() and "number" in msg.lower():
-            return f"Training failed: feature mismatch. {msg}"
-        return f"CatBoost could not train {context}: {msg}"
+            return (
+                f"{operation_noun} failed: feature mismatch — the data's "
+                "columns do not match what the model expects. The full error "
+                "is recorded in the job's error details."
+            )
+        return (
+            f"{operation_noun} of {context} failed with a CatBoost error "
+            f"({exc_type}). The full error is recorded in the job's error details."
+        )
 
     if isinstance(exc, OSError):
-        # str(OSError) embeds the internal staging path; surface only the
-        # OS-level reason and keep the path in the diagnostic fields.
-        reason = exc.strerror or exc_type
+        # Surface only an OS-authored reason: exc.strerror is
+        # constructor-supplied (a dependency can put arbitrary text there), so
+        # the reason is re-derived from the numeric errno.
+        reason: str | None = None
+        if isinstance(exc.errno, int):
+            try:
+                reason = os.strerror(exc.errno)
+            except (ValueError, OverflowError):
+                reason = None
+        if reason:
+            return (
+                f"{operation_noun} could not save its output files ({reason}). "
+                "Check the server's disk space and file permissions, then try again."
+            )
         return (
-            f"{operation_noun} could not save its output files ({reason}). "
-            "Check the server's disk space and file permissions, then try again."
+            f"{operation_noun} could not save its output files because of a "
+            "file-system error. Check the server's disk space and file "
+            "permissions, then try again."
         )
 
     return (
@@ -810,10 +840,15 @@ def _memory_limit_user_message(
     if exc.reason == "process_rss_limit_exceeded" and exc.rss_limit_bytes is not None:
         allowed = exc.rss_limit_bytes
     elif used is not None and exc.baseline_rss_bytes is not None:
-        used = used - exc.baseline_rss_bytes
+        # Sampler noise can put the observed RSS below the admission baseline;
+        # never render a negative usage.
+        used = max(used - exc.baseline_rss_bytes, 0)
+    # This runs on a failure path: a partially-populated exception must
+    # degrade to omitting the sizes, never crash into a TypeError that
+    # replaces the real memory error.
     detail = (
         ""
-        if used is None
+        if used is None or allowed is None
         else f" ({_format_byte_size(used)} used, {_format_byte_size(allowed)} allowed)"
     )
     return (

--- a/src/haute/routes/_train_service.py
+++ b/src/haute/routes/_train_service.py
@@ -190,7 +190,12 @@ def _memory_limit_http_exception(
     exc: ExecutionAdmissionError | ExecutionMemoryLimitExceededError,
 ) -> HTTPException:
     detail = exc.to_payload()
-    detail.setdefault("message", str(exc))
+    if isinstance(exc, ExecutionMemoryLimitExceededError):
+        # str(exc) names the internal operation and raw byte counts; author
+        # the public message from the structured attributes instead.
+        detail.setdefault("message", _memory_limit_user_message(exc, operation_noun="Training"))
+    else:
+        detail.setdefault("message", str(exc))
     return HTTPException(status_code=507, detail=detail)
 
 
@@ -572,24 +577,68 @@ def _find_modelling_node(graph: PipelineGraph, node_id: str) -> GraphNode:
     return find_typed_node(graph, node_id, NodeType.MODELLING, "modelling")
 
 
-def _classified_friendly_error(exc: Exception) -> tuple[str, bool]:
-    """Translate common training exceptions; flag whether the shape is recognised.
+def _format_byte_size(size_bytes: int) -> str:
+    """Render a byte count in human units for user-facing messages."""
+    value = float(size_bytes)
+    unit = "bytes"
+    for larger_unit in ("KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0:
+            break
+        value /= 1024.0
+        unit = larger_unit
+    return f"{size_bytes} bytes" if unit == "bytes" else f"{value:.1f} {unit}"
 
-    The boolean is the curation signal for the worker boundary: ``True``
-    means the message is a deliberately shaped, haute-authored surface safe
-    to promote verbatim as the job's terminal message; ``False`` means the
-    fallback branch fired and the message body is an arbitrary third-party
-    exception's text, which keeps the typed wrapper surface instead.
+
+def _training_context_phrase(job_kwargs: Mapping[str, Any] | None) -> str:
+    """Name the failing fit's target and objective from bounded config values.
+
+    Used in failure messages so the user learns *which* fit failed without the
+    message quoting anything from the data or the filesystem.
+    """
+    if not isinstance(job_kwargs, Mapping):
+        return "the model"
+    target = job_kwargs.get("target")
+    params = job_kwargs.get("params")
+    objective = (
+        job_kwargs.get("loss_function")
+        or (params.get("family") if isinstance(params, Mapping) else None)
+        # Raw node configs (the preparation path) carry the GLM family at the
+        # top level rather than under built params.
+        or job_kwargs.get("family")
+    )
+    if not (isinstance(target, str) and target):
+        return "the model"
+    if isinstance(objective, str) and objective:
+        return f"target {target!r} (objective {objective!r})"
+    return f"target {target!r}"
+
+
+def _friendly_error(
+    exc: Exception,
+    *,
+    operation_noun: str = "Training",
+    context: str = "the model",
+) -> str:
+    """Translate a training-path exception into a curated, actionable message.
+
+    Every returned shape is haute-authored and safe to promote verbatim as the
+    job's terminal message; the raw exception text stays in the diagnostic
+    ``error`` field and the traceback. The unexpected-error fallback names the
+    target/objective context and the exception type but deliberately not the
+    third-party message body (which may carry internal paths), and it stays a
+    plain system ``error`` — a system fault is never relabelled as a
+    ``contract_error``.
     """
     msg = str(exc)
 
     if isinstance(exc, ValueError):
         # ValueError is the package's deliberate validation channel: gates,
         # column checks, and the metric-stage wrap all speak through it.
-        return msg, True
+        return msg
 
     if isinstance(exc, FileNotFoundError):
-        return f"File not found: {msg}", True
+        # The missing path is itself the actionable object here.
+        return f"File not found: {msg}"
 
     exc_type = type(exc).__name__
     if "CatBoost" in exc_type or "catboost" in msg.lower():
@@ -598,20 +647,24 @@ def _classified_friendly_error(exc: Exception) -> tuple[str, bool]:
                 "Training failed: the data contains NaN or infinite values. "
                 "Add a polars node upstream to handle missing values "
                 "(e.g. .fill_null() or .drop_nulls()) before training."
-            ), True
+            )
         if "feature" in msg.lower() and "number" in msg.lower():
-            return f"Training failed: feature mismatch. {msg}", True
-        return f"CatBoost error: {msg}", True
+            return f"Training failed: feature mismatch. {msg}"
+        return f"CatBoost could not train {context}: {msg}"
 
     if isinstance(exc, OSError):
-        return f"Could not save model file: {msg}", True
+        # str(OSError) embeds the internal staging path; surface only the
+        # OS-level reason and keep the path in the diagnostic fields.
+        reason = exc.strerror or exc_type
+        return (
+            f"{operation_noun} could not save its output files ({reason}). "
+            "Check the server's disk space and file permissions, then try again."
+        )
 
-    return f"Training failed ({exc_type}): {msg}", False
-
-
-def _friendly_error(exc: Exception) -> str:
-    """Translate common training exceptions into actionable messages."""
-    return _classified_friendly_error(exc)[0]
+    return (
+        f"{operation_noun} of {context} failed with an unexpected internal error "
+        f"({exc_type}). The full error is recorded in the job's error details."
+    )
 
 
 def _assert_json_finite(value: Any, path: str = "result") -> None:
@@ -720,8 +773,9 @@ def _worker_failure_payload(
     payload_fields = dict(fields) if fields is not None else {"error": detail}
     # Only deliberately curated messages are marked user-facing (haute-authored
     # wording: the gates, the metric wrap, ValueError validation messages, the
-    # recognised _classified_friendly_error shapes). An unrecognised
-    # third-party exception's text stays behind the typed
+    # _friendly_error shapes — whose fallback names only the target/objective
+    # context and exception type, never the third-party message body). Raw
+    # third-party text stays behind the typed
     # "Isolated worker raised {type}: {message}" wrapper.
     if user_facing:
         payload_fields.setdefault(WORKER_USER_MESSAGE_FIELD, detail)
@@ -734,10 +788,46 @@ def _worker_failure_payload(
     )
 
 
+def _memory_limit_user_message(
+    exc: ExecutionMemoryLimitExceededError,
+    *,
+    operation_noun: str,
+) -> str:
+    """Author the user-facing memory-limit message from structured attributes.
+
+    ``str(exc)`` names the internal operation and raw byte counts; that stays
+    in the diagnostic ``error`` field. This shape says what ran out of memory
+    and what to do about it.
+    """
+    if exc.reason == "memory_sampler_unavailable":
+        return (
+            f"{operation_noun} was stopped because the server could no longer "
+            "measure its memory use. Try again; if this keeps happening, "
+            "restart the app."
+        )
+    used = exc.rss_bytes
+    allowed = exc.limit_bytes
+    if exc.reason == "process_rss_limit_exceeded" and exc.rss_limit_bytes is not None:
+        allowed = exc.rss_limit_bytes
+    elif used is not None and exc.baseline_rss_bytes is not None:
+        used = used - exc.baseline_rss_bytes
+    detail = (
+        ""
+        if used is None
+        else f" ({_format_byte_size(used)} used, {_format_byte_size(allowed)} allowed)"
+    )
+    return (
+        f"{operation_noun} needs more memory than this server allows{detail}. "
+        "Reduce the data size or the number of features, or run on a server "
+        "with more memory, then try again."
+    )
+
+
 def _known_training_worker_failure(
     exc: Exception,
     *,
     bounded_memory_prefix: str,
+    operation_noun: str = "Training",
 ) -> WorkerFailurePayload | None:
     if isinstance(exc, ExecutionCancelledError):
         # Match the preparation path's terminal message: the internal
@@ -755,6 +845,7 @@ def _known_training_worker_failure(
         return _worker_failure_payload(
             exc,
             terminal_reason="memory_limited",
+            message=_memory_limit_user_message(exc, operation_noun=operation_noun),
             fields={
                 "error": str(exc),
                 "error_detail": payload,
@@ -873,12 +964,14 @@ def _run_training_process_job(
 ) -> WorkerResultManifest | WorkerFailurePayload:
     """Spawn entrypoint for fit, evaluation, diagnostics, and staged artifacts."""
     execution_context: ExecutionContext | None = None
+    failure_context = "the model"
     try:
         payload = _worker_request_payload(request, expected_kind="training")
         raw_kwargs = payload.get("job_kwargs")
         if not isinstance(raw_kwargs, dict):
             raise ValueError("Training worker job_kwargs must be an object")
         job_kwargs = dict(raw_kwargs)
+        failure_context = _training_context_phrase(job_kwargs)
         staged_output = runtime.staged_path("output")
         staged_output.mkdir()
         job_kwargs["output_dir"] = str(staged_output)
@@ -1019,16 +1112,17 @@ def _run_training_process_job(
         known = _known_training_worker_failure(
             exc,
             bounded_memory_prefix="Training cannot run in bounded streaming mode",
+            operation_noun="Training",
         )
         if known is not None:
             return _with_worker_failure_metrics(known, execution_context)
-        friendly, recognised = _classified_friendly_error(exc)
         return _with_worker_failure_metrics(
             _worker_failure_payload(
                 exc,
                 terminal_reason="error",
-                message=friendly,
-                user_facing=recognised,
+                message=_friendly_error(exc, context=failure_context),
+                fields={"error": str(exc) or type(exc).__name__},
+                user_facing=True,
             ),
             execution_context,
         )
@@ -1040,6 +1134,7 @@ def _run_dispersion_process_job(
 ) -> WorkerResultManifest | WorkerFailurePayload:
     """Spawn entrypoint for the bounded GLM profile-likelihood search."""
     execution_context: ExecutionContext | None = None
+    failure_context = "the model"
     try:
         payload = _worker_request_payload(request, expected_kind="dispersion")
         raw_kwargs = payload.get("job_kwargs")
@@ -1062,6 +1157,7 @@ def _run_dispersion_process_job(
             operation="dispersion_estimate",
         )
         job_kwargs = dict(raw_kwargs)
+        failure_context = _training_context_phrase(job_kwargs)
         job = TrainingJob(**job_kwargs)
         train_params = job_kwargs["params"]
 
@@ -1153,16 +1249,21 @@ def _run_dispersion_process_job(
         known = _known_training_worker_failure(
             exc,
             bounded_memory_prefix=("Dispersion estimation cannot run in bounded streaming mode"),
+            operation_noun="Dispersion estimation",
         )
         if known is not None:
             return _with_worker_failure_metrics(known, execution_context)
-        friendly, recognised = _classified_friendly_error(exc)
         return _with_worker_failure_metrics(
             _worker_failure_payload(
                 exc,
                 terminal_reason="error",
-                message=friendly,
-                user_facing=recognised,
+                message=_friendly_error(
+                    exc,
+                    operation_noun="Dispersion estimation",
+                    context=failure_context,
+                ),
+                fields={"error": str(exc) or type(exc).__name__},
+                user_facing=True,
             ),
             execution_context,
         )
@@ -1984,7 +2085,10 @@ class TrainService:
         except Exception as exc:
             logger.exception("training_preparation_failed", job_id=job_id)
             self._lifecycle.transition(
-                job_id, to="error", message=_friendly_error(exc), fields={"error": str(exc)}
+                job_id,
+                to="error",
+                message=_friendly_error(exc, context=_training_context_phrase(config)),
+                fields={"error": str(exc)},
             )
         finally:
             if not worker_owns_cleanup:

--- a/tests/test_modelling_routes.py
+++ b/tests/test_modelling_routes.py
@@ -982,11 +982,14 @@ class TestFriendlyError:
         exc = ValueError("Target column 'z' not found")
         assert _friendly_error(exc) == "Target column 'z' not found"
 
-    def test_file_not_found(self):
-        exc = FileNotFoundError("/data/missing.parquet")
+    def test_file_not_found_does_not_quote_the_path(self):
+        """A fit-stage missing file is typically an internal staged asset —
+        the path stays diagnostic, never in the terminal message."""
+        exc = FileNotFoundError(2, "No such file or directory", "/data/missing.parquet")
         result = _friendly_error(exc)
-        assert result.startswith("File not found:")
-        assert "missing.parquet" in result
+        assert "could not find a file it needs" in result
+        assert "missing.parquet" not in result
+        assert "/data" not in result
 
     def test_catboost_nan(self):
         """CatBoost NaN/Inf errors should recommend upstream transforms."""
@@ -1000,32 +1003,57 @@ class TestFriendlyError:
         exc = type("CatBoostError", (Exception,), {})("feature number mismatch: expected 10 got 8")
         result = _friendly_error(exc)
         assert "feature mismatch" in result.lower()
+        # The third-party body is never interpolated.
+        assert "expected 10" not in result
 
     def test_catboost_generic(self):
-        exc = type("CatBoostError", (Exception,), {})("internal pool error")
+        """The generic CatBoost shape names the type, never the body."""
+        exc = type("CatBoostError", (Exception,), {})("internal pool error at /tmp/pool")
         result = _friendly_error(exc)
-        assert result.startswith("CatBoost could not train the model:")
-        assert "internal pool error" in result
+        assert "CatBoostError" in result
+        assert "internal pool error" not in result
+        assert "/tmp" not in result
 
     def test_catboost_generic_names_training_context(self):
         exc = type("CatBoostError", (Exception,), {})("internal pool error")
         result = _friendly_error(exc, context="target 'sev' (objective 'RMSE')")
         assert "target 'sev' (objective 'RMSE')" in result
-        assert "internal pool error" in result
+        assert "internal pool error" not in result
+
+    def test_catboost_in_message_only_is_not_classified_catboost(self):
+        """Classification keys on the exception TYPE — a non-CatBoost error
+        that merely mentions catboost in its text takes the generic fallback
+        and never embeds its body."""
+        exc = RuntimeError("catboost cache failed at /var/lib/haute/token=abc")
+        result = _friendly_error(exc)
+        assert "RuntimeError" in result
+        assert "CatBoost error" not in result
+        assert "/var/lib" not in result
+        assert "token" not in result
 
     def test_os_error(self):
-        """The OS-level reason is surfaced; the staging path is not."""
+        """The errno-derived OS reason is surfaced; the staging path is not."""
         exc = OSError(13, "Permission denied", "/models/model.cbm")
         result = _friendly_error(exc)
         assert result.startswith("Training could not save its output files")
         assert "Permission denied" in result
         assert "/models" not in result
 
-    def test_os_error_without_strerror_names_the_type(self):
+    def test_os_error_strerror_is_rederived_from_errno(self):
+        """OSError.strerror is constructor-supplied — a dependency can put
+        arbitrary text there. The reason comes from os.strerror(errno)."""
+        exc = OSError(5, "failed opening /tmp/secret credential=xyz")
+        result = _friendly_error(exc)
+        assert "/tmp/secret" not in result
+        assert "credential" not in result
+        assert "Input/output error" in result
+
+    def test_os_error_without_errno_uses_generic_reason(self):
         exc = OSError("raw single-argument message")
         result = _friendly_error(exc)
-        assert "OSError" in result
+        assert "file-system error" in result
         assert "raw single-argument message" not in result
+        assert "OSError" not in result
 
     def test_fallback_includes_type_but_not_third_party_text(self):
         exc = RuntimeError("something unexpected")
@@ -1056,13 +1084,15 @@ class TestFriendlyError:
         result = _friendly_error(exc)
         assert ".fill_null()" in result or ".drop_nulls()" in result
 
-    def test_catboost_feature_mismatch_includes_original_message(self):
+    def test_catboost_feature_mismatch_excludes_original_message(self):
+        """Flipped from the pre-curation pin: the CatBoost body is never
+        interpolated, even in the feature-mismatch shape."""
         exc = type("CatBoostError", (Exception,), {})(
             "feature number mismatch: expected 5 but got 3"
         )
         result = _friendly_error(exc)
         assert "feature mismatch" in result.lower()
-        assert "expected 5 but got 3" in result
+        assert "expected 5 but got 3" not in result
 
 
 class TestClampRowLimit:
@@ -1521,6 +1551,9 @@ class TestBackgroundThreadErrors:
             launched[0].join_and_raise(timeout=10)
             status = client.get(f"/api/modelling/train/status/{data['job_id']}").json()
             assert status["status"] == "error"
+            # The curated fallback is promoted verbatim: the entrypoint must
+            # stamp user_message, or the wrapper prefix would appear here.
+            assert status["message"].startswith("Training of ")
             assert "RuntimeError" in status["message"]
             assert "CUDA out of memory" not in status["message"]
             # The raw third-party text stays in the server-side job record
@@ -1549,6 +1582,7 @@ class TestBackgroundThreadErrors:
             launched[0].join_and_raise(timeout=10)
             status = client.get(f"/api/modelling/train/status/{data['job_id']}").json()
             assert status["status"] == "error"
+            assert status["message"].startswith("Training of ")
             assert "RuntimeError" in status["message"]
             assert "target" in status["message"]
             assert "unexpected crash" not in status["message"]
@@ -2340,6 +2374,31 @@ class TestDispersionErrorPaths:
         )
         assert thread is not None
         return job_id, tmp_parquet, thread
+
+    def test_worker_fallback_stamps_curated_message(self, tmp_path: Path):
+        """Entrypoint-level stamp pin: an unexpected in-worker exception must
+        surface the curated dispersion fallback verbatim (no wrapper prefix,
+        no third-party body) — removing the entrypoint's user_message stamp
+        turns the terminal message into the typed wrapper and fails here."""
+        store, service = self._service()
+
+        class ExplodingJob:
+            def __init__(self, **_kwargs):
+                pass
+
+            def _prepare_data(self, *_args, **_kwargs):
+                raise RuntimeError("librs panic at /opt/rustystats/cache")
+
+        with patch("haute.modelling.TrainingJob", ExplodingJob):
+            job_id, _tmp_parquet, thread = self._launch(service, store, tmp_path)
+            thread.join_and_raise(timeout=10)
+
+        job = store.require_job(job_id)
+        assert job["status"] == "error"
+        assert job["message"].startswith("Dispersion estimation of ")
+        assert "RuntimeError" in job["message"]
+        assert "librs panic" not in job["message"]
+        assert "/opt/rustystats" not in job["message"]
 
     def test_start_maps_execute_http_error_to_contract_error(self, nb_training_data):
         from haute.schemas import DispersionEstimateRequest

--- a/tests/test_modelling_routes.py
+++ b/tests/test_modelling_routes.py
@@ -1004,20 +1004,40 @@ class TestFriendlyError:
     def test_catboost_generic(self):
         exc = type("CatBoostError", (Exception,), {})("internal pool error")
         result = _friendly_error(exc)
-        assert result.startswith("CatBoost error:")
+        assert result.startswith("CatBoost could not train the model:")
+        assert "internal pool error" in result
+
+    def test_catboost_generic_names_training_context(self):
+        exc = type("CatBoostError", (Exception,), {})("internal pool error")
+        result = _friendly_error(exc, context="target 'sev' (objective 'RMSE')")
+        assert "target 'sev' (objective 'RMSE')" in result
         assert "internal pool error" in result
 
     def test_os_error(self):
-        exc = OSError("Permission denied: /models/model.cbm")
+        """The OS-level reason is surfaced; the staging path is not."""
+        exc = OSError(13, "Permission denied", "/models/model.cbm")
         result = _friendly_error(exc)
-        assert result.startswith("Could not save model file:")
+        assert result.startswith("Training could not save its output files")
         assert "Permission denied" in result
+        assert "/models" not in result
 
-    def test_fallback_includes_type(self):
+    def test_os_error_without_strerror_names_the_type(self):
+        exc = OSError("raw single-argument message")
+        result = _friendly_error(exc)
+        assert "OSError" in result
+        assert "raw single-argument message" not in result
+
+    def test_fallback_includes_type_but_not_third_party_text(self):
         exc = RuntimeError("something unexpected")
         result = _friendly_error(exc)
         assert "RuntimeError" in result
-        assert "something unexpected" in result
+        assert "something unexpected" not in result
+        assert "error details" in result
+
+    def test_fallback_names_training_context(self):
+        exc = RuntimeError("boom")
+        result = _friendly_error(exc, context="target 'freq' (objective 'Poisson')")
+        assert result.startswith("Training of target 'freq' (objective 'Poisson') failed")
 
     def test_catboost_inf_message(self):
         """'inf' in message also triggers NaN/Inf advice."""

--- a/tests/test_modelling_routes.py
+++ b/tests/test_modelling_routes.py
@@ -1499,7 +1499,11 @@ class TestBackgroundThreadErrors:
             assert "Invalid target column" in status["message"]
 
     def test_background_runtime_error(self, client, training_data, monkeypatch):
-        """RuntimeError in TrainingJob.run() is translated via _friendly_error."""
+        """RuntimeError in TrainingJob.run() surfaces the curated fallback.
+
+        The terminal message names the exception type and training context but
+        never the third-party message body; the raw text stays diagnostic.
+        """
         graph = _make_modelling_graph(training_data)
 
         class FailingJob:
@@ -1517,10 +1521,17 @@ class TestBackgroundThreadErrors:
             launched[0].join_and_raise(timeout=10)
             status = client.get(f"/api/modelling/train/status/{data['job_id']}").json()
             assert status["status"] == "error"
-            assert "CUDA out of memory" in status["message"]
+            assert "RuntimeError" in status["message"]
+            assert "CUDA out of memory" not in status["message"]
+            # The raw third-party text stays in the server-side job record
+            # (the public status response whitelist never exposed it).
+            from haute.routes.modelling import _store
+
+            job = _store.require_job(data["job_id"])
+            assert "CUDA out of memory" in job["worker_remote_traceback"]
 
     def test_background_generic_exception(self, client, training_data, monkeypatch):
-        """Generic exception in TrainingJob.run() includes exception type."""
+        """The curated fallback names the exception type and the fit's target."""
         graph = _make_modelling_graph(training_data)
 
         class FailingJob:
@@ -1538,7 +1549,13 @@ class TestBackgroundThreadErrors:
             launched[0].join_and_raise(timeout=10)
             status = client.get(f"/api/modelling/train/status/{data['job_id']}").json()
             assert status["status"] == "error"
-            assert "unexpected crash" in status["message"]
+            assert "RuntimeError" in status["message"]
+            assert "target" in status["message"]
+            assert "unexpected crash" not in status["message"]
+            from haute.routes.modelling import _store
+
+            job = _store.require_job(data["job_id"])
+            assert "unexpected crash" in job["worker_remote_traceback"]
 
     def test_ram_warning_propagated(self, client, training_data, monkeypatch):
         """RAM warning from estimate should appear in job status."""

--- a/tests/test_target_task_gate.py
+++ b/tests/test_target_task_gate.py
@@ -760,34 +760,61 @@ class TestWorkerBoundaryUserMessage:
         assert payload.fields["error_code"] == "memory_limit"
         assert WORKER_USER_MESSAGE_FIELD not in payload.fields
 
-    def test_unrecognised_exception_shapes_are_not_vouched(self) -> None:
-        """The generic fallback embeds arbitrary third-party text — it keeps
-        the typed wrapper surface instead of being promoted as curated."""
-        from haute.routes._train_service import _classified_friendly_error
+    def test_unexpected_exception_fallback_is_curated_without_third_party_text(self) -> None:
+        """The fallback names the fit context and exception type only — the
+        arbitrary third-party message body (which may carry internal paths)
+        stays in the diagnostic ``error`` field, and the failure remains a
+        plain system ``error``, never a ``contract_error``."""
+        from haute.routes._train_service import _friendly_error
 
-        message, recognised = _classified_friendly_error(
-            RuntimeError("failed to lock /var/lib/haute/internal/state.db")
-        )
-        assert message.startswith("Training failed (RuntimeError):")
-        assert recognised is False
+        exc = RuntimeError("failed to lock /var/lib/haute/internal/state.db")
+        message = _friendly_error(exc, context="target 'sev' (objective 'Tweedie')")
+        assert "RuntimeError" in message
+        assert "target 'sev' (objective 'Tweedie')" in message
+        assert "/var/lib" not in message
         payload = _worker_failure_payload(
-            RuntimeError("failed to lock /var/lib/haute/internal/state.db"),
+            exc,
             terminal_reason="error",
             message=message,
-            user_facing=recognised,
+            fields={"error": str(exc)},
+            user_facing=True,
         )
-        assert WORKER_USER_MESSAGE_FIELD not in payload.fields
+        assert payload.terminal_reason == "error"
+        assert payload.fields[WORKER_USER_MESSAGE_FIELD] == message
+        assert payload.fields["error"] == "failed to lock /var/lib/haute/internal/state.db"
 
-    def test_recognised_friendly_shapes_are_vouched(self) -> None:
-        from haute.routes._train_service import _classified_friendly_error
+    def test_model_save_os_error_names_the_reason_not_the_staging_path(self) -> None:
+        from haute.routes._train_service import _friendly_error
 
-        for exc in (
-            FileNotFoundError("data/train.parquet"),
-            ValueError("GLM terms reference columns not present"),
-            OSError("disk full"),
-        ):
-            _message, recognised = _classified_friendly_error(exc)
-            assert recognised is True, type(exc).__name__
+        exc = OSError(28, "No space left on device", "/tmp/.haute-training-j1/output/model.cbm")
+        message = _friendly_error(exc)
+        assert "No space left on device" in message
+        assert "/tmp" not in message
+        assert "model.cbm" not in message
+
+    def test_memory_limit_failure_names_budget_and_call_to_action(self) -> None:
+        from haute._execution_context import ExecutionMemoryLimitExceededError
+        from haute.routes._train_service import _known_training_worker_failure
+
+        exc = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=3 * 1024**3,
+            limit_bytes=2 * 1024**3,
+            job_id="abc",
+        )
+        payload = _known_training_worker_failure(
+            exc,
+            bounded_memory_prefix="Training cannot run in bounded streaming mode",
+            operation_noun="Training",
+        )
+        assert payload is not None
+        assert payload.terminal_reason == "memory_limited"
+        assert payload.fields[WORKER_USER_MESSAGE_FIELD] == payload.message
+        assert "3.0 GiB used, 2.0 GiB allowed" in payload.message
+        assert "try again" in payload.message
+        assert "training_job" not in payload.message
+        # The internal wording stays available for diagnostics.
+        assert "training_job" in payload.fields["error"]
 
     def test_overlong_curated_message_truncates_instead_of_raising(self) -> None:
         """A wrapped message beyond the 512-char worker bound must truncate at
@@ -890,7 +917,7 @@ class TestWorkerBoundaryUserMessage:
         [
             (
                 lambda: IsolatedWorkerCrashedError(exitcode=-9, memory_limit_bytes=None),
-                "exited without a result payload",
+                "stopped unexpectedly before returning a result",
                 "error",
             ),
             (

--- a/tests/test_target_task_gate.py
+++ b/tests/test_target_task_gate.py
@@ -816,6 +816,84 @@ class TestWorkerBoundaryUserMessage:
         # The internal wording stays available for diagnostics.
         assert "training_job" in payload.fields["error"]
 
+    def test_memory_limit_message_branches_never_crash_the_failure_path(self) -> None:
+        """Every authored branch of the memory-limit message: sampler loss,
+        process-cap override, baseline subtraction (with negative clamp), and
+        size omission when a bound is missing — a partially-populated
+        exception must degrade to omitting sizes, never TypeError."""
+        from haute._execution_context import ExecutionMemoryLimitExceededError
+        from haute.routes._train_service import _memory_limit_user_message
+
+        sampler_lost = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=None,
+            limit_bytes=1024**3,
+            reason="memory_sampler_unavailable",
+        )
+        message = _memory_limit_user_message(sampler_lost, operation_noun="Training")
+        assert "could no longer measure its memory use" in message
+
+        process_cap = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=4 * 1024**3,
+            limit_bytes=1024**3,
+            baseline_rss_bytes=1024**3,
+            rss_limit_bytes=3 * 1024**3,
+            reason="process_rss_limit_exceeded",
+        )
+        message = _memory_limit_user_message(process_cap, operation_noun="Training")
+        assert "4.0 GiB used, 3.0 GiB allowed" in message
+
+        growth = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=3 * 1024**3,
+            limit_bytes=1024**3,
+            baseline_rss_bytes=2 * 1024**3 + 512 * 1024**2,
+        )
+        message = _memory_limit_user_message(growth, operation_noun="Training")
+        assert "512.0 MiB used, 1.0 GiB allowed" in message
+
+        below_baseline = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=1024**3,
+            limit_bytes=1024**3,
+            baseline_rss_bytes=2 * 1024**3,
+        )
+        message = _memory_limit_user_message(below_baseline, operation_noun="Training")
+        assert "(0 bytes used" in message
+
+        no_limit = ExecutionMemoryLimitExceededError(
+            "training_job",
+            rss_bytes=1024**3,
+            limit_bytes=None,  # type: ignore[arg-type]
+        )
+        message = _memory_limit_user_message(no_limit, operation_noun="Training")
+        assert "used" not in message
+        assert "needs more memory than this server allows." in message
+
+    def test_507_detail_message_is_curated_even_when_payload_carries_one(self) -> None:
+        """The curated wording is assigned unconditionally — a payload-carried
+        message (now or via a future to_payload change) cannot expose
+        str(exc)."""
+        from haute._execution_context import ExecutionMemoryLimitExceededError
+        from haute.routes._train_service import _memory_limit_http_exception
+
+        class PayloadMessageError(ExecutionMemoryLimitExceededError):
+            def to_payload(self) -> dict[str, object]:
+                payload = super().to_payload()
+                payload["message"] = str(self)
+                return payload
+
+        exc = PayloadMessageError(
+            "training_job",
+            rss_bytes=3 * 1024**3,
+            limit_bytes=2 * 1024**3,
+        )
+        http_exc = _memory_limit_http_exception(exc)
+        assert isinstance(http_exc.detail, dict)
+        assert "training_job" not in http_exc.detail["message"]
+        assert "needs more memory than this server allows" in http_exc.detail["message"]
+
     def test_overlong_curated_message_truncates_instead_of_raising(self) -> None:
         """A wrapped message beyond the 512-char worker bound must truncate at
         the payload builder, never detonate into a protocol-length error."""
@@ -919,6 +997,13 @@ class TestWorkerBoundaryUserMessage:
                 lambda: IsolatedWorkerCrashedError(exitcode=-9, memory_limit_bytes=None),
                 "stopped unexpectedly before returning a result",
                 "error",
+            ),
+            (
+                # SIGKILL under a configured cap: the OOM wording is hedged —
+                # the exit-code heuristic is indicative, not proof.
+                lambda: IsolatedWorkerCrashedError(exitcode=-9, memory_limit_bytes=100),
+                "may have run out of memory",
+                "memory_limited",
             ),
             (
                 lambda: IsolatedWorkerTimeoutError(timeout_seconds=30.0),


### PR DESCRIPTION
Follow-up to #159's worker-boundary error contract: curates the four sibling surfaces its review left uncurated, following the user_message routing-key contract (child wording surfaced verbatim; wrapper text only for crash/timeout).

1. Fit-stage friendly-error fallbacks now name the training context (target + objective). The unexpected-error fallback is a haute-authored system-error shape naming the exception type but never the third-party message body (which may carry internal paths); it stays terminal_reason="error" — a system fault is never relabelled contract_error. Raw text stays in the diagnostic error field and traceback.
2. Child-crash surface: IsolatedWorkerCrashedError's parent-authored message is now user-facing — out-of-memory phrasing when the exit code looks memory-limited, unexpected-stop phrasing otherwise, exit code included.
3. Model-save OSError no longer surfaces internal temp/staging parquet paths: the message names only the OS-level reason (exc.strerror); the path stays diagnostic.
4. Memory-limit surface is authored from the exception's structured attributes: human-readable used/allowed sizes plus a call to action, no internal operation name; also used for the 507 preparation-path detail message.

Specs updated alongside (modelling low/high, background-jobs high, execution-engine low). The stamping-matrix tests flip deliberately with each curated branch.

Verification: backend gate pre-rebase (two message-pin failures fixed; remaining failures reproduced the known load-flake class and pass in isolation); post-rebase targeted suites green (gate suite, worker isolation/protocol, docs-accuracy, friendly-error and background-thread repins); mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
