### PR TITLE
Rename resetIoCapabilitiesCacheForTests to match its actual state

### DIFF
--- a/frontend/src/panels/editors/__tests__/DataInputEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/DataInputEditor.test.tsx
@@ -49,7 +49,7 @@ import {
   getInputCacheStatus,
 } from "../../../api/client"
 import DataInputEditor from "../DataInputEditor"
-import { resetIoCapabilitiesCacheForTests } from "../_ioFormats"
+import { resetIoCapabilitiesRequestForTests } from "../_ioFormats"
 
 const groups: IoCapabilityGroup[] = [
   {
@@ -302,7 +302,7 @@ function renderEditor(
 
 beforeEach(() => {
   vi.clearAllMocks()
-  resetIoCapabilitiesCacheForTests()
+  resetIoCapabilitiesRequestForTests()
   vi.mocked(fetchIoCapabilities).mockResolvedValue({
     schema_version: 1,
     groups,

--- a/frontend/src/panels/editors/__tests__/DataOutputEditor.test.tsx
+++ b/frontend/src/panels/editors/__tests__/DataOutputEditor.test.tsx
@@ -31,7 +31,7 @@ import {
 } from "../../../api/client"
 import { GraphProvider } from "../../GraphContext"
 import DataOutputEditor from "../DataOutputEditor"
-import { resetIoCapabilitiesCacheForTests } from "../_ioFormats"
+import { resetIoCapabilitiesRequestForTests } from "../_ioFormats"
 import useOutputWriteStore, {
   resetOutputWriteStoreForTests,
 } from "../../../stores/useOutputWriteStore"
@@ -208,7 +208,7 @@ function renderEditor(
 beforeEach(() => {
   vi.clearAllMocks()
   resetOutputWriteStoreForTests()
-  resetIoCapabilitiesCacheForTests()
+  resetIoCapabilitiesRequestForTests()
   vi.mocked(fetchIoCapabilities).mockReset().mockResolvedValue({
     schema_version: 1,
     groups,

--- a/frontend/src/panels/editors/__tests__/_ioFormats.test.tsx
+++ b/frontend/src/panels/editors/__tests__/_ioFormats.test.tsx
@@ -9,7 +9,7 @@ vi.mock("../../../api/client", () => ({
   fetchIoCapabilities: (...args: unknown[]) => mockFetchIoCapabilities(...args),
 }))
 
-import { resetIoCapabilitiesCacheForTests, useIoCapabilities } from "../_ioFormats"
+import { resetIoCapabilitiesRequestForTests, useIoCapabilities } from "../_ioFormats"
 
 function capabilities(label: string): IoCapabilitiesResponse {
   return {
@@ -37,7 +37,7 @@ function CapabilityProbe({ name }: { name: string }) {
 describe("useIoCapabilities", () => {
   beforeEach(() => {
     mockFetchIoCapabilities.mockReset()
-    resetIoCapabilitiesCacheForTests()
+    resetIoCapabilitiesRequestForTests()
   })
 
   afterEach(cleanup)

--- a/frontend/src/panels/editors/_ioFormats.ts
+++ b/frontend/src/panels/editors/_ioFormats.ts
@@ -32,7 +32,7 @@ function loadIoCapabilities(): Promise<IoCapabilitiesResponse> {
 }
 
 /** Test hook: clear the module-level in-flight request between tests. */
-export function resetIoCapabilitiesCacheForTests(): void {
+export function resetIoCapabilitiesRequestForTests(): void {
   inflight = null
 }
 

--- a/specs/frontend-node-editors/low-level.md
+++ b/specs/frontend-node-editors/low-level.md
@@ -119,9 +119,8 @@ guarded `/api/io-capabilities` client returns ordered groups, fields,
 directional formats/modes/arguments/engines, snapshot build class and schema
 requirements, writer class, and publication modes; each mount refreshes it and
 only concurrent pending requests coalesce. Test seam:
-`resetIoCapabilitiesCacheForTests()` clears the in-flight coalescing promise —
-the module's only state; despite the name, no result cache exists to clear.
-`_IoFormatEditor` renders one
+`resetIoCapabilitiesRequestForTests()` clears the in-flight coalescing promise —
+the module's only state. `_IoFormatEditor` renders one
 selected group/direction, while dedicated provider sections cover file,
 database, lakehouse, Databricks, and inline fields. `OnReplaceConfig` constructs
 and commits one fresh active branch for a provider change. Data Input provider


### PR DESCRIPTION
## Summary
`resetIoCapabilitiesCacheForTests` in `frontend/src/panels/editors/_ioFormats.ts` was misnamed: the module's only state is the `inflight` request-coalescing promise — there is no result cache (each mount refetches via `useIoCapabilities`, whose state is component-local). PR #172's external review flagged the name/state mismatch, and the merged spec seam note documented it explicitly ("despite the name, no result cache exists to clear").

This renames the helper to `resetIoCapabilitiesRequestForTests`, following the convention #172 pinned for promise-clearing seams (cf. `resetGitStatusRequestForTests`, which likewise "clears that promise"), and simplifies the spec sentence to drop the now-obsolete caveat.

## Files
- `frontend/src/panels/editors/_ioFormats.ts` — rename the exported test seam (behaviour unchanged)
- `frontend/src/panels/editors/__tests__/_ioFormats.test.tsx`, `__tests__/DataInputEditor.test.tsx`, `__tests__/DataOutputEditor.test.tsx` — update import + call sites
- `specs/frontend-node-editors/low-level.md` — seam note now reads: "Test seam: `resetIoCapabilitiesRequestForTests()` clears the in-flight coalescing promise — the module's only state."

## Verification
- `vitest run` (frontend): 301 files, 5811 passed + 1 expected fail
- `tsc -b --force` (clean build, no stale .tsbuildinfo): 0 errors
- `eslint src`: 0 errors (26 pre-existing warnings, untouched files)
- `uv run pytest tests/test_docs_accuracy.py`: 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
