### PR TITLE
Address PR #211 post-merge review findings

### DIFF
--- a/frontend/src/__tests__/hooks/useBackgroundJobs.test.ts
+++ b/frontend/src/__tests__/hooks/useBackgroundJobs.test.ts
@@ -302,6 +302,73 @@ describe("useBackgroundJobs", () => {
   // Train job polling
   // ────────────────────────────────────────────────────────────────
 
+  describe("invalid status payloads end the affected job", () => {
+    const cases = [
+      {
+        kind: "optimiser",
+        arrange: (failure: Error) => {
+          const mockGetStatus = vi.mocked(getOptimiserStatus)
+          mockGetStatus.mockResolvedValueOnce(makeSolveProgress())
+          mockGetStatus.mockRejectedValue(failure)
+          useNodeResultsStore.getState().startSolveJob("n1", "job-1", "Solve", {}, "config", "live", 0)
+          return {
+            pollCount: () => mockGetStatus.mock.calls.length,
+            progressMessage: () => useNodeResultsStore.getState().solveJobs.n1?.progress?.message,
+            jobRemoved: () => useNodeResultsStore.getState().solveJobs.n1 === undefined,
+            resultError: () => useNodeResultsStore.getState().solveResults.n1?.error,
+          }
+        },
+      },
+      {
+        kind: "Explore",
+        arrange: (failure: Error) => {
+          const mockGetStatus = vi.mocked(getExploreStatus)
+          mockGetStatus.mockResolvedValueOnce(makeExploreProgress())
+          mockGetStatus.mockRejectedValue(failure)
+          useNodeResultsStore.getState().startExploreJob("n1", "job-1", "Explore", "config", "live", 0)
+          return {
+            pollCount: () => mockGetStatus.mock.calls.length,
+            progressMessage: () => useNodeResultsStore.getState().exploreJobs.n1?.progress?.message,
+            jobRemoved: () => useNodeResultsStore.getState().exploreJobs.n1 === undefined,
+            resultError: () => useNodeResultsStore.getState().exploreResults.n1?.error,
+          }
+        },
+      },
+      {
+        kind: "pivot",
+        arrange: (failure: Error) => {
+          const mockGetStatus = vi.mocked(getExplorePivotStatus)
+          mockGetStatus.mockResolvedValueOnce(makePivotProgress())
+          mockGetStatus.mockRejectedValue(failure)
+          useNodeResultsStore.getState().startExplorePivotJob("n1", "job-1", "n1", "p1", "Explore", "Pivot", "calculation", "live", 0)
+          return {
+            pollCount: () => mockGetStatus.mock.calls.length,
+            progressMessage: () => useNodeResultsStore.getState().pivotJobs.n1?.progress?.message,
+            jobRemoved: () => useNodeResultsStore.getState().pivotJobs.n1 === undefined,
+            resultError: () => useNodeResultsStore.getState().pivotResults.n1?.error,
+          }
+        },
+      },
+    ]
+
+    it.each(cases)("replaces stuck $kind polling with a response error and stops retrying", async ({ kind, arrange }) => {
+      const cause = new Error(`parse${kind}StatusResponse: invalid payload`)
+      const failure = new ApiResponseValidationError(`Could not read ${kind} status: ${cause.message}`, cause)
+      let observe!: ReturnType<typeof arrange>
+      act(() => { observe = arrange(failure) })
+      renderHook(() => useBackgroundJobs())
+
+      await advance(500)
+      expect(observe.progressMessage()).toBeDefined()
+      expect(observe.jobRemoved()).toBe(false)
+      await advance(1_000)
+      expect(observe.jobRemoved()).toBe(true)
+      expect(observe.resultError()).toBe(failure.message)
+      await advance(10_000)
+      expect(observe.pollCount()).toBe(2)
+    })
+  })
+
   describe("train job polling", () => {
     it("completes diagnostic progress with a missing categorical PDP level", async () => {
       const mockGetStatus = vi.mocked(getTrainStatus)

--- a/frontend/src/api/__tests__/client.contract.test.ts
+++ b/frontend/src/api/__tests__/client.contract.test.ts
@@ -581,7 +581,36 @@ describe("client runtime contracts", () => {
       }),
     )
 
-    await expect(getOptimiserStatus("job-1")).rejects.toThrow(/parseOptimiserStatusResponse/i)
+    await expect(getOptimiserStatus("job-1")).rejects.toMatchObject({
+      name: "ApiResponseValidationError",
+      message: expect.stringMatching(/could not read optimiser status.*parseOptimiserStatusResponse/i),
+      cause: expect.any(Error),
+    })
+    await expect(getOptimiserStatus("job-1")).rejects.toBeInstanceOf(ApiResponseValidationError)
+  })
+
+  it("getExploreStatus rejects malformed status payloads as response validation errors", async () => {
+    mockFetch.mockReturnValue(
+      jsonResponse({ ...loadUiContractFixture<Record<string, unknown>>("explore_status_response"), progress: "bad" }),
+    )
+
+    await expect(getExploreStatus("explore-job-1")).rejects.toMatchObject({
+      name: "ApiResponseValidationError",
+      message: expect.stringMatching(/could not read explore status.*parseExploreStatusResponse/i),
+      cause: expect.any(Error),
+    })
+  })
+
+  it("getExplorePivotStatus rejects malformed status payloads as response validation errors", async () => {
+    mockFetch.mockReturnValue(
+      jsonResponse({ ...loadUiContractFixture<Record<string, unknown>>("explore_pivot_status_response"), progress: "bad" }),
+    )
+
+    await expect(getExplorePivotStatus("pivot-job-1")).rejects.toMatchObject({
+      name: "ApiResponseValidationError",
+      message: expect.stringMatching(/could not read pivot status.*parseExplorePivotStatusResponse/i),
+      cause: expect.any(Error),
+    })
   })
 
   it("preserves optimiser auto-range start contract metadata", async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -185,7 +185,7 @@ import {
   type RemoveUnavailableNodeRequest,
 } from "../types/pipelineRepair"
 
-import { ApiResponseValidationError } from "./responseValidation"
+import { validateApiResponse } from "./responseValidation"
 
 export class ApiError extends Error {
   status: number
@@ -1144,7 +1144,7 @@ export function getExploreStatus<T extends ExploreStatusResponse = ExploreStatus
   options?: { signal?: AbortSignal },
 ): Promise<T> {
   return request<unknown>(`/api/explore/status/${encodeURIComponent(jobId)}`, options)
-    .then((data) => parseExploreStatusResponse(data) as T)
+    .then((data) => validateApiResponse("Could not read Explore status", () => parseExploreStatusResponse(data) as T))
 }
 
 export function cancelExplore<T extends ExploreStatusResponse = ExploreStatusResponse>(
@@ -1179,7 +1179,7 @@ export function getExplorePivotStatus(
   options?: { signal?: AbortSignal },
 ): Promise<ExplorePivotStatusResponse> {
   return request<unknown>(`/api/explore/pivots/status/${encodeURIComponent(jobId)}`, options)
-    .then(parseExplorePivotStatusResponse)
+    .then((data) => validateApiResponse("Could not read pivot status", () => parseExplorePivotStatusResponse(data)))
 }
 
 export function cancelExplorePivot(
@@ -1229,12 +1229,7 @@ export function getTrainStatus<T extends TrainStatusResponse = TrainStatusRespon
   return request<unknown>(`/api/modelling/train/status/${encodeURIComponent(jobId)}`, options)
     .then(async (data) => {
       const { parseTrainStatusResponse } = await import("../types/trainGuards")
-      try {
-        return parseTrainStatusResponse(data) as T
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error)
-        throw new ApiResponseValidationError(`Could not read training status: ${detail}`, error)
-      }
+      return validateApiResponse("Could not read training status", () => parseTrainStatusResponse(data) as T)
     })
 }
 
@@ -1338,7 +1333,7 @@ export function getOptimiserStatus<T extends OptimiserStatusResponse = Optimiser
   options?: { signal?: AbortSignal },
 ): Promise<T> {
   return request<unknown>(`/api/optimiser/solve/status/${encodeURIComponent(jobId)}`, options)
-    .then((data) => parseOptimiserStatusResponse(data) as T)
+    .then((data) => validateApiResponse("Could not read optimiser status", () => parseOptimiserStatusResponse(data) as T))
 }
 
 export function applyOptimiser(

--- a/frontend/src/api/responseValidation.ts
+++ b/frontend/src/api/responseValidation.ts
@@ -5,3 +5,13 @@ export class ApiResponseValidationError extends Error {
     this.name = "ApiResponseValidationError"
   }
 }
+
+/** Run a response parser, reporting its failure as a contract violation. */
+export function validateApiResponse<T>(context: string, parse: () => T): T {
+  try {
+    return parse()
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new ApiResponseValidationError(`${context}: ${detail}`, error)
+  }
+}

--- a/frontend/src/hooks/__tests__/ensureInputSnapshots.test.ts
+++ b/frontend/src/hooks/__tests__/ensureInputSnapshots.test.ts
@@ -215,6 +215,29 @@ describe("ensureInputSnapshots", () => {
     expect(onProgress).toHaveBeenLastCalledWith(null)
   })
 
+  it("finishes the build when progress polling fails, without retrying progress", async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      vi.mocked(getJsonCacheStatusForSchema).mockResolvedValue(jsonStatus(false))
+      vi.mocked(getJsonCacheProgress).mockRejectedValue(new Error("Progress endpoint unavailable"))
+      let finish!: (value: JsonCacheBuildResponse) => void
+      vi.mocked(buildJsonCache).mockImplementation(() => new Promise((resolve) => { finish = resolve }))
+      const onProgress = vi.fn()
+      const pending = ensureInputSnapshots([quoteInput()], { onProgress })
+      await vi.advanceTimersByTimeAsync(800)
+      expect(getJsonCacheProgress).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(1600)
+      expect(getJsonCacheProgress).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledOnce()
+      finish(jsonBuild)
+      await pending
+      expect(onProgress).toHaveBeenLastCalledWith(null)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it.each([null, { unexpected: true }])(
     "propagates status failures for Quote Inputs with a declared invalid tables value: %j",
     async (tables) => {

--- a/frontend/src/hooks/ensureInputSnapshots.ts
+++ b/frontend/src/hooks/ensureInputSnapshots.ts
@@ -88,7 +88,11 @@ async function ensureQuoteInputCache(
           }
         }
       } catch (error) {
-        if (!controller.signal.aborted) throw error
+        // Progress display is presentational; only the build outcome may
+        // decide this preparation. Stop polling and keep the last message.
+        if (!controller.signal.aborted) {
+          console.warn("Quote Input cache progress polling stopped:", error)
+        }
       }
     }
     try {

--- a/frontend/src/hooks/ensureInputSnapshots.ts
+++ b/frontend/src/hooks/ensureInputSnapshots.ts
@@ -88,9 +88,9 @@ async function ensureQuoteInputCache(
           }
         }
       } catch (error) {
-        // Progress display is presentational; only the build outcome may
-        // decide this preparation. Stop polling and keep the last message.
         if (!controller.signal.aborted) {
+          // Progress display is presentational; only the build outcome may
+          // decide this preparation. Stop polling and keep the last message.
           console.warn("Quote Input cache progress polling stopped:", error)
         }
       }

--- a/frontend/src/hooks/useBackgroundJobs.ts
+++ b/frontend/src/hooks/useBackgroundJobs.ts
@@ -42,7 +42,10 @@ function getMissingJobPollErrorMessage(error: unknown): string | undefined {
   return "Job not found"
 }
 
-function getTrainPollErrorMessage(error: unknown): string | undefined {
+// An ApiResponseValidationError is deterministic — the same payload fails the
+// same way on every poll — so it ends the job with a visible error instead of
+// leaving stale progress behind a retry loop. Transport failures stay retryable.
+function getJobPollErrorMessage(error: unknown): string | undefined {
   if (error instanceof ApiResponseValidationError) return error.message
   return getMissingJobPollErrorMessage(error)
 }
@@ -110,7 +113,7 @@ export default function useBackgroundJobs() {
       status: s.status,
       terminalReason: s.terminal_reason,
     }),
-    getTerminalPollErrorMessage: getMissingJobPollErrorMessage,
+    getTerminalPollErrorMessage: getJobPollErrorMessage,
     addToast,
     successLabel: "Optimisation complete",
     failLabel: "Optimisation failed",
@@ -151,7 +154,7 @@ export default function useBackgroundJobs() {
       status: s.status,
       terminalReason: s.terminal_reason,
     }),
-    getTerminalPollErrorMessage: getTrainPollErrorMessage,
+    getTerminalPollErrorMessage: getJobPollErrorMessage,
     addToast,
     successLabel: "Training complete",
     failLabel: "Training failed",
@@ -192,7 +195,7 @@ export default function useBackgroundJobs() {
       status: s.status,
       terminalReason: s.terminal_reason,
     }),
