### PR TITLE
Let one committed polars schema serve the whole polars cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,15 @@ jobs:
 
       # --frozen again: a bare `uv run` re-locks at the default resolution and
       # would silently swap the floor env back to highest before testing.
+      # HAUTE_POLARS_UNPINNED declares the same thing the re-resolve above
+      # does: polars is deliberately not at the lockfile's version, so the
+      # interface contract test asserts its cap-range half rather than
+      # snapshot equality with the version the committed schema records. The
+      # floor and the lock happen to name the same polars today; that is a
+      # coincidence of this lane, not a property it should depend on.
       - name: Core subset at floors
+        env:
+          HAUTE_POLARS_UNPINNED: "1"
         run: >
           uv run --frozen pytest $(grep -v '^#' scripts/core_test_files.txt)
           -q -n 4 --timeout=60 --timeout-method=signal

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,6 +10,19 @@ name: Dependencies
 # landings. Non-blocking but loud: a failure finds-or-creates a
 # `dependency-watch` issue with the run URL.
 #
+# Because it is loud, it only fails on a broken install. It used to also fail
+# on a *stale* one: the polars I/O interface contract asserted snapshot
+# equality with the single version `src/haute/_polars_io_arguments.json`
+# records, so any in-cap polars release that renumbered an argument or widened
+# an annotation rang the alarm. Issue #111 was opened by exactly that — five
+# cosmetic differences, none reachable by a user — and the lane then stayed red
+# for a fortnight, so the material drift that arrived later landed as another
+# "Still red" comment on an issue nobody was reading. The contract now
+# separates the two: the registry intersects the committed schema with the
+# installed signature (so a version difference cannot produce a wrong argument
+# surface), the test asserts only what must hold across the whole cap, and
+# staleness is reported to the run summary instead of paging anyone.
+#
 # The two jobs here run on deliberately different cadences, because they answer
 # questions that move at different speeds:
 #
@@ -127,9 +140,29 @@ jobs:
       - name: Show the unlocked resolution
         run: uv pip list --python .unlocked/bin/python
 
+      # Freshness, not health: a newer in-cap polars that moved the I/O surface
+      # leaves arguments this schema has not classified yet, which is worth
+      # reading but is not a broken install — the registry intersects the
+      # committed schema with the installed signature, so an unclassified
+      # argument is simply not offered. Reported to the run summary rather than
+      # asserted; the health question is the core subset's job below.
+      # pipefail so a broken extractor still fails the step: "report only"
+      # means a drifted schema is not a failure, not that the report may
+      # silently go missing.
+      - name: Polars I/O interface freshness (report only)
+        run: |
+          set -o pipefail
+          .unlocked/bin/python scripts/extract_polars_io.py --diff | tee -a "$GITHUB_STEP_SUMMARY"
+
       # The core subset runs from the checkout but imports the wheel-installed
       # haute (src layout keeps the checkout's sources off sys.path).
+      # HAUTE_POLARS_UNPINNED declares what this lane is: polars resolved away
+      # from uv.lock on purpose. The interface contract test applies its
+      # cap-range assertions there instead of snapshot equality with the one
+      # version the committed schema records.
       - name: Core subset against the unlocked install
+        env:
+          HAUTE_POLARS_UNPINNED: "1"
         run: >
           .unlocked/bin/python -m pytest $(grep -v '^#' scripts/core_test_files.txt)
           -q -n 4 --timeout=60 --timeout-method=signal
@@ -143,7 +176,7 @@ jobs:
           title="Scheduled unlocked-resolve lane is red"
           body="A fresh latest-within-caps resolve of the built wheel failed. Run: ${RUN_URL}
 
-          Likely cause: a new release of a dependency inside our caps. Triage: compare the run's 'Show the unlocked resolution' step against uv.lock to spot what moved."
+          A new release of a dependency inside our caps has broken the install, the smoke, or the core subset. Triage: compare the run's 'Show the unlocked resolution' step against uv.lock to spot what moved. Note that a merely *stale* polars I/O schema does not reach here — that is reported without failing, in the run summary's 'Polars I/O interface freshness' section."
           gh label create dependency-watch --color D93F0B --force \
             --description "Automated: scheduled dependency lane failures"
           existing="$(gh issue list --state open --label dependency-watch \

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,13 +15,16 @@ name: Dependencies
 # equality with the single version `src/haute/_polars_io_arguments.json`
 # records, so any in-cap polars release that renumbered an argument or widened
 # an annotation rang the alarm. Issue #111 was opened by exactly that — five
-# cosmetic differences, none reachable by a user — and the lane then stayed red
-# for a fortnight, so the material drift that arrived later landed as another
-# "Still red" comment on an issue nobody was reading. The contract now
-# separates the two: the registry intersects the committed schema with the
-# installed signature (so a version difference cannot produce a wrong argument
-# surface), the test asserts only what must hold across the whole cap, and
-# staleness is reported to the run summary instead of paging anyone.
+# differences, not one of which stopped a fresh install working, and 25 of the
+# 33 by the time anyone looked were keyword-only position renumbering. The lane
+# stayed red for a fortnight, so the drift that arrived later landed as another
+# "Still red" comment on an issue nobody was reading. The contract now sorts
+# the classes rather than treating them alike: the registry intersects the
+# committed schema with the installed signature (so a version difference cannot
+# produce an argument surface the installed polars would reject), the test
+# asserts only what a version difference cannot absorb, and everything else —
+# including changed defaults, which alter results without breaking a call — is
+# reported to the run summary instead of paging anyone.
 #
 # The two jobs here run on deliberately different cadences, because they answer
 # questions that move at different speeds:
@@ -146,10 +149,13 @@ jobs:
       # committed schema with the installed signature, so an unclassified
       # argument is simply not offered. Reported to the run summary rather than
       # asserted; the health question is the core subset's job below.
-      # pipefail so a broken extractor still fails the step: "report only"
-      # means a drifted schema is not a failure, not that the report may
-      # silently go missing.
+      # continue-on-error so this can never abort the job before the health
+      # check below, nor page anyone: a drifted schema is not a failure, and a
+      # broken extractor is a red step here but is already a hard failure of
+      # the interface contract test on every pull request. pipefail so the
+      # step's own status is honest rather than tee's.
       - name: Polars I/O interface freshness (report only)
+        continue-on-error: true
         run: |
           set -o pipefail
           .unlocked/bin/python scripts/extract_polars_io.py --diff | tee -a "$GITHUB_STEP_SUMMARY"
@@ -176,7 +182,7 @@ jobs:
           title="Scheduled unlocked-resolve lane is red"
           body="A fresh latest-within-caps resolve of the built wheel failed. Run: ${RUN_URL}
 
-          A new release of a dependency inside our caps has broken the install, the smoke, or the core subset. Triage: compare the run's 'Show the unlocked resolution' step against uv.lock to spot what moved. Note that a merely *stale* polars I/O schema does not reach here — that is reported without failing, in the run summary's 'Polars I/O interface freshness' section."
+          A new release of a dependency inside our caps has broken the wheel build, the fresh-install smoke, or the core subset. Triage: compare the run's 'Show the unlocked resolution' step against uv.lock to spot what moved. A merely *stale* polars I/O schema never reaches here — that is reported without failing, in the run summary's 'Polars I/O interface freshness' section, which is worth reading on the way past."
           gh label create dependency-watch --color D93F0B --force \
             --description "Automated: scheduled dependency lane failures"
           existing="$(gh issue list --state open --label dependency-watch \

--- a/scripts/core_test_files.txt
+++ b/scripts/core_test_files.txt
@@ -22,10 +22,11 @@
 # re-extracts the polars I/O surface from the installed polars and checks it
 # against the committed schema JSON, so the dependency-floors and
 # unlocked-resolve lanes prove that a polars resolved away from the lockfile
-# still gives users a usable I/O surface. Those two lanes set
-# HAUTE_POLARS_UNPINNED=1, which selects the cap-range half of that contract
-# (callables present, positional parameters unmoved) over exact equality with
-# the one polars version the committed schema records.
+# can still be called the way haute calls it. Those two lanes set
+# HAUTE_POLARS_UNPINNED=1, which selects the cap-range half of that contract —
+# every registry callable present and introspectable, the leading positionals
+# haute supplies unmoved, and the keyword names haute hardcodes still accepted
+# — over exact equality with the one polars version the schema records.
 tests/test_git_engine.py
 tests/test_model_scorer.py
 tests/test_optimiser_routes.py

