### PR TITLE
Clarify Haute README and fix frontend test-debt scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,8 @@ haute serve
 `haute serve` opens the visual editor in your browser. See the [getting started guide](https://haute.dev/getting-started/) for installation and configuration.
 
 Haute is currently in alpha. The library is licensed under the [GNU Affero General Public License v3.0](LICENSE).
+
+## Development checks
+
+For local performance, benchmark, bundle, and memory smoke commands, see
+[Local Performance Checks](docs/PERFORMANCE_CHECKS.md).

--- a/README.md
+++ b/README.md
@@ -2,207 +2,102 @@
 
 # Haute
 
-### Open-source pricing engine.
-
-<br>
+### Open-source pricing engine for insurance teams.
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776AB?style=flat-square&logo=python&logoColor=white)](https://python.org)
 [![AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square)](LICENSE)
-[![Databricks](https://img.shields.io/badge/deploy-Databricks-FF3621?style=flat-square&logo=databricks&logoColor=white)](https://databricks.com)
-[![Azure Container Apps](https://img.shields.io/badge/deploy-Azure_Container_Apps-0078D4?style=flat-square&logo=microsoftazure&logoColor=white)](https://azure.microsoft.com/en-us/products/container-apps)
-[![AWS ECS](https://img.shields.io/badge/deploy-AWS_ECS-FF9900?style=flat-square&logo=amazonaws&logoColor=white)](https://aws.amazon.com/ecs/)
-[![GCP Cloud Run](https://img.shields.io/badge/deploy-Cloud_Run-4285F4?style=flat-square&logo=googlecloud&logoColor=white)](https://cloud.google.com/run)
-[![Docker](https://img.shields.io/badge/deploy-Docker-2496ED?style=flat-square&logo=docker&logoColor=white)](https://docker.com)
+
+[Documentation](https://haute.dev) · [Getting started](https://haute.dev/getting-started/)
 
 </div>
 
 ---
 
-Haute is a free, open-source pricing engine. It gives you a visual editor that runs in your browser - you build pricing pipelines by connecting nodes on a canvas rather than writing code from scratch.
+Haute is a free, open-source pricing engine for insurance teams. Build rating pipelines visually, explore data, train and score models, optimise prices, and trace how each price was calculated.
 
-Everything you build is saved as a standard Python file on disk. Not a proprietary format. Not a binary export. A Python file you can open, read, version, and take with you.
+Pipelines are saved as readable Python with configuration alongside. Pricing analysts can work on a canvas, developers can work in code, and both use the same project files, with standard version control, testing, and deployment workflows.
 
----
+## Build your pricing pipeline
 
-## Getting started
+Connect data sources, transformations, models, rating steps, and outputs in a browser-based editor. Preview data at each step, configure rating logic through tables and forms, and write focused Python expressions in the built-in code editor when you need custom calculations.
 
-One line to install, one to initialise the project, one to open your model.
+Rating steps support multiple factor tables, banded and raw categorical factors, spreadsheet-style copy and paste, and combined outputs. Banding nodes turn continuous or categorical values into rating groups. Join data through the canvas, and group related steps into reusable submodels to keep larger pipelines readable.
 
-```bash
-uv add haute
-haute init
-haute serve
-```
+Changes saved in the visual editor update the Python and configuration files on disk. External file changes are picked up by a file watcher, keeping visual and code-based workflows connected.
 
-On managed Windows, if application policy blocks the generated `haute.exe`
-launcher, run the same CLI through an organisation-approved Python runtime:
-`python -m haute serve`. Both forms use the same commands and options.
+### Reuse logic across your pipeline
 
----
+Instances let you apply shared logic to different inputs. Reuse a transformation, score the same model against different datasets, or connect a shared submodel in several places. Update the original definition and its instances use the updated logic, so you can maintain it in one place.
 
-## Why open source matters for pricing
+### Your work stays yours
 
-Pricing models sit at the centre of regulated businesses. They determine what customers pay, they get scrutinised by regulators, and they need to be understood by people who didn't build them. When the tool that produces those models is a black box, everyone - actuaries, regulators, auditors - has to take it on trust that the numbers are right.
+The pricing engine is open source, so your team can inspect, test, and extend how it calculates results. Pipelines and configuration remain ordinary project files that you can manage with standard Python tools and run with the open-source Haute library in your own infrastructure.
 
-Open source changes that relationship. The engine that calculates your prices is fully visible. Anyone on your team can inspect how it works, verify its behaviour, or extend it. There is no hidden logic, no opaque compilation step, no proprietary runtime sitting between your model and your output.
+### An assistant for pipeline authoring (early preview)
 
-This also means your work is portable. Your pipelines are Python files. Your models are standard formats. Your data stays in your infrastructure. If you ever want to stop using Haute, everything you've built still works: your pipelines are ordinary Python files (with JSON config saved alongside) that run with the open-source library - there's no hosted service or proprietary runtime to lose access to.
+Describe an edit in plain language, such as "add this parquet file as a data source" or "band vehicle age into five groups". The assistant can inspect your graph and data columns, then make changes through the editor's validated save path. Its edits are saved to the same project files as your own.
 
-Being open source and code means Haute can lean on best-in-class tools and engineering practices instead of reinventing them. Polars, Catboost, MLFlow, GIT, CI/CD, Haute doesn't try to rebuild these things behind a proprietary wall. It connects them and wraps them in an interface designed for pricing work.
+Bring your own model through Anthropic, OpenAI, or Databricks.
 
----
+## Audit history and team collaboration
 
-## A visual editor, and a code editor
+Haute's built-in Git panel keeps a history of how your pricing pipeline evolved, with recorded versions, authors, and change messages. Save incremental progress and group it into meaningful milestones, giving colleagues and reviewers a record of what changed and the context your team recorded alongside it.
 
-Haute opens in your browser. You build pricing pipelines by dragging nodes onto a canvas and connecting them - data sources, transforms, model scores, rating steps, outputs. Click any node and its data appears instantly in a preview table below. For nodes that involve data logic, there's a built-in code editor with line numbers, auto-indentation, and bracket matching - you write small, focused pieces of Python, not entire programs.
+Analysts can work on separate branches and share their changes through a shared Git repository, all from the visual editor. The underlying Python and configuration files fit standard code review workflows, so pricing and engineering teams can collaborate on the same project using their preferred tools.
 
-The visual editor and the code are always the same thing. Every node you create, every connection you draw, every parameter you set - it's all reflected in a Python file on disk in real time. This means a team can have some members working visually and others working in code, on the same pipeline, at the same time.
+## Explore data and build models
 
-If you've built rating structures in spreadsheets or used other pricing tools, this will feel familiar - except everything runs on your machine and you own the output.
+Attach an Explore node at any point in a pipeline to inspect the data there. Profile columns, check data quality, build pivot tables, and create charts without adding that analysis work to the live scoring path.
 
-Rating step nodes are built for the messy middle of pricing work: many factor tables, raw string factors as well as banded factors, Excel-style copy and paste, optional combined outputs, and optional Polars code that runs after the table lookups. Their sidecar config files store lookup entries as compact factor-value maps, while the editor and runtime keep the row shape they need. Banding nodes use compact boxed cells for continuous, categorical, and breakpoint rules, with range paste, whole-factor copy, and ordering flags for breakpoints. Compact edge-join nodes let you join another dataframe into an existing connection without dropping into custom code, while still saving as standard Python.
+Train CatBoost models and GLMs through dedicated modelling nodes, with insurance conventions such as exposure weights, offsets, and Poisson, Gamma, and Tweedie losses. Model development includes:
 
----
+- **Evaluation:** random, temporal, or group-based partitions, validation options, and an optional held-out final test.
+- **Tuning:** CatBoost hyperparameter searches using the configured validation strategy.
+- **Diagnostics:** metrics and charts such as Gini, actual-versus-expected, residuals, SHAP, and GLM coefficients, depending on the model.
+- **Reproducibility:** saved models and runnable Python training scripts exported from the same configuration used by the editor.
+- **Model documentation:** explicitly log completed results to MLflow, including a self-contained HTML model card for review and sharing.
 
-## An AI assistant that authors your pipeline (early preview)
+For scoring, Haute supports CatBoost and RustyStats models, plus other frameworks through compatible MLflow models. Scoring nodes handle model loading, feature validation, and supported type conversions, so you can combine predictions with rating logic in the same pipeline.
 
-Open the Assistant panel and describe what you want in plain language — "add
-`data/nb_batch.parquet` as a data source", "band vehicle age into five groups" — and the
-assistant reads your graph, checks the real columns in your data, and makes the edit
-through the same validated save path the visual editor uses. Every change lands in your
-Python file, on your git working branch, exactly as if you had made it by hand.
+## Optimise prices and explain the result
 
-Bring your own model through an explicit Anthropic, OpenAI, or Databricks provider.
-Databricks model serving reuses the project's standard `DATABRICKS_HOST` and
-`DATABRICKS_TOKEN` values from `.env`; its serving URL is derived automatically, so
-workspace identity is not duplicated in `haute.toml`. Credentials stay in `.env`;
-conversations persist per project in the untracked `.haute/` directory, so they survive
-server restarts and never enter git.
+Haute integrates constrained price optimisation through the open-source `price-contour` library. Choose among scored candidate prices for each quote, or optimise banded rating factors across a ratebook, using your objectives and constraints.
 
-This is an early preview — the core authoring loop is solid and fully tested, but expect
-rough edges while the experience gets tuned.
+Inspect convergence diagnostics and efficient-frontier results to understand the trade-offs. Save a selected result and apply it to new data downstream in your pricing pipeline.
 
----
+### Trace a price through the pipeline
 
-## Click any price. See exactly how it was calculated.
+Click an output cell to inspect how its value was calculated:
 
-Click any cell in your output table. Haute traces the path through every node that contributed to it, showing the value at each step:
-
-```
+```text
 base rate → area factor → discount → loading → final price
 ```
 
-The graph highlights the path visually. Nodes that contributed glow. The rest fade. A sidebar shows what happened at each step - which values were used, what changed, and what the result was. Rating steps show the table factors used, the selected value from each table, default usage, and combined-output inputs. Banding traces show the source value that selected the band and continue the upstream lineage.
+The graph highlights the contributing path, and the trace panel shows the values used along the way. Rating traces show selected factors and default usage; banding traces show which source value selected a band. Model and optimiser traces provide explanations specific to those steps, with upstream lineage available for further inspection.
 
-The first click runs through the full pipeline and caches the result. Every click after that pulls from cache - the trace updates instantly. Click a different row, a different column, a different output. Each one is immediate.
+Trace results are cached for reuse, making it easier to explore different rows and outputs. This gives analysts, reviewers, and stakeholders a way to investigate a price directly in the pipeline.
 
-When you need to show a regulator, a stakeholder, or a colleague exactly how a price was derived, this gives you that answer in a click.
+### One pipeline for live and batch pricing
 
----
+Use the same pricing logic for individual quotes, batch scoring, what-if work, and impact analysis. Source switches let development and batch data feed the same downstream logic used for live requests.
 
-## Your file on disk is the source of truth
+Polars powers execution. Preview caching reuses intermediate results where valid, while batch execution builds an optimised lazy plan. Timing breakdowns help identify expensive steps, and memory estimates help assess large training jobs before they start.
 
-There is no database behind Haute. No proprietary project file. Every pipeline is a `.py` file on disk.
+## Deploy your pricing API
 
-Edit a node in the visual editor and the Python file updates. Edit the Python file in a text editor and the visual editor updates. Both views stay in sync automatically through a file watcher - changes propagate in under a second.
+Haute packages the live scoring path of your pipeline as an API that accepts quote data and returns pricing outputs. Training and analysis branches stay outside that scoring path.
 
-This means your pipeline works with every tool that understands files: version control, code review, text editors, automated testing. You don't need to learn those tools to use Haute, but they're there when your team is ready for them.
+Pre-deployment validation runs test quotes through the pipeline and can check expected outputs with tolerances. Impact analysis compares staging and production predictions across a sample, including segment-level changes, to support release review.
 
----
-
-## Built to be fast
-
-When you click a node, you want to see its data now. Haute caches results at every node in the pipeline, so previewing data at any point is near-instant. Change a rating factor and only the downstream nodes recalculate - everything upstream stays cached.
-
-For batch work, Haute builds a full execution plan and optimises it end-to-end before processing your data. This is a different execution strategy to the one used for preview, and it's chosen automatically - you don't need to configure anything.
-
-There's a built-in timing breakdown that shows how long each step took, colour-coded so you can see at a glance where time is being spent.
-
----
-
-## Built-in price optimisation
-
-Haute includes a constrained price optimisation engine as a core part of the pipeline.
-
-You can optimise prices in real time (per-record, gradient-based) or across a ratebook (factor-table, coordinate descent). Set constraints - minimum and maximum prices, factor bounds - and the optimiser finds the best solution within them.
-
-The results include convergence diagnostics, scenario distributions, and an efficient frontier showing the tradeoff between your objectives. You can save the optimisation output and apply it downstream in the same pipeline.
-
----
-
-## Any model, same interface
-
-Haute works with any Python model. CatBoost, scikit-learn, LightGBM, XGBoost, Rustystats - if it runs in Python, it works in Haute.
-
-Behind the scenes, every model is wrapped in a uniform interface. You can swap a CatBoost model for an XGBoost model without changing your pipeline configuration. Feature type casting is handled automatically - the model receives data in the format it expects.
-
-Models are loaded with an intelligent cache that watches for file changes. Update a model file and the next pipeline run picks it up automatically.
-
----
-
-## Safe deployments, built in
-
-When you're ready to go live, Haute packages your pipeline and deploys it as a service that returns a price when it receives a request.
-
-**Before anything goes live**, Haute runs your pipeline against a set of test inputs. If anything breaks, the deployment stops. You can also set expected outputs with tolerances, so you're testing not just "does it run" but "does it produce the right results."
-
-**Before you promote to production**, Haute scores a sample through both the new version and the current one, and produces a segment-level impact report - how many results changed, by how much, and which groups were affected most. You review the report, approve the change, and promote. Every deployment records what changed, who approved it, and what it replaced.
-
-You choose where to deploy during initial setup:
-
-| Target | What it does |
+| Target | Current support |
 |---|---|
-| **Databricks** | Deploys to a Databricks serving endpoint |
-| **Docker** | Builds a container that runs anywhere |
-| **Azure / AWS / GCP** | Deploys to your cloud provider |
+| **Databricks** | Registers the packaged pipeline and creates or updates a Model Serving endpoint. |
+| **Docker** | Builds a serving container image and optionally pushes it to a registry for your team to run. |
+| **Azure Container Apps / AWS ECS / GCP Cloud Run** | Builds and pushes a container image; updating the running cloud service currently requires a manual step. |
 
-The infrastructure is set up once by whoever manages your technical environment. After that, every change follows the same path: test, review, deploy.
+Project scaffolding includes CI/CD templates for GitHub Actions, GitLab CI, and Azure DevOps, supporting testing, impact analysis, and approval before production promotion. Your platform team configures the infrastructure and release controls for your environment.
 
----
-
-## Version control without the learning curve
-
-Haute includes a built-in panel for saving and managing versions of your work. You don't need to know what Git is - the interface gives you simple actions: save your progress, see your history, go back to a previous version, and submit your work for review.
-
-Behind the scenes, it uses Git with guardrails. Protected branches can't be overwritten. Destructive actions create automatic backups. Switching between versions saves your current work first. The complexity is handled for you; you just see a clean history of your changes.
-
----
-
-## Knows your machine's limits
-
-Before training a model on a large dataset, Haute probes a sample of your data to estimate how much memory the full run will need. If it would exceed your machine's available memory, it tells you before you start - and suggests a safe dataset size.
-
-This is a small detail, but it catches the kind of silent crash that can lose work before it happens. The estimate reads the effective host or container memory limit and current headroom. Heavy server work then runs in an isolated process with a native memory cap; if Haute cannot establish that cap, it refuses the work instead of silently treating an unknown limit as safe. An explicitly selected `best_effort` mode remains available for compatibility-only environments.
-
----
-
-## Keep complex pipelines manageable
-
-Pricing work often has many steps. Submodels let you group a set of nodes into a single collapsible block. In the main view, you see one clean node. Double-click it to see the internals. Click the breadcrumb to go back.
-
-You can reuse a submodel across different pipelines - build something once and reference it everywhere. If you change your mind, dissolve the submodel and the nodes expand back into the parent pipeline.
-
----
-
-## One pipeline, many uses
-
-Build it once. Use it five ways:
-
-- **Live pricing** - a single request, real-time response from your deployed service
-- **Batch scoring** - process large datasets on your machine
-- **What-if analysis** - change inputs and watch the price move through every step
-- **Impact analysis** - compare a new version against the current one across your data
-- **Price tracing** - click any output and see exactly how it was calculated
-
-No rebuilding, no re-exporting, no maintaining separate versions for different use cases.
-
----
-
-## Open source
-
-Licensed under the [GNU Affero General Public License v3.0](LICENSE).
-
----
+See the [deployment documentation](https://haute.dev/deployment/) for target capabilities and release workflows.
 
 ## Getting started
 
@@ -212,14 +107,6 @@ haute init
 haute serve
 ```
 
-`haute serve` opens the visual editor in your browser. From there, you're building.
+`haute serve` opens the visual editor in your browser. See the [getting started guide](https://haute.dev/getting-started/) for installation and configuration.
 
-The local editor API is protected by a per-session token that `haute serve`
-wires into the browser automatically. Keep the default loopback host for normal
-use. For local debugging only, set `HAUTE_DISABLE_LOCAL_SESSION_AUTH=1` before
-starting the server to disable the token and WebSocket origin checks.
-
-## Development checks
-
-For local performance, benchmark, bundle, and memory smoke commands, see
-[Local Performance Checks](docs/PERFORMANCE_CHECKS.md).
+Haute is currently in alpha. The library is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/specs/engineering-quality/low-level.md
+++ b/specs/engineering-quality/low-level.md
@@ -363,6 +363,10 @@
   reviewed and budgeted, and a removed site fails until its stale entry is
   deleted (ruled 2026-07-27: no calendar expiry — review is event-driven,
   triggered by the ratchet, not by dates).
+- Frontend debt chains continue only through calls or explicit member access
+  (`.`, `?.`, or `[...]`). Adjacent declarations without semicolons are separate
+  expressions: a later skip/focus marker must not be attributed to earlier
+  tests, and each earlier declaration must stop before scanning later bodies.
 - Frontend shuffled tests are a nightly monitor for within-file state leaks,
   not an ordinary PR requirement. A captured seed makes a failed ordering
   reproducible.

--- a/tests/_test_debt_scanner.py
+++ b/tests/_test_debt_scanner.py
@@ -598,6 +598,10 @@ def _frontend_debt_chain(
                 continue
         elif masked[index] == ".":
             index = _skip_frontend_whitespace(masked, index + 1)
+        elif masked[index] != "[":
+            # A new identifier starts another expression, not a member of
+            # this chain (frontend tests commonly omit semicolons).
+            break
 
         if index < len(masked) and masked[index] == "[":
             computed = _read_frontend_computed_property(masked, original, index)

--- a/tests/test_test_debt.py
+++ b/tests/test_test_debt.py
@@ -717,6 +717,20 @@ def test_frontend_scanner_detects_skip_fixme_fail_only_variants() -> None:
     ]
 
 
+def test_frontend_scanner_keeps_adjacent_declarations_separate() -> None:
+    source = (
+        'test("ordinary case", () => {})\n'
+        'test.skip("skipped case", () => {})\n'
+        'it.only("focused case", () => {})\n'
+    )
+    sites = _scan_frontend_source(source, Path("frontend/src/example.test.ts"))
+
+    assert [(site.line, site.callee, site.source) for site in sites] == [
+        (2, "test.skip", 'test.skip("skipped case", () => {})'),
+        (3, "it.only", 'it.only("focused case", () => {})'),
+    ]
+
+
 def test_frontend_scanner_detects_chained_skip_fail_and_focus_variants() -> None:
     sites = _scan_frontend_source(
         """


### PR DESCRIPTION
The README mixed the product overview with implementation details and overstated model compatibility, deployment automation, and release controls. This update presents Haute around insurance pricing workflows and describes its current capabilities and limitations more precisely, retaining installation, deployment, and contributor guidance.

The frontend test-debt scanner also treated adjacent declarations without semicolons as one continuous member chain. That repeatedly scanned later test bodies, could attribute later skip/focus markers to earlier tests, and caused the backend coverage job to exceed its 60-second test timeout. Stop a chain at the next independent expression, document the boundary, and add a regression covering consecutive ordinary, skipped, and focused tests. Existing marker detection, fingerprints, and timeout budgets remain intact.

Validation:
- The new regression failed before the scanner fix and passes afterward.
- The frontend repository scan fell from 14.10 seconds to 1.88 seconds locally.
- All 69 tests across the test-debt and workflow-coverage modules were verified: 67 passed in the working checkout; two repository-inventory checks passed in a clean temporary checkout, avoiding an ignored local tool-state directory.
- Ruff lint and formatting checks passed for both touched Python files; `git diff --check` passed.
- The earlier README change passed 10 targeted documentation tests.