-    getTerminalPollErrorMessage: getMissingJobPollErrorMessage,
+    getTerminalPollErrorMessage: getJobPollErrorMessage,
     addToast,
     successLabel: "Explore complete",
     failLabel: "Explore failed",
@@ -236,7 +239,7 @@ export default function useBackgroundJobs() {
         terminalReason: s.terminal_reason,
       },
     ),
-    getTerminalPollErrorMessage: getMissingJobPollErrorMessage,
+    getTerminalPollErrorMessage: getJobPollErrorMessage,
     addToast,
     successLabel: "Pivot complete",
     failLabel: "Pivot failed",

--- a/frontend/src/panels/editors/banding/BandingRulesGrid.tsx
+++ b/frontend/src/panels/editors/banding/BandingRulesGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react"
+import { useMemo, useCallback, useState } from "react"
 import { Copy, Trash } from "lucide-react"
 import { CHART_COLORS } from "../../../theme/colors"
 import useToastStore from "../../../stores/useToastStore"
@@ -18,13 +18,23 @@ export function nextRuleId(): string {
   return `rule_${++_ruleIdSeq}_${Date.now().toString(36)}`
 }
 
-/** Ensure every rule has a stable `_id` key. */
-function ensureRuleIds(rules: (ContinuousRule | CategoricalRule | BreakpointRule)[]): (ContinuousRule | CategoricalRule | BreakpointRule)[] {
+/** Ensure every rule has a stable `_id` key. Ids generated for id-less rules
+ *  are remembered per rule object, so a parent that recreates the rules array
+ *  without an edit keeps the same row identity (and the user's focus). */
+function ensureRuleIds(
+  rules: (ContinuousRule | CategoricalRule | BreakpointRule)[],
+  generatedIds: WeakMap<object, string>,
+): (ContinuousRule | CategoricalRule | BreakpointRule)[] {
   let changed = false
   const result = rules.map((r) => {
     if ((r as Record<string, unknown>)._id) return r
     changed = true
-    return { ...r, _id: nextRuleId() }
+    let id = generatedIds.get(r)
+    if (!id) {
+      id = nextRuleId()
+      generatedIds.set(r, id)
+    }
+    return { ...r, _id: id }
   })
   return changed ? result : rules
 }
@@ -197,7 +207,8 @@ export function BandingRulesGrid({
   const addToast = useToastStore(s => s.addToast)
   const rawRules = useMemo(() => factor.rules || [], [factor.rules])
 
-  const rules = useMemo(() => ensureRuleIds(rawRules), [rawRules])
+  const [generatedRuleIds] = useState(() => new WeakMap<object, string>())
+  const rules = useMemo(() => ensureRuleIds(rawRules, generatedRuleIds), [rawRules, generatedRuleIds])
 
   const bt = factor.banding || "continuous"
 

--- a/frontend/src/panels/editors/banding/__tests__/BandingRulesGrid.test.tsx
+++ b/frontend/src/panels/editors/banding/__tests__/BandingRulesGrid.test.tsx
@@ -119,6 +119,24 @@ describe("BandingRulesGrid", () => {
     expect(assignedRules[0]._id.length).toBeGreaterThan(0)
   })
 
+  it("keeps row identity when the parent recreates an id-less rules array", () => {
+    const onUpdate = vi.fn()
+    const rules: ContinuousRule[] = [
+      { op1: "<", val1: "25", op2: "", val2: "", assignment: "young" },
+      { op1: ">=", val1: "25", op2: "", val2: "", assignment: "old" },
+    ]
+    const factor = makeFactor({ rules })
+    const { rerender } = render(<BandingRulesGrid factor={factor} onUpdateFactor={onUpdate} />)
+    const textbox = screen.getByLabelText("Rule 1 lower value")
+    textbox.focus()
+
+    rerender(<BandingRulesGrid factor={{ ...factor, rules: [...rules] }} onUpdateFactor={onUpdate} />)
+
+    expect(onUpdate).not.toHaveBeenCalled()
+    expect(screen.getByLabelText("Rule 1 lower value")).toBe(textbox)
+    expect(document.activeElement).toBe(textbox)
+  })
+
   it("rules with existing _id are not reassigned", () => {
     const onUpdate = vi.fn()
     const rules = [

--- a/specs/caching/high-level.md
+++ b/specs/caching/high-level.md
@@ -76,7 +76,9 @@ in-memory schema, builds a missing or invalid full cache through the existing
 JSON-cache build endpoint, and awaits publication before execution. The preview
 panel shows cache preparation and elapsed build time. Build or status failures
 stop preview with an actionable error; cancellation prevents stale progress or
-late execution. A valid cache is reused without rebuilding.
+late execution. A valid cache is reused without rebuilding. Progress reporting
+is presentational only: a failed progress poll stops further progress updates
+without failing the preparation — the build outcome alone decides it.
 
 Before Studio sends a preview that uses snapshot-backed Data Inputs, it checks
 each required snapshot through the existing status endpoint. A missing,

--- a/specs/frontend-modelling-optimiser-ui/high-level.md
+++ b/specs/frontend-modelling-optimiser-ui/high-level.md
@@ -31,9 +31,10 @@ results are supplied by API and result-store layers.
   feature importance, AVE and PDP) only when backed by non-empty result data, and resets
   selection to summary when the result changes.
 - Completed training accepts missing categorical PDP levels as JSON `null` and labels
-  them `(missing)` in the chart. Numeric PDP levels remain non-null. Invalid training
-  status responses stop polling with a visible response error; network failures remain
-  retryable, so a rejected result cannot leave the last diagnostic stage running forever.
+  them `(missing)` in the chart. Numeric PDP levels remain non-null. Invalid status
+  responses stop polling with a visible response error for every background job type
+  (training, optimiser, Explore and pivot); network failures remain retryable, so a
+  rejected result cannot leave the last reported stage running forever.
 - CatBoost and RustyStats/GLM results use Explore's full-width, equal-width preview
   buttons, with keyboard navigation and an explicitly labelled active pane. Narrow
   panels scroll the button strip horizontally rather than clipping view names.

--- a/specs/frontend-modelling-optimiser-ui/low-level.md
+++ b/specs/frontend-modelling-optimiser-ui/low-level.md
@@ -115,9 +115,10 @@ Only a current, accepted save response may acknowledge this revision transition.
 5. `parseTrainStatusResponse` preserves explicit `null` values in categorical PDP grids;
    missing value fields, non-scalar values and null numeric grid values remain invalid.
    `PdpTab` displays the null level as `(missing)` without changing its prediction or
-   conflating the payload with a literal string. `getTrainStatus` wraps parser failures
+   conflating the payload with a literal string. `getTrainStatus`, `getOptimiserStatus`,
+   `getExploreStatus` and `getExplorePivotStatus` wrap parser failures
    in `ApiResponseValidationError`, retaining the original cause and field detail.
-   Training polling treats that error as terminal for result delivery, removes the active
+   Every job poller treats that error as terminal for result delivery, removes the active
    job and displays the error. Request failures and lazy-module loading failures retain
    normal retry behavior. A running-to-completed nullable-category response must publish
    the completed result, including its missing-level chart, and clear running progress.

--- a/specs/frontend-node-editors/low-level.md
+++ b/specs/frontend-node-editors/low-level.md
@@ -128,7 +128,8 @@
    Clipboard/drag/dialog operations remain local until that callback. `BandingRulesGrid` derives
    stable local keys for legacy rules without `_id` when it opens or rerenders, but this view-only
    work never calls `onUpdateFactor`; generated keys enter persisted rules only with a subsequent
-   user edit, paste, or delete operation.
+   user edit, paste, or delete operation. Generated keys are remembered per rule record, so a
+   parent that recreates the rules array without an edit keeps row identity and the user's focus.
 5. Format, file, catalog and MLflow controls issue their own API calls. I/O capabilities are
    fetched for each later editor mount, while consumers mounting during one pending fetch share
    that request. Request state is local to the editor; the editor never assumes an out-of-order response still describes a

--- a/specs/frontend-shared/low-level.md
+++ b/specs/frontend-shared/low-level.md
@@ -4,7 +4,7 @@
 
 | File | Responsibility |
 |---|---|
-| `frontend/src/api/responseValidation.ts` | `ApiResponseValidationError` distinguishes invalid API responses from retryable transport failures while preserving the parser error as its cause; training polling reports it as a terminal response error. |
+| `frontend/src/api/responseValidation.ts` | `ApiResponseValidationError` distinguishes invalid API responses from retryable transport failures while preserving the parser error as its cause; `validateApiResponse` wraps a parser call in that contract. Every background job poller (train, optimiser, Explore, pivot) reports it as a terminal response error. |
 | `frontend/src/utils/editorIdentities.ts` | Builds bounded identity requests, applies exact-order server responses, and attaches authoritative node/edge metadata without mutating the candidate graph. |
 | `frontend/src/main.tsx` | Local-session bootstrap: establishes the browser-managed HttpOnly cookie before mounting `App` inside `StrictMode` + a root `ErrorBoundary`; renders an actionable reload state if the local backend is unavailable. |
 | `frontend/src/api/client.ts` | Typed `fetch()` wrapper: same-origin cookie credentials, single-flight `bootstrapHauteSession`, retry/backoff, timeout, abort handling, session-expiry event, and one function per backend endpoint. Exports `request`/`post` so split-chunk endpoint modules can reuse the same fetch machinery, and a raw-stream helper (cookie credentials + `ApiError` mapping, no JSON parse) for split modules with non-JSON transports — the assistant SSE stream (see [frontend-assistant-ui](../frontend-assistant-ui/low-level.md)). Modelling train/status/estimate methods dynamically import `types/trainGuards.ts` only after their response arrives so the large training contract stays out of the initial bundle. |
@@ -262,7 +262,11 @@ poll errors trigger a toast (poll errors are tolerated silently up to that
 point — the network hiccup case is expected). A 404/410 from the poll
 endpoint (`TERMINAL_MISSING_JOB_STATUSES`, checked via
 `getMissingJobPollErrorMessage`) is treated as "job is gone, stop polling"
-rather than a retryable transient error. Reconciliation aborts and retires a
+rather than a retryable transient error. An `ApiResponseValidationError`
+from any of the four status parsers is likewise terminal
+(`getJobPollErrorMessage`): the same payload would fail identically on every
+poll, so the job ends with the validation message instead of holding stale
+progress behind the retry loop. Reconciliation aborts and retires a
 poller when its node disappears or the same node is replaced by a different
 job id; completions from retired identities cannot publish progress or
 terminal state. Controller disposal performs the same retirement for every

--- a/specs/json-shredding/low-level.md
+++ b/specs/json-shredding/low-level.md
@@ -7,7 +7,9 @@ Studio's preview preflight checks structured Quote Inputs with
 `volatile_schema`. When `cached` is false it awaits `POST /api/json-cache/build`
 before sending the preview request. It uses the existing full-cache publication
 and progress endpoints, and shows the building phase until completion. Status
-and build errors propagate through the normal preview error surface. All
+and build errors propagate through the normal preview error surface; a
+progress-poll failure only ends progress reporting (with a console warning)
+and never fails the preparation itself. All
 requests and progress callbacks respect the owning preview's AbortSignal.
 Ready caches are not refreshed; recovery-document previews retain their
 server-planned, read-only execution boundary.


### PR DESCRIPTION
Follow-ups from the post-merge review of #211. Three fixes, no behaviour outside them:

- **Terminal validation errors for every job poller.** `getOptimiserStatus`, `getExploreStatus` and `getExplorePivotStatus` now wrap parser failures in `ApiResponseValidationError` exactly like `getTrainStatus` (shared `validateApiResponse` helper), and all four background pollers treat that error as terminal. A deterministic contract gap now ends the job with the visible response error instead of retrying for up to 24 hours behind stale progress. Transport failures remain retryable.
- **Progress polling can no longer fail a healthy Quote Input cache build.** A progress-poll error stops further progress reporting (with a console warning) and leaves the build promise to decide the preparation outcome.
- **Banding rule row identity survives parent array recreation.** Generated `_id`s are remembered per rule record (WeakMap held in state), so an id-less rules array recreated without an edit keeps row keys and the user's focus. Ids still only persist through a real edit.

Specs updated: frontend-shared, frontend-modelling-optimiser-ui (high+low), caching, json-shredding, frontend-node-editors.

Validation: RED-first — all 8 new tests failed for the intended reasons before the fix; targeted suites now 198/198, neighbouring hooks/api/banding suites 992/992, `tsc -b` clean, ESLint at the 17-warning baseline (0 errors). Full compatibility, coverage, browser and mutation checks run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)