--- a/scripts/core_test_files.txt
+++ b/scripts/core_test_files.txt
@@ -19,10 +19,13 @@
 #   ~2.5 min at -n 4. The known load-sensitive wall-clock benchmark in
 #   test_column_contracts_adoption is deliberately excluded.
 # test_polars_io_interface_contracts is here by design, not fix-frequency: it
-# re-extracts the polars I/O surface from the installed polars and diffs it
-# against the committed schema JSON, so the dependency-floors lane proves the
-# floor's interface matches and the unlocked-resolve lane catches an in-cap
-# polars release drifting the I/O surface (argument-level) before users do.
+# re-extracts the polars I/O surface from the installed polars and checks it
+# against the committed schema JSON, so the dependency-floors and
+# unlocked-resolve lanes prove that a polars resolved away from the lockfile
+# still gives users a usable I/O surface. Those two lanes set
+# HAUTE_POLARS_UNPINNED=1, which selects the cap-range half of that contract
+# (callables present, positional parameters unmoved) over exact equality with
+# the one polars version the committed schema records.
 tests/test_git_engine.py
 tests/test_model_scorer.py
 tests/test_optimiser_routes.py

--- a/scripts/extract_polars_io.py
+++ b/scripts/extract_polars_io.py
@@ -19,11 +19,12 @@ Usage:
 Run from the repo root; the default output path is the committed schema.
 
 ``--diff`` writes nothing: it reports how the installed polars differs from
-the committed schema, as Markdown, and always exits 0. That report is the
-scheduled unlocked-resolve lane's freshness signal — a newer in-cap polars
-having moved the I/O surface is worth seeing, but it is not a failure, because
+the committed schema, as Markdown. That report is the scheduled
+unlocked-resolve lane's freshness signal — a newer in-cap polars having moved
+the I/O surface is worth seeing, but it is not a failure, because
 ``haute._polars_io_schema.supported_argument_names`` intersects the two sides
-before anything reaches a node config.
+before anything reaches a node config. A drifted schema exits 0; only a
+failure of the extraction itself is a non-zero exit.
 """
 
 from __future__ import annotations
@@ -297,19 +298,52 @@ def diff_report() -> list[str]:
         if keys:
             findings.append(f"- **{label}:** {', '.join(keys)}")
 
+    defaults: list[str] = []
+    shape_only = 0
     for key in sorted(set(old) & set(new)):
-        old_names = {a["name"] for a in old[key]["arguments"]}
-        new_names = {a["name"] for a in new[key]["arguments"]}
-        gained, lost = sorted(new_names - old_names), sorted(old_names - new_names)
+        # An introspection failure yields an empty argument list, which would
+        # otherwise read as "polars removed every argument".
+        if "introspection_error" in new[key]:
+            findings.append(
+                f"- `{key}` could not be introspected on the installed polars: "
+                f"{new[key]['introspection_error']}"
+            )
+            continue
+        old_args = {a["name"]: a for a in old[key]["arguments"]}
+        new_args = {a["name"]: a for a in new[key]["arguments"]}
+        gained, lost = sorted(set(new_args) - set(old_args)), sorted(set(old_args) - set(new_args))
         if gained:
             findings.append(f"- `{key}` gained: {', '.join(gained)}")
         if lost:
             findings.append(f"- `{key}` no longer declares: {', '.join(lost)}")
+        for shared in sorted(set(old_args) & set(new_args)):
+            was, now = old_args[shared], new_args[shared]
+            if was["default"] != now["default"] or was["has_default"] != now["has_default"]:
+                defaults.append(f"- `{key}.{shared}` default {was['default']} → {now['default']}")
+            elif any(was[field] != now[field] for field in ("kind", "position", "annotation")):
+                shape_only += 1
 
-    lines.extend(
-        findings
-        or ["- No argument-name differences; only metadata such as defaults or positions moved."]
-    )
+    if not findings:
+        findings.append("- No argument-name differences.")
+    if defaults:
+        # Listed, not counted, and listed apart: a default is what an argument
+        # does when nobody sets it, so this is the class that quietly changes
+        # results. polars 1.43 renaming read_lines' produced column from
+        # `lines` to `line` is the shape of it.
+        findings.append("")
+        findings.append("**Changed defaults** — behaviour on this polars for arguments left unset:")
+        findings.extend(defaults)
+    if shape_only:
+        # Counted, not listed: keyword-only position renumbering alone produced
+        # 25 of the 33 drift lines that kept issue #111 red, and a position is
+        # invisible to a caller that passes the argument by name.
+        findings.append("")
+        findings.append(
+            f"- A further {shape_only} argument(s) differ only in kind, position or "
+            "annotation. Run `uv run python scripts/extract_polars_io.py` and diff the "
+            "JSON to see them."
+        )
+    lines.extend(findings)
     return lines
 
 

--- a/scripts/extract_polars_io.py
+++ b/scripts/extract_polars_io.py
@@ -14,8 +14,16 @@ drift, with instructions to re-run this script and review the diff.
 
 Usage:
     uv run python scripts/extract_polars_io.py [output.json]
+    uv run python scripts/extract_polars_io.py --diff
 
 Run from the repo root; the default output path is the committed schema.
+
+``--diff`` writes nothing: it reports how the installed polars differs from
+the committed schema, as Markdown, and always exits 0. That report is the
+scheduled unlocked-resolve lane's freshness signal — a newer in-cap polars
+having moved the I/O surface is worth seeing, but it is not a failure, because
+``haute._polars_io_schema.supported_argument_names`` intersects the two sides
+before anything reaches a node config.
 """
 
 from __future__ import annotations
@@ -254,7 +262,62 @@ def extract_schema() -> dict[str, Any]:
 DEFAULT_OUTPUT = Path(__file__).resolve().parents[1] / "src" / "haute" / "_polars_io_arguments.json"
 
 
