### PR TITLE
fix: enforce singleton nodes across submodels

### DIFF
--- a/frontend/e2e/core-flows.spec.ts
+++ b/frontend/e2e/core-flows.spec.ts
@@ -15,43 +15,28 @@ const browserSubmodelPath = resolve(e2eProjectRoot, "rating", "modules", "browse
 const selectAll = process.platform === "darwin" ? "Meta+A" : "Control+A"
 
 async function connectHandles(page: Page, source: Locator, target: Locator): Promise<void> {
+  const collapsePalette = page.getByTitle("Collapse palette")
+  if (await collapsePalette.isVisible()) await collapsePalette.click()
   await page.getByTestId("toolbar-centre").click()
   const zoomIn = page.getByRole("button", { name: "Zoom in", exact: true })
   for (let step = 0; step < 4; step += 1) await zoomIn.click()
   await expect(source).toBeVisible()
   await expect(target).toBeVisible()
-  const [sourceBox, targetBox] = await Promise.all([
-    source.boundingBox(),
-    target.boundingBox(),
-  ])
-  if (sourceBox === null || targetBox === null) {
-    throw new Error("Could not measure the handles for a graph connection")
-  }
-  await page.mouse.move(
-    sourceBox.x + sourceBox.width / 2,
-    sourceBox.y + sourceBox.height / 2,
-  )
+  // Locator actions wait for fit-view animation to settle before resolving
+  // the live handle position. Cached bounding boxes can become stale here;
+  // collapsing the palette keeps both endpoints in view after zooming.
+  await source.hover()
   await page.mouse.down()
-  await page.mouse.move(
-    targetBox.x + targetBox.width / 2,
-    targetBox.y + targetBox.height / 2,
-    { steps: 12 },
-  )
-  const expectedTargetHandle = await target.getAttribute("data-handleid")
-  const hitTargetHandle = await page.evaluate(({ x, y }) => (
-    document.elementFromPoint(x, y)
-      ?.closest(".react-flow__handle")
-      ?.getAttribute("data-handleid") ?? null
-  ), {
-    x: targetBox.x + targetBox.width / 2,
-    y: targetBox.y + targetBox.height / 2,
-  })
-  if (hitTargetHandle !== expectedTargetHandle) {
-    throw new Error(
-      `Connection drop missed handle ${String(expectedTargetHandle)}; hit ${String(hitTargetHandle)}`,
-    )
+  try {
+    await target.hover()
+    // Releasing before React Flow processes the move makes the connection a
+    // no-op, even when the browser has geometrically reached the target.
+    await expect(source).toHaveClass(/(^|\s)connectingfrom(\s|$)/)
+    await expect(target).toHaveClass(/(^|\s)connectingto(\s|$)/)
+    await expect(target).toHaveClass(/(^|\s)valid(\s|$)/)
+  } finally {
+    await page.mouse.up()
   }
-  await page.mouse.up()
 }
 
 test.describe.configure({ mode: "serial" })
@@ -343,8 +328,8 @@ test.describe("core browser flows", () => {
     await page.reload()
     await expect(submodelNode).toBeVisible()
 
-    const sourceNode = page.getByTestId("rf__node-raw_rows")
-    const sourceHandle = sourceNode.getByTestId("output-connector[0]:raw_rows")
+    const sourceNode = page.getByTestId("rf__node-browser_optimiser_rows")
+    const sourceHandle = sourceNode.getByTestId("output-connector[0]:browser_optimiser_rows")
     const newInputHandle = submodelNode.getByTestId("submodel-input-handle")
     await expect(sourceHandle).toBeVisible()
     await expect(newInputHandle).toBeVisible()
@@ -357,7 +342,7 @@ test.describe("core browser flows", () => {
     )
     await expect(submodelNode.getByTestId(/^submodel-input-frame-row-/)).toHaveCount(0)
     await expect(submodelNode.getByText("enriched", { exact: true })).toHaveCount(0)
-    const frameName = "raw_rows"
+    const frameName = "browser_optimiser_rows"
     await connectHandles(page, sourceHandle, newInputHandle)
     await expect(submodelNode.locator('[data-handleid="in__input_2"]')).toBeAttached()
     await expect(collapsedTargets).toHaveCount(3)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,12 @@ import useNodeResultsStore from "./stores/useNodeResultsStore"
 import useDocumentStatusStore from "./stores/useDocumentStatusStore"
 import { HAUTE_SESSION_EXPIRED_EVENT } from "./api/client"
 
-import { NODE_TYPES, isSingletonType } from "./utils/nodeTypes"
+import {
+  NODE_TYPES,
+  isSingletonType,
+  singletonTypesInDocument,
+  singletonTypesInSubmodelDefinition,
+} from "./utils/nodeTypes"
 import { previewForActiveNode } from "./utils/activePreview"
 import { swapEdgeJoinInputs, type EdgeJoinSwapInputsFailureReason } from "./utils/edgeJoinGraph"
 import { validatePipelineConnection, type ConnectionValidationResult } from "./utils/connectionValidation"
@@ -849,6 +854,17 @@ function FlowEditor() {
     reservedApiInputFrameLabels,
   })
 
+  // Drilling replaces the visible graph in the store. The reactive navigation
+  // snapshot retains the root graph while a definition is on screen, so the
+  // document-wide singleton policy does not depend on the current view.
+  const documentRootNodes = viewStack.length > 1
+    ? (viewStack[0]._savedNodes ?? nodes)
+    : nodes
+  const existingSingletonTypes = useMemo(
+    () => singletonTypesInDocument(documentRootNodes, submodels),
+    [documentRootNodes, submodels],
+  )
+
   const handleRepairApplied = useCallback((
     document: import("./types/pipelineDocument").PipelineEditorDocument,
   ) => {
@@ -1037,6 +1053,7 @@ function FlowEditor() {
     closePanel,
     isInsideSubmodel: viewStack.length > 1,
     readOnly: editingReadOnly,
+    existingSingletonTypes,
     resolveGraphIdentities: resolveCandidateGraphIdentities,
     commitSharedNodeDeletion,
   })
@@ -1049,6 +1066,7 @@ function FlowEditor() {
     setNodes, setNodesAndEdges, setSelectedNode,
     setLastSelectedId,
     setPreviewData, fitView,
+    submodels,
     resolveNodeIdentities,
     commitSharedNodeDeletion,
   })
@@ -1063,12 +1081,21 @@ function FlowEditor() {
     [nodes],
   )
   const selectedNodeIds = useMemo(() => selectedNodes.map((n) => n.id), [selectedNodes])
+  const selectedSubmodelHasSingleton = useMemo(() => {
+    if (selectedNodes.length !== 1) return false
+    const data = nodeData(selectedNodes[0])
+    if (data.nodeType !== NODE_TYPES.SUBMODEL || !isSubmodelInstanceConfig(data.config)) {
+      return false
+    }
+    return singletonTypesInSubmodelDefinition(data.config.definitionId, submodels).size > 0
+  }, [selectedNodes, submodels])
   const canCreateSubmodel = !editingReadOnly
     && viewStack.length <= 1
     && selectedNodeIds.length >= 2
   const canCreateInstance = !editingReadOnly
     && selectedNodes.length === 1
     && !isSingletonType(nodeData(selectedNodes[0]).nodeType)
+    && !selectedSubmodelHasSingleton
   // The `can*` flags above drive presentation only. The request paths below
   // enforce policy AND say why they refused, exactly as Ctrl+G does — a
   // toolbar button that swallows the click in silence is the one case where the
@@ -1167,6 +1194,7 @@ function FlowEditor() {
     clearTrace,
     screenToFlowPosition,
     graphRefreshingRef,
+    existingSingletonTypes,
     resolveGraphIdentities: resolveCandidateGraphIdentities,
     findEdgeIdAtPoint,
     validateConnection,
@@ -1385,7 +1413,10 @@ function FlowEditor() {
         >
           {paletteOpen ? (
             <ErrorBoundary name="NodePalette">
-              <NodePalette onCollapse={() => setPaletteOpen(false)} nodes={nodes} />
+              <NodePalette
+                onCollapse={() => setPaletteOpen(false)}
+                existingSingletonTypes={existingSingletonTypes}
+              />
             </ErrorBoundary>
           ) : (
             <button

--- a/frontend/src/__tests__/App.integration.test.tsx
+++ b/frontend/src/__tests__/App.integration.test.tsx
@@ -969,6 +969,66 @@ describe("App integration — add a node via drag-and-drop from the palette", ()
       expect(useGraphStore.getState().nodes.length).toBe(before + 1)
     })
   })
+
+  it("keeps a Quote Input inside a submodel singleton across the whole document", async () => {
+    const occurrence = makeNode("inputs", "Inputs", "submodel")
+    occurrence.data.config = { definitionId: "definition_inputs", alias: "inputs" }
+    const nestedApiInput = makeNode("quote_input", "Nested Quote Input", "apiInput")
+
+    vi.mocked(api.loadPipeline).mockResolvedValueOnce(makePipelineEditorDocument({
+      nodes: [occurrence],
+      edges: [],
+      preamble: "",
+      preserved_blocks: [],
+      source_file: "main.py",
+      source_revision: "revision-nested-singleton",
+      submodels: {
+        definition_inputs: {
+          definitionId: "definition_inputs",
+          file: "modules/inputs.py",
+          graph: { nodes: [nestedApiInput], edges: [] },
+          inputPorts: [],
+          outputPorts: [],
+        },
+      },
+    }))
+    render(<App />)
+    await waitForAppReady()
+
+    const paletteItem = screen.getByTestId("node-palette-item-apiInput")
+    expect(paletteItem).toHaveAttribute("draggable", "false")
+    expect(paletteItem).toHaveAttribute("title", expect.stringMatching(/only one Quote Input/i))
+    const identityCallsBeforeDrop = vi.mocked(api.resolveEditorNodeIdentities).mock.calls.length
+
+    // The drop handler is an independent commit-time guard: a stale drag that
+    // began before navigation, or a synthetic payload, must not bypass the
+    // palette's presentation state.
+    const canvas = document.querySelector(".react-flow") as HTMLElement | null
+    expect(canvas, "ReactFlow canvas container rendered").not.toBeNull()
+    const data = new Map<string, string>([
+      ["application/reactflow-type", "apiInput"],
+      ["application/reactflow-config", JSON.stringify({ path: "" })],
+    ])
+    const dataTransfer = {
+      dropEffect: "none",
+      effectAllowed: "move",
+      getData: (type: string): string => data.get(type) ?? "",
+      setData: (type: string, value: string): void => { data.set(type, value) },
+      clearData: (): void => { data.clear() },
+      types: [] as ReadonlyArray<string>,
+      files: [] as unknown as FileList,
+      items: [] as unknown as DataTransferItemList,
+    }
+
+    fireEvent.dragOver(canvas!, { dataTransfer })
+    fireEvent.drop(canvas!, { dataTransfer })
+
+    await waitFor(() => {
+      expect(useToastStore.getState().toasts.at(-1)?.text).toMatch(/only one Quote Input/i)
+    })
+    expect(useGraphStore.getState().nodes).toHaveLength(1)
+    expect(api.resolveEditorNodeIdentities).toHaveBeenCalledTimes(identityCallsBeforeDrop)
+  })
 })
 
 describe("App integration — save pipeline", () => {

--- a/frontend/src/__tests__/hover/modellingMiscHoverAndTeardown.test.tsx
+++ b/frontend/src/__tests__/hover/modellingMiscHoverAndTeardown.test.tsx
@@ -718,7 +718,7 @@ describe("modelling subpanels and hoverHandlers teardown", () => {
         const { default: NodePalette } = await import(
           "../../panels/NodePalette"
         )
-        const { container } = render(<NodePalette nodes={[]} />)
+        const { container } = render(<NodePalette />)
 
         // The palette should render at least one row (there are
         // 15 PALETTE_TYPES entries today; any positive count proves

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -9,6 +9,7 @@ interface ContextMenuProps {
   isSubmodel?: boolean
   /** A created instance copy: deletable directly, unlike its definition owner. */
   isSubmodelCopy?: boolean
+  /** Direct singleton, or a submodel whose definition contains one. */
   isSingleton?: boolean
   onClose: () => void
   onDelete: (id: string) => void
@@ -44,7 +45,7 @@ export default function ContextMenu({
     if (!isSingleton && !isSubmodel) {
       list.push({ label: "Duplicate", icon: Copy, action: () => onDuplicate(nodeId) })
     }
-    if (isSubmodel && onCreateInstance) {
+    if (isSubmodel && onCreateInstance && !isSingleton) {
       list.push({ label: "Create Instance", icon: Link2, action: () => onCreateInstance(nodeId) })
     }
     if (isSubmodel && onDissolveSubmodel) {

--- a/frontend/src/components/__tests__/ContextMenu.test.tsx
+++ b/frontend/src/components/__tests__/ContextMenu.test.tsx
@@ -43,6 +43,11 @@ describe("ContextMenu", () => {
     expect(screen.queryByText("Duplicate")).not.toBeInTheDocument()
   })
 
+  it("hides Create Instance when a submodel contains a singleton", () => {
+    render(<ContextMenu {...makeProps({ onCreateInstance: vi.fn(), isSubmodel: true, isSingleton: true })} />)
+    expect(screen.queryByText("Create Instance")).not.toBeInTheDocument()
+  })
+
   it("shows Dissolve Submodel but no Delete for a definition owner", () => {
     render(<ContextMenu {...makeProps({ isSubmodel: true, nodeId: "instance_pricing", onDissolveSubmodel: vi.fn() })} />)
     expect(screen.getByText("Dissolve Submodel")).toBeInTheDocument()

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.dragJson.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.dragJson.test.ts
@@ -16,7 +16,7 @@ import { renderHook, cleanup, act } from "@testing-library/react"
 import type { Node, Edge } from "@xyflow/react"
 import useEdgeHandlers from "../useEdgeHandlers"
 import useToastStore from "../../stores/useToastStore"
-import { NODE_TYPES } from "../../utils/nodeTypes"
+import { NODE_TYPES, type NodeTypeValue } from "../../utils/nodeTypes"
 
 vi.mock("@xyflow/react", async () => {
   const actual = await vi.importActual("@xyflow/react")
@@ -47,6 +47,7 @@ function makeParams() {
     clearTrace: vi.fn(),
     screenToFlowPosition: vi.fn((pos: { x: number; y: number }) => pos),
     graphRefreshingRef: { current: 0 },
+    existingSingletonTypes: new Set<NodeTypeValue>(),
     resolveGraphIdentities: vi.fn(async (nodes: readonly Node[], edges: readonly Edge[]) => ({ nodes: [...nodes], edges: [...edges] })),
   }
 }

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -3,7 +3,7 @@ import { renderHook, cleanup, act } from "@testing-library/react"
 import type { Node, Edge, Connection } from "@xyflow/react"
 import useEdgeHandlers from "../useEdgeHandlers"
 import useToastStore from "../../stores/useToastStore"
-import { NODE_TYPES } from "../../utils/nodeTypes"
+import { NODE_TYPES, type NodeTypeValue } from "../../utils/nodeTypes"
 import { DEFAULT_TARGET_HANDLE, SUBMODEL_INPUT_HANDLE } from "../../utils/flowHandles"
 import { validatePipelineConnection } from "../../utils/connectionValidation"
 import type { SimpleNode } from "../../panels/editors/_shared"
@@ -28,6 +28,7 @@ function makeParams() {
     clearTrace: vi.fn(),
     screenToFlowPosition: vi.fn((pos: { x: number; y: number }) => pos),
     graphRefreshingRef: { current: 0 },
+    existingSingletonTypes: new Set<NodeTypeValue>(),
     resolveGraphIdentities: vi.fn(async (
       nodes: readonly Node[],
       edges: readonly Edge[],

--- a/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useEdgeHandlers.test.ts
@@ -116,14 +116,14 @@ function makeEdgeJoinInsertionParams() {
   return params
 }
 
-function droppedPolarsEvent(): React.DragEvent {
+function droppedNodeEvent(type: NodeTypeValue = NODE_TYPES.POLARS): React.DragEvent {
   return {
     preventDefault: vi.fn(),
     clientX: 300,
     clientY: 400,
     dataTransfer: {
       getData: vi.fn((key: string) => {
-        if (key === "application/reactflow-type") return NODE_TYPES.POLARS
+        if (key === "application/reactflow-type") return type
         if (key === "application/reactflow-config") return "{}"
         return ""
       }),
@@ -177,7 +177,7 @@ describe("useEdgeHandlers", () => {
     })
     const { result } = renderHook(() => useEdgeHandlers(params))
 
-    act(() => result.current.onDrop(droppedPolarsEvent()))
+    act(() => result.current.onDrop(droppedNodeEvent()))
     await flushIdentityCommit()
 
     expect(useToastStore.getState().toasts.at(-1)?.text).toContain(
@@ -1698,6 +1698,40 @@ describe("useEdgeHandlers", () => {
     )
   })
 
+  it("onNodeContextMenu marks a submodel containing a singleton as singleton", () => {
+    const params = makeParams()
+    const node = {
+      id: "inputs",
+      data: {
+        label: "Inputs",
+        nodeType: NODE_TYPES.SUBMODEL,
+        config: { definitionId: "definition_inputs", alias: "inputs" },
+      },
+    } as unknown as Node
+    const submodels = {
+      definition_inputs: {
+        definitionId: "definition_inputs",
+        file: "modules/inputs.py",
+        graph: {
+          nodes: [identifiedNode("quote_input", NODE_TYPES.API_INPUT)],
+          edges: [],
+        },
+        inputPorts: [],
+        outputPorts: [],
+      },
+    }
+    const { result } = renderHook(() => useEdgeHandlers({ ...params, submodels }))
+    const event = { preventDefault: vi.fn(), clientX: 50, clientY: 60 } as unknown as React.MouseEvent
+
+    act(() => {
+      result.current.onNodeContextMenu(event, node)
+    })
+
+    expect(params.setContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({ isSubmodel: true, isSingleton: true }),
+    )
+  })
+
   it("onDragOver enables dropping by preventing default and signalling a move", () => {
     const params = makeParams()
     const { result } = renderHook(() => useEdgeHandlers(params))
@@ -1767,6 +1801,39 @@ describe("useEdgeHandlers", () => {
     )
   })
 
+  it("onDrop rejects a singleton already present elsewhere in the document", () => {
+    const params = makeParams()
+    params.existingSingletonTypes = new Set([NODE_TYPES.API_INPUT])
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onDrop(droppedNodeEvent(NODE_TYPES.API_INPUT))
+    })
+
+    expect(params.resolveGraphIdentities).not.toHaveBeenCalled()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts.at(-1)).toMatchObject({
+      type: "info",
+      text: "Only one Quote Input node is allowed per pipeline",
+    })
+  })
+
+  it("onDrop rechecks the current graph before accepting a stale singleton drag", () => {
+    const params = makeParams()
+    params.graphRef.current.nodes = [identifiedNode("quote_input", NODE_TYPES.API_INPUT)]
+    const { result } = renderHook(() => useEdgeHandlers(params))
+
+    act(() => {
+      result.current.onDrop(droppedNodeEvent(NODE_TYPES.API_INPUT))
+    })
+
+    expect(params.resolveGraphIdentities).not.toHaveBeenCalled()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts.at(-1)?.text).toBe(
+      "Only one Quote Input node is allowed per pipeline",
+    )
+  })
+
   it("keeps a dropped-node creation atomic when identity resolution rejects", async () => {
     const params = makeParams()
     params.resolveGraphIdentities = vi.fn(async () => {
@@ -1774,7 +1841,7 @@ describe("useEdgeHandlers", () => {
     })
     const { result } = renderHook(() => useEdgeHandlers(params))
 
-    act(() => result.current.onDrop(droppedPolarsEvent()))
+    act(() => result.current.onDrop(droppedNodeEvent()))
     await flushIdentityCommit()
 
     expect(params.setNodes).not.toHaveBeenCalled()
@@ -1789,7 +1856,7 @@ describe("useEdgeHandlers", () => {
     params.resolveGraphIdentities = vi.fn(async () => ({ nodes: [], edges: [] }))
     const { result } = renderHook(() => useEdgeHandlers(params))
 
-    act(() => result.current.onDrop(droppedPolarsEvent()))
+    act(() => result.current.onDrop(droppedNodeEvent()))
     await flushIdentityCommit()
 
     expect(params.setNodes).not.toHaveBeenCalled()
@@ -1807,7 +1874,7 @@ describe("useEdgeHandlers", () => {
     })
     const { result } = renderHook(() => useEdgeHandlers(params))
 
-    act(() => result.current.onDrop(droppedPolarsEvent()))
+    act(() => result.current.onDrop(droppedNodeEvent()))
     await vi.waitFor(() => expect(params.resolveGraphIdentities).toHaveBeenCalledOnce())
     params.graphRef.current = { nodes: [], edges: [] }
     await act(async () => {

--- a/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -5,6 +5,7 @@ import useKeyboardShortcuts from "../useKeyboardShortcuts"
 import useUIStore from "../../stores/useUIStore"
 import useToastStore from "../../stores/useToastStore"
 import { makeNode } from "../../test-utils/factories"
+import type { NodeTypeValue } from "../../utils/nodeTypes"
 
 function resolvedIdentityGraph(
   nodes: readonly Node[],
@@ -45,6 +46,7 @@ function makeParams(overrides: Partial<Parameters<typeof useKeyboardShortcuts>[0
     closePanel: vi.fn(),
     isInsideSubmodel: false,
     readOnly: false,
+    existingSingletonTypes: new Set<NodeTypeValue>(),
     resolveGraphIdentities: vi.fn(async (
       nodes: readonly Node[],
       edges: readonly Edge[],
@@ -356,6 +358,22 @@ describe("useKeyboardShortcuts", () => {
       edges: [],
     }
     fireKey("v", { ctrlKey: true })
+    expect(params.setNodesAndEdges).not.toHaveBeenCalled()
+  })
+
+  it("Ctrl+V treats a singleton inside another document graph as occupied", () => {
+    const occupiedSingletonTypes = params.existingSingletonTypes as Set<NodeTypeValue>
+    occupiedSingletonTypes.add("apiInput")
+    params.clipboard.current = {
+      nodes: [
+        { id: "api1", position: { x: 0, y: 0 }, data: { label: "Quote Input", nodeType: "apiInput" }, type: "pipelineNode" } as unknown as Node,
+      ],
+      edges: [],
+    }
+
+    fireKey("v", { ctrlKey: true })
+
+    expect(params.resolveGraphIdentities).not.toHaveBeenCalled()
     expect(params.setNodesAndEdges).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts
@@ -34,6 +34,7 @@ function makeParams() {
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),
+    submodels: {},
     resolveNodeIdentities: vi.fn(async (nodes: readonly Node[]) => [...nodes]),
   }
 }

--- a/frontend/src/hooks/__tests__/useNodeHandlers.gaps.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.gaps.test.ts
@@ -24,6 +24,7 @@ function makeParams() {
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),
+    submodels: {},
     resolveNodeIdentities: vi.fn(async (nodes: readonly Node[]) => [...nodes]),
   }
 }

--- a/frontend/src/hooks/__tests__/useNodeHandlers.test.ts
+++ b/frontend/src/hooks/__tests__/useNodeHandlers.test.ts
@@ -21,6 +21,7 @@ function makeParams() {
     setSelectedNode: vi.fn(),
     setPreviewData: vi.fn(),
     fitView: vi.fn(),
+    submodels: {} as Record<string, unknown>,
     resolveNodeIdentities: vi.fn(async (nodes: readonly Node[]) => [...nodes]),
   }
 }
@@ -516,6 +517,45 @@ describe("useNodeHandlers", () => {
     expect(created.data.config).not.toHaveProperty("graph")
     expect(created.data.config).not.toHaveProperty("file")
     expect(created.data.config).not.toHaveProperty("childNodeIds")
+  })
+
+  it("refuses to instance a submodel definition containing a singleton", async () => {
+    const params = makeParams()
+    const source = makeNode("submodel_inputs", "submodel", {
+      data: {
+        label: "Inputs",
+        nodeType: "submodel",
+        config: { definitionId: "definition_inputs", alias: "inputs" },
+      },
+    })
+    params.graphRef.current = { nodes: [source], edges: [] }
+    params.submodels = {
+      definition_inputs: {
+        definitionId: "definition_inputs",
+        file: "modules/inputs.py",
+        graph: {
+          nodes: [makeNode("quote_input", "apiInput", {
+            data: { label: "Quote Input", nodeType: "apiInput", config: {} },
+          })],
+          edges: [],
+        },
+        inputPorts: [],
+        outputPorts: [],
+      },
+    }
+    const { result } = renderHook(() => useNodeHandlers(params))
+
+    await act(async () => {
+      await result.current.handleCreateInstance(source.id)
+    })
+
+    expect(params.resolveNodeIdentities).not.toHaveBeenCalled()
+    expect(params.setNodes).not.toHaveBeenCalled()
+    expect(params.setSelectedNode).not.toHaveBeenCalled()
+    expect(useToastStore.getState().toasts.at(-1)).toMatchObject({
+      type: "info",
+      text: expect.stringMatching(/contains.*Quote Input.*only one/i),
+    })
   })
 
   it("continues copy numbering past nine instead of nesting suffixes", async () => {

--- a/frontend/src/hooks/useEdgeHandlers.ts
+++ b/frontend/src/hooks/useEdgeHandlers.ts
@@ -540,7 +540,7 @@ export default function useEdgeHandlers({
           || graphRef.current.nodes.some((node) => nodeData(node).nodeType === type)
         )
       ) {
-        const name = NODE_TYPE_META[type as NodeTypeValue]?.name ?? type
+        const name = NODE_TYPE_META[type as NodeTypeValue].name
         addToast("info", `Only one ${name} node is allowed per pipeline`)
         return
       }

--- a/frontend/src/hooks/useEdgeHandlers.ts
+++ b/frontend/src/hooks/useEdgeHandlers.ts
@@ -17,7 +17,13 @@ import {
   type OnSelectionChangeFunc,
 } from "@xyflow/react"
 import { effectiveNodeType, isSubmodelInstanceConfig, nodeData } from "../types/node"
-import { NODE_TYPES, NODE_TYPE_META, isSingletonType, type NodeTypeValue } from "../utils/nodeTypes"
+import {
+  NODE_TYPES,
+  NODE_TYPE_META,
+  isSingletonType,
+  singletonTypesInSubmodelDefinition,
+  type NodeTypeValue,
+} from "../utils/nodeTypes"
 import {
   finalizeResolvedEdgeJoinInsertion,
   insertEdgeJoinNode,
@@ -117,6 +123,7 @@ type UseEdgeHandlersParams = {
   clearTrace: () => void
   screenToFlowPosition: (pos: { x: number; y: number }) => { x: number; y: number }
   graphRefreshingRef: MutableRefObject<number>
+  existingSingletonTypes: ReadonlySet<NodeTypeValue>
   resolveGraphIdentities: (nodes: readonly Node[], edges: readonly Edge[]) => Promise<{ nodes: Node[]; edges: Edge[] }>
   findEdgeIdAtPoint?: (point: { x: number; y: number }) => string | null
   validateConnection?: (connection: Connection) => ConnectionValidationResult
@@ -153,6 +160,7 @@ export default function useEdgeHandlers({
   clearTrace,
   screenToFlowPosition,
   graphRefreshingRef,
+  existingSingletonTypes,
   resolveGraphIdentities,
   findEdgeIdAtPoint = () => null,
   validateConnection,
@@ -498,6 +506,9 @@ export default function useEdgeHandlers({
     event.preventDefault()
     const data = nodeData(node)
     const nt = data.nodeType
+    const containedSingletons = nt === NODE_TYPES.SUBMODEL && isSubmodelInstanceConfig(data.config)
+      ? singletonTypesInSubmodelDefinition(data.config.definitionId, submodels)
+      : new Set<NodeTypeValue>()
     setContextMenu({
       x: event.clientX,
       y: event.clientY,
@@ -507,9 +518,9 @@ export default function useEdgeHandlers({
       isSubmodelCopy: nt === NODE_TYPES.SUBMODEL
         && isSubmodelInstanceConfig(data.config)
         && data.config.instanceOf !== undefined,
-      isSingleton: isSingletonType(nt),
+      isSingleton: isSingletonType(nt) || containedSingletons.size > 0,
     })
-  }, [setContextMenu])
+  }, [setContextMenu, submodels])
 
   const onDragOver = useCallback((event: DragEvent) => {
     event.preventDefault()
@@ -521,6 +532,18 @@ export default function useEdgeHandlers({
       event.preventDefault()
       const type = event.dataTransfer.getData("application/reactflow-type")
       if (!type) return
+
+      if (
+        isSingletonType(type)
+        && (
+          existingSingletonTypes.has(type as NodeTypeValue)
+          || graphRef.current.nodes.some((node) => nodeData(node).nodeType === type)
+        )
+      ) {
+        const name = NODE_TYPE_META[type as NodeTypeValue]?.name ?? type
+        addToast("info", `Only one ${name} node is allowed per pipeline`)
+        return
+      }
 
       // Parse the drag-config JSON. Malformed payloads must fail loudly
       // (Issue #35) — silently swallowing the error would create a node
@@ -573,7 +596,7 @@ export default function useEdgeHandlers({
         }
       })()
     },
-    [screenToFlowPosition, nodeIdCounterRef, graphRef, setNodes, setSelectedNode, setLastSelectedId, addToast, resolveGraphIdentities],
+    [screenToFlowPosition, nodeIdCounterRef, graphRef, setNodes, setSelectedNode, setLastSelectedId, addToast, existingSingletonTypes, resolveGraphIdentities],
   )
 
   return {

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -4,7 +4,7 @@ import useToastStore from "../stores/useToastStore"
 import useUIStore from "../stores/useUIStore"
 import useNodeResultsStore from "../stores/useNodeResultsStore"
 import { isProtectedSubmodelNodeData, nodeData } from "../types/node"
-import { isSingletonType } from "../utils/nodeTypes"
+import { isSingletonType, type NodeTypeValue } from "../utils/nodeTypes"
 import { requestSubmodelCreation } from "../utils/submodelCreation"
 import type { SharedNodeDeletionResult } from "./useSubmodelBoundaryEditing"
 
@@ -29,6 +29,7 @@ interface KeyboardShortcutsParams {
   closePanel: () => void
   isInsideSubmodel: boolean
   readOnly: boolean
+  existingSingletonTypes: ReadonlySet<NodeTypeValue>
   resolveGraphIdentities: (
     nodes: readonly Node[],
     edges: readonly Edge[],
@@ -72,7 +73,7 @@ export default function useKeyboardShortcuts({
   handleSave, setNodes, setEdges, setNodesAndEdges, undo, redo, fitView,
   graphRef, clipboard, nodeIdCounter,
   setSelectedNode, setLastSelectedId, setPreviewData, clearTrace, closePanel,
-  isInsideSubmodel, readOnly,
+  isInsideSubmodel, readOnly, existingSingletonTypes,
   resolveGraphIdentities,
   commitSharedNodeDeletion,
 }: KeyboardShortcutsParams) {
@@ -138,15 +139,19 @@ export default function useKeyboardShortcuts({
         if (copiedNodes.length === 0) return
         e.preventDefault()
         const capturedGraph = graphRef.current
-        // Filter out singleton types that already exist in the graph
-        const existingSingletonTypes = new Set<string>()
+        // Submodel boundaries do not create a second singleton scope. Include
+        // the immediate graph too in case it changed before React re-rendered.
+        const occupiedSingletonTypes = new Set<string>(existingSingletonTypes)
         for (const n of capturedGraph.nodes) {
           const nt = nodeData(n).nodeType
-          if (isSingletonType(nt)) existingSingletonTypes.add(nt!)
+          if (isSingletonType(nt)) occupiedSingletonTypes.add(nt!)
         }
         const pasteable = copiedNodes.filter((n) => {
           const nt = nodeData(n).nodeType
-          return !(isSingletonType(nt) && existingSingletonTypes.has(nt!))
+          if (!isSingletonType(nt)) return true
+          if (occupiedSingletonTypes.has(nt!)) return false
+          occupiedSingletonTypes.add(nt!)
+          return true
         })
         if (pasteable.length === 0) return
         const idMap = new Map<string, string>()
@@ -330,6 +335,7 @@ export default function useKeyboardShortcuts({
     graphRef, clipboard, nodeIdCounter,
     setSelectedNode, setLastSelectedId, setPreviewData, clearTrace, closePanel,
     addToast, setShortcutsOpen, setSubmodelDialog, setNodeSearchOpen, isInsideSubmodel, readOnly,
+    existingSingletonTypes,
     resolveGraphIdentities, commitSharedNodeDeletion,
   ])
 }

--- a/frontend/src/hooks/useNodeHandlers.ts
+++ b/frontend/src/hooks/useNodeHandlers.ts
@@ -15,7 +15,12 @@ import {
   isSubmodelInstanceConfig,
   nodeData,
 } from "../types/node"
-import { NODE_TYPES, isSingletonType } from "../utils/nodeTypes"
+import {
+  NODE_TYPES,
+  NODE_TYPE_META,
+  isSingletonType,
+  singletonTypesInSubmodelDefinition,
+} from "../utils/nodeTypes"
 import { getLayoutedElements } from "../utils/layout"
 import type { PreviewData } from "../panels/DataPreview"
 import type { SharedNodeDeletionResult } from "./useSubmodelBoundaryEditing"
@@ -33,6 +38,7 @@ type UseNodeHandlersParams = {
   setLastSelectedId?: (id: string | null) => void
   setPreviewData: (updater: React.SetStateAction<PreviewData | null>) => void
   fitView: (opts?: { padding?: number }) => void
+  submodels: Record<string, unknown>
   resolveNodeIdentities: (nodes: readonly Node[]) => Promise<Node[]>
   commitSharedNodeDeletion?: (
     nodeIds: ReadonlySet<string>,
@@ -68,6 +74,7 @@ export default function useNodeHandlers({
   setLastSelectedId,
   setPreviewData,
   fitView,
+  submodels,
   resolveNodeIdentities,
   commitSharedNodeDeletion,
 }: UseNodeHandlersParams) {
@@ -213,6 +220,20 @@ export default function useNodeHandlers({
         addToast("error", `Cannot create instance of "${origData.label}": missing submodel definition identity`)
         return
       }
+      const containedSingletons = singletonTypesInSubmodelDefinition(
+        config.definitionId,
+        submodels,
+      )
+      if (containedSingletons.size > 0) {
+        const names = [...containedSingletons]
+          .map((nodeType) => NODE_TYPE_META[nodeType].name)
+          .join(", ")
+        addToast(
+          "info",
+          `Cannot create instance of "${origData.label}": its definition contains ${names}, and only one node of each singleton type is allowed per pipeline`,
+        )
+        return
+      }
       const ownerId = config.instanceOf ?? original.id
       const owner = n.find((node) => node.id === ownerId)
       const ownerConfig = owner ? nodeData(owner).config : undefined
@@ -304,7 +325,7 @@ export default function useNodeHandlers({
     } catch (err: unknown) {
       addToast("error", `Create node failed: ${err instanceof Error ? err.message : String(err)}`)
     }
-  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode, setLastSelectedId, addToast, resolveNodeIdentities])
+  }, [graphRef, nodeIdCounterRef, setNodes, setSelectedNode, setLastSelectedId, addToast, submodels, resolveNodeIdentities])
 
   const handleRenameNode = useCallback((id: string) => {
     const { nodes: n } = graphRef.current

--- a/frontend/src/panels/NodePalette.tsx
+++ b/frontend/src/panels/NodePalette.tsx
@@ -1,6 +1,5 @@
 import { PanelLeftClose } from "lucide-react"
 import type { DragEvent } from "react"
-import type { Node } from "@xyflow/react"
 import { NODE_TYPE_META, PALETTE_TYPES, SINGLETON_TYPES } from "../utils/nodeTypes"
 import type { NodeTypeValue } from "../utils/nodeTypes"
 
@@ -11,16 +10,13 @@ function onDragStart(event: DragEvent, type: NodeTypeValue) {
   event.dataTransfer.effectAllowed = "move"
 }
 
-export default function NodePalette({ onCollapse, nodes }: { onCollapse?: () => void; nodes?: Node[] }) {
-  // Build set of singleton types already present in the graph
-  const existingSingletons = new Set<string>()
-  if (nodes) {
-    for (const n of nodes) {
-      const nt = n.data.nodeType as string
-      if (nt && SINGLETON_TYPES.has(nt as NodeTypeValue)) existingSingletons.add(nt)
-    }
-  }
-
+export default function NodePalette({
+  onCollapse,
+  existingSingletonTypes = new Set<NodeTypeValue>(),
+}: {
+  onCollapse?: () => void
+  existingSingletonTypes?: ReadonlySet<NodeTypeValue>
+}) {
   return (
     <div className="w-[180px] h-full overflow-y-auto shrink-0 flex flex-col" style={{ background: "var(--chrome)", borderRight: "1px solid var(--chrome-border)" }}>
       <div className="px-4 py-3 flex items-center justify-between">
@@ -41,7 +37,7 @@ export default function NodePalette({ onCollapse, nodes }: { onCollapse?: () => 
         {PALETTE_TYPES.map((type) => {
           const meta = NODE_TYPE_META[type]
           const Icon = meta.icon
-          const disabled = SINGLETON_TYPES.has(type) && existingSingletons.has(type)
+          const disabled = SINGLETON_TYPES.has(type) && existingSingletonTypes.has(type)
           return (
             <div
               key={type}

--- a/frontend/src/panels/__tests__/NodePalette.test.tsx
+++ b/frontend/src/panels/__tests__/NodePalette.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup } from "@testing-library/react"
 import NodePalette from "../NodePalette"
-import type { Node } from "@xyflow/react"
 import { NODE_TYPES } from "../../utils/nodeTypes"
 
 describe("NodePalette", () => {
@@ -37,10 +36,7 @@ describe("NodePalette", () => {
   })
 
   it("disables singleton types already present in graph", () => {
-    const nodes: Node[] = [
-      { id: "ai1", data: { label: "Quote Input", nodeType: NODE_TYPES.API_INPUT } } as unknown as Node,
-    ]
-    render(<NodePalette nodes={nodes} />)
+    render(<NodePalette existingSingletonTypes={new Set([NODE_TYPES.API_INPUT])} />)
     // The Quote Input item should have a "Only one" title indicating it's disabled
     const apiInputItem = screen.getByTitle(/Only one Quote Input/i)
     expect(apiInputItem).toBeInTheDocument()
@@ -48,14 +44,14 @@ describe("NodePalette", () => {
   })
 
   it("non-singleton items are draggable", () => {
-    render(<NodePalette nodes={[]} />)
+    render(<NodePalette />)
     // Data Input is not a singleton and should be draggable
     const item = screen.getByText("Data Input").closest("[draggable]")
     expect(item).toHaveAttribute("draggable", "true")
   })
 
   it("sets drag data on drag start for non-disabled items", () => {
-    render(<NodePalette nodes={[]} />)
+    render(<NodePalette />)
     const transformItem = screen.getByText("Polars").closest("[draggable]")!
     const setData = vi.fn()
     fireEvent.dragStart(transformItem, {
@@ -85,10 +81,7 @@ describe("NodePalette", () => {
   })
 
   it("disabled singleton shows visual disabled state", () => {
-    const nodes: Node[] = [
-      { id: "ai1", data: { label: "Quote Input", nodeType: NODE_TYPES.API_INPUT } } as unknown as Node,
-    ]
-    render(<NodePalette nodes={nodes} />)
+    render(<NodePalette existingSingletonTypes={new Set([NODE_TYPES.API_INPUT])} />)
     const item = screen.getByTitle(/Only one Quote Input/i)
     // Class assertion kept intentionally: opacity is the visible indicator of disabled state,
     // and there is no ARIA attribute or other behavioral signal to assert on here.
@@ -96,19 +89,13 @@ describe("NodePalette", () => {
   })
 
   it("disabled singleton item is not draggable", () => {
-    const nodes: Node[] = [
-      { id: "ai1", data: { label: "Quote Input", nodeType: NODE_TYPES.API_INPUT } } as unknown as Node,
-    ]
-    render(<NodePalette nodes={nodes} />)
+    render(<NodePalette existingSingletonTypes={new Set([NODE_TYPES.API_INPUT])} />)
     const item = screen.getByTitle(/Only one Quote Input/i)
     expect(item).not.toHaveAttribute("draggable", "true")
   })
 
   it("drag start does not set data for disabled items", () => {
-    const nodes: Node[] = [
-      { id: "ai1", data: { label: "Quote Input", nodeType: NODE_TYPES.API_INPUT } } as unknown as Node,
-    ]
-    render(<NodePalette nodes={nodes} />)
+    render(<NodePalette existingSingletonTypes={new Set([NODE_TYPES.API_INPUT])} />)
     const item = screen.getByTitle(/Only one Quote Input/i)
     const setData = vi.fn()
     fireEvent.dragStart(item, {
@@ -118,7 +105,7 @@ describe("NodePalette", () => {
   })
 
   it("sets effectAllowed to move on drag start", () => {
-    render(<NodePalette nodes={[]} />)
+    render(<NodePalette />)
     const transformItem = screen.getByText("Polars").closest("[draggable]")!
     const dataTransfer = { setData: vi.fn(), effectAllowed: "" }
     fireEvent.dragStart(transformItem, { dataTransfer })

--- a/frontend/src/utils/nodeTypes.ts
+++ b/frontend/src/utils/nodeTypes.ts
@@ -1,7 +1,9 @@
 import { Database, Brain, TableProperties, CircleDot, HardDriveDownload, FileArchive, Package, ArrowRight, Radio, ToggleLeft, SlidersHorizontal, FlaskConical, Target, Crosshair, Rows3, Hash, Search, GitMerge } from "lucide-react"
+import type { Node } from "@xyflow/react"
 import PolarsIcon from "../components/PolarsIcon"
 import { NODE_GROUP_COLORS } from "../theme/colors"
 import {
+  isSubmodelDefinition,
   PIPELINE_NODE_TYPES,
   type NodeTypeValue,
 } from "../types/node"
@@ -69,6 +71,53 @@ export const SINGLETON_TYPES = new Set<NodeTypeValue>([
 /** Whether a node type allows only one instance per pipeline. */
 export function isSingletonType(nodeType: string | undefined): boolean {
   return Boolean(nodeType && SINGLETON_TYPES.has(nodeType as NodeTypeValue))
+}
+
+type NodeTypeCarrier = Pick<Node, "data">
+
+function collectSingletonTypes(
+  nodes: readonly NodeTypeCarrier[],
+  submodels: Record<string, unknown> | null | undefined,
+  result: Set<NodeTypeValue>,
+  visitedDefinitions: Set<string>,
+): void {
+  for (const node of nodes) {
+    const nodeType = node.data.nodeType
+    if (typeof nodeType === "string" && isSingletonType(nodeType)) {
+      result.add(nodeType as NodeTypeValue)
+    }
+  }
+  for (const [definitionId, candidate] of Object.entries(submodels ?? {})) {
+    if (visitedDefinitions.has(definitionId)) continue
+    if (!isSubmodelDefinition(candidate, definitionId)) continue
+    visitedDefinitions.add(definitionId)
+    collectSingletonTypes(
+      candidate.graph.nodes,
+      candidate.graph.submodels,
+      result,
+      visitedDefinitions,
+    )
+  }
+}
+
+/** Singleton types occupied anywhere in one canonical pipeline document. */
+export function singletonTypesInDocument(
+  rootNodes: readonly NodeTypeCarrier[],
+  submodels?: Record<string, unknown> | null,
+): Set<NodeTypeValue> {
+  const result = new Set<NodeTypeValue>()
+  collectSingletonTypes(rootNodes, submodels, result, new Set<string>())
+  return result
+}
+
+/** Singleton types that would be cloned by another occurrence of a definition. */
+export function singletonTypesInSubmodelDefinition(
+  definitionId: string,
+  submodels?: Record<string, unknown> | null,
+): Set<NodeTypeValue> {
+  const definition = submodels?.[definitionId]
+  if (!isSubmodelDefinition(definition, definitionId)) return new Set<NodeTypeValue>()
+  return singletonTypesInDocument(definition.graph.nodes, definition.graph.submodels)
 }
 
 /** Nodes that only produce data — no input handle. */

--- a/specs/frontend-graph-canvas/low-level.md
+++ b/specs/frontend-graph-canvas/low-level.md
@@ -886,13 +886,18 @@ newer overlapping transform.
   rejected, and a third incoming edge of any role is rejected — independent
   of the generic `maxInputs` check, which edge-join nodes bypass entirely.
 - **`handleDuplicateNode`, singleton types, and reusable submodels.**
-  Duplicating a node whose type is in `SINGLETON_TYPES` (`apiInput`, `output`,
-  or `liveSwitch`) is a silent no-op because the palette already prevents a
-  second one. Generic duplication of a `SUBMODEL` is absent from its context
-  menu and rejected visibly by the handler with direction to use Create
-  Instance; that path allocates a fresh occurrence id and alias. Duplication,
-  paste, and context-menu creation consume the same singleton metadata that
-  mirrors the backend save invariant.
+  Singleton occupancy is document-wide, not limited to the graph currently
+  visible on the canvas: root nodes and every embedded submodel definition are
+  considered together. The palette disables an occupied `SINGLETON_TYPES`
+  entry (`apiInput`, `output`, or `liveSwitch`), while the drop handler repeats
+  the check at commit time so stale or synthetic drag data cannot bypass it.
+  Duplicating a singleton remains a silent no-op and paste filters occupied
+  singleton types against the same document-wide set. Generic duplication of
+  a `SUBMODEL` is absent from its context menu and rejected visibly by the
+  handler with direction to use Create Instance; a definition that contains a
+  singleton cannot be instantiated because that would create a second
+  executable occurrence. These creation paths consume the same singleton
+  metadata and mirror the backend save invariant.
 - **`onDrop`'s config JSON never falls back to `{}` on a parse failure** — a
   malformed or non-object payload aborts node creation entirely (toast,
   return) rather than creating a node with an empty config that would then

--- a/specs/server-api/low-level.md
+++ b/specs/server-api/low-level.md
@@ -317,9 +317,12 @@ crash. Every filesystem event batches into `pending_changes`; a 300ms debounce t
 **Pipeline save (`SavePipelineService.save`)**, run inside the process-wide `save_lock` (an
 `asyncio.Lock`, so it serialises against concurrent submodel create/dissolve as well as
 concurrent plain saves, but does not coordinate another worker process):
-1. Validate singleton node types (at most one `apiInput`/`output`/`liveSwitch`), unique
-   sanitized node names (per-graph, then cross-module against every embedded submodel graph),
-   and that no node carries a `_load_error` marker.
+1. Flatten submodel occurrences and validate singleton node types (at most one
+   `apiInput`/`output`/`liveSwitch`) across the resulting executable pipeline, then validate
+   unique sanitized node names (per-graph, then cross-module against every embedded submodel
+   graph) and that no node carries a `_load_error` marker. A submodel boundary cannot hide a
+   second singleton, and creating another occurrence of a definition that contains one counts
+   as another executable singleton.
 2. Resolve and validate `source_file` against the active pipeline root.
    Before the remaining preflights, parse the current persisted parent and
    diff its canonical definition registry against the submitted graph. Every

--- a/specs/submodels/high-level.md
+++ b/specs/submodels/high-level.md
@@ -98,10 +98,13 @@ by one shared **definition** and any number of parent-graph **instances**:
 Creating another instance is a pure parent-graph mutation performed by the
 canvas: it adds a new occurrence with a fresh immutable id and stable alias
 whose `instanceOf` points at the definition owner, and does not create or copy
-a file. Removing an instance copy removes only that occurrence and its parent
-bindings, and is permitted from every canvas delete surface. The definition
-owner is never raw-deleted from any surface — it anchors the shared
-definition, so retiring it means dissolving the submodel (after its copies are
+a file. A definition containing a document-wide singleton node (`apiInput`,
+`output`, or `liveSwitch`) cannot be instantiated because flattening would
+create another executable occurrence of that singleton. Removing an instance
+copy removes only that occurrence and its parent bindings, and is permitted
+from every canvas delete surface. The definition owner is never raw-deleted
+from any surface — it anchors the shared definition, so retiring it means
+dissolving the submodel (after its copies are
 removed or dissolved); blocked attempts say so visibly. The owner cannot be
 dissolved while instances still reference it. Renaming an occurrence changes
 presentation only. Drilling into the owner opens the shared definition editor and states

--- a/src/haute/routes/_save_pipeline.py
+++ b/src/haute/routes/_save_pipeline.py
@@ -409,8 +409,8 @@ class SavePipelineService:
         drift onto separate structural validators.
         """
 
-        self._validate_singletons(graph)
         flattened = flatten_graph(graph)
+        self._validate_singletons(flattened)
         self._validate_edge_join_configs(flattened)
         self._validate_optimiser_input_selectors(flattened)
         self._validate_strict_node_configs(graph)
@@ -628,7 +628,7 @@ class SavePipelineService:
 
     @staticmethod
     def _validate_singletons(graph: PipelineGraph) -> None:
-        """Ensure singleton node types appear at most once."""
+        """Ensure singleton node types appear at most once in an executable graph."""
         for singleton_type, label in _SINGLETON_NODE_TYPES:
             count = sum(1 for n in graph.nodes if n.data.nodeType == singleton_type)
             if count > 1:

--- a/tests/test_route_save_pipeline.py
+++ b/tests/test_route_save_pipeline.py
@@ -112,6 +112,42 @@ class TestValidateSingletons:
         assert "API Input" in exc_info.value.detail
         assert "found 2" in exc_info.value.detail
 
+    def test_api_input_in_root_and_submodel_raises_400(self, tmp_path: Path) -> None:
+        """Singletons are unique across the flattened executable pipeline."""
+        graph = _make_submodel_graph(
+            _make_node("child_api", "Child API", "apiInput", {"path": "child.parquet"}),
+            root_nodes=(_make_node("root_api", "Root API", "apiInput", {"path": "root.parquet"}),),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService(tmp_path).validate_graph(graph, source_file="main.py")
+        assert exc_info.value.status_code == 400
+        assert "API Input" in exc_info.value.detail
+        assert "found 2" in exc_info.value.detail
+
+    def test_api_input_in_repeated_submodel_raises_400(self, tmp_path: Path) -> None:
+        """Each occurrence contributes its singleton nodes to execution."""
+        graph = _make_submodel_graph(
+            _make_node("child_api", "Child API", "apiInput", {"path": "child.parquet"}),
+        )
+        owner_id = "submodel_instance__pricing"
+        graph.nodes.append(
+            _make_node(
+                "submodel_instance__pricing_copy",
+                "pricing copy",
+                "submodel",
+                {
+                    "definitionId": "pricing",
+                    "alias": "pricing_copy",
+                    "instanceOf": owner_id,
+                },
+            )
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            SavePipelineService(tmp_path).validate_graph(graph, source_file="main.py")
+        assert exc_info.value.status_code == 400
+        assert "API Input" in exc_info.value.detail
+        assert "found 2" in exc_info.value.detail
+
     def test_duplicate_output_raises_400(self) -> None:
         """Two Output nodes should raise 400."""
         graph = _make_graph(


### PR DESCRIPTION
## Summary
- enforce API Input, Quote Response, and Source Switch uniqueness across the full executable graph, including embedded submodels
- prevent palette drops, paste, and submodel instancing from creating duplicate singleton nodes
- validate singleton counts after backend graph flattening so invalid documents cannot bypass editor guards
- document the document-wide invariant and add frontend/backend regressions

## Verification
- `npm --prefix frontend test -- src/panels/__tests__/NodePalette.test.tsx src/components/__tests__/ContextMenu.test.tsx src/hooks/__tests__/useEdgeHandlers.test.ts src/hooks/__tests__/useEdgeHandlers.dragJson.test.ts src/hooks/__tests__/useKeyboardShortcuts.test.ts src/hooks/__tests__/useNodeHandlers.test.ts src/hooks/__tests__/useNodeHandlers.deferCleanup.test.ts src/hooks/__tests__/useNodeHandlers.gaps.test.ts src/utils/__tests__/nodeTypes.test.ts src/__tests__/App.integration.test.tsx` (295 passed)
- `uv run pytest tests/test_route_save_pipeline.py -q` (79 passed)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint`
- `uv run ruff check src/haute/routes/_save_pipeline.py tests/test_route_save_pipeline.py`
- `uv run ruff format --check src/haute/routes/_save_pipeline.py tests/test_route_save_pipeline.py`
- verified against the locally installed `haute-demo` graph: existing document accepted; an added root API Input rejected with HTTP 400