### PR TITLE
Consolidate git-store test resets into a drift-proof resetForTests

### DIFF
--- a/frontend/src/components/__tests__/RemotePushControl.gaps.test.tsx
+++ b/frontend/src/components/__tests__/RemotePushControl.gaps.test.tsx
@@ -150,7 +150,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
     )
     mockBranchAway.mockRejectedValue(new Error("worktree dirty"))
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() =>
       expect(screen.getByTestId("git-push-rejected-branch-away")).toBeInTheDocument(),
@@ -178,7 +180,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
     )
     mockBranchAway.mockRejectedValue({ code: "EBUSY" })
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() =>
       expect(screen.getByTestId("git-push-rejected-branch-away")).toBeInTheDocument(),
@@ -201,7 +205,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
       new ApiError("HTTP 409 conflict", 409, JSON.stringify(garbage), garbage),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() =>
       expect(mockAddToast).toHaveBeenCalledWith("error", "Push failed: HTTP 409 conflict"),
@@ -217,7 +223,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
       new ApiError("HTTP 409 conflict", 409, JSON.stringify(malformed), malformed),
     )
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
 
     await waitFor(() =>
@@ -233,7 +241,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
     mockGetGitRemotes.mockResolvedValue({ remotes: [remote()], working_branch: "dev" })
     mockGitPush.mockRejectedValue(new ApiError("HTTP 409 conflict", 409, "no body"))
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
     await waitFor(() =>
       expect(mockAddToast).toHaveBeenCalledWith("error", "Push failed: no body"),
@@ -259,7 +269,9 @@ describe("RemotePushControl — error paths and catch-up matrix", () => {
     )
 
     render(<RemotePushControl pendingSaveCount={0} />)
-    await waitFor(() => expect(screen.getByTestId("git-push-control")).toBeInTheDocument())
+    // Enabled implies the remotes have loaded AND the sole remote is selected;
+    // clicking in that window would no-op on a disabled button.
+    await waitFor(() => expect(screen.getByTestId("git-push-button")).toBeEnabled())
     fireEvent.click(screen.getByTestId("git-push-button"))
 
     await waitFor(() => expect(screen.getByTestId("git-push-rejected")).toBeInTheDocument())

--- a/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.cache.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
+import useGitStore, { resetGitStoreForTests } from "../../stores/useGitStore"
 import type { GitWorkingBranchResponse } from "../../api/types"
 
 // Perf behaviours of the Version Control panel:
@@ -124,14 +124,14 @@ const waitForRefreshSettled = async () => {
 describe("GitPanel session cache + unchanged-payload short-circuit", () => {
   const defaultProps = { onClose: vi.fn() }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     clearGitPanelCaches()
-    // (e)/(e2) hold getWorkingBranch open forever; without this the stuck
-    // single-flight starves loadStatus() in every test shuffled after them.
-    resetGitStatusRequestForTests()
+    // (e)/(e2) hold getWorkingBranch open forever; without the single-flight
+    // clears inside this reset the stuck request starves loadStatus() in
+    // every test shuffled after them.
+    await resetGitStoreForTests()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockSetWorkingBranch.mockResolvedValue({})
     // Fresh, deep-equal object per call: proves the short-circuit works on
@@ -144,9 +144,9 @@ describe("GitPanel session cache + unchanged-payload short-circuit", () => {
     mockGetGitGraph.mockImplementation(() => Promise.resolve(structuredClone(graphTwoBranch)))
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
-    resetGitStatusRequestForTests()
+    await resetGitStoreForTests()
   })
 
   it("(a) a byte-identical refresh applies no state: rail layout untouched, row nodes stable", async () => {

--- a/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.gaps.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
+import useGitStore, { resetGitStoreForTests } from "../../stores/useGitStore"
 
 // Mirror of GitPanel.test.tsx's client mock — the panel reads working-branch
 // status from useGitStore and fetches milestone/ledger history directly.
@@ -57,13 +57,12 @@ const milestones = {
 describe("GitPanel — uncovered fork/view/peek paths", () => {
   const defaultProps = { onClose: vi.fn() }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     // The panel's session caches are module-level (they survive remounts by
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
-    resetGitStatusRequestForTests()
-    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    await resetGitStoreForTests()
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestones.mockResolvedValue(milestones)
     mockGetPendingSaves.mockResolvedValue({ saves: [] })
@@ -72,9 +71,9 @@ describe("GitPanel — uncovered fork/view/peek paths", () => {
     mockGetWorkingBranches.mockResolvedValue({ current: "pricing-dev", branches: [] })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
-    resetGitStatusRequestForTests()
+    await resetGitStoreForTests()
   })
 
   it("reloads the page after a fork that switches the working branch", async () => {

--- a/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.staleRefresh.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches, readBranchHistory } from "../gitPanelCache"
-import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
+import useGitStore, { resetGitStoreForTests } from "../../stores/useGitStore"
 
 // Regression pin for the refresh() generation guard: a refresh captured for
 // the PREVIOUS branch (its fetches still in flight when a peek retargets the
@@ -78,21 +78,20 @@ const spurMilestones = {
 const emptyGraph = { working_branch: null, order: [], branches: [] }
 
 describe("GitPanel stale refresh (generation guard)", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    resetGitStatusRequestForTests()
-    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    await resetGitStoreForTests()
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
     mockGetMilestoneSaves.mockResolvedValue({ saves: [] })
     mockGetWorkingBranches.mockResolvedValue({ current: "pricing-dev", branches: [] })
     mockGetGitGraph.mockResolvedValue(emptyGraph)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
-    resetGitStatusRequestForTests()
+    await resetGitStoreForTests()
   })
 
   it("peeking triggers one refresh without replaying active nonce effects", async () => {

--- a/frontend/src/panels/__tests__/GitPanel.test.tsx
+++ b/frontend/src/panels/__tests__/GitPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
 import GitPanel from "../GitPanel"
 import { clearGitPanelCaches } from "../gitPanelCache"
-import useGitStore, { resetGitStatusRequestForTests } from "../../stores/useGitStore"
+import useGitStore, { resetGitStoreForTests } from "../../stores/useGitStore"
 import useGraphStore from "../../stores/useGraphStore"
 import useToastStore from "../../stores/useToastStore"
 
@@ -118,14 +118,13 @@ const graphSaveFork = {
 describe("GitPanel", () => {
   const defaultProps = { onClose: vi.fn() }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     // The panel's session caches are module-level (they survive remounts by
     // design) — reset them so tests stay independent.
     clearGitPanelCaches()
     globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
-    resetGitStatusRequestForTests()
-    useGitStore.setState({ status: null, loading: false, statusError: null, branches: [], branchesLoaded: false, branchesLoading: false, branchesError: null, modal: null, pendingAction: null, peekBranch: null, historyNonce: 0, commitNonce: 0, branchesExpandNonce: 0, moveTarget: null, comparison: null })
+    await resetGitStoreForTests()
     // Switches record undoable VC entries on the graph store's history stacks.
     useGraphStore.setState({ dirty: false, undoStack: [], redoStack: [], vcBusy: false })
     mockGetWorkingBranch.mockResolvedValue(readyStatus)
@@ -138,9 +137,9 @@ describe("GitPanel", () => {
     mockGetGitGraph.mockResolvedValue(emptyGraph)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
-    resetGitStatusRequestForTests()
+    await resetGitStoreForTests()
   })
 
   it("renders the panel", async () => {

--- a/frontend/src/stores/__tests__/useGitStore.test.ts
+++ b/frontend/src/stores/__tests__/useGitStore.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../api/client", () => ({
   retryGitStorageSync: vi.fn(),
 }))
 
-import useGitStore, { resetGitStatusRequestForTests } from "../useGitStore"
+import useGitStore, { resetGitStatusRequestForTests, resetGitStoreForTests } from "../useGitStore"
 import { resetGitBranchLoaderForTests } from "../gitBranchLoader"
 import { DEFAULT_STALE_PENDING_AFTER_MS } from "../singleFlight"
 import {
@@ -38,21 +38,32 @@ const READY: GitWorkingBranchResponse = {
   user_email: "u@x.y",
 }
 
+// The store singleton is pristine at import time; resetForTests must restore
+// exactly this snapshot, however the store's shape grows.
+const PRISTINE = { ...useGitStore.getState() }
+
 describe("useGitStore", () => {
-  beforeEach(() => {
-    useGitStore.setState({
-      status: null, loading: false, statusError: null, branches: [], branchesLoaded: false,
-      branchesLoading: false, branchesError: null, modal: null, pendingAction: null,
-    })
+  beforeEach(async () => {
+    await resetGitStoreForTests()
     vi.clearAllMocks()
-    resetGitStatusRequestForTests()
   })
-  afterEach(() => {
-    resetGitStatusRequestForTests()
+  afterEach(async () => {
+    await resetGitStoreForTests()
+  })
+
+  it("resetForTests restores every data field to its initial value", () => {
     useGitStore.setState({
-      status: null, loading: false, statusError: null, branches: [], branchesLoaded: false,
-      branchesLoading: false, branchesError: null, modal: null, pendingAction: null,
+      status: READY, loading: true, statusError: "boom", branchesLoaded: true,
+      branchesLoading: true, branchesError: "boom", modal: "select", pendingAction: "save",
+      peekBranch: "pricing/nick/spur", branchesExpandNonce: 3, historyNonce: 4, commitNonce: 5,
+      comparison: { sha: "a", label: "A" }, moveTarget: { sha: "b", label: "B" },
+      branches: [{
+        name: "dev", is_current: true, is_archived: false, has_unmerged_saves: false,
+        has_uncommitted_changes: false,
+      }],
     })
+    useGitStore.getState().resetForTests()
+    expect(useGitStore.getState()).toEqual(PRISTINE)
   })
 
   it("loadStatus stores the result and returns it", async () => {
@@ -470,9 +481,8 @@ describe("useGitStore durable-storage actions", () => {
     sync: { state: "synced", pending: 0, failure: null, message: null },
   }
 
-  beforeEach(() => {
-    resetGitStatusRequestForTests()
-    useGitStore.setState({ status: null, loading: false, statusError: null })
+  beforeEach(async () => {
+    await resetGitStoreForTests()
     vi.clearAllMocks()
   })
 
@@ -560,9 +570,8 @@ describe("useGitStore reopens the storage dialog when a background bind fails", 
     },
   })
 
-  beforeEach(() => {
-    resetGitStatusRequestForTests()
-    useGitStore.setState({ status: null, modal: null, loading: false, statusError: null })
+  beforeEach(async () => {
+    await resetGitStoreForTests()
     vi.clearAllMocks()
   })
 

--- a/frontend/src/stores/__tests__/useGitStore.test.ts
+++ b/frontend/src/stores/__tests__/useGitStore.test.ts
@@ -39,8 +39,15 @@ const READY: GitWorkingBranchResponse = {
 }
 
 // The store singleton is pristine at import time; resetForTests must restore
-// exactly this snapshot, however the store's shape grows.
-const PRISTINE = { ...useGitStore.getState() }
+// exactly this snapshot, however the store's shape grows. Data fields only,
+// deep-cloned: a shallow spread would share the pristine `branches` reference
+// with the store, so an in-place corruption would move both sides of the
+// comparison identically and the pin would be blind to it.
+const PRISTINE = structuredClone(
+  Object.fromEntries(
+    Object.entries(useGitStore.getState()).filter(([, v]) => typeof v !== "function"),
+  ),
+)
 
 describe("useGitStore", () => {
   beforeEach(async () => {
@@ -63,7 +70,37 @@ describe("useGitStore", () => {
       }],
     })
     useGitStore.getState().resetForTests()
-    expect(useGitStore.getState()).toEqual(PRISTINE)
+    expect(useGitStore.getState()).toMatchObject(PRISTINE)
+
+    // In-place corruption of the published array must not survive a reset:
+    // the baseline hands out a fresh array per reset, never a shared one.
+    useGitStore.getState().branches.push({
+      name: "corrupt", is_current: false, is_archived: false, has_unmerged_saves: false,
+      has_uncommitted_changes: false,
+    })
+    useGitStore.getState().resetForTests()
+    expect(useGitStore.getState().branches).toEqual([])
+  })
+
+  it("resetGitStoreForTests unsticks both held-open single-flights (status and branch loader)", async () => {
+    // Stick both: never-settling fetches occupy each single-flight slot.
+    vi.mocked(getWorkingBranch).mockReturnValueOnce(new Promise(() => {}))
+    vi.mocked(getWorkingBranches).mockReturnValueOnce(new Promise(() => {}))
+    void useGitStore.getState().loadStatus()
+    void useGitStore.getState().loadBranches()
+    await vi.waitFor(() => expect(getWorkingBranches).toHaveBeenCalledOnce())
+    expect(getWorkingBranch).toHaveBeenCalledOnce()
+
+    // A refactor that drops either clear from the family reset would otherwise
+    // pass every test and resurface only as a nightly shuffle starvation.
+    await resetGitStoreForTests()
+
+    vi.mocked(getWorkingBranch).mockResolvedValueOnce(READY)
+    vi.mocked(getWorkingBranches).mockResolvedValueOnce({ current: "dev", branches: [] })
+    await expect(useGitStore.getState().loadStatus()).resolves.toEqual(READY)
+    await expect(useGitStore.getState().loadBranches()).resolves.toEqual([])
+    expect(getWorkingBranch).toHaveBeenCalledTimes(2)
+    expect(getWorkingBranches).toHaveBeenCalledTimes(2)
   })
 
   it("loadStatus stores the result and returns it", async () => {

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -148,6 +148,19 @@ interface GitActions {
 
 type GitState = GitData & GitActions
 
+/** Compile-time guard closing the one filing mistake the split can't stop
+ *  structurally: a DATA field mis-declared in GitActions would type-check,
+ *  yet never join the reset. Resolves to a key union that must be never —
+ *  adding a non-function member to GitActions turns this into a type error. */
+type NonFunctionGitActionKeys = {
+  [K in keyof GitActions]: GitActions[K] extends (...args: never[]) => unknown ? never : K
+}[keyof GitActions]
+type StaticAssert<T extends true> = T
+/** Exported only so noUnusedLocals keeps the assertion alive; never import it. */
+export type GitActionsHoldOnlyFunctions = StaticAssert<
+  [NonFunctionGitActionKeys] extends [never] ? true : false
+>
+
 /** Initial value for every data field. `resetForTests` restores exactly this
  *  shape, so the reset can never drift behind the store's. A factory, not a
  *  shared const: `branches` must be a FRESH array per reset — with a shared

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -53,7 +53,10 @@ export interface GitComparison {
  *  modal. */
 export type GitPendingAction = "save" | "commit" | null
 
-interface GitState {
+/** The store's data half. Every field added here MUST get an initial value in
+ *  `initialGitData` below (TypeScript enforces it), and `resetForTests` spreads
+ *  that object — so a new field cannot silently leak between shuffled tests. */
+interface GitData {
   /** Latest readiness signal, or null before the first load. */
   status: GitWorkingBranchResponse | null
   /** True while a status fetch is in flight (suppresses premature modal logic). */
@@ -90,7 +93,9 @@ interface GitState {
    *  pending. Distinct from `comparison` (read-only view) — a move mutates the
    *  working tree. */
   moveTarget: GitComparison | null
+}
 
+interface GitActions {
   /** Load readiness. `refresh: true` guarantees the published state comes from
    *  a request issued no earlier than the call — required after a mutation,
    *  where joining an already-in-flight request would publish pre-mutation
@@ -133,9 +138,15 @@ interface GitState {
   pullUpstream: () => Promise<GitFastForwardResponse>
   /** Retry a failed sync to the bound remote, refreshing readiness afterwards. */
   retrySync: () => Promise<GitWorkingBranchResponse | null>
+  /** Restore every `GitData` field to its initial value (test isolation only). */
+  resetForTests: () => void
 }
 
-const useGitStore = create<GitState>()((set, get) => ({
+type GitState = GitData & GitActions
+
+/** Initial value for every data field. `resetForTests` restores exactly this
+ *  object, so the reset can never drift behind the store's shape. */
+const initialGitData: GitData = {
   status: null,
   loading: false,
   statusError: null,
@@ -151,6 +162,10 @@ const useGitStore = create<GitState>()((set, get) => ({
   commitNonce: 0,
   comparison: null,
   moveTarget: null,
+}
+
+const useGitStore = create<GitState>()((set, get) => ({
+  ...initialGitData,
 
   loadStatus: (options) =>
     // Single-flight/queue/reset/stall bookkeeping lives in ./singleFlight;
@@ -257,6 +272,20 @@ const useGitStore = create<GitState>()((set, get) => ({
     set({ status })
     return status
   },
+
+  resetForTests: () => set(initialGitData),
 }))
+
+/** One-call reset of the whole git-store family between tests: the data state
+ *  plus both module-level single-flights (the status request above and the
+ *  branch loader's). Async because the loader import must stay dynamic, like
+ *  `loadBranches`' — a static import would fold the split chunk back into the
+ *  main bundle. */
+export const resetGitStoreForTests = async (): Promise<void> => {
+  resetGitStatusRequestForTests()
+  const { resetGitBranchLoaderForTests } = await import("./gitBranchLoader")
+  resetGitBranchLoaderForTests()
+  useGitStore.getState().resetForTests()
+}
 
 export default useGitStore

--- a/frontend/src/stores/useGitStore.ts
+++ b/frontend/src/stores/useGitStore.ts
@@ -54,8 +54,12 @@ export interface GitComparison {
 export type GitPendingAction = "save" | "commit" | null
 
 /** The store's data half. Every field added here MUST get an initial value in
- *  `initialGitData` below (TypeScript enforces it), and `resetForTests` spreads
- *  that object — so a new field cannot silently leak between shuffled tests. */
+ *  `freshGitData` below (TypeScript enforces it for required members), and
+ *  `resetForTests` spreads that object — so a new field here cannot silently
+ *  leak between shuffled tests. Two conventions keep that guarantee honest:
+ *  keep every field REQUIRED (zustand's merge-mode set() never clears absent
+ *  keys, so an optional field would dodge both the compiler and the reset),
+ *  and file data here, never in GitActions. */
 interface GitData {
   /** Latest readiness signal, or null before the first load. */
   status: GitWorkingBranchResponse | null
@@ -145,8 +149,11 @@ interface GitActions {
 type GitState = GitData & GitActions
 
 /** Initial value for every data field. `resetForTests` restores exactly this
- *  object, so the reset can never drift behind the store's shape. */
-const initialGitData: GitData = {
+ *  shape, so the reset can never drift behind the store's. A factory, not a
+ *  shared const: `branches` must be a FRESH array per reset — with a shared
+ *  reference, one in-place mutation would corrupt the baseline permanently and
+ *  every later "reset" would restore the corruption. */
+const freshGitData = (): GitData => ({
   status: null,
   loading: false,
   statusError: null,
@@ -162,10 +169,10 @@ const initialGitData: GitData = {
   commitNonce: 0,
   comparison: null,
   moveTarget: null,
-}
+})
 
 const useGitStore = create<GitState>()((set, get) => ({
-  ...initialGitData,
+  ...freshGitData(),
 
   loadStatus: (options) =>
     // Single-flight/queue/reset/stall bookkeeping lives in ./singleFlight;
@@ -273,7 +280,7 @@ const useGitStore = create<GitState>()((set, get) => ({
     return status
   },
 
-  resetForTests: () => set(initialGitData),
+  resetForTests: () => set(freshGitData()),
 }))
 
 /** One-call reset of the whole git-store family between tests: the data state


### PR DESCRIPTION
## Summary

- Split `GitState` into `GitData` + `GitActions` in `useGitStore.ts` and hoist the initial values into `initialGitData`, which both seeds the store and backs a new `resetForTests` action (the `useOutputWriteStore` precedent). A new data field must now get an initial value there or the build fails, and the reset spreads the same object — the new-field-leaks-between-shuffled-tests drift class (the cause of the original shuffle flake, #115) can't recur.
- Add `resetGitStoreForTests()`, folding in the single-flight clears (`resetGitStatusRequestForTests` + the branch loader's) so one call resets the whole git-store family. Async because the branch-loader import must stay dynamic — a static import would fold that split chunk back into the main bundle.
- Migrate the four per-file 15-key reset literals (GitPanel(.gaps/.staleRefresh/.cache).test.tsx, completed by #164) and `useGitStore.test.ts`'s three partial hook pairs onto the one call; pin the reset against the store's pristine import-time snapshot with a new test. (The redundant `useEdgeHandlers.test.ts` toast resets were already stripped by #168's rebase.)
- Harden `RemotePushControl.gaps.test.tsx`: six tests clicked the push button after waiting only for the container; a click landing before the sole remote auto-selects hits a disabled button and no-ops. The consolidation's async hooks shifted worker scheduling enough for the nightly shuffle seed to expose this latent race deterministically (main is green on the same seed). All six clicks now gate on `toBeEnabled()`, matching the file's existing 409-refresh test.

## Verification

- Touched test modules green (90 tests); touched files lint-clean; `tsc -b` clean.
- Full-suite shuffle sweep green at 5779/5779 on three seeds: `1784689972006` (the nightly-failure seed from #115), `424242`, `20260807`. Before the RemotePushControl fix, seed `1784689972006` failed deterministically on this branch and passed on main — that race is the only ordering defect the sweep surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)