+# ---------------------------------------------------------------------------
+# Freshness report (--diff).
+# ---------------------------------------------------------------------------
+
+
+def _by_key(schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {f"{fn['owner']}.{fn['name']}": fn for fn in schema["functions"]}
+
+
+def diff_report() -> list[str]:
+    """Markdown lines describing installed-polars drift from the committed schema."""
+    committed = json.loads(DEFAULT_OUTPUT.read_text(encoding="utf-8"))
+    fresh = extract_schema()
+    recorded, installed = committed["polars_version"], fresh["polars_version"]
+
+    lines = ["## Polars I/O interface freshness", ""]
+    if recorded == installed:
+        lines.append(f"Installed polars {installed} is the version the committed schema records.")
+        return lines
+    lines.append(
+        f"Committed schema records polars {recorded}; this resolve installed {installed}. "
+        "Argument names present on only one side are not config-expressible — the registry "
+        "intersects the two — so the list below is a regeneration prompt, not a failure."
+    )
+    lines.append("")
+
+    old, new = _by_key(committed), _by_key(fresh)
+    findings: list[str] = []
+    for label, keys in (
+        ("Callables only in the installed polars", sorted(set(new) - set(old))),
+        ("Callables only in the committed schema", sorted(set(old) - set(new))),
+    ):
+        if keys:
+            findings.append(f"- **{label}:** {', '.join(keys)}")
+
+    for key in sorted(set(old) & set(new)):
+        old_names = {a["name"] for a in old[key]["arguments"]}
+        new_names = {a["name"] for a in new[key]["arguments"]}
+        gained, lost = sorted(new_names - old_names), sorted(old_names - new_names)
+        if gained:
+            findings.append(f"- `{key}` gained: {', '.join(gained)}")
+        if lost:
+            findings.append(f"- `{key}` no longer declares: {', '.join(lost)}")
+
+    lines.extend(
+        findings
+        or ["- No argument-name differences; only metadata such as defaults or positions moved."]
+    )
+    return lines
+
+
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "--diff":
+        print("\n".join(diff_report()))
+        return
+
     out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_OUTPUT
 
     payload = extract_schema()

--- a/specs/engineering-quality/low-level.md
+++ b/specs/engineering-quality/low-level.md
@@ -221,10 +221,15 @@
   equality with the single version `src/haute/_polars_io_arguments.json`
   records. Without the declaration a Polars whose version differs from the
   recorded one is an un-regenerated lockfile bump and fails, so the
-  regenerate-on-bump gate still binds on every pinned lane. The unlocked lane
-  additionally prints `scripts/extract_polars_io.py --diff` to the run summary:
-  a stale schema is a regeneration prompt, not a lane failure, because the
-  registry intersects the committed schema with the installed signature.
+  regenerate-on-bump gate still binds on every pinned lane; the skip is gated
+  on the versions actually differing, so a declared lane that resolves the
+  recorded version still runs the full comparison. The unlocked lane
+  additionally prints `scripts/extract_polars_io.py --diff` to the run summary
+  as a `continue-on-error` step: a stale schema is a regeneration prompt, not a
+  lane failure, because the registry intersects the committed schema with the
+  installed signature. That report names changed defaults individually, since a
+  default is what an argument does when nobody sets it, and counts differences
+  of kind, position or annotation, which no caller can observe.
 - Mutation shards partition a shared initial work order and run mutants one at
   a time per runner. Separate CI runners provide the shard parallelism while
   serial execution avoids concurrent in-place mutation races; merge expects

--- a/specs/engineering-quality/low-level.md
+++ b/specs/engineering-quality/low-level.md
@@ -44,7 +44,7 @@
 | `security/accepted-risks.toml` | Versioned exact advisory acceptance registry. Entries require ecosystem/package/advisory identity, owner, exposure, compensating control, approval date, and non-expired review date; stale, duplicate, malformed, mismatched, or unused entries fail the audit. |
 | `scripts/core_test_files.txt` | Curated core test-subset manifest and its selection/refresh rationale for canary/dependency lanes. |
 | `scripts/e2e_git_topologies.py` | Exercises Git topology scenarios used by repository-level verification. |
-| `scripts/extract_polars_io.py` | Extracts/checks Polars I/O information used by related verification and maintenance workflows. |
+| `scripts/extract_polars_io.py` | Extracts the Polars I/O argument schema by introspection, and with `--diff` reports installed-versus-committed drift as a non-failing Markdown freshness summary. |
 | `scripts/init_smoke.py` | Builds/installs or consumes a wheel in a fresh environment, initialises a project, serves it headlessly, exercises an authenticated endpoint, and shuts it down. |
 | `scripts/memory_smoke.py` | Runs the maintained memory-safety smoke path. |
 | `scripts/package_smoke_check.py` | Validates an installed distribution's package/runtime expectations. |
@@ -214,6 +214,17 @@
   `--frozen` thereafter; it must not silently re-lock at the normal highest
   resolution. The scheduled dependency job instead tests a fresh
   latest-within-caps wheel installation.
+- Both of those lanes run the core subset with `HAUTE_POLARS_UNPINNED=1`,
+  declaring that they resolved Polars away from the lockfile on purpose. That
+  selects the cap-range half of the Polars I/O interface contract — every
+  registry callable still present, positional parameters unmoved — over exact
+  equality with the single version `src/haute/_polars_io_arguments.json`
+  records. Without the declaration a Polars whose version differs from the
+  recorded one is an un-regenerated lockfile bump and fails, so the
+  regenerate-on-bump gate still binds on every pinned lane. The unlocked lane
+  additionally prints `scripts/extract_polars_io.py --diff` to the run summary:
+  a stale schema is a regeneration prompt, not a lane failure, because the
+  registry intersects the committed schema with the installed signature.
 - Mutation shards partition a shared initial work order and run mutants one at
   a time per runner. Separate CI runners provide the shard parallelism while
   serial execution avoids concurrent in-place mutation races; merge expects

--- a/specs/io-layer/low-level.md
+++ b/specs/io-layer/low-level.md
@@ -10,7 +10,7 @@
 | `src/haute/_database_io.py` | Credential-free database locator/query validation and bounded read-only SQLite snapshot batches. |
 | `src/haute/_credential_security.py` | Shared URI credential detection and provider-diagnostic redaction. |
 | `src/haute/_source_cache.py` | Primary owner of source-cache identities, generations, metadata, publication, leases, quota, status, and cleanup. |
-| `src/haute/_polars_io_schema.py` | Cached index over the committed Polars callable schema. |
+| `src/haute/_polars_io_schema.py` | Cached index over the committed Polars callable schema, live introspection of the installed Polars, and the intersection of the two. |
 | `src/haute/_polars_io_arguments.json` | Generated Polars callable signature data checked against the pinned Polars version. |
 | `src/haute/_polars_dtypes.py` | Struct-capable dtype JSON codec used by registry schema arguments. |
 | `src/haute/_polars_utils.py` | Streaming and cancellable streaming collect, bounded/atomic sink, Parquet metadata, chunk-size scope, and allocator trim helpers. |
@@ -184,6 +184,19 @@ checkpoint failure. Neither helper has an eager or non-streaming fallback.
 - Partitioned Parquet sinks validate the final layout and preserve the previous published
   target if publication fails.
 - Bounded profiles require declared CSV dtypes and reject eager-only plain JSON.
+- An argument is config-expressible only when both the committed interface schema and the
+  installed Polars declare it. `haute._polars_io_schema.supported_argument_names()` is that
+  intersection and `haute._polars_io_registry.allowed_arguments()` subtracts the excluded
+  classes from it. The committed schema records one Polars version while the `polars`
+  specifier admits a range, so the two sides disagree in both directions: an argument only
+  the installed Polars has would otherwise become expressible without ever being classified
+  against the remote-IO, object-valued, and execution-owned exclusions, and an argument only
+  the committed schema has would otherwise stay on offer while resting on whatever
+  deprecation shim still accepts it. Rejection names the version boundary when
+  `haute._polars_io_schema.retired_argument_names()` explains the miss.
+- The registry supplies each node's source/target fields positionally, so a Polars release
+  inside the specifier may add or rename keyword arguments but must not move a callable's
+  positional parameters or remove a callable the registry dispatches to.
 
 ## Error handling
 

--- a/specs/io-layer/low-level.md
+++ b/specs/io-layer/low-level.md
@@ -194,9 +194,28 @@ checkpoint failure. Neither helper has an eager or non-streaming fallback.
   the committed schema has would otherwise stay on offer while resting on whatever
   deprecation shim still accepts it. Rejection names the version boundary when
   `haute._polars_io_schema.retired_argument_names()` explains the miss.
-- The registry supplies each node's source/target fields positionally, so a Polars release
-  inside the specifier may add or rename keyword arguments but must not move a callable's
-  positional parameters or remove a callable the registry dispatches to.
+- The registry supplies each node's source/target fields positionally — one leading argument
+  for a path or inline source and for every output target, two (query, uri) for a database
+  input — so a Polars release inside the specifier may append or rename later parameters but
+  must not move those leading positions or remove a callable the registry dispatches to.
+- `haute._polars_io_registry.registry_capabilities()` publishes only the modes whose Polars
+  callable the installed Polars still provides introspectably, tested by
+  `haute._polars_io_schema.installed_provides_callable()`. A Polars that has dropped one
+  callable therefore costs the editor that one mode rather than the whole format catalogue;
+  configuring or executing such a format raises `PolarsIoConfigError` from
+  `haute._polars_io_registry.allowed_arguments()` rather than a bare `AttributeError`, and
+  the interface contract test fails on the same condition in CI.
+- The intersection governs node-config arguments only. Keyword names haute itself writes as
+  literals — `haute.executor._output_row_count_scan_kwargs()` for exact artifact row counts,
+  `haute._io.read_source()` for declared-dtype CSV scans, and the compression argument in
+  `src/haute/_polars_utils.py` — carry no such protection and are held instead by
+  `tests/test_polars_io_interface_contracts.py`'s `_LITERAL_KEYWORDS` inventory.
+- Argument *defaults* are Polars'. haute forwards what a node config sets and takes the
+  installed Polars' behaviour for everything else, so a default that moves inside the
+  specifier moves haute's results with it. That is reported by
+  `scripts/extract_polars_io.py --diff` rather than gated: pinning every default haute does
+  not set would be a promise of result-stability across the specifier that haute has never
+  made.
 
 ## Error handling
 

--- a/src/haute/_polars_io_registry.py
+++ b/src/haute/_polars_io_registry.py
@@ -41,7 +41,11 @@ import polars as pl
 
 from haute._execution_context import ExecutionProfile
 from haute._polars_dtypes import parse_schema_mapping
-from haute._polars_io_schema import retired_argument_names, supported_argument_names
+from haute._polars_io_schema import (
+    installed_provides_callable,
+    retired_argument_names,
+    supported_argument_names,
+)
 from haute._polars_utils import is_bounded_execution_profile
 from haute.errors import BoundedMemoryUnsupportedError
 
@@ -591,6 +595,17 @@ def allowed_arguments(fmt: IoFormat, owner: str, callable_name: str) -> frozense
     from the signature would otherwise stay on offer, resting on whatever
     deprecation shim happens to still accept it.
     """
+    if not installed_provides_callable(owner, callable_name):
+        # Keeps the curated config-error surface in front of the raw
+        # AttributeError the schema layer raises. The capabilities catalogue
+        # never reaches here — it stops offering the mode — so this is the
+        # execution and validation path for a format configured before the
+        # polars underneath it changed.
+        raise PolarsIoConfigError(
+            f"Format {fmt.name!r} needs polars.{callable_name}, which the installed "
+            f"polars {pl.__version__} does not provide. This haute release cannot use "
+            "that format on this polars."
+        )
     names = set(supported_argument_names(owner, callable_name))
     names -= {n for n in names if n.startswith("_")}
     names -= REMOTE_IO_ARGUMENTS
@@ -617,11 +632,15 @@ def validate_arguments(
     allowed = allowed_arguments(fmt, owner, callable_name)
     unknown = sorted(set(arguments) - allowed)
     if unknown:
-        # Name the version boundary when that is what removed the argument;
-        # "unknown argument" alone sends the reader hunting for a typo.
+        # Name the version boundary when that is what withdrew the argument;
+        # "unknown argument" alone sends the reader hunting for a typo. Say
+        # "signature", not "polars": a withdrawn name may still be accepted by
+        # a deprecation shim, and haute declines to build on one.
         retired = sorted(retired_argument_names(owner, callable_name).intersection(unknown))
         because = (
-            f" Argument(s) {retired} are absent from the installed polars {pl.__version__}."
+            f" Argument(s) {retired} are no longer in the installed polars "
+            f"{pl.__version__} signature for {owner}.{callable_name}; check the polars "
+            "changelog for a replacement."
             if retired
             else ""
         )
@@ -939,6 +958,22 @@ def registry_capabilities() -> dict[str, Any]:
         if fmt.source_kind == "database":
             input_modes = []
             output_modes = ["write"] if fmt.writer is not None else []
+        # An in-cap polars that has dropped or obscured one callable costs the
+        # editor that one mode, not the whole catalogue. The condition is a CI
+        # failure in its own right (the interface contract test asserts every
+        # registry callable survives the installed polars), and configuring or
+        # executing the format still fails loudly — this only keeps a broken
+        # format from taking the other thirteen down with it.
+        input_modes = [
+            mode
+            for mode in input_modes
+            if installed_provides_callable(*input_callable_key(fmt, cast(InputMode, mode)))
+        ]
+        output_modes = [
+            mode
+            for mode in output_modes
+            if installed_provides_callable(*output_callable_key(fmt, cast(OutputMode, mode)))
+        ]
         input_arguments = {
             mode: sorted(allowed_arguments(fmt, *input_callable_key(fmt, cast(InputMode, mode))))
             for mode in input_modes

--- a/src/haute/_polars_io_registry.py
+++ b/src/haute/_polars_io_registry.py
@@ -4,9 +4,10 @@ One frozen dataclass + one tuple: everything else derives. A fully-configured
 ``dataInput`` node is equivalent to exactly one invocation of a polars input
 callable (``read_*``/``scan_*``/``from_*``); ``dataOutput`` covers the
 ``write_*``/``sink_*`` surface for single tables. The argument surface is not
-hand-typed — it derives from the committed interface schema
-(:mod:`haute._polars_io_schema`), so a polars bump that changes a signature is
-caught by the drift contract test, not by users.
+hand-typed — it derives from the committed interface schema intersected with
+the installed polars (:mod:`haute._polars_io_schema`), so any polars inside
+the specifier gets an argument surface that version actually accepts, and a
+signature change is caught by the drift contract test rather than by users.
 
 Design rules carried over from the io-nodes review (IO12):
 
@@ -40,7 +41,7 @@ import polars as pl
 
 from haute._execution_context import ExecutionProfile
 from haute._polars_dtypes import parse_schema_mapping
-from haute._polars_io_schema import argument_names
+from haute._polars_io_schema import retired_argument_names, supported_argument_names
 from haute._polars_utils import is_bounded_execution_profile
 from haute.errors import BoundedMemoryUnsupportedError
 
@@ -577,12 +578,20 @@ def resolve_output_mode(fmt: IoFormat, config: Mapping[str, Any]) -> OutputMode:
 def allowed_arguments(fmt: IoFormat, owner: str, callable_name: str) -> frozenset[str]:
     """Config-expressible argument names for one polars callable.
 
-    Derived from the committed interface schema minus the excluded classes:
-    underscore-private plumbing, remote-IO arguments, object-valued arguments,
-    execution-owned sink arguments, and the source/target arguments owned by
-    the node's own fields.
+    Derived from the committed interface schema intersected with the installed
+    polars' signature, minus the excluded classes: underscore-private
+    plumbing, remote-IO arguments, object-valued arguments, execution-owned
+    sink arguments, and the source/target arguments owned by the node's own
+    fields.
+
+    The intersection is what lets one committed schema serve the whole
+    ``polars`` specifier. The exclusions below are subtractive, so an argument
+    a newer polars introduces would otherwise be config-expressible without
+    ever having been classified; and an argument a newer polars has dropped
+    from the signature would otherwise stay on offer, resting on whatever
+    deprecation shim happens to still accept it.
     """
-    names = set(argument_names(owner, callable_name))
+    names = set(supported_argument_names(owner, callable_name))
     names -= {n for n in names if n.startswith("_")}
     names -= REMOTE_IO_ARGUMENTS
     names -= _OBJECT_VALUED_ARGUMENTS
@@ -608,9 +617,17 @@ def validate_arguments(
     allowed = allowed_arguments(fmt, owner, callable_name)
     unknown = sorted(set(arguments) - allowed)
     if unknown:
+        # Name the version boundary when that is what removed the argument;
+        # "unknown argument" alone sends the reader hunting for a typo.
+        retired = sorted(retired_argument_names(owner, callable_name).intersection(unknown))
+        because = (
+            f" Argument(s) {retired} are absent from the installed polars {pl.__version__}."
+            if retired
+            else ""
+        )
         raise PolarsIoConfigError(
             f"Unknown or unsupported argument(s) {unknown} for polars.{callable_name} "
-            f"(format {fmt.name!r}). Config-expressible arguments: {sorted(allowed)}."
+            f"(format {fmt.name!r}). Config-expressible arguments: {sorted(allowed)}.{because}"
         )
     decoded: dict[str, Any] = {}
     for name, value in arguments.items():

--- a/src/haute/_polars_io_schema.py
+++ b/src/haute/_polars_io_schema.py
@@ -8,21 +8,27 @@ docstring-documentation flags — for the polars version haute pins.
 It serves two purposes:
 
 1. **Interface contract.** ``tests/test_polars_io_interface_contracts.py``
-   re-extracts the schema from the installed polars and fails on any
-   argument-level drift, so an in-cap polars release that changes the I/O
-   surface is caught by CI (including the scheduled unlocked-resolve lane)
+   re-extracts the schema from the installed polars and fails on drift that
+   would break a fresh install, so an in-cap polars release that changes the
+   I/O surface is caught by CI (including the scheduled unlocked-resolve lane)
    rather than by a user.
-2. **Config validation source.** The data-input/data-output node machinery
-   validates node-config argument names against this schema instead of
-   hand-maintaining per-function argument lists.
+2. **Reviewed half of the config validation surface.** The committed schema
+   records one polars version, while the ``polars`` specifier admits a range,
+   so the schema and a user's installed polars can disagree in both
+   directions. :func:`supported_argument_names` intersects the two: an
+   argument is config-expressible only when it has been through schema
+   regeneration *and* the installed polars declares it.
 
-The JSON is loaded lazily and cached; importing this module does no I/O.
+The JSON is loaded lazily and cached; importing this module does no I/O and
+does not import polars (:func:`installed_argument_names` imports it on first
+use).
 """
 
 from __future__ import annotations
 
+import inspect
 import json
-from functools import lru_cache
+from functools import cache, lru_cache
 from importlib.resources import files
 from typing import Any
 
@@ -58,3 +64,41 @@ def io_function(owner: str, name: str) -> dict[str, Any]:
 def argument_names(owner: str, name: str) -> tuple[str, ...]:
     """Argument names of one I/O callable, in signature order."""
     return tuple(arg["name"] for arg in io_function(owner, name)["arguments"])
+
+
+@cache
+def installed_argument_names(owner: str, name: str) -> frozenset[str]:
+    """Argument names of one I/O callable on the *installed* polars.
+
+    Read from the interpreter's own polars rather than the committed schema,
+    because a fresh install resolves anything inside the ``polars`` specifier
+    and only the installed signature says what the call will accept.
+    """
+    import polars
+
+    holder: Any = polars if owner == "polars" else getattr(polars, owner, None)
+    func = getattr(holder, name, None) if holder is not None else None
+    if func is None:
+        raise AttributeError(
+            f"The installed polars {polars.__version__} has no I/O callable "
+            f"{owner}.{name}, which haute's data-input/data-output registry requires. "
+            "This polars is outside the range this haute release supports."
+        )
+    return frozenset(pname for pname in inspect.signature(func).parameters if pname != "self")
+
+
+def supported_argument_names(owner: str, name: str) -> frozenset[str]:
+    """Argument names haute honours for one I/O callable.
+
+    The committed schema intersected with the installed polars. Both halves
+    are load-bearing: the schema half keeps an argument out of node configs
+    until a regeneration has classified it, and the installed half keeps haute
+    from offering an argument the caller's polars no longer declares — whether
+    that name is gone outright or survives only as a deprecation shim.
+    """
+    return frozenset(argument_names(owner, name)) & installed_argument_names(owner, name)
+
+
+def retired_argument_names(owner: str, name: str) -> frozenset[str]:
+    """Committed argument names the installed polars no longer declares."""
+    return frozenset(argument_names(owner, name)) - installed_argument_names(owner, name)

--- a/src/haute/_polars_io_schema.py
+++ b/src/haute/_polars_io_schema.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import inspect
 import json
-from functools import cache, lru_cache
+from functools import lru_cache
 from importlib.resources import files
 from typing import Any
 
@@ -66,23 +66,54 @@ def argument_names(owner: str, name: str) -> tuple[str, ...]:
     return tuple(arg["name"] for arg in io_function(owner, name)["arguments"])
 
 
-@cache
+def _installed_callable(owner: str, name: str) -> Any:
+    import polars
+
+    holder: Any = polars if owner == "polars" else getattr(polars, owner, None)
+    return getattr(holder, name, None) if holder is not None else None
+
+
+def installed_provides_callable(owner: str, name: str) -> bool:
+    """Whether the installed polars offers this I/O callable, introspectably.
+
+    Asked before publishing a format's capabilities, so a polars that has
+    dropped or obscured one callable costs the editor that one format rather
+    than the whole catalogue. Configuring or executing such a format still
+    fails loudly.
+    """
+    func = _installed_callable(owner, name)
+    if func is None:
+        return False
+    try:
+        inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def installed_argument_names(owner: str, name: str) -> frozenset[str]:
     """Argument names of one I/O callable on the *installed* polars.
 
     Read from the interpreter's own polars rather than the committed schema,
     because a fresh install resolves anything inside the ``polars`` specifier
     and only the installed signature says what the call will accept.
+
+    Deliberately uncached, unlike the committed schema above: the value comes
+    from a mutable module attribute, so a cache entry taken while a test had a
+    polars method patched would outlive the patch and silently narrow the
+    argument surface for the rest of the process. A full 37-callable catalogue
+    build costs about 0.3 ms of ``inspect.signature``, which buys nothing worth
+    that risk.
     """
     import polars
 
-    holder: Any = polars if owner == "polars" else getattr(polars, owner, None)
-    func = getattr(holder, name, None) if holder is not None else None
+    func = _installed_callable(owner, name)
     if func is None:
         raise AttributeError(
             f"The installed polars {polars.__version__} has no I/O callable "
-            f"{owner}.{name}, which haute's data-input/data-output registry requires. "
-            "This polars is outside the range this haute release supports."
+            f"{owner}.{name}, which haute's data-input/data-output registry dispatches "
+            "to. Either the registry or the polars specifier in pyproject.toml is wrong "
+            "for this release."
         )
     return frozenset(pname for pname in inspect.signature(func).parameters if pname != "self")
 

--- a/tests/test-health-summary.md
+++ b/tests/test-health-summary.md
@@ -4,7 +4,7 @@ Generated deterministically from the live test-debt scanners and mutation target
 
 | Signal | Count / max survivor rate | Enforcement/source |
 | --- | ---: | --- |
-| Backend skip/skipif | 43 | Backend AST scanner |
+| Backend skip/skipif | 44 | Backend AST scanner |
 | Backend importorskip | 63 | Backend AST scanner |
 | Backend xfail | 1 | Backend AST scanner |
 | Backend flaky | 0 | Backend AST scanner (zero-budget fingerprint ratchet) |

--- a/tests/test_polars_io_interface_contracts.py
+++ b/tests/test_polars_io_interface_contracts.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
+import json
 import os
 import sys
 from pathlib import Path
@@ -39,11 +40,20 @@ from typing import Any
 import polars
 import pytest
 
+from haute import _polars_io_registry as registry_module
 from haute import _polars_io_schema as schema_module
-from haute._polars_io_registry import FORMATS
+from haute._polars_io_registry import (
+    FORMATS,
+    FORMATS_BY_NAME,
+    PolarsIoConfigError,
+    input_callable_key,
+    registry_capabilities,
+    validate_arguments,
+)
 from haute._polars_io_schema import (
     argument_names,
     installed_argument_names,
+    installed_provides_callable,
     io_function,
     io_functions_by_key,
     load_io_schema,
@@ -75,6 +85,32 @@ _BREAKING_HINT = (
 # fields become leading positional arguments in `_resolve_input_source`.
 _POSITIONAL_KINDS = frozenset({"POSITIONAL_ONLY", "POSITIONAL_OR_KEYWORD", "VAR_POSITIONAL"})
 
+# Polars keyword arguments haute writes as literals OUTSIDE the config surface.
+# The committed-schema intersection cannot protect these — it governs only what
+# a node config may carry — so they need naming here or a rename inside the cap
+# turns into a TypeError at execution. Keep in step with the call sites:
+#   haute.executor._output_row_count_scan_kwargs()  — exact artifact row counts
+#   haute._io.read_source()                         — declared-dtype CSV scans
+#   haute._polars_utils                             — bounded/atomic sink writes
+_LITERAL_KEYWORDS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "polars",
+        "scan_csv",
+        (
+            "decimal_comma",
+            "eol_char",
+            "has_header",
+            "infer_schema",
+            "quote_char",
+            "raise_if_empty",
+            "schema_overrides",
+            "separator",
+        ),
+    ),
+    ("DataFrame", "write_parquet", ("compression",)),
+    ("LazyFrame", "sink_parquet", ("compression",)),
+)
+
 
 def _load_extractor() -> Any:
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "extract_polars_io.py"
@@ -94,20 +130,32 @@ def _functions_by_key(schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {f"{fn['owner']}.{fn['name']}": fn for fn in schema["functions"]}
 
 
+def _registry_callables() -> list[tuple[str, int]]:
+    """Every ``owner.name`` the registry dispatches to, with how many leading
+    positional arguments haute supplies to it.
+
+    Inputs get their source from ``_resolve_input_source``: one positional for
+    a path or inline records, two (query, uri) for a database. Outputs get the
+    resolved target path, always one.
+    """
+    supplied: dict[str, int] = {}
+    for fmt in FORMATS:
+        leading = 2 if fmt.source_kind == "database" else 1
+        for owner, name, count in (
+            ("polars", fmt.reader, leading),
+            ("polars", fmt.scanner, leading),
+            ("DataFrame", fmt.writer, 1),
+            ("LazyFrame", fmt.sinker, 1),
+        ):
+            if name is None:
+                continue
+            key = f"{owner}.{name}"
+            supplied[key] = max(supplied.get(key, 0), count)
+    return sorted(supplied.items())
+
+
 def _registry_callable_keys() -> list[str]:
-    """Every ``owner.name`` the format registry dispatches to."""
-    keys = {
-        f"{owner}.{name}"
-        for fmt in FORMATS
-        for owner, name in (
-            ("polars", fmt.reader),
-            ("polars", fmt.scanner),
-            ("DataFrame", fmt.writer),
-            ("LazyFrame", fmt.sinker),
-        )
-        if name is not None
-    }
-    return sorted(keys)
+    return [key for key, _ in _registry_callables()]
 
 
 def _positional_names(record: dict[str, Any]) -> list[str]:
@@ -122,7 +170,7 @@ class TestNoBreakingDriftAcrossTheCap:
         fresh = _functions_by_key(extract_polars_io.extract_schema())
 
         problems: list[str] = []
-        for key in _registry_callable_keys():
+        for key, supplied in _registry_callables():
             if key not in committed:
                 problems.append(f"{key}: dispatched by the registry but absent from the schema")
                 continue
@@ -132,11 +180,60 @@ class TestNoBreakingDriftAcrossTheCap:
             if "introspection_error" in fresh[key]:
                 problems.append(f"{key}: not introspectable: {fresh[key]['introspection_error']}")
                 continue
-            was, now = _positional_names(committed[key]), _positional_names(fresh[key])
+            # Only the leading positionals haute actually supplies. Polars may
+            # append a new trailing positional-or-keyword parameter inside the
+            # cap without touching how haute calls it, and that must not be a
+            # failure — a reorder or a rename of what haute does supply must.
+            was = _positional_names(committed[key])[:supplied]
+            now = _positional_names(fresh[key])[:supplied]
             if was != now:
-                problems.append(f"{key}: positional parameters moved: {was} -> {now}")
+                problems.append(
+                    f"{key}: the {supplied} leading positional parameter(s) haute supplies "
+                    f"moved: {was} -> {now}"
+                )
 
         assert not problems, _BREAKING_HINT + "\n\nBreaking drift:\n- " + "\n- ".join(problems)
+
+    def test_keywords_haute_writes_as_literals_still_exist(self) -> None:
+        """The call sites the config-argument intersection cannot cover.
+
+        `allowed_arguments` protects what a node config may carry. It says
+        nothing about the keyword names haute itself hardcodes when it calls
+        polars, and those break with a TypeError rather than a validation
+        error. This is the invariant that used to ride on exact snapshot
+        equality; naming the keywords keeps it across the whole cap.
+        """
+        problems: list[str] = []
+        for owner, name, keywords in _LITERAL_KEYWORDS:
+            live = installed_argument_names(owner, name)
+            missing = sorted(set(keywords) - live)
+            if missing:
+                problems.append(f"{owner}.{name}: {missing}")
+        assert not problems, (
+            f"The installed polars {polars.__version__} no longer accepts keyword argument(s) "
+            f"haute passes literally: {problems}. Those call sites will raise TypeError; fix "
+            "them, and keep _LITERAL_KEYWORDS in step with the call sites it names."
+        )
+
+    def test_every_registry_callable_keeps_a_usable_argument_surface(self) -> None:
+        """No registry callable may intersect down to nothing.
+
+        The guard against a signature this contract cannot read literally: a
+        callable wrapped so ``inspect.signature`` reports ``(*args, **kwargs)``
+        introspects cleanly and matches on positionals, yet intersects with the
+        committed names to the empty set — silently costing that format every
+        configurable argument rather than failing.
+        """
+        empty = [
+            key
+            for key in _registry_callable_keys()
+            if not supported_argument_names(*key.split(".", 1))
+        ]
+        assert empty == [], (
+            f"These callables share no argument name between the committed schema and the "
+            f"installed polars {polars.__version__}: {empty}. Their formats would publish an "
+            "empty argument surface."
+        )
 
     def test_committed_function_count_matches_functions_list(self) -> None:
         schema = load_io_schema()
@@ -148,11 +245,20 @@ class TestCommittedSnapshotMatchesPinnedPolars:
 
     def test_no_interface_drift_against_installed_polars(self) -> None:
         recorded = load_io_schema()["polars_version"]
-        if os.environ.get(_UNPINNED_ENV) == "1":
+        if polars.__version__ != recorded and os.environ.get(_UNPINNED_ENV) == "1":
             # A lane that resolved polars away from the lockfile on purpose
-            # (unlocked-resolve, dependency-floors). Snapshot equality is not
-            # the contract there; TestNoBreakingDriftAcrossTheCap is.
-            return
+            # (unlocked-resolve, dependency-floors) landed on a version this
+            # snapshot cannot describe. TestNoBreakingDriftAcrossTheCap is the
+            # applicable contract there. Skipped rather than silently returned
+            # so the run log says which contract was applied — and the version
+            # guard comes first, so a declared-unpinned lane that happens to
+            # resolve the recorded version still runs the full comparison. The
+            # declaration can never turn a check off while it is meaningful.
+            pytest.skip(
+                "HAUTE_POLARS_UNPINNED: the installed polars is not the version the "
+                "committed schema records, so snapshot equality cannot hold; "
+                "TestNoBreakingDriftAcrossTheCap is the applicable contract"
+            )
 
         assert polars.__version__ == recorded, (
             f"{_REGENERATE_HINT} Installed polars is {polars.__version__}, the committed "
@@ -263,6 +369,49 @@ class TestSchemaLoaderHelpers:
         else:  # pragma: no cover - defensive
             raise AssertionError("expected AttributeError")
 
+    def test_installed_provides_callable_answers_both_ways(self) -> None:
+        assert installed_provides_callable("polars", "read_csv")
+        assert installed_provides_callable("LazyFrame", "sink_parquet")
+        assert not installed_provides_callable("polars", "read_nonexistent")
+        assert not installed_provides_callable("Nonexistent", "read_csv")
+
+
+class TestCapabilitiesSurviveAMissingCallable:
+    """One callable the installed polars lacks costs one mode, not the catalogue."""
+
+    def test_capabilities_drop_only_the_affected_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def absent_scan_csv(owner: str, name: str) -> bool:
+            return not (owner == "polars" and name == "scan_csv")
+
+        monkeypatch.setattr(registry_module, "installed_provides_callable", absent_scan_csv)
+        payload = registry_capabilities()
+        formats = {f["name"]: f for group in payload["groups"] for f in group["formats"]}
+        assert formats["csv"]["input"]["modes"] == []
+        assert formats["csv"]["input"]["arguments"] == {}
+        # Every other format, and CSV's own output side, still published.
+        assert formats["parquet"]["input"]["modes"] == ["scan"]
+        assert formats["csv"]["output"]["modes"]
+        assert len(formats) >= 14
+
+    def test_configuring_the_absent_format_fails_in_the_config_error_family(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A pipeline configured before the polars underneath it changed still
+        # reaches validation. It must land in the curated error family, not as
+        # a raw AttributeError out of the schema layer.
+        monkeypatch.setattr(
+            registry_module,
+            "installed_provides_callable",
+            lambda owner, name: not (owner == "polars" and name == "scan_csv"),
+        )
+        fmt = FORMATS_BY_NAME["csv"]
+        with pytest.raises(PolarsIoConfigError) as excinfo:
+            validate_arguments(fmt, "polars", "scan_csv", {})
+        assert "scan_csv" in str(excinfo.value)
+        assert polars.__version__ in str(excinfo.value)
+
 
 class TestSupportedArgumentNames:
     """The intersection that lets one committed snapshot serve the whole cap."""
@@ -295,7 +444,79 @@ class TestSupportedArgumentNames:
         assert "empty_string_is_null" not in supported_argument_names("polars", "read_csv")
         assert retired_argument_names("polars", "read_csv") == frozenset()
 
-    def test_supported_equals_committed_when_the_versions_agree(self) -> None:
-        for key in _registry_callable_keys():
-            owner, name = key.split(".", 1)
-            assert supported_argument_names(owner, name) <= frozenset(argument_names(owner, name))
+    def test_a_retired_argument_is_rejected_with_the_version_named(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The user-facing half of a withdrawn argument. Monkeypatched rather
+        # than left to a polars that happens to have withdrawn something: on a
+        # pinned install nothing is retired, so the message would otherwise be
+        # exercised only on versions nobody runs in CI.
+        fmt = FORMATS_BY_NAME["csv"]
+        owner, callable_name = input_callable_key(fmt, "scan")
+        committed = set(argument_names(owner, callable_name))
+        assert "low_memory" in committed
+        monkeypatch.setattr(
+            schema_module,
+            "installed_argument_names",
+            lambda o, n: frozenset(committed - {"low_memory"}),
+        )
+        with pytest.raises(PolarsIoConfigError) as excinfo:
+            validate_arguments(fmt, owner, callable_name, {"low_memory": True})
+        message = str(excinfo.value)
+        assert "low_memory" in message
+        assert polars.__version__ in message
+        assert "no longer in the installed polars" in message
+
+
+class TestFreshnessReport:
+    """`extract_polars_io.py --diff` — the signal that replaced the alarm."""
+
+    def test_matching_versions_report_no_drift(self) -> None:
+        report = "\n".join(extract_polars_io.diff_report())
+        assert "Polars I/O interface freshness" in report
+        if polars.__version__ == load_io_schema()["polars_version"]:
+            assert "is the version the committed schema records" in report
+        else:
+            assert f"this resolve installed {polars.__version__}" in report
+
+    def test_drift_is_sorted_into_names_defaults_and_shape(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        committed = extract_polars_io.extract_schema()
+        committed["polars_version"] = "0.0.0-committed"
+        for fn in committed["functions"]:
+            if fn["owner"] != "polars" or fn["name"] != "read_csv":
+                continue
+            fn["arguments"] = [dict(arg) for arg in fn["arguments"]]
+            fn["arguments"][1]["name"] = "gone_upstream"
+            fn["arguments"][2]["default"] = "'was'"
+            fn["arguments"][3]["annotation"] = "OldAnnotation"
+        snapshot = tmp_path / "committed.json"
+        snapshot.write_text(json.dumps(committed), encoding="utf-8")
+        monkeypatch.setattr(extract_polars_io, "DEFAULT_OUTPUT", snapshot)
+
+        report = "\n".join(extract_polars_io.diff_report())
+        assert "no longer declares: gone_upstream" in report
+        assert "**Changed defaults**" in report
+        assert "default 'was' →" in report
+        assert "A further 1 argument(s) differ only in kind, position or annotation" in report
+
+    def test_an_introspection_failure_is_not_reported_as_a_removal(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        committed = extract_polars_io.extract_schema()
+        committed["polars_version"] = "0.0.0-committed"
+        snapshot = tmp_path / "committed.json"
+        snapshot.write_text(json.dumps(committed), encoding="utf-8")
+        monkeypatch.setattr(extract_polars_io, "DEFAULT_OUTPUT", snapshot)
+
+        broken = extract_polars_io.extract_schema()
+        for fn in broken["functions"]:
+            if fn["owner"] == "polars" and fn["name"] == "read_csv":
+                fn["arguments"] = []
+                fn["introspection_error"] = "ValueError: no signature found"
+        monkeypatch.setattr(extract_polars_io, "extract_schema", lambda: broken)
+
+        report = "\n".join(extract_polars_io.diff_report())
+        assert "could not be introspected" in report
+        assert "no longer declares" not in report

--- a/tests/test_polars_io_interface_contracts.py
+++ b/tests/test_polars_io_interface_contracts.py
@@ -1,14 +1,25 @@
 """Contract tests for the committed polars I/O argument schema.
 
-The committed schema (``src/haute/_polars_io_arguments.json``) is the
-interface contract for the polars I/O surface haute's data-input /
-data-output machinery builds on. These tests re-extract the schema from the
-*installed* polars and fail on any argument-level drift, so:
+The committed schema (``src/haute/_polars_io_arguments.json``) records one
+polars version, but the ``polars`` specifier admits a range, so the schema and
+an installed polars can legitimately differ. Two contracts follow from that,
+and this module keeps them apart:
 
-- a lockfile polars bump that changes the I/O surface fails at PR time, and
-- the scheduled unlocked-resolve lane (which runs the core subset against a
-  latest-within-caps resolve) catches an in-cap upstream release changing
-  the surface before a user's fresh install does.
+- **Cap-range contract** (:class:`TestNoBreakingDriftAcrossTheCap`) — what
+  must hold for *every* polars inside the specifier, and therefore for a
+  user's fresh install. Argument-name differences are not in it: the registry
+  intersects the committed schema with the installed signature
+  (``haute._polars_io_schema.supported_argument_names``), so a name present on
+  only one side is simply not config-expressible. What remains is the surface
+  haute uses *positionally* or by identity: the callables must exist and their
+  positional parameters must not move.
+- **Snapshot contract** (:class:`TestCommittedSnapshotMatchesPinnedPolars`) —
+  exact equality with the version the schema records. This is the
+  regenerate-on-bump gate for the pinned lanes: move polars in ``uv.lock``
+  without re-running the extractor and it fails. A lane that deliberately
+  resolves polars away from the lockfile declares itself with
+  ``HAUTE_POLARS_UNPINNED=1``; there the cap-range contract is the applicable
+  one.
 
 On a legitimate upstream change, the fix is deliberate: re-run
 ``uv run python scripts/extract_polars_io.py``, review the diff, and commit
@@ -19,16 +30,28 @@ data-input/data-output argument surface.
 from __future__ import annotations
 
 import importlib.util
+import inspect
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
+import polars
+import pytest
+
+from haute import _polars_io_schema as schema_module
+from haute._polars_io_registry import FORMATS
 from haute._polars_io_schema import (
     argument_names,
+    installed_argument_names,
     io_function,
     io_functions_by_key,
     load_io_schema,
+    retired_argument_names,
+    supported_argument_names,
 )
+
+_UNPINNED_ENV = "HAUTE_POLARS_UNPINNED"
 
 _REGENERATE_HINT = (
     "The installed polars I/O interface no longer matches the committed schema "
@@ -38,6 +61,19 @@ _REGENERATE_HINT = (
     "in-range upstream release has drifted the interface — triage before trusting "
     "data-input/data-output argument validation."
 )
+
+_BREAKING_HINT = (
+    "The installed polars has moved part of the I/O surface haute depends on by "
+    "identity or by position, which no committed schema can absorb: a callable the "
+    "registry dispatches to is gone, or a parameter haute passes positionally has "
+    "shifted. Fix the registry (src/haute/_polars_io_registry.py) or the polars "
+    "specifier in pyproject.toml — regenerating the schema alone does not make a "
+    "fresh install correct."
+)
+
+# Parameter kinds haute may supply positionally; the node's own source/target
+# fields become leading positional arguments in `_resolve_input_source`.
+_POSITIONAL_KINDS = frozenset({"POSITIONAL_ONLY", "POSITIONAL_OR_KEYWORD", "VAR_POSITIONAL"})
 
 
 def _load_extractor() -> Any:
@@ -58,10 +94,71 @@ def _functions_by_key(schema: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {f"{fn['owner']}.{fn['name']}": fn for fn in schema["functions"]}
 
 
-class TestCommittedSchemaMatchesInstalledPolars:
-    """The drift tripwire: committed JSON == live introspection, argument-level."""
+def _registry_callable_keys() -> list[str]:
+    """Every ``owner.name`` the format registry dispatches to."""
+    keys = {
+        f"{owner}.{name}"
+        for fmt in FORMATS
+        for owner, name in (
+            ("polars", fmt.reader),
+            ("polars", fmt.scanner),
+            ("DataFrame", fmt.writer),
+            ("LazyFrame", fmt.sinker),
+        )
+        if name is not None
+    }
+    return sorted(keys)
+
+
+def _positional_names(record: dict[str, Any]) -> list[str]:
+    return [a["name"] for a in record["arguments"] if a["kind"] in _POSITIONAL_KINDS]
+
+
+class TestNoBreakingDriftAcrossTheCap:
+    """What must hold for every polars inside the specifier, not just the pinned one."""
+
+    def test_registry_callables_survive_the_installed_polars(self) -> None:
+        committed = _functions_by_key(load_io_schema())
+        fresh = _functions_by_key(extract_polars_io.extract_schema())
+
+        problems: list[str] = []
+        for key in _registry_callable_keys():
+            if key not in committed:
+                problems.append(f"{key}: dispatched by the registry but absent from the schema")
+                continue
+            if key not in fresh:
+                problems.append(f"{key}: absent from the installed polars {polars.__version__}")
+                continue
+            if "introspection_error" in fresh[key]:
+                problems.append(f"{key}: not introspectable: {fresh[key]['introspection_error']}")
+                continue
+            was, now = _positional_names(committed[key]), _positional_names(fresh[key])
+            if was != now:
+                problems.append(f"{key}: positional parameters moved: {was} -> {now}")
+
+        assert not problems, _BREAKING_HINT + "\n\nBreaking drift:\n- " + "\n- ".join(problems)
+
+    def test_committed_function_count_matches_functions_list(self) -> None:
+        schema = load_io_schema()
+        assert schema["function_count"] == len(schema["functions"])
+
+
+class TestCommittedSnapshotMatchesPinnedPolars:
+    """The regenerate-on-bump gate: committed JSON == live introspection, exactly."""
 
     def test_no_interface_drift_against_installed_polars(self) -> None:
+        recorded = load_io_schema()["polars_version"]
+        if os.environ.get(_UNPINNED_ENV) == "1":
+            # A lane that resolved polars away from the lockfile on purpose
+            # (unlocked-resolve, dependency-floors). Snapshot equality is not
+            # the contract there; TestNoBreakingDriftAcrossTheCap is.
+            return
+
+        assert polars.__version__ == recorded, (
+            f"{_REGENERATE_HINT} Installed polars is {polars.__version__}, the committed "
+            f"schema records {recorded}."
+        )
+
         committed = _functions_by_key(load_io_schema())
         fresh = _functions_by_key(extract_polars_io.extract_schema())
 
@@ -95,10 +192,6 @@ class TestCommittedSchemaMatchesInstalledPolars:
                     problems.append(f"{key}.{name}: changed {details}")
 
         assert not problems, _REGENERATE_HINT + "\n\nDrift:\n- " + "\n- ".join(problems)
-
-    def test_committed_function_count_matches_functions_list(self) -> None:
-        schema = load_io_schema()
-        assert schema["function_count"] == len(schema["functions"])
 
 
 class TestCommittedSchemaInvariants:
@@ -153,3 +246,56 @@ class TestSchemaLoaderHelpers:
         # forces the regeneration to be reviewed); it must never silently
         # shrink below the researched 63-callable width.
         assert len(io_functions_by_key()) >= 63
+
+    def test_installed_argument_names_reads_the_live_signature(self) -> None:
+        live = {p for p in inspect.signature(polars.read_csv).parameters}
+        assert installed_argument_names("polars", "read_csv") == live
+
+    def test_installed_argument_names_drops_the_method_receiver(self) -> None:
+        assert "self" not in installed_argument_names("DataFrame", "write_csv")
+
+    def test_installed_argument_names_names_a_callable_this_polars_lacks(self) -> None:
+        try:
+            installed_argument_names("polars", "read_nonexistent")
+        except AttributeError as exc:
+            assert "read_nonexistent" in str(exc)
+            assert polars.__version__ in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected AttributeError")
+
+
+class TestSupportedArgumentNames:
+    """The intersection that lets one committed snapshot serve the whole cap."""
+
+    def test_a_committed_argument_the_installed_polars_dropped_is_not_supported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        committed = set(argument_names("polars", "read_csv"))
+        assert "schema_overrides" in committed
+        monkeypatch.setattr(
+            schema_module,
+            "installed_argument_names",
+            lambda owner, name: frozenset(committed - {"schema_overrides"}),
+        )
+        assert "schema_overrides" not in supported_argument_names("polars", "read_csv")
+        assert retired_argument_names("polars", "read_csv") == frozenset({"schema_overrides"})
+
+    def test_an_argument_only_the_installed_polars_has_is_not_supported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A newer in-cap polars introducing an argument must not make it
+        # config-expressible: the exclusion classes in the registry are
+        # subtractive, so an unclassified argument would be allowed by default.
+        committed = set(argument_names("polars", "read_csv"))
+        monkeypatch.setattr(
+            schema_module,
+            "installed_argument_names",
+            lambda o, n: frozenset(committed | {"empty_string_is_null"}),
+        )
+        assert "empty_string_is_null" not in supported_argument_names("polars", "read_csv")
+        assert retired_argument_names("polars", "read_csv") == frozenset()
+
+    def test_supported_equals_committed_when_the_versions_agree(self) -> None:
+        for key in _registry_callable_keys():
+            owner, name = key.split(".", 1)
+            assert supported_argument_names(owner, name) <= frozenset(argument_names(owner, name))

--- a/tests/test_test_debt.py
+++ b/tests/test_test_debt.py
@@ -267,6 +267,19 @@ _EXPECTED_DEBT_IDS = {
     # tests/test_host_memory.py::TestAvailableRamMacOS
     # ::test_real_darwin_kernel_reports_available_memory.
     "23fb0fa7068e4340",
+    # Polars snapshot contract on a deliberately unpinned resolve — the
+    # committed I/O schema records one polars version, so exact snapshot
+    # equality is unsatisfiable in the two lanes that resolve polars away from
+    # the lockfile (unlocked-resolve, dependency-floors) and those lanes
+    # declare themselves with HAUTE_POLARS_UNPINNED=1. Not a suppressed
+    # failure: TestNoBreakingDriftAcrossTheCap asserts the contract that does
+    # hold across the whole specifier in the same run, and the skip is gated on
+    # the versions actually differing, so a declared lane that lands on the
+    # recorded version still runs the full comparison. See
+    # tests/test_polars_io_interface_contracts.py
+    # ::TestCommittedSnapshotMatchesPinnedPolars
+    # ::test_no_interface_drift_against_installed_polars.
+    "ba1f02fb9964cdf3",
 }
 
 _EXPECTED_NON_STRICT_XFAIL_IDS = {


### PR DESCRIPTION
`Closes #111.`

The scheduled unlocked-resolve lane has been red since 20 July. It failed on the polars I/O interface contract, which asserted that a committed argument schema generated from exactly one polars version matched whatever a latest-within-caps resolve installed. With `polars>=1.39.3,<2` and polars moving inside it, that assertion cannot hold.

The first red run was five differences, none of which stopped a fresh install working; by 3 August, 25 of the 33 were keyword-only position renumbering. The alarm could not tell that apart from a broken install, so the lane stayed red and the drift that mattered arrived as another "Still red" comment.

Underneath it was a real defect: the committed snapshot was the only source for the config-argument surface, so on polars ≥1.43 haute offered a CSV argument the signature had withdrawn and refused two the installed polars declared.

The registry now intersects the committed schema with the installed signature, which lets one snapshot serve the whole specifier: an argument is config-expressible only when a regeneration has classified it *and* the installed polars declares it. The contract test splits to match — a cap-range half that always runs (callables present and introspectable, the leading positionals haute supplies unmoved, the keyword names haute hardcodes still accepted, no empty argument surfaces) and an exact snapshot half that stays the regenerate-on-bump gate for the pinned lanes. Staleness is reported to the run summary instead of paging anyone, with changed defaults named individually because a default is what an argument does when nobody sets it.

No lockfile, floor, or dependency change.

Verified against a fresh 1.43.2 resolve: the lane's core subset passes 1174/0. Full backend suite 15058 